### PR TITLE
fix: properly using gRPC port

### DIFF
--- a/k8s-deployment.yaml
+++ b/k8s-deployment.yaml
@@ -33,14 +33,12 @@ spec:
             cpu: "200m"
             memory: "128Mi"
         livenessProbe:
-          httpGet:
-            path: /health
+          tcpSocket:
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
-          httpGet:
-            path: /health
+          tcpSocket:
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/model_express_server/src/main.rs
+++ b/model_express_server/src/main.rs
@@ -23,7 +23,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting model_express_server with gRPC...");
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], constants::DEFAULT_GRPC_PORT));
+    // Read port from environment variable or use default
+    let port = std::env::var("SERVER_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(constants::DEFAULT_GRPC_PORT);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
 
     // Create service implementations
     let health_service = HealthServiceImpl;


### PR DESCRIPTION
When I migrated my initial HTTP proof of concept to using gRPC, I didn't fully tie together the port mapping as I should've. This fixes this oversight.