### PR TITLE
fix: Fixing configuration file validation.

### DIFF
--- a/model_express_common/src/config.rs
+++ b/model_express_common/src/config.rs
@@ -6,7 +6,7 @@ use clap::ValueEnum;
 use config::{Config, ConfigError, Environment, File};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tracing::Level;
 
@@ -217,14 +217,35 @@ pub trait ConfigLoader<T> {
         T: serde::de::DeserializeOwned + Default;
 }
 
-/// Default implementation of layered configuration loading
-pub fn load_layered_config<T>(
+/// Load configuration file strictly without any fallbacks to defaults.
+/// This function will return an error if the file doesn't exist, has invalid syntax,
+/// or contains invalid values. Use this for validation purposes.
+pub fn load_config_file_strict<T>(config_file: &Path) -> Result<T, ConfigError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    if !config_file.exists() {
+        return Err(ConfigError::Message(format!(
+            "Configuration file not found: {}",
+            config_file.display()
+        )));
+    }
+
+    let config = Config::builder()
+        .add_source(File::from(config_file.to_path_buf()))
+        .build()?;
+
+    config.try_deserialize::<T>()
+}
+
+/// Load configuration with strict file parsing but with environment variable overrides.
+/// This is used internally by both strict validation and normal loading with fallbacks.
+fn load_config_with_env_strict<T>(
     config_file: Option<PathBuf>,
     env_prefix: &str,
-    defaults: T,
 ) -> Result<T, ConfigError>
 where
-    T: serde::de::DeserializeOwned + Default,
+    T: serde::de::DeserializeOwned,
 {
     let mut builder = Config::builder();
 
@@ -262,23 +283,35 @@ where
             .separator("_"),
     );
 
-    // Build the config and merge with defaults
-    let config_result = builder.build();
+    // Build and deserialize strictly
+    let config = builder.build()?;
+    config.try_deserialize::<T>()
+}
 
-    match config_result {
-        Ok(c) => {
-            // Try to deserialize the full config
-            match c.try_deserialize::<T>() {
-                Ok(full_config) => Ok(full_config),
-                Err(_) => {
-                    // If deserialization fails, fall back to defaults
-                    // This is a safe fallback for partial configurations
-                    Ok(defaults)
-                }
-            }
-        }
+/// Validate a configuration file by attempting to parse it strictly.
+/// Returns detailed error information if the file is invalid.
+pub fn validate_config_file<T>(config_file: &Path) -> Result<T, ConfigError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    load_config_file_strict(config_file)
+}
+
+/// Default implementation of layered configuration loading with fallback to defaults
+pub fn load_layered_config<T>(
+    config_file: Option<PathBuf>,
+    env_prefix: &str,
+    defaults: T,
+) -> Result<T, ConfigError>
+where
+    T: serde::de::DeserializeOwned + Default,
+{
+    // Try to load configuration strictly first
+    match load_config_with_env_strict(config_file, env_prefix) {
+        Ok(config) => Ok(config),
         Err(_) => {
-            // If building the config fails entirely, use defaults
+            // If strict loading fails, fall back to defaults
+            // This provides a safe fallback for partial configurations or errors
             Ok(defaults)
         }
     }
@@ -336,6 +369,8 @@ impl ConnectionConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn test_duration_config_from_string() {
@@ -386,5 +421,108 @@ mod tests {
         assert_eq!(config.timeout_secs, Some(60));
         assert_eq!(config.max_retries, Some(5));
         assert_eq!(config.retry_delay_secs, Some(2));
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_load_config_file_strict_missing_file() {
+        let non_existent_file = PathBuf::from("/non/existent/file.yaml");
+        let result: Result<ConnectionConfig, ConfigError> =
+            load_config_file_strict(&non_existent_file);
+
+        assert!(result.is_err());
+        let error_message = result
+            .expect_err("Expected error for missing file")
+            .to_string();
+        assert!(error_message.contains("Configuration file not found"));
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_load_config_file_strict_valid_file() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let config_file = temp_dir.path().join("test_config.yaml");
+
+        let valid_config = r#"
+endpoint: "http://localhost:9999"
+timeout_secs: 60
+max_retries: 5
+retry_delay_secs: 2
+"#;
+
+        fs::write(&config_file, valid_config).expect("Failed to write config file");
+
+        let result: Result<ConnectionConfig, ConfigError> = load_config_file_strict(&config_file);
+        assert!(result.is_ok());
+
+        let config = result.expect("Expected successful config parsing");
+        assert_eq!(config.endpoint, "http://localhost:9999");
+        assert_eq!(config.timeout_secs, Some(60));
+        assert_eq!(config.max_retries, Some(5));
+        assert_eq!(config.retry_delay_secs, Some(2));
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_load_config_file_strict_invalid_yaml() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let config_file = temp_dir.path().join("invalid_config.yaml");
+
+        let invalid_config = r#"
+endpoint: "http://localhost:9999"
+timeout_secs: not_a_number
+invalid_yaml_structure:
+  missing_indent
+"#;
+
+        fs::write(&config_file, invalid_config).expect("Failed to write config file");
+
+        let result: Result<ConnectionConfig, ConfigError> = load_config_file_strict(&config_file);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_load_config_file_strict_wrong_type() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let config_file = temp_dir.path().join("wrong_type_config.yaml");
+
+        let wrong_type_config = r#"
+endpoint: "http://localhost:9999"
+timeout_secs: "this_should_be_a_number"
+"#;
+
+        fs::write(&config_file, wrong_type_config).expect("Failed to write config file");
+
+        let result: Result<ConnectionConfig, ConfigError> = load_config_file_strict(&config_file);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_validate_config_file_same_as_strict() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let config_file = temp_dir.path().join("test_config.yaml");
+
+        let valid_config = r#"
+endpoint: "http://localhost:9999"
+timeout_secs: 60
+"#;
+
+        fs::write(&config_file, valid_config).expect("Failed to write config file");
+
+        let strict_result: Result<ConnectionConfig, ConfigError> =
+            load_config_file_strict(&config_file);
+        let validate_result: Result<ConnectionConfig, ConfigError> =
+            validate_config_file(&config_file);
+
+        assert!(strict_result.is_ok());
+        assert!(validate_result.is_ok());
+
+        let strict_config = strict_result.expect("Expected successful strict config parsing");
+        let validate_config = validate_result.expect("Expected successful validate config parsing");
+
+        assert_eq!(strict_config.endpoint, validate_config.endpoint);
+        assert_eq!(strict_config.timeout_secs, validate_config.timeout_secs);
     }
 }

--- a/model_express_server/src/config.rs
+++ b/model_express_server/src/config.rs
@@ -149,11 +149,33 @@ impl ServerConfig {
     /// 3. Configuration file
     /// 4. Default values (lowest priority)
     pub fn load(args: ServerArgs) -> Result<Self, ConfigError> {
-        // Use the common layered config loading
-        let mut config =
-            load_layered_config(args.config.clone(), "MODEL_EXPRESS", Self::default())?;
+        Self::load_internal(args, false)
+    }
 
-        // Override with command line arguments
+    /// Load and validate configuration file strictly without fallbacks.
+    /// This method should be used when validating configuration files.
+    /// It will return an error if the file has invalid syntax or values.
+    pub fn load_and_validate_strict(args: ServerArgs) -> Result<Self, ConfigError> {
+        Self::load_internal(args, true)
+    }
+
+    /// Internal method to load configuration with optional strict mode
+    fn load_internal(args: ServerArgs, strict_mode: bool) -> Result<Self, ConfigError> {
+        let mut config = if strict_mode {
+            // Use strict loading - fail on any configuration errors
+            if let Some(ref config_file) = args.config {
+                // Load file strictly without fallbacks
+                model_express_common::config::validate_config_file(config_file)?
+            } else {
+                // No config file specified, use defaults
+                Self::default()
+            }
+        } else {
+            // Use layered config loading with fallbacks to defaults
+            load_layered_config(args.config.clone(), "MODEL_EXPRESS", Self::default())?
+        };
+
+        // Apply command line overrides (same for both modes)
         if let Some(port) = args.port {
             config.server.port = port;
         }
@@ -174,7 +196,7 @@ impl ServerConfig {
             config.database.path = database_path;
         }
 
-        // Validate configuration
+        // Validate the final configuration
         config.validate()?;
 
         Ok(config)
@@ -262,6 +284,8 @@ mod tests {
     use chrono::Duration;
     use clap::Parser;
     use model_express_common::config::{DurationConfig, parse_duration_string};
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn test_log_level_enum_parsing() {
@@ -475,5 +499,179 @@ mod tests {
         let duration_config = DurationConfig::hours(1);
         let serialized = serde_json::to_string(&duration_config).expect("Failed to serialize");
         assert_eq!(serialized, r#"{"duration":3600}"#);
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_server_config_load_and_validate_strict_valid_config() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let config_file = temp_dir.path().join("valid_server_config.yaml");
+
+        let valid_config = r#"
+server:
+  host: "127.0.0.1"
+  port: 8002
+  graceful_shutdown: true
+  shutdown_timeout_seconds: 60
+database:
+  path: "./test.db"
+  wal_mode: false
+  pool_size: 5
+  connection_timeout_seconds: 15
+cache:
+  eviction:
+    enabled: false
+    policy:
+      type: lru
+      unused_threshold: "3d"
+      max_models: 10
+      min_free_space_bytes: 1000000
+    check_interval: "30m"
+  directory: "./test_cache"
+  max_size_bytes: 5000000
+logging:
+  level: Debug
+  format: Json
+  file: null
+  structured: true
+"#;
+
+        fs::write(&config_file, valid_config).expect("Failed to write config file");
+
+        let args = ServerArgs {
+            config: Some(config_file),
+            port: None,
+            host: None,
+            log_level: None,
+            log_format: None,
+            database_path: None,
+            validate_config: false,
+        };
+
+        let result = ServerConfig::load_and_validate_strict(args);
+        assert!(result.is_ok());
+
+        let config = result.expect("Expected successful config parsing");
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port.get(), 8002);
+        assert_eq!(config.database.path, PathBuf::from("./test.db"));
+        assert!(!config.cache.eviction.enabled);
+        assert_eq!(config.logging.level, LogLevel::Debug);
+        assert_eq!(config.logging.format, LogFormat::Json);
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_server_config_load_and_validate_strict_invalid_config() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let config_file = temp_dir.path().join("invalid_server_config.yaml");
+
+        let invalid_config = r#"
+server:
+  host: "127.0.0.1"
+  port: 8002
+database:
+  pat: "./test.db"  # Wrong field name (should be 'path')
+cache:
+  eviction:
+    enabled: "not_a_boolean"  # Invalid type
+"#;
+
+        fs::write(&config_file, invalid_config).expect("Failed to write config file");
+
+        let args = ServerArgs {
+            config: Some(config_file),
+            port: None,
+            host: None,
+            log_level: None,
+            log_format: None,
+            database_path: None,
+            validate_config: false,
+        };
+
+        let result = ServerConfig::load_and_validate_strict(args);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_server_config_load_and_validate_strict_with_cli_overrides() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let config_file = temp_dir.path().join("override_test_config.yaml");
+
+        let base_config = r#"
+server:
+  host: "127.0.0.1"
+  port: 8002
+  graceful_shutdown: true
+  shutdown_timeout_seconds: 30
+database:
+  path: "./test.db"
+  wal_mode: true
+  pool_size: 10
+  connection_timeout_seconds: 30
+cache:
+  eviction:
+    enabled: true
+    policy:
+      type: lru
+      unused_threshold: "1d"
+      max_models: null
+      min_free_space_bytes: null
+    check_interval: "1h"
+  directory: "./cache"
+  max_size_bytes: null
+logging:
+  level: Info
+  format: Pretty
+  file: null
+  structured: false
+"#;
+
+        fs::write(&config_file, base_config).expect("Failed to write config file");
+
+        let args = ServerArgs {
+            config: Some(config_file),
+            port: Some(NonZeroU16::new(9000).expect("9000 is non-zero")),
+            host: Some("0.0.0.0".to_string()),
+            log_level: Some(LogLevel::Error),
+            log_format: Some(LogFormat::Json),
+            database_path: Some(PathBuf::from("./override.db")),
+            validate_config: false,
+        };
+
+        let result = ServerConfig::load_and_validate_strict(args);
+        assert!(result.is_ok());
+
+        let config = result.expect("Expected successful config parsing");
+        // CLI overrides should be applied
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port.get(), 9000);
+        assert_eq!(config.database.path, PathBuf::from("./override.db"));
+        assert_eq!(config.logging.level, LogLevel::Error);
+        assert_eq!(config.logging.format, LogFormat::Json);
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_server_config_load_and_validate_strict_no_config_file() {
+        let args = ServerArgs {
+            config: None,
+            port: Some(NonZeroU16::new(9001).expect("9001 is non-zero")),
+            host: Some("localhost".to_string()),
+            log_level: Some(LogLevel::Warn),
+            log_format: None,
+            database_path: None,
+            validate_config: false,
+        };
+
+        // When no config file is specified, it should fall back to normal loading
+        let result = ServerConfig::load_and_validate_strict(args);
+        assert!(result.is_ok());
+
+        let config = result.expect("Expected successful config parsing");
+        assert_eq!(config.server.host, "localhost");
+        assert_eq!(config.server.port.get(), 9001);
+        assert_eq!(config.logging.level, LogLevel::Warn);
     }
 }

--- a/model_express_server/src/main.rs
+++ b/model_express_server/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check if we should validate config and exit
     if args.validate_config {
-        match ServerConfig::load(args) {
+        match ServerConfig::load_and_validate_strict(args) {
             Ok(config) => {
                 println!("Configuration is valid ✓");
                 config.print_config();


### PR DESCRIPTION
The falling back to defaults in the case of an invalid configuration made the whole validation mechanism moot. Splitting out the parsing and the defaulting in different parts to properly validate a configuration file individually, and added corresponding tests.