### PR TITLE
fix: ensure tilde expands to system home directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
             "--all-targets",
             "--all-features",
             "--fix",
+            "--allow-dirty",
             "--",
             "-D",
             "warnings",

--- a/modelexpress_common/src/cache.rs
+++ b/modelexpress_common/src/cache.rs
@@ -142,10 +142,9 @@ impl CacheConfig {
         ];
 
         for path in common_paths {
-            let expanded_path = Self::expand_path(&path)?;
-            if expanded_path.exists() && expanded_path.is_dir() {
+            if path.exists() && path.is_dir() {
                 return Ok(Self {
-                    local_path: expanded_path,
+                    local_path: path,
                     server_endpoint: Self::get_default_server_endpoint(),
                     timeout_secs: None,
                 });
@@ -190,18 +189,6 @@ impl CacheConfig {
         let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());
 
         Ok(PathBuf::from(home).join(constants::DEFAULT_CONFIG_PATH))
-    }
-
-    /// Expand path with tilde and environment variables
-    fn expand_path(path: &Path) -> Result<PathBuf> {
-        let path_str = path.to_string_lossy();
-
-        if let Some(stripped) = path_str.strip_prefix("~/") {
-            let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());
-            Ok(PathBuf::from(home).join(stripped))
-        } else {
-            Ok(path.to_path_buf())
-        }
     }
 
     /// Get cache statistics

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -23,10 +23,9 @@ pub async fn download_model(
 ) -> Result<PathBuf> {
     let provider_impl = get_provider(provider);
     info!(
-        "Downloading model '{}' from {} into {:?}",
+        "Downloading model '{}' using provider: {}",
         model_name,
-        provider_impl.provider_name(),
-        cache_dir
+        provider_impl.provider_name()
     );
     provider_impl.download_model(model_name, cache_dir).await
 }

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -23,9 +23,10 @@ pub async fn download_model(
 ) -> Result<PathBuf> {
     let provider_impl = get_provider(provider);
     info!(
-        "Downloading model '{}' using provider: {}",
+        "Downloading model '{}' from {} into {:?}",
         model_name,
-        provider_impl.provider_name()
+        provider_impl.provider_name(),
+        cache_dir
     );
     provider_impl.download_model(model_name, cache_dir).await
 }

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use std::env;
 
 pub mod cache;
 pub mod client_config;
@@ -70,9 +71,25 @@ impl From<tonic::transport::Error> for Box<Error> {
 /// Common result type for the project
 pub type Result<T> = std::result::Result<T, Box<Error>>;
 
+/// Marker struct to use Utils methods
+pub struct Utils;
+
+impl Utils {
+    /// Get home directory from environment variables
+    pub fn get_home_dir() -> String {
+        env::var("HOME")
+            .or_else(|_| env::var("USERPROFILE"))
+            .unwrap_or_else(|_| ".".to_string())
+    }
+}
+
 /// Constants shared between client and server
 pub mod constants {
     use std::num::NonZeroU16;
+
+    pub const DEFAULT_CACHE_PATH: &str = ".model-express/cache";
+    pub const DEFAULT_HF_CACHE_PATH: &str = ".cache/huggingface/hub";
+    pub const DEFAULT_CONFIG_PATH: &str = ".model-express/config.yaml";
 
     pub const DEFAULT_GRPC_PORT: NonZeroU16 = NonZeroU16::new(8001).expect("8001 is non-zero");
     pub const DEFAULT_TIMEOUT_SECS: u64 = 30;

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::providers::ModelProviderTrait;
+use crate::{Utils, constants, providers::ModelProviderTrait};
 use anyhow::{Context, Result};
 use hf_hub::api::tokio::ApiBuilder;
 use std::env;
@@ -34,11 +34,8 @@ fn get_cache_dir(cache_dir: Option<PathBuf>) -> PathBuf {
     }
 
     // Fall back to default location
-    let home = env::var("HOME")
-        .or_else(|_| env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".to_string());
-
-    PathBuf::from(home).join(".cache/huggingface/hub")
+    let home = Utils::get_home_dir();
+    PathBuf::from(home).join(constants::DEFAULT_HF_CACHE_PATH)
 }
 
 /// Hugging Face model provider implementation

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -34,7 +34,7 @@ fn get_cache_dir(cache_dir: Option<PathBuf>) -> PathBuf {
     }
 
     // Fall back to default location
-    let home = Utils::get_home_dir();
+    let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());
     PathBuf::from(home).join(constants::DEFAULT_HF_CACHE_PATH)
 }
 


### PR DESCRIPTION
### Summary

This pull request refactors how home directory paths are determined and used throughout the codebase, improving consistency and reliability. It introduces a new `Utils` struct with a `get_home_dir` method to standardize home directory retrieval, updates default cache and config paths to use constants, and adds related unit tests. Additionally, a generic error variant is added for improved error handling.

**Home directory and path handling improvements:**
* Added a `Utils` struct with a `get_home_dir` method to consistently retrieve the user's home directory from environment variables, replacing direct environment variable access throughout the codebase.
* Updated default path construction in `CacheConfig` (including `default`, `auto_detect`, `get_config_path`, and `expand_path` methods) to use `Utils::get_home_dir` and centralized constants for cache and config paths.
* Refactored Hugging Face provider to use `Utils::get_home_dir` and path constants for cache directory fallback. 

**Constants and error handling:**
* Introduced constants for default cache, Hugging Face cache, and config paths in the `constants` module, and updated usages to reference these constants.
* Added a new `Generic` variant to the `Error` enum for more flexible error reporting.
