### PR TITLE
feat: add `get_model_path` api for dynamo integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +547,24 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "digest"
@@ -1526,6 +1554,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -3374,6 +3403,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -120,7 +120,7 @@ impl Client {
         })
     }
 
-    /// TODO: change to using default client/server cache dirs
+    /// TODO: change to using the current client cache dir
     fn get_model_express_cache_dir() -> PathBuf {
         if let Ok(cache_path) = env::var("HF_HUB_CACHE") {
             return PathBuf::from(cache_path);

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -3,8 +3,9 @@
 
 mod error;
 
+use modelexpress_common::providers::ModelProviderTrait;
 use modelexpress_common::{
-    Result as CommonResult,
+    Result as CommonResult, Utils,
     cache::{CacheConfig, CacheStats},
     client_config::ClientConfig as Config,
     constants, download,
@@ -14,8 +15,11 @@ use modelexpress_common::{
         model::{ModelDownloadRequest, model_service_client::ModelServiceClient},
     },
     models::{ModelStatus, Status},
+    providers::huggingface::HuggingFaceProvider,
 };
 use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
 use std::time::Duration;
 use tonic::transport::Channel;
 use tracing::info;
@@ -113,6 +117,35 @@ impl Client {
         cache_config.clear_all().map_err(|e| {
             modelexpress_common::Error::Server(format!("Failed to clear cache: {e}")).into()
         })
+    }
+
+    /// TODO: change to using default client/server cache dirs
+    fn get_model_express_cache_dir() -> PathBuf {
+        if let Ok(cache_path) = env::var("HF_HUB_CACHE") {
+            return PathBuf::from(cache_path);
+        }
+
+        if let Ok(cache_path) = env::var("MODEL_EXPRESS_PATH") {
+            return PathBuf::from(cache_path);
+        }
+        let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());
+
+        PathBuf::from(home).join(".cache/huggingface/hub")
+    }
+
+    pub async fn get_model_path(&self, model_name: &str) -> anyhow::Result<PathBuf> {
+        let cache_dir = Client::get_model_express_cache_dir();
+
+        info!("### CACHE DIR: {:?}", cache_dir);
+
+        let model_path = HuggingFaceProvider
+            .get_model_path(model_name, cache_dir)
+            .await
+            .map_err(|e| anyhow::anyhow!(format!("Failed to get model path: {e}")))?;
+
+        info!("### MODEL PATH: {:?}", model_path);
+
+        Ok(model_path)
     }
 
     /// Pre-download model to cache

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -22,6 +22,7 @@ use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
 use tonic::transport::Channel;
+use tracing::debug;
 use tracing::info;
 #[cfg(test)]
 use tracing::warn;
@@ -135,16 +136,12 @@ impl Client {
 
     pub async fn get_model_path(&self, model_name: &str) -> anyhow::Result<PathBuf> {
         let cache_dir = Client::get_model_express_cache_dir();
-
-        info!("### CACHE DIR: {:?}", cache_dir);
-
         let model_path = HuggingFaceProvider
             .get_model_path(model_name, cache_dir)
             .await
             .map_err(|e| anyhow::anyhow!(format!("Failed to get model path: {e}")))?;
 
-        info!("### MODEL PATH: {:?}", model_path);
-
+        debug!("Found model path at {:?}", model_path);
         Ok(model_path)
     }
 

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -126,7 +126,7 @@ impl Client {
             return PathBuf::from(cache_path);
         }
 
-        if let Ok(cache_path) = env::var("MODEL_EXPRESS_PATH") {
+        if let Ok(cache_path) = env::var("MODEL_EXPRESS_CACHE_PATH") {
             return PathBuf::from(cache_path);
         }
         let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());

--- a/modelexpress_common/Cargo.toml
+++ b/modelexpress_common/Cargo.toml
@@ -30,6 +30,7 @@ jiff = { workspace = true }
 mockall = "0.13"
 tempfile = "3.20"
 tokio-test = "0.4"
+wiremock = "0.6.5"
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -65,6 +65,14 @@ mod tests {
             }
         }
 
+        async fn get_model_path(&self, _model_name: &str, _cache_dir: PathBuf) -> Result<PathBuf> {
+            if self.should_succeed {
+                Ok(self.return_path.clone())
+            } else {
+                Err(anyhow::anyhow!("Mock get_model_path failed"))
+            }
+        }
+
         fn provider_name(&self) -> &'static str {
             "Mock Provider"
         }
@@ -146,6 +154,14 @@ mod tests {
 
             async fn delete_model(&self, _model_name: &str) -> Result<()> {
                 Ok(())
+            }
+
+            async fn get_model_path(
+                &self,
+                _model_name: &str,
+                _cache_dir: PathBuf,
+            ) -> Result<PathBuf> {
+                Ok(PathBuf::from("/tmp"))
             }
 
             fn provider_name(&self) -> &'static str {

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -19,7 +19,7 @@ pub trait ModelProviderTrait: Send + Sync {
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
     async fn delete_model(&self, model_name: &str) -> Result<()>;
 
-    /// Get the local path of a model if it exists
+    /// Get the full path to the latest model snapshot if it exists
     /// Returns the path if found, or an error if not found
     async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
 

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -19,6 +19,10 @@ pub trait ModelProviderTrait: Send + Sync {
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
     async fn delete_model(&self, model_name: &str) -> Result<()>;
 
+    /// Get the local path of a model if it exists
+    /// Returns the path if found, or an error if not found
+    async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
+
     /// Get the provider name for logging
     fn provider_name(&self) -> &'static str;
 

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -223,18 +223,25 @@ impl ModelProviderTrait for HuggingFaceProvider {
     async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf> {
         // Get cache directory and ensure it exists
         let cache = Cache::new(cache_dir.clone());
+        let normalized_name = model_name.replace("/", "--");
 
         // TODO: need more investigation to know we really need this api call
         let api = ApiBuilder::from_cache(cache).build()?;
         let repo = api.model(model_name.to_string());
-        let info = repo.info().await
-            .map_err(|e| anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace: {e}. Is this a valid HuggingFace ID?"))?;
+        let info = repo.info().await.map_err(|e| {
+            anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace: {e}")
+        })?;
 
-        let normalized_model_name = model_name.replace("/", "--");
-        Ok(cache_dir
-            .join(format!["models--{normalized_model_name}"])
+        let model_path = cache_dir
+            .join(format!["models--{normalized_name}"])
             .join("snapshots")
-            .join(info.sha))
+            .join(info.sha);
+
+        if !model_path.exists() {
+            anyhow::bail!("Model '{model_name}' not found in cache");
+        }
+
+        Ok(model_path)
     }
 
     fn provider_name(&self) -> &'static str {

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -7,7 +7,7 @@ use hf_hub::api::tokio::ApiBuilder;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tracing::info;
+use tracing::{info, warn};
 
 const HF_TOKEN_ENV_VAR: &str = "HF_TOKEN";
 const HF_HUB_CACHE_ENV_VAR: &str = "HF_HUB_CACHE";
@@ -234,18 +234,39 @@ impl ModelProviderTrait for HuggingFaceProvider {
         }
 
         let mut files: Vec<fs::DirEntry> = fs::read_dir(path)?.filter_map(Result::ok).collect();
+        if files.is_empty() {
+            anyhow::bail!("Model snapshots for '{model_name}' is empty");
+        }
+
+        // A bit hacky way to figure out the latest snapshot
         files.sort_by_key(|e| {
             e.metadata()
                 .and_then(|m| m.created().or_else(|_| m.modified()))
                 .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
         });
-        files.reverse(); // newest first
+        files.reverse();
 
-        if files.is_empty() {
-            anyhow::bail!("Model snapshots for '{model_name}' is empty");
+        // Check against the latest commit hash from HF
+        let token = env::var(HF_TOKEN_ENV_VAR).ok();
+        let api = ApiBuilder::from_env().with_token(token).build()?;
+        let repo = api.model(model_name.to_string());
+        let info = repo.info().await.map_err(|e| {
+            anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace: {e}")
+        })?;
+
+        for file in &files {
+            if file.file_name().display().to_string() == info.sha {
+                return Ok(file.path());
+            }
         }
 
-        Ok(files[0].path()) // Return the path to the newest snapshot
+        warn!(
+            "Existing model snapshots do not match the latest commit hash '{0}'. \
+            Returning the best-effort, latest model snapshot.",
+            info.sha
+        );
+
+        Ok(files[0].path())
     }
 
     fn provider_name(&self) -> &'static str {
@@ -257,8 +278,11 @@ impl ModelProviderTrait for HuggingFaceProvider {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use tempfile::TempDir;
     use tokio::time::Duration;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_hugging_face_provider_name() {
@@ -285,6 +309,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_model_path_trait() {
+        let server = MockServer::start().await;
+
+        // Return the desired sha we want get_model_path to pick
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/api/models/test/model(?:/.*)?$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "test/model",
+                "sha": "def5678",
+                "siblings": []
+            })))
+            .mount(&server)
+            .await;
+
+        unsafe {
+            std::env::set_var("HF_ENDPOINT", server.uri());
+        }
+
         // Construct a temporary cache dir with a model snapshots
         let temp_dir = TempDir::new().expect("Failed to create temporary directory");
         let path = temp_dir
@@ -292,17 +333,9 @@ mod tests {
             .join("models--test--model")
             .join("snapshots");
 
-        std::fs::DirBuilder::new()
-            .recursive(true)
-            .create(path.join("abc1234"))
-            .expect("Failed to create directory");
-
+        std::fs::create_dir_all(path.join("abc1234")).expect("Failed to create directory");
         tokio::time::sleep(Duration::from_secs(1)).await;
-
-        std::fs::DirBuilder::new()
-            .recursive(true)
-            .create(path.join("def5678"))
-            .expect("Failed to create directory");
+        std::fs::create_dir_all(path.join("def5678")).expect("Failed to create directory");
 
         let provider = HuggingFaceProvider;
         let result = provider

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -77,7 +77,9 @@ impl ModelProviderTrait for HuggingFaceProvider {
 
         let repo = api.model(model_name.clone());
 
-        let info = repo.info().await.map_err(|e| anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace. Is this a valid HuggingFace ID? Error: {e}"))?;
+        let info = repo.info().await.map_err(
+            |e| anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace. Is this a valid HuggingFace ID? Error: {e}"),
+        )?;
         info!("Got model info: {info:?}");
 
         if info.siblings.is_empty() {

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -295,14 +295,14 @@ mod tests {
         std::fs::DirBuilder::new()
             .recursive(true)
             .create(path.join("abc1234"))
-            .unwrap();
+            .expect("Failed to create directory");
 
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         std::fs::DirBuilder::new()
             .recursive(true)
             .create(path.join("def5678"))
-            .unwrap();
+            .expect("Failed to create directory");
 
         let provider = HuggingFaceProvider;
         let result = provider
@@ -310,6 +310,9 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), path.join("def5678"));
+        assert_eq!(
+            result.expect("Failed to get model path"),
+            path.join("def5678")
+        );
     }
 }

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -262,7 +262,7 @@ impl ModelProviderTrait for HuggingFaceProvider {
 
         warn!(
             "Existing model snapshots do not match the latest commit hash '{0}'. \
-            Returning the best-effort, latest model snapshot.",
+            Returning the best-effort, latest local model snapshot.",
             info.sha
         );
 

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -223,12 +223,18 @@ impl ModelProviderTrait for HuggingFaceProvider {
     async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf> {
         // Get cache directory and ensure it exists
         let cache = Cache::new(cache_dir.clone());
+
+        // TODO: need more investigation to know we really need this api call
         let api = ApiBuilder::from_cache(cache).build()?;
         let repo = api.model(model_name.to_string());
         let info = repo.info().await
             .map_err(|e| anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace: {e}. Is this a valid HuggingFace ID?"))?;
 
-        Ok(cache_dir.join(model_name).join(info.sha))
+        let normalized_model_name = model_name.replace("/", "--");
+        Ok(cache_dir
+            .join(format!["models--{normalized_model_name}"])
+            .join("snapshots")
+            .join(info.sha))
     }
 
     fn provider_name(&self) -> &'static str {


### PR DESCRIPTION
The PR adds a new client api for retrieving the path to a locally cached model snapshot, integrating it into the `ModelProviderTrait` and implementing it for the HuggingFace provider.

### Client API

* Added `get_model_path` to the `Client` struct in `modelexpress_client`, including logic to determine the cache directory and call the provider's method.

### Trait and Provider Implementation

* Added the `get_model_path` async method to the `ModelProviderTrait`, allowing providers to return the path to the latest cached model snapshot or an error if not found.
* Implemented `get_model_path` for `HuggingFaceProvider`, which locates the newest model snapshot directory in the cache and returns its path, with error handling for missing or empty cache directories.

### Testing

* Updated and expanded tests for provider trait implementations and added a new async test for `get_model_path` in the HuggingFace provider, using a temporary directory to verify correct snapshot selection.
