### PR TITLE
feat: bring dockerfile into compliance with OSRB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+.dockerignore
+.git/
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,6 @@
 *.swp
 *.swo
 
-# Docker and Kubernetes generated files
-.dockerignore
-
 # Logs
 *.log
 log/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN cargo build --release --bin modelexpress-server && \
     cargo build --release --bin fallback_test
 
 # Create a minimal runtime image
-FROM debian:bookworm-slim 
+FROM nvcr.io/nvidia/base/ubuntu:jammy-20250619 
 
 WORKDIR /app
 
@@ -35,6 +35,9 @@ COPY --from=builder /app/target/release/model-express-cli .
 COPY --from=builder /app/target/release/test_client .
 COPY --from=builder /app/target/release/test_single_client .
 COPY --from=builder /app/target/release/fallback_test .
+
+# Copy the Attribution files
+COPY ATTRIBUTIONS_Rust.md .
 
 # Expose the default port
 EXPOSE 8001


### PR DESCRIPTION
This bases the to-be-published container on an NVIDIA OSRB approved container.

This change will not change the image size.