### PR TITLE
feat: move versioning and dependency refs to top Cargo.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 .env
 .env.local
 *.local.toml
+.cargo/
 
 # Backup files
 *~

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "model-express-workspace-tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "modelexpress-client",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ members = [
 ]
 resolver = "3"
 
+[workspace.package]
+version = "0.2.0"
+edition = "2024"
+description = "Model Express: High-performance model serving and management"
+authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
+license = "Apache-2.0"
+homepage = "https://github.com/ai-dynamo/modelexpress"
+repository = "https://github.com/ai-dynamo/modelexpress.git"
+keywords = ["llm", "inference", "nvidia"]
+
 [workspace.dependencies]
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 async-trait = "0.1"
@@ -24,6 +34,9 @@ hf-hub = { version = "0.4.3", default-features = false, features = [
     "rustls-tls",
 ] }
 jiff = { version = "0.2.15", features = ["serde"] }
+modelexpress-common = { path = "modelexpress_common", version = "0.2.0" }
+modelexpress-client = { path = "modelexpress_client", version = "0.2.0" }
+modelexpress-server = { path = "modelexpress_server", version = "0.2.0" }
 once_cell = "1.21.3"
 prost = "0.13"
 rusqlite = { version = "0.37", features = ["bundled", "chrono"] }

--- a/modelexpress_client/Cargo.toml
+++ b/modelexpress_client/Cargo.toml
@@ -3,14 +3,17 @@
 
 [package]
 name = "modelexpress-client"
-version = "0.1.0"
-edition = "2024"
-license = "Apache-2.0"
 description = "Client library for Model Express gRPC server"
-repository = "https://github.com/ai-dynamo/modelexpress"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
-modelexpress-common = { version = "0.1.0", path = "../modelexpress_common" }
+modelexpress-common = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/modelexpress_common/Cargo.toml
+++ b/modelexpress_common/Cargo.toml
@@ -3,11 +3,14 @@
 
 [package]
 name = "modelexpress-common"
-version = "0.1.0"
-edition = "2024"
-license = "Apache-2.0"
 description = "Shared utilities for Model Express client and server"
-repository = "https://github.com/ai-dynamo/modelexpress"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [dependencies]
 serde = { workspace = true }

--- a/modelexpress_server/Cargo.toml
+++ b/modelexpress_server/Cargo.toml
@@ -3,14 +3,18 @@
 
 [package]
 name = "modelexpress-server"
-version = "0.1.0"
-edition = "2024"
-license = "Apache-2.0"
 description = "High-performance gRPC server for model serving and management"
-repository = "https://github.com/ai-dynamo/modelexpress"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+
 
 [dependencies]
-modelexpress-common = { version = "0.1.0", path = "../modelexpress_common" }
+modelexpress-common = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/workspace-tests/Cargo.toml
+++ b/workspace-tests/Cargo.toml
@@ -3,16 +3,20 @@
 
 [package]
 name = "model-express-workspace-tests"
-version = "0.1.0"
-edition = "2024"
-license = "Apache-2.0"
 description = "Tests for Model Express workspace"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
 publish = false
 
 [dependencies]
-modelexpress-client = { version = "0.1.0" , path = "../modelexpress_client" }
-modelexpress-common = { version = "0.1.0" , path = "../modelexpress_common" }
-modelexpress-server = { version = "0.1.0" , path = "../modelexpress_server" }
+modelexpress-client = { workspace = true }
+modelexpress-common = { workspace = true }
+modelexpress-server = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
The version, license, and a slate of other things were defined on the individual cargo libraries rather than defined at the top level and referenced. This change makes versioning only needed at the top level as well as making version references between the repos libraries clearer.

Also this bumps the version to `0.2.0` for inclusion in `release/0.2.0` branch