### PR TITLE
chore: update devcontainer.json

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,19 +54,8 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-# Create a non-root user
-ARG USERNAME=vscode
-ARG USER_UID=1234
-ARG USER_GID=$USER_UID
-
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" \
-    && echo "$USERNAME" ALL=\(root\) NOPASSWD:ALL > "/etc/sudoers.d/$USERNAME" \
-    && chmod 0440 "/etc/sudoers.d/$USERNAME"
-
-USER vscode
+# Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,8 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
+    "remoteUser": "ubuntu", // Matches our container user
+    "updateRemoteUserUID": true, // Updates the UID of the remote user to match the host user, avoids permission errors
     "customizations": {
         "vscode": {
             "extensions": [
@@ -11,9 +13,7 @@
                 "fill-labs.dependi",
                 "vadimcn.vscode-lldb",
                 "ms-kubernetes-tools.vscode-kubernetes-tools",
-                "github.vscode-github-actions",
-                "GitHub.copilot",
-                "GitHub.copilot-chat"
+                "github.vscode-github-actions"
             ],
             "settings": {
                 "rust-analyzer.checkOnSave.command": "clippy",
@@ -27,7 +27,7 @@
                 "editor.codeActionsOnSave": {
                     "source.fixAll": "explicit"
                 },
-                "terminal.integrated.defaultProfile.linux": "zsh",
+                "terminal.integrated.defaultProfile.linux": "bash",
                 "files.watcherExclude": {
                     "**/target/**": true
                 }
@@ -43,7 +43,6 @@
             "onAutoForward": "notify"
         }
     },
-    "remoteUser": "vscode",
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
     ],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
         args: ["--allow-multiple-documents"]
       - id: check-toml
       - id: check-json
+        exclude: .devcontainer
       - id: check-merge-conflict
       - id: check-added-large-files
         args: ["--maxkb=1000"]


### PR DESCRIPTION
- set remote user to ubuntu (following [dynamo](https://github.com/ai-dynamo/dynamo/blob/main/.devcontainer/vllm/devcontainer.json) example) to avoid permission errors caused by UID and GID setup in Dockerfile.
- removed default github copilot extension for cursor users
- set default shell to bash