### PR TITLE
fix: fix clear cache issue

### DIFF
--- a/modelexpress_common/src/cache.rs
+++ b/modelexpress_common/src/cache.rs
@@ -587,7 +587,10 @@ mod tests {
         };
 
         // Should succeed without error even if directory doesn't exist
-        config.clear_all().expect("clear_all should handle nonexistent directory");
+        config
+            .clear_all()
+            .with_context(|| format!("Failed to clear cache: {cache_path:?}"))
+            .expect("Failed to clear cache");
         assert!(!cache_path.exists());
     }
 


### PR DESCRIPTION
 `remove_dir_all` attempts to delete the directory itself, not just its contents. Doing so on a mount point fails because the mount point is protected. 
 
 Before fix, check nvbug for the logs
 
 After fix, the log shows as following:
 ```
 root@78032ef-lcedt:/app# ./modelexpress-cli model stats --detailed
Model Storage Statistics
========================
Total models: 1
Total size: 2.83 GB
Detailed Statistics:
  Qwen/Qwen3-0.6B: 3038387456 bytes (2.83 GB)
root@78032ef-lcedt:/app# ./modelexpress-cli model clear-all
Are you sure you want to clear all models from storage? [y/N]: y
✅ All models cleared from storage
```