### PR TITLE
fix: disable automountServiceAccountToken by default

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   create: true
   annotations: {}
   name: ""
-  automount: true
+  automount: false
 
 podAnnotations: {}
 


### PR DESCRIPTION
The server does not need Kubernetes API access, so there is no reason to mount the service account token into pods. Setting automount to false reduces attack surface, resolving S6865.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Changed default service account token auto-mounting from enabled to disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->