### PR TITLE
fix: add ephemeral-storage resource limits to Helm chart

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -59,9 +59,11 @@ resources:
   limits:
     cpu: 500m
     memory: 256Mi
+    ephemeral-storage: 1Gi
   requests:
     cpu: 200m
     memory: 128Mi
+    ephemeral-storage: 256Mi
 
 persistence:
   enabled: true


### PR DESCRIPTION
Addressing S6870 by setting ephemeral-storage limits and requests on the container to prevent unbounded node storage consumption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ephemeral storage resource allocation to ensure improved application reliability and optimal resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->