### PR TITLE
fix: honor explicit cache dir in delete_model

### DIFF
--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -66,7 +66,7 @@ mod tests {
             }
         }
 
-        async fn delete_model(&self, _model_name: &str) -> Result<()> {
+        async fn delete_model(&self, _model_name: &str, _cache_dir: Option<PathBuf>) -> Result<()> {
             if self.should_succeed {
                 Ok(())
             } else {
@@ -162,7 +162,11 @@ mod tests {
                 Ok(PathBuf::from("/tmp"))
             }
 
-            async fn delete_model(&self, _model_name: &str) -> Result<()> {
+            async fn delete_model(
+                &self,
+                _model_name: &str,
+                _cache_dir: Option<PathBuf>,
+            ) -> Result<()> {
                 Ok(())
             }
 

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -18,7 +18,7 @@ pub trait ModelProviderTrait: Send + Sync {
 
     /// Delete a model from the provider's cache
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
-    async fn delete_model(&self, model_name: &str) -> Result<()>;
+    async fn delete_model(&self, model_name: &str, cache_dir: Option<PathBuf>) -> Result<()>;
 
     /// Get the full path to the latest model snapshot if it exists
     /// Returns the path if found, or an error if not found


### PR DESCRIPTION
`delete_model` previously built an `hf_hub` client without the per-call cache root, so it could target `env/default` cache instead of the directory used by `download_model`.

This change threads `cache_dir` through `ModelProviderTrait::delete_model` and configures the Hugging Face client with `get_cache_dir(cache_dir) + ApiBuilder::with_cache_dir(...)`.

Also adds a regression test that sets env cache to a different directory and verifies explicit cache-dir precedence during delete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional cache directory selection for model deletion, enabling explicit override of default cache settings.

* **Bug Fixes**
  * Enhanced model deletion to automatically remove empty model directories after successful file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->