### PR TITLE
fix: prevent downloads in delete_model

### DIFF
--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -66,7 +66,7 @@ mod tests {
             }
         }
 
-        async fn delete_model(&self, _model_name: &str, _cache_dir: Option<PathBuf>) -> Result<()> {
+        async fn delete_model(&self, _model_name: &str, _cache_dir: PathBuf) -> Result<()> {
             if self.should_succeed {
                 Ok(())
             } else {
@@ -162,11 +162,7 @@ mod tests {
                 Ok(PathBuf::from("/tmp"))
             }
 
-            async fn delete_model(
-                &self,
-                _model_name: &str,
-                _cache_dir: Option<PathBuf>,
-            ) -> Result<()> {
+            async fn delete_model(&self, _model_name: &str, _cache_dir: PathBuf) -> Result<()> {
                 Ok(())
             }
 

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -18,7 +18,7 @@ pub trait ModelProviderTrait: Send + Sync {
 
     /// Delete a model from the provider's cache
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
-    async fn delete_model(&self, model_name: &str, cache_dir: Option<PathBuf>) -> Result<()>;
+    async fn delete_model(&self, model_name: &str, cache_dir: PathBuf) -> Result<()>;
 
     /// Get the full path to the latest model snapshot if it exists
     /// Returns the path if found, or an error if not found

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -172,9 +172,8 @@ impl ModelProviderTrait for HuggingFaceProvider {
 
     /// Attempt to delete a model from Hugging Face cache
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
-    async fn delete_model(&self, model_name: &str, cache_dir: Option<PathBuf>) -> Result<()> {
+    async fn delete_model(&self, model_name: &str, cache_dir: PathBuf) -> Result<()> {
         info!("Deleting model from Hugging Face cache: {model_name}");
-        let cache_dir = get_cache_dir(cache_dir);
         let token = env::var(HF_TOKEN_ENV_VAR).ok();
         let api = ApiBuilder::from_env()
             .with_token(token)
@@ -452,10 +451,13 @@ mod tests {
     #[tokio::test]
     async fn test_delete_model_trait() {
         let provider = HuggingFaceProvider;
+        let cache_dir = TempDir::new().expect("Failed to create temporary cache directory");
         // Test that the delete method exists and can be called
         // Note: This won't actually delete anything since we're not providing a real model
         // but it tests the trait implementation
-        let result = provider.delete_model("nonexistent/model", None).await;
+        let result = provider
+            .delete_model("nonexistent/model", cache_dir.path().to_path_buf())
+            .await;
         // Should succeed (return Ok(())) even if model doesn't exist
         assert!(result.is_ok());
     }
@@ -501,7 +503,7 @@ mod tests {
         }
 
         let delete_result = provider
-            .delete_model("test/model", Some(explicit_cache.path().to_path_buf()))
+            .delete_model("test/model", explicit_cache.path().to_path_buf())
             .await;
 
         unsafe {
@@ -577,7 +579,9 @@ mod tests {
             env::set_var("HF_ENDPOINT", server.uri());
         }
 
-        let result = provider.delete_model(model_name, None).await;
+        let result = provider
+            .delete_model(model_name, temp_cache.path().to_path_buf())
+            .await;
 
         unsafe {
             if let Some(value) = old_cache {


### PR DESCRIPTION
**Problem**
- `delete_model` used `repo.get(...)` to find cache paths.
- In `hf_hub`, `repo.get(...)` downloads on cache miss.
- The cleanup loop could call `repo.get(...)` again after deletion, re-creating files.

**Fix**
- Switch delete path resolution to cache-only lookups via `hf_hub::Cache`.
- Track parent directories from files actually deleted in cache.
- Perform empty-directory cleanup only on those tracked local directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model deletion now requires specifying a cache directory for enhanced control over cached file cleanup.

* **Bug Fixes**
  * Model deletion operations are now cache-aware, eliminating unnecessary network requests during deletion.
  * Improved error handling and automatic cleanup of empty cached directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->