### PR TITLE
fix: guard model clear against shared filesystem mode

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -150,8 +150,8 @@ modelexpress-cli model stats --detailed
 - `init`: Initialize model storage configuration
 - `list`: List downloaded models (use `--detailed` for more info)
 - `status`: Show model storage status and usage
-- `clear`: Clear specific model from storage
-- `clear-all`: Clear all models from storage (use `--yes` to skip confirmation)
+- `clear`: Clear specific model from local P2P client cache (disabled in shared storage mode)
+- `clear-all`: Clear all models from local P2P client cache (disabled in shared storage mode, use `--yes` to skip confirmation)
 - `validate`: Validate model integrity
 - `stats`: Show model storage statistics (use `--detailed` for more info)
 

--- a/modelexpress_client/src/bin/modules/args.rs
+++ b/modelexpress_client/src/bin/modules/args.rs
@@ -104,7 +104,7 @@ pub enum ModelCommands {
     /// Show model storage status and usage
     Status,
 
-    /// Clear specific model from storage
+    /// Clear specific model from local P2P client cache (not available in shared storage mode)
     Clear {
         /// Model provider
         #[arg(long, short = 'p', value_enum, default_value_t = ModelProvider::HuggingFace)]
@@ -114,7 +114,7 @@ pub enum ModelCommands {
         model_name: String,
     },
 
-    /// Clear all models from storage
+    /// Clear all models from local P2P client cache (not available in shared storage mode)
     ClearAll {
         /// Confirm without prompting
         #[arg(long)]

--- a/modelexpress_client/src/bin/modules/handlers.rs
+++ b/modelexpress_client/src/bin/modules/handlers.rs
@@ -120,9 +120,11 @@ pub async fn handle_model_command(
         ModelCommands::Clear {
             provider,
             model_name,
-        } => clear_model(storage_path_override, provider, &model_name, format).await,
+        } => {
+            clear_model(storage_path_override, provider, &model_name, &server_config, format).await
+        }
         ModelCommands::ClearAll { yes } => {
-            clear_all_models(storage_path_override, yes, format).await
+            clear_all_models(storage_path_override, yes, &server_config, format).await
         }
         ModelCommands::Validate { model_name } => {
             validate_models(storage_path_override, model_name, format).await
@@ -433,13 +435,54 @@ async fn show_model_status(
     Ok(())
 }
 
+/// Check whether clearing local model files is safe.
+///
+/// Refuses if shared storage mode is enabled (the client's local path IS the server's
+/// storage, so deleting files would corrupt the server's database). Also refuses if
+/// the server reports a cache directory that matches the client's local path, even
+/// when shared_storage is not explicitly set (belt and suspenders).
+async fn check_shared_storage_guard(
+    storage_config: &CacheConfig,
+    server_config: &ClientConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if server_config.cache.shared_storage {
+        return Err(
+            "model clear is not available in shared storage mode (client and server share the same filesystem)"
+                .into(),
+        );
+    }
+
+    // Belt and suspenders: even if shared_storage is false, check whether the server's
+    // cache directory actually matches our local path.
+    if let Ok(mut client) = Client::new(server_config.clone()).await
+        && let Ok(status) = client.health_check().await
+        && let Some(server_dir) = status.cache_directory
+    {
+        let server_path =
+            std::fs::canonicalize(&server_dir).unwrap_or_else(|_| PathBuf::from(&server_dir));
+        let local_path = std::fs::canonicalize(&storage_config.local_path)
+            .unwrap_or_else(|_| storage_config.local_path.clone());
+        if server_path == local_path {
+            return Err(
+                "model clear is not available: local cache path matches the server's cache directory"
+                    .into(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
 async fn clear_model(
     storage_path_override: Option<PathBuf>,
     provider: ModelProvider,
     model_name: &str,
+    server_config: &ClientConfig,
     format: &OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let storage_config = get_storage_config(storage_path_override)?;
+
+    check_shared_storage_guard(&storage_config, server_config).await?;
 
     storage_config.clear_model(model_name, provider)?;
 
@@ -467,9 +510,12 @@ async fn clear_model(
 async fn clear_all_models(
     storage_path_override: Option<PathBuf>,
     yes: bool,
+    server_config: &ClientConfig,
     format: &OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let storage_config = get_storage_config(storage_path_override)?;
+
+    check_shared_storage_guard(&storage_config, server_config).await?;
 
     if !yes && matches!(format, OutputFormat::Human) {
         print!("Are you sure you want to clear all models from storage? [y/N]: ");

--- a/modelexpress_common/proto/health.proto
+++ b/modelexpress_common/proto/health.proto
@@ -19,4 +19,5 @@ message HealthResponse {
   string version = 1;
   string status = 2;
   uint64 uptime = 3;
+  string cache_directory = 4;
 }

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -123,16 +123,23 @@ impl From<&models::Status> for grpc::health::HealthResponse {
             version: status.version.clone(),
             status: status.status.clone(),
             uptime: status.uptime,
+            cache_directory: status.cache_directory.clone().unwrap_or_default(),
         }
     }
 }
 
 impl From<grpc::health::HealthResponse> for models::Status {
     fn from(response: grpc::health::HealthResponse) -> Self {
+        let cache_directory = if response.cache_directory.is_empty() {
+            None
+        } else {
+            Some(response.cache_directory)
+        };
         Self {
             version: response.version,
             status: response.status,
             uptime: response.uptime,
+            cache_directory,
         }
     }
 }
@@ -209,6 +216,7 @@ mod tests {
             version: "1.0.0".to_string(),
             status: "ok".to_string(),
             uptime: 3600,
+            cache_directory: Some("/tmp/cache".to_string()),
         };
 
         let grpc_response: grpc::health::HealthResponse = (&status).into();
@@ -216,6 +224,7 @@ mod tests {
         assert_eq!(grpc_response.version, status.version);
         assert_eq!(grpc_response.status, status.status);
         assert_eq!(grpc_response.uptime, status.uptime);
+        assert_eq!(grpc_response.cache_directory, "/tmp/cache");
     }
 
     #[test]
@@ -224,6 +233,7 @@ mod tests {
             version: "1.0.0".to_string(),
             status: "ok".to_string(),
             uptime: 3600,
+            cache_directory: "/tmp/cache".to_string(),
         };
 
         let status: models::Status = grpc_response.into();
@@ -231,6 +241,7 @@ mod tests {
         assert_eq!(status.version, "1.0.0");
         assert_eq!(status.status, "ok");
         assert_eq!(status.uptime, 3600);
+        assert_eq!(status.cache_directory, Some("/tmp/cache".to_string()));
     }
 
     #[test]

--- a/modelexpress_common/src/models.rs
+++ b/modelexpress_common/src/models.rs
@@ -11,6 +11,7 @@ pub struct Status {
     pub version: String,
     pub status: String,
     pub uptime: u64,
+    pub cache_directory: Option<String>,
 }
 
 /// Status of a model download
@@ -115,6 +116,7 @@ mod tests {
             version: "1.0.0".to_string(),
             status: "ok".to_string(),
             uptime: 3600,
+            cache_directory: Some("/tmp/cache".to_string()),
         };
 
         let serialized = serde_json::to_string(&status).expect("Failed to serialize Status");
@@ -124,6 +126,7 @@ mod tests {
         assert_eq!(status.version, deserialized.version);
         assert_eq!(status.status, deserialized.status);
         assert_eq!(status.uptime, deserialized.uptime);
+        assert_eq!(status.cache_directory, deserialized.cache_directory);
     }
 
     #[test]

--- a/modelexpress_server/src/main.rs
+++ b/modelexpress_server/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Create service implementations
-    let health_service = HealthServiceImpl;
+    let health_service = HealthServiceImpl::new(config.cache.directory.display().to_string());
     let api_service = ApiServiceImpl;
     let model_service = ModelServiceImpl;
 

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -59,8 +59,16 @@ fn convert_provider(grpc_provider: i32) -> ModelProvider {
 }
 
 /// Health service implementation
-#[derive(Debug, Default)]
-pub struct HealthServiceImpl;
+#[derive(Debug)]
+pub struct HealthServiceImpl {
+    cache_directory: String,
+}
+
+impl HealthServiceImpl {
+    pub fn new(cache_directory: String) -> Self {
+        Self { cache_directory }
+    }
+}
 
 #[tonic::async_trait]
 impl HealthService for HealthServiceImpl {
@@ -78,6 +86,7 @@ impl HealthService for HealthServiceImpl {
             version: env!("CARGO_PKG_VERSION").to_string(),
             status: "ok".to_string(),
             uptime,
+            cache_directory: self.cache_directory.clone(),
         };
 
         Ok(Response::new(response))
@@ -753,7 +762,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_health_service() {
-        let service = HealthServiceImpl;
+        let service = HealthServiceImpl::new("/tmp/test-cache".to_string());
         let request = Request::new(HealthRequest {});
 
         let response = service.get_health(request).await;
@@ -762,6 +771,7 @@ mod tests {
         let health_response = response.expect("Health response should be ok").into_inner();
         assert_eq!(health_response.version, env!("CARGO_PKG_VERSION"));
         assert_eq!(health_response.status, "ok");
+        assert_eq!(health_response.cache_directory, "/tmp/test-cache");
         // uptime is u64, always >= 0, so just verify it exists
         let _uptime = health_response.uptime;
     }

--- a/workspace-tests/benches/performance.rs
+++ b/workspace-tests/benches/performance.rs
@@ -87,6 +87,7 @@ fn benchmark_serialization(c: &mut Criterion) {
             version: "1.0.0".to_string(),
             status: "ok".to_string(),
             uptime: 3600,
+            cache_directory: None,
         };
 
         b.iter(|| {


### PR DESCRIPTION
- Add cache_directory field to HealthResponse proto and Status model
- HealthServiceImpl now holds and returns the server's cache directory
- Client refuses model clear/clear-all when shared_storage is enabled
- Belt-and-suspenders check compares canonicalized paths even when shared_storage is not explicitly set
- Update CLI help text and docs to note clear is for P2P client cache only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check endpoint now reports the server's cache directory.
  * Added safety guard preventing model-clearing operations in shared storage mode.

* **Documentation**
  * Updated CLI documentation for `model clear` and `clear-all` commands to clarify they target the local P2P cache and are disabled when shared storage mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->