### PR TITLE
feat: add safety checks for P2P weight transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ cargo bench
 
 ## Known Issues
 
+- **MLA models blocked from P2P transfer** — Models using Multi-head Latent Attention (DeepSeek-V2/V3, Kimi K2/K2.5) are automatically blocked from GPU-to-GPU transfer and fall back to disk loading. Bytes transfer correctly but inference produces corrupted output. Set `MX_SKIP_FEATURE_CHECK=1` to bypass for debugging. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 - **NIXL_ERR_REMOTE_DISCONNECT** — Source restarts invalidate rkeys. Flush Redis, redeploy.
 - **Long source warmup** — DeepSeek-V3 (DeepGemm, CUDA graphs) can take significant time; targets wait via coordination.
 - **Large model gRPC stream** — May not close automatically; use client timeout.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -516,13 +516,14 @@ Currently validated (tested on nScale B200 cluster):
 | Qwen2-7B-Instruct | qwen2 (GQA) | none (BF16) | PASS |
 | Phi-3.5-mini-instruct | phi3 (GQA) | none (BF16) | PASS |
 | Gemma-2-2b-it | gemma2 (GQA) | none (BF16) | PASS |
-| DeepSeek-V2-Lite-Chat-FP8 | deepseek_v2 (MLA) | fp8 | **FAIL** |
+| DeepSeek-V2-Lite-Chat-FP8 | deepseek_v2 (MLA) | fp8 | vLLM >= 0.16.0 only |
 
 Blocked features:
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| DeepSeek MLA | **Blocked** | Dequantized KV projections not transferable |
+| DeepSeek MLA on vLLM < 0.16.0 | **Blocked** | Derived tensors on non-Module ABC, invisible to tensor capture |
+| DeepSeek MLA on vLLM >= 0.16.0 | **Allowed** | vLLM PR #33284 moved post-processing onto nn.Module |
 | Other quantization methods | **Blocked** | Not yet validated (bitsandbytes, compressed-tensors, etc.) |
 | Unknown model architectures | **Blocked** | Must be explicitly added to allow-list after validation |
 
@@ -651,9 +652,11 @@ Target fails with `Remote access error on mlx5_X:1/IB`. Common causes: source cr
 
 ### DeepSeek MLA P2P Transfer
 
-P2P weight transfer does not work with DeepSeek models that use Multi-head Latent Attention (MLA). During `process_weights_after_loading()`, the MLA attention layer dequantizes `kv_b_proj` into BF16 and creates `W_UV` and `W_UK_T` as views into the dequantized intermediate. These derived tensors depend on the actual weight values, not just tensor shapes. The target's dummy-load-then-overwrite pattern runs post-processing on dummy data, creating dummy-derived intermediates that the RDMA byte overwrite cannot correctly replace. The transfer safety allow-list automatically blocks MLA models and falls back to disk loading. Set `MX_SKIP_FEATURE_CHECK=1` to bypass (for debugging only).
+P2P weight transfer for DeepSeek models using Multi-head Latent Attention (MLA) is version-gated on vLLM >= 0.16.0. On older vLLM versions, `process_weights_after_loading()` runs on `MLACommonBaseImpl`, an ABC that does not inherit from `nn.Module`. The derived tensors `W_UV` and `W_UK_T` are assigned as bare Python attributes on this non-Module object, making them invisible to `named_buffers()` and the `nn.Module.__setattr__` patch used for tensor capture. vLLM PR #33284 (included in v0.16.0) moved this logic onto `MLAAttention` (an `nn.Module`), making the tensors visible through standard PyTorch mechanisms.
 
-Affected models: DeepSeek-V2, DeepSeek-V2-Lite, DeepSeek-V3, and any model with `model_type` in `{deepseek_v2, deepseek_v3, deepseek_v32, deepseek_mtp}` or with `kv_lora_rank` in its config.
+The transfer safety check automatically blocks MLA models on vLLM < 0.16.0 and falls back to disk loading. On vLLM >= 0.16.0, MLA models are allowed for P2P transfer. Set `MX_SKIP_FEATURE_CHECK=1` to bypass the check (for debugging only).
+
+Affected models: DeepSeek-V2, DeepSeek-V2-Lite, DeepSeek-V3, Kimi K2/K2.5, and any model with `model_type` in `{deepseek_v2, deepseek_v3, deepseek_v32, deepseek_mtp, kimi_k2, kimi_k25}` or with `kv_lora_rank` in its config.
 
 ### Contiguous Region Failures
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -502,30 +502,9 @@ P2P weight transfer works by loading dummy weights on the target, running `proce
 
 Three safety mechanisms prevent silent transfer failures:
 
-**1. Model feature allow-list** (`transfer_safety.py`): Before attempting P2P transfer, the loader checks the model's architecture, quantization method, dtype, and attention type against strict allow-lists. Only explicitly validated combinations are permitted. Unknown model architectures, quantization methods, or attention types cause automatic fallback to disk loading. Set `MX_SKIP_FEATURE_CHECK=1` to bypass (for testing only).
+**1. MLA feature gate** (`transfer_safety.py`): Before attempting P2P transfer, the loader checks the model's HF config for `kv_lora_rank`, which indicates Multi-head Latent Attention (MLA). MLA models (DeepSeek-V2/V3, Kimi K2/K2.5, and any future model using MLA) are blocked from P2P transfer and fall back to disk loading. All other models are allowed. Set `MX_SKIP_FEATURE_CHECK=1` to bypass (for testing only).
 
-Currently validated (tested on nScale B200 cluster):
-
-| Model | Architecture | Quantization | P2P Transfer |
-|-------|-------------|--------------|--------------|
-| Llama-3.1-8B-Instruct | llama (GQA) | none (BF16) | PASS |
-| Llama-3.1-8B-Instruct-FP8 | llama (GQA) | fp8 | PASS |
-| Llama-3-8B-Instruct-AWQ | llama (GQA) | awq | PASS |
-| Llama-3-8B-Instruct-GPTQ | llama (GQA) | gptq | PASS |
-| Mistral-7B-Instruct-v0.3 | mistral (GQA) | none (BF16) | PASS |
-| Qwen2-7B-Instruct | qwen2 (GQA) | none (BF16) | PASS |
-| Phi-3.5-mini-instruct | phi3 (GQA) | none (BF16) | PASS |
-| Gemma-2-2b-it | gemma2 (GQA) | none (BF16) | PASS |
-| DeepSeek-V2-Lite-Chat-FP8 | deepseek_v2 (MLA) | fp8 | vLLM >= 0.16.0 only |
-
-Blocked features:
-
-| Feature | Status | Notes |
-|---------|--------|-------|
-| DeepSeek MLA on vLLM < 0.16.0 | **Blocked** | Derived tensors on non-Module ABC, invisible to tensor capture |
-| DeepSeek MLA on vLLM >= 0.16.0 | **Allowed** | vLLM PR #33284 moved post-processing onto nn.Module |
-| Other quantization methods | **Blocked** | Not yet validated (bitsandbytes, compressed-tensors, etc.) |
-| Unknown model architectures | **Blocked** | Must be explicitly added to allow-list after validation |
+MLA models produce correct inference when loaded from disk but corrupted inference after RDMA weight transfer. The bytes transfer correctly (checksums match), but inference diverges. This has been reproduced across all tested vLLM versions (0.12.0 through 0.17.1). Root cause is under investigation.
 
 **2. Manifest mismatch detection** (`nixl_transfer.py`): During the transfer, the receiver validates that every source tensor has a matching local tensor (by name) and that sizes match. Any mismatch raises `ManifestMismatchError`, which skips that source and tries the next candidate. This is important during rolling updates and canary deployments where the fleet temporarily has pods running different image versions. A target on v2 may encounter a v1 source with a different tensor structure, reject it, then find a compatible v2 source and transfer successfully. Only after all candidates are exhausted does the loader fall back to disk. This also catches environment divergences (different vLLM versions, different attention backends, different CUDA versions) that produce different tensor structures.
 
@@ -650,13 +629,11 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 
 Target fails with `Remote access error on mlx5_X:1/IB`. Common causes: source crashed/restarted (stale rkeys), UCX transport misconfiguration, premature target connection. Fix: use robust ready coordination, check for restarts, enable `UCX_LOG_LEVEL=DEBUG`.
 
-### DeepSeek MLA P2P Transfer
+### MLA Models and P2P Transfer
 
-P2P weight transfer for DeepSeek models using Multi-head Latent Attention (MLA) is version-gated on vLLM >= 0.16.0. On older vLLM versions, `process_weights_after_loading()` runs on `MLACommonBaseImpl`, an ABC that does not inherit from `nn.Module`. The derived tensors `W_UV` and `W_UK_T` are assigned as bare Python attributes on this non-Module object, making them invisible to `named_buffers()` and the `nn.Module.__setattr__` patch used for tensor capture. vLLM PR #33284 (included in v0.16.0) moved this logic onto `MLAAttention` (an `nn.Module`), making the tensors visible through standard PyTorch mechanisms.
+P2P weight transfer is blocked for models using Multi-head Latent Attention (MLA), including DeepSeek-V2/V3, Kimi K2/K2.5, and any model with `kv_lora_rank` in its HF config. MLA models fall back to disk loading automatically.
 
-The transfer safety check automatically blocks MLA models on vLLM < 0.16.0 and falls back to disk loading. On vLLM >= 0.16.0, MLA models are allowed for P2P transfer. Set `MX_SKIP_FEATURE_CHECK=1` to bypass the check (for debugging only).
-
-Affected models: DeepSeek-V2, DeepSeek-V2-Lite, DeepSeek-V3, Kimi K2/K2.5, and any model with `model_type` in `{deepseek_v2, deepseek_v3, deepseek_v32, deepseek_mtp, kimi_k2, kimi_k25}` or with `kv_lora_rank` in its config.
+The bytes transfer correctly via RDMA (checksums match), but inference produces corrupted output. This has been reproduced across all tested vLLM versions (0.12.0 through 0.17.1). Root cause is under investigation. Set `MX_SKIP_FEATURE_CHECK=1` to bypass the block for debugging.
 
 ### Contiguous Region Failures
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -471,11 +471,12 @@ Manages a NIXL agent and RDMA transfers for a single GPU worker:
 
 **MxModelLoader** (extends `BaseModelLoader`, registered as `--load-format mx`):
 
-Auto-detects the best loading strategy with a three-tier fallback:
+Auto-detects the best loading strategy with a four-tier fallback:
 
-1. **RDMA**: Call `ListSources(identity, status=READY)`, filter by `worker_rank`, shuffle for load balancing. For each candidate (max `MAX_SOURCE_RETRIES`), call `GetMetadata` on demand, attempt RDMA transfer. On `SourceTransferError`, try next candidate.
-2. **GDS**: If no RDMA source available and GPUDirect Storage is available, load directly from file to GPU via `MxGdsLoader`.
-3. **Disk**: Standard vLLM `DefaultModelLoader` as final fallback.
+1. **Safety check**: Verify the model's features are validated for P2P transfer (see [Transfer Safety](#transfer-safety) below). If not, skip directly to GDS/disk.
+2. **P2P transfer**: Call `ListSources(identity, status=READY)`, filter by `worker_rank`, shuffle for load balancing. For each candidate (max `MAX_SOURCE_RETRIES`), call `GetMetadata` on demand, validate manifest compatibility, attempt transfer. On `SourceTransferError` or `ManifestMismatchError`, try next candidate or fall back.
+3. **GDS**: If no P2P source available and GPUDirect Storage is available, load directly from file to GPU via `MxGdsLoader`.
+4. **Disk**: Standard vLLM `DefaultModelLoader` as final fallback.
 
 After loading by any path, the worker registers ALL final tensors with NIXL, publishes metadata, and starts a `HeartbeatThread` that periodically sends `UpdateStatus(READY)` to keep `updated_at` fresh. On clean shutdown, the heartbeat sends `UpdateStatus(STALE)` via an `atexit` handler.
 
@@ -494,6 +495,40 @@ The loader uses `_iter_module_tensors()` to walk the full PyTorch module tree an
 | Tensor attributes | `dir(module)` scan | FP8 `weight_scale`, `_k_scale` |
 
 This is more thorough than `named_parameters()` which only finds parameters and would miss tensors created during `process_weights_after_loading()`. Non-contiguous tensors (e.g. transposed views like `W_UK_T`) are skipped because they are views over contiguous tensors already in the module tree. Tensors are deduplicated by `data_ptr()` so tied weights (e.g. `embed_tokens.weight` and `lm_head.weight` sharing the same memory) are only registered and transferred once.
+
+### Transfer Safety
+
+P2P weight transfer works by loading dummy weights on the target, running `process_weights_after_loading()` to establish the final tensor layout, then overwriting the tensor data via RDMA. This requires that the dummy-load path produces an identical tensor structure to the real-load path. Some model architectures create derived state during post-processing that the byte-level overwrite cannot correctly replicate (e.g. DeepSeek MLA's dequantized `kv_b_proj` intermediates).
+
+Three safety mechanisms prevent silent transfer failures:
+
+**1. Model feature allow-list** (`transfer_safety.py`): Before attempting P2P transfer, the loader checks the model's architecture, quantization method, dtype, and attention type against strict allow-lists. Only explicitly validated combinations are permitted. Unknown model architectures, quantization methods, or attention types cause automatic fallback to disk loading. Set `MX_SKIP_FEATURE_CHECK=1` to bypass (for testing only).
+
+Currently validated (tested on nScale B200 cluster):
+
+| Model | Architecture | Quantization | P2P Transfer |
+|-------|-------------|--------------|--------------|
+| Llama-3.1-8B-Instruct | llama (GQA) | none (BF16) | PASS |
+| Llama-3.1-8B-Instruct-FP8 | llama (GQA) | fp8 | PASS |
+| Llama-3-8B-Instruct-AWQ | llama (GQA) | awq | PASS |
+| Llama-3-8B-Instruct-GPTQ | llama (GQA) | gptq | PASS |
+| Mistral-7B-Instruct-v0.3 | mistral (GQA) | none (BF16) | PASS |
+| Qwen2-7B-Instruct | qwen2 (GQA) | none (BF16) | PASS |
+| Phi-3.5-mini-instruct | phi3 (GQA) | none (BF16) | PASS |
+| Gemma-2-2b-it | gemma2 (GQA) | none (BF16) | PASS |
+| DeepSeek-V2-Lite-Chat-FP8 | deepseek_v2 (MLA) | fp8 | **FAIL** |
+
+Blocked features:
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| DeepSeek MLA | **Blocked** | Dequantized KV projections not transferable |
+| Other quantization methods | **Blocked** | Not yet validated (bitsandbytes, compressed-tensors, etc.) |
+| Unknown model architectures | **Blocked** | Must be explicitly added to allow-list after validation |
+
+**2. Manifest mismatch detection** (`nixl_transfer.py`): During the transfer, the receiver validates that every source tensor has a matching local tensor (by name) and that sizes match. Any mismatch raises `ManifestMismatchError`, which skips that source and tries the next candidate. This is important during rolling updates and canary deployments where the fleet temporarily has pods running different image versions. A target on v2 may encounter a v1 source with a different tensor structure, reject it, then find a compatible v2 source and transfer successfully. Only after all candidates are exhausted does the loader fall back to disk. This also catches environment divergences (different vLLM versions, different attention backends, different CUDA versions) that produce different tensor structures.
+
+**3. Transfer fingerprint** (`transfer_safety.py`): Both source and target log a fingerprint containing the vLLM version, CUDA version, DeepGemm version, attention backend, and a SHA256 hash of the tensor manifest (names + shapes + dtypes, excluding addresses). This aids debugging when transfers produce incorrect results.
 
 ## NIXL Integration
 
@@ -613,6 +648,12 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 ### NIXL_ERR_REMOTE_DISCONNECT
 
 Target fails with `Remote access error on mlx5_X:1/IB`. Common causes: source crashed/restarted (stale rkeys), UCX transport misconfiguration, premature target connection. Fix: use robust ready coordination, check for restarts, enable `UCX_LOG_LEVEL=DEBUG`.
+
+### DeepSeek MLA P2P Transfer
+
+P2P weight transfer does not work with DeepSeek models that use Multi-head Latent Attention (MLA). During `process_weights_after_loading()`, the MLA attention layer dequantizes `kv_b_proj` into BF16 and creates `W_UV` and `W_UK_T` as views into the dequantized intermediate. These derived tensors depend on the actual weight values, not just tensor shapes. The target's dummy-load-then-overwrite pattern runs post-processing on dummy data, creating dummy-derived intermediates that the RDMA byte overwrite cannot correctly replace. The transfer safety allow-list automatically blocks MLA models and falls back to disk loading. Set `MX_SKIP_FEATURE_CHECK=1` to bypass (for debugging only).
+
+Affected models: DeepSeek-V2, DeepSeek-V2-Lite, DeepSeek-V3, and any model with `model_type` in `{deepseek_v2, deepseek_v3, deepseek_v32, deepseek_mtp}` or with `kv_lora_rank` in its config.
 
 ### Contiguous Region Failures
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -228,6 +228,7 @@ ModelExpress supports GPU-to-GPU model weight transfers between vLLM instances u
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
 | `MX_REGISTER_LOADERS` | `1` | Auto-register the mx loader with vLLM |
 | `MX_CONTIGUOUS_REG` | `0` | Contiguous region registration (experimental) |
+| `MX_SKIP_FEATURE_CHECK` | `0` | Bypass the model feature allow-list for P2P transfer (testing only) |
 | `MX_P2P_METADATA` | `0` | Enable P2P metadata exchange (source workers only) |
 | `MX_METADATA_PORT` | `5555` | Base NIXL listen port; effective port is `MX_METADATA_PORT + device_id` |
 | `MX_WORKER_GRPC_PORT` | `0` | Worker gRPC port for P2P tensor manifest serving |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -228,7 +228,7 @@ ModelExpress supports GPU-to-GPU model weight transfers between vLLM instances u
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
 | `MX_REGISTER_LOADERS` | `1` | Auto-register the mx loader with vLLM |
 | `MX_CONTIGUOUS_REG` | `0` | Contiguous region registration (experimental) |
-| `MX_SKIP_FEATURE_CHECK` | `0` | Bypass the model feature allow-list for P2P transfer (testing only) |
+| `MX_SKIP_FEATURE_CHECK` | `0` | Bypass the MLA feature gate for P2P transfer (testing only) |
 | `MX_P2P_METADATA` | `0` | Enable P2P metadata exchange (source workers only) |
 | `MX_METADATA_PORT` | `5555` | Base NIXL listen port; effective port is `MX_METADATA_PORT + device_id` |
 | `MX_WORKER_GRPC_PORT` | `0` | Worker gRPC port for P2P tensor manifest serving |

--- a/examples/p2p_transfer_k8s/client/README.md
+++ b/examples/p2p_transfer_k8s/client/README.md
@@ -6,8 +6,8 @@ vLLM instances with ModelExpress P2P weight transfer support.
 
 | Topology | Manifest | Model | Configuration |
 |----------|----------|-------|---------------|
-| **Single-node** | [`vllm/vllm-single-node.yaml`](vllm/vllm-single-node.yaml) | DeepSeek-V3 | TP=8, 1 node (8 GPUs) |
-| **Multi-node** | [`vllm/vllm-multi-node.yaml`](vllm/vllm-multi-node.yaml) | Kimi-K2.5 | TP=8, PP=2, 2 nodes (16 GPUs) |
+| **Single-node** | [`vllm/vllm-single-node.yaml`](vllm/vllm-single-node.yaml) | Llama-3.1-405B-Instruct | TP=8, 1 node (8 GPUs) |
+| **Multi-node** | [`vllm/vllm-multi-node.yaml`](vllm/vllm-multi-node.yaml) | Llama-3.1-405B-Instruct | TP=4, PP=2, 2 nodes (8 GPUs) |
 
 ## How It Works
 

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -3,10 +3,9 @@
 
 # Multi-node vLLM StatefulSet with ModelExpress P2P weight transfer.
 #
-# Deploys Kimi-K2.5 as a single StatefulSet across 2 nodes (8 GPUs total):
+# Deploys Llama-3.1-405B-Instruct as a single StatefulSet across 2 nodes (8 GPUs total):
 #   - tensor-parallel-size=4 (within each node)
 #   - pipeline-parallel-size=2 (across nodes)
-#   - expert-parallel enabled
 #
 # Pod roles are determined by ordinal index:
 #   - pod-0: Ray head node + vLLM API server
@@ -93,7 +92,7 @@ spec:
             - name: HF_HUB_CACHE
               value: "/models"
             - name: MODEL_NAME
-              value: "moonshotai/Kimi-K2.5"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             - name: VLLM_PLUGINS
               value: "modelexpress"
             - name: MX_SERVER_ADDRESS
@@ -142,7 +141,6 @@ spec:
                   --load-format mx \
                   --tensor-parallel-size 4 \
                   --pipeline-parallel-size 2 \
-                  --enable-expert-parallel \
                   --trust-remote-code \
                   --distributed-executor-backend ray
               else

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -59,7 +59,7 @@ spec:
             - name: HF_HUB_CACHE
               value: "/models"
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             - name: VLLM_PLUGINS
               value: "modelexpress"
             - name: MX_SERVER_ADDRESS

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Single-node vLLM deployment with ModelExpress P2P weight transfer.
-# Deploys DeepSeek-V3 on 1 node (8 GPUs, TP=8).
+# Deploys Llama-3.1-405B-Instruct on 1 node (8 GPUs, TP=8).
 #
 # Prerequisites:
 #   - ModelExpress server deployed (see ../../server/)
@@ -61,7 +61,7 @@ spec:
             - name: HF_HUB_CACHE
               value: "/models"
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             # Register ModelExpress loaders via vLLM plugin system
             - name: VLLM_PLUGINS
               value: "modelexpress"

--- a/examples/p2p_transfer_k8s/model-download.yaml
+++ b/examples/p2p_transfer_k8s/model-download.yaml
@@ -45,7 +45,7 @@ spec:
             - name: HF_HUB_CACHE
               value: /models
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/examples/p2p_transfer_k8s/server/kubernetes_backend/crd-modelmetadata.yaml
+++ b/examples/p2p_transfer_k8s/server/kubernetes_backend/crd-modelmetadata.yaml
@@ -29,7 +29,7 @@ spec:
               properties:
                 modelName:
                   type: string
-                  description: Full model name (e.g., deepseek-ai/DeepSeek-V3)
+                  description: Full model name (e.g., meta-llama/Llama-3.1-405B-Instruct)
             status:
               type: object
               properties:

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import torch
 
-from .types import TensorDescriptor
+from .types import ManifestMismatchError, TensorDescriptor
 
 logger = logging.getLogger("modelexpress.nixl_transfer")
 
@@ -134,7 +134,7 @@ class NixlTransferManager:
 
         for name, tensor in tensors.items():
             if not tensor.is_contiguous():
-                raise RuntimeError(
+                raise ManifestMismatchError(
                     f"Tensor '{name}' is not contiguous. "
                     "Non-contiguous tensors cannot be used for RDMA transfers."
                 )
@@ -331,7 +331,7 @@ class NixlTransferManager:
             if self._registered_regions is None:
                 logger.error("Source sent region descriptors but we didn't register regions!")
                 logger.error("Set MX_CONTIGUOUS_REG=1 on target to enable region transfer")
-                raise RuntimeError("Region transfer mismatch: target must also use MX_CONTIGUOUS_REG=1")
+                raise ManifestMismatchError("Region transfer mismatch: target must also use MX_CONTIGUOUS_REG=1")
 
             logger.info(f"Region-based transfer: {len(source_tensors)} source regions -> {len(self._registered_regions)} local regions")
 
@@ -377,11 +377,53 @@ class NixlTransferManager:
             local_tensor_list = []
             total_bytes = 0
             matched_tensors = 0
+            skipped_source = []
+            skipped_target = []
+
+            source_names = {t.name for t in source_tensors}
+            local_names = set(self._tensors.keys())
+
+            # Detect manifest mismatches BEFORE transfer
+            source_only = source_names - local_names
+            target_only = local_names - source_names
+            if source_only:
+                skipped_source = sorted(source_only)
+                logger.warning(
+                    f"[Manifest Mismatch] {len(source_only)} source tensors have no "
+                    f"local match (will NOT be transferred): "
+                    f"{skipped_source[:5]}{'...' if len(skipped_source) > 5 else ''}"
+                )
+            if target_only:
+                skipped_target = sorted(target_only)
+                logger.warning(
+                    f"[Manifest Mismatch] {len(target_only)} local tensors have no "
+                    f"source match (will keep dummy values): "
+                    f"{skipped_target[:5]}{'...' if len(skipped_target) > 5 else ''}"
+                )
+            if source_only or target_only:
+                raise ManifestMismatchError(
+                    f"[Manifest Mismatch] Source has {len(source_names)} tensors, "
+                    f"target has {len(local_names)} tensors, "
+                    f"{len(source_names & local_names)} matched. "
+                    f"Source-only: {skipped_source[:5]}, "
+                    f"Target-only: {skipped_target[:5]}. "
+                    f"Aborting transfer to prevent incorrect inference."
+                )
 
             for src_tensor in source_tensors:
                 if src_tensor.name not in self._tensors:
                     continue
                 local_tensor = self._tensors[src_tensor.name]
+
+                # Validate size match for each tensor
+                local_size = local_tensor.numel() * local_tensor.element_size()
+                if src_tensor.size != local_size:
+                    raise ManifestMismatchError(
+                        f"[Manifest Mismatch] Tensor '{src_tensor.name}' size mismatch: "
+                        f"source={src_tensor.size}, target={local_size}. "
+                        f"Aborting transfer to prevent incorrect inference."
+                    )
+
                 remote_descs.append((src_tensor.addr, src_tensor.size, src_tensor.device_id))
                 local_tensor_list.append(local_tensor)
                 total_bytes += src_tensor.size
@@ -471,7 +513,7 @@ class NixlTransferManager:
                 break
             if status in ("ERR", "ERROR", "FAIL"):
                 self._agent.release_xfer_handle(handle)
-                raise RuntimeError(f"Transfer failed with status {status}")
+                raise ManifestMismatchError(f"Transfer failed with status {status}")
             time.sleep(0.001)
 
         # CRITICAL: Synchronize CUDA to ensure RDMA writes are visible

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -513,7 +513,7 @@ class NixlTransferManager:
                 break
             if status in ("ERR", "ERROR", "FAIL"):
                 self._agent.release_xfer_handle(handle)
-                raise ManifestMismatchError(f"Transfer failed with status {status}")
+                raise RuntimeError(f"NIXL transfer failed with status {status}")
             time.sleep(0.001)
 
         # CRITICAL: Synchronize CUDA to ensure RDMA writes are visible

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -239,6 +239,25 @@ def get_deep_gemm_version() -> str:
         return "unknown"
 
 
+def get_gpu_capability() -> str:
+    """Get the GPU compute capability as 'major.minor' (e.g. '9.0', '10.0').
+
+    Different GPU architectures can trigger different post-processing paths
+    (e.g. DeepGemm TMA scale packing differs between SM90 and SM100).
+    Including this in SourceIdentity ensures heterogeneous clusters don't
+    attempt cross-architecture transfers.
+
+    Returns 'unknown' if CUDA is not available.
+    """
+    try:
+        if torch.cuda.is_available():
+            props = torch.cuda.get_device_properties(0)
+            return f"{props.major}.{props.minor}"
+    except Exception:
+        pass
+    return "unknown"
+
+
 @dataclass
 class TransferFingerprint:
     """Captures runtime environment and tensor manifest structure.
@@ -250,6 +269,7 @@ class TransferFingerprint:
     torch_version: str = ""
     cuda_version: str = ""
     deep_gemm_version: str = ""
+    gpu_capability: str = ""
     attention_backend: str = ""
     manifest_hash: str = ""
     tensor_count: int = 0
@@ -262,6 +282,7 @@ class TransferFingerprint:
             torch_version=get_torch_version(),
             cuda_version=get_cuda_version(),
             deep_gemm_version=get_deep_gemm_version(),
+            gpu_capability=get_gpu_capability(),
             attention_backend=_get_attention_backend(),
         )
         if tensors is not None:
@@ -276,6 +297,7 @@ class TransferFingerprint:
             "torch_version": self.torch_version,
             "cuda_version": self.cuda_version,
             "deep_gemm_version": self.deep_gemm_version,
+            "gpu_capability": self.gpu_capability,
             "attention_backend": self.attention_backend,
             "manifest_hash": self.manifest_hash,
             "tensor_count": self.tensor_count,

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -7,8 +7,11 @@ Transfer safety checks for ModelExpress GPU-to-GPU weight transfer.
 Two independent safety mechanisms:
 
 1. Feature allow-list: checks model config before attempting P2P transfer.
-   Models with unsupported post-processing features (MLA, FP8 TMA scales)
-   are rejected early and fall back to disk loading.
+   Models with unsupported features are rejected early and fall back to
+   disk loading. MLA attention is version-gated: blocked on vLLM < 0.16.0
+   (where process_weights_after_loading runs on a non-Module ABC and derived
+   tensors are invisible to PyTorch), allowed on >= 0.16.0 (where vLLM PR
+   #33284 moved the logic onto nn.Module).
 
 2. Transfer fingerprint: captures the runtime environment and tensor
    manifest structure. Source publishes its fingerprint; target computes
@@ -51,19 +54,22 @@ ALLOWED_MODEL_TYPES: set[str] = {
     "opt",
     "falcon",
     "codellama",
+    "deepseek_v2",   # MLA - version-gated (requires vLLM >= 0.16.0)
+    "deepseek_v3",   # MLA - version-gated
+    "deepseek_v32",  # MLA - version-gated
+    "deepseek_mtp",  # MLA - version-gated
+    "AXK1",          # MLA variant - version-gated
+    "kimi_k2",       # MLA (Moonshot Kimi K2) - version-gated
+    "kimi_k25",      # MLA (Moonshot Kimi K2.5) - version-gated
 }
 
-# Model types known to be unsafe for P2P transfer.
-# Listed for documentation; anything not in ALLOWED_MODEL_TYPES is denied.
-BLOCKED_MODEL_TYPES: set[str] = {
-    "deepseek_v2",   # MLA
-    "deepseek_v3",   # MLA
-    "deepseek_v32",  # MLA
-    "deepseek_mtp",  # MLA
-    "AXK1",          # MLA variant
-    "kimi_k2",       # MLA (Moonshot Kimi K2)
-    "kimi_k25",      # MLA (Moonshot Kimi K2.5)
-}
+# Minimum vLLM version for MLA P2P transfers.
+# vLLM PR #33284 (v0.16.0) moved process_weights_after_loading from
+# MLACommonBaseImpl (ABC, not nn.Module) into MLAAttention (nn.Module).
+# Before this change, derived tensors W_UV and W_UK_T are bare attributes
+# on a non-Module object, invisible to named_buffers() and the
+# nn.Module.__setattr__ patch used for tensor capture.
+MLA_MIN_VLLM_VERSION: tuple[int, ...] = (0, 16, 0)
 
 # Quantization methods validated for P2P transfer.
 ALLOWED_QUANTIZATIONS: set[str | None] = {
@@ -83,6 +89,32 @@ ALLOWED_DTYPES: set[str] = {
     "float32",
     "float8_e4m3fn",  # FP8 quantized weights
 }
+
+
+def _parse_version(version_str: str) -> tuple[int, ...]:
+    """Parse a version string like '0.16.0' into a comparable tuple.
+
+    Strips dev/rc/post suffixes (e.g. '0.16.0.dev123' -> (0, 16, 0)).
+    Returns (0,) for unparseable strings so comparisons fail safe (deny).
+    """
+    try:
+        # Strip everything after the numeric portion
+        parts = []
+        for part in version_str.split("."):
+            # Stop at first non-numeric segment
+            digits = ""
+            for ch in part:
+                if ch.isdigit():
+                    digits += ch
+                else:
+                    break
+            if digits:
+                parts.append(int(digits))
+            else:
+                break
+        return tuple(parts) if parts else (0,)
+    except Exception:
+        return (0,)
 
 
 def detect_model_features(model_config) -> dict[str, str]:
@@ -145,7 +177,12 @@ def check_transfer_allowed(model_config) -> tuple[bool, str]:
         reasons.append(f"quantization '{quant}' is not validated for P2P transfer")
 
     if features["attention"] == "mla":
-        reasons.append("MLA attention creates derived tensors incompatible with P2P transfer")
+        vllm_ver = _parse_version(get_vllm_version())
+        if vllm_ver < MLA_MIN_VLLM_VERSION:
+            reasons.append(
+                f"MLA attention requires vLLM >= {'.'.join(str(v) for v in MLA_MIN_VLLM_VERSION)} "
+                f"for P2P transfer (found {get_vllm_version()})"
+            )
 
     if reasons:
         reason_str = "; ".join(reasons)

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -86,7 +86,7 @@ def check_transfer_allowed(model_config) -> tuple[bool, str]:
     if features["attention"] == "mla":
         reason = (
             "MLA attention models are blocked from P2P transfer due to "
-            "unresolved weight corruption (NVBug 6066010)"
+            "unresolved weight corruption after RDMA receive"
         )
         logger.warning(
             f"[Transfer Safety] P2P transfer denied: {reason}. "
@@ -211,33 +211,6 @@ class TransferFingerprint:
         d = json.loads(s)
         return cls(**d)
 
-    def validate_against(self, source: TransferFingerprint) -> tuple[bool, list[str]]:
-        """Compare this (target) fingerprint against a source fingerprint.
-
-        Returns (compatible, mismatches). Mismatches is a list of human-readable
-        strings describing each incompatibility.
-        """
-        mismatches: list[str] = []
-
-        # vllm_version, cuda_version, torch_version, and deep_gemm_version
-        # are checked at source-selection time via extra_parameters in
-        # SourceIdentity (hashed into mx_source_id).
-        # Only runtime-resolved properties are validated here.
-        if self.attention_backend != source.attention_backend:
-            mismatches.append(
-                f"attention backend: source={source.attention_backend}, target={self.attention_backend}"
-            )
-
-        # Manifest structure: tensor names, sizes, dtypes must match
-        if self.manifest_hash and source.manifest_hash:
-            if self.manifest_hash != source.manifest_hash:
-                mismatches.append(
-                    f"tensor manifest hash: source={source.manifest_hash[:12]}..., "
-                    f"target={self.manifest_hash[:12]}... "
-                    f"(source={source.tensor_count} tensors, target={self.tensor_count} tensors)"
-                )
-
-        return len(mismatches) == 0, mismatches
 
 
 def _compute_manifest_hash(tensors: dict[str, torch.Tensor]) -> str:

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Transfer safety checks for ModelExpress GPU-to-GPU weight transfer.
+
+Two independent safety mechanisms:
+
+1. Feature allow-list: checks model config before attempting P2P transfer.
+   Models with unsupported post-processing features (MLA, FP8 TMA scales)
+   are rejected early and fall back to disk loading.
+
+2. Transfer fingerprint: captures the runtime environment and tensor
+   manifest structure. Source publishes its fingerprint; target computes
+   its own and rejects the transfer if they don't match.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+
+import torch
+
+logger = logging.getLogger("modelexpress.transfer_safety")
+
+# ---------------------------------------------------------------------------
+# Feature allow-list
+# ---------------------------------------------------------------------------
+
+# Model features that are known to produce correct results via P2P weight transfer.
+# Any feature not on this list causes automatic fallback to disk loading.
+# Add features here only after validating RDMA correctness end-to-end.
+# Model architectures validated for P2P weight transfer.
+# Only models whose model_type is in this set are allowed.
+# Any unknown architecture falls back to disk loading.
+ALLOWED_MODEL_TYPES: set[str] = {
+    "llama",
+    "mistral",
+    "qwen2",
+    "gemma",
+    "gemma2",
+    "phi3",
+    "phi",
+    "starcoder2",
+    "gpt_neox",
+    "gpt2",
+    "opt",
+    "falcon",
+    "codellama",
+}
+
+# Model types known to be unsafe for P2P transfer.
+# Listed for documentation; anything not in ALLOWED_MODEL_TYPES is denied.
+BLOCKED_MODEL_TYPES: set[str] = {
+    "deepseek_v2",   # MLA
+    "deepseek_v3",   # MLA
+    "deepseek_v32",  # MLA
+    "deepseek_mtp",  # MLA
+    "AXK1",          # MLA variant
+    "kimi_k2",       # MLA (Moonshot Kimi K2)
+    "kimi_k25",      # MLA (Moonshot Kimi K2.5)
+}
+
+# Quantization methods validated for P2P transfer.
+ALLOWED_QUANTIZATIONS: set[str | None] = {
+    None,            # No quantization (BF16/FP16/FP32)
+    "",              # Empty string (same as None)
+    "fp8",           # FP8 block quantization (scales are pure data)
+    "awq",           # AWQ quantization (packed int4 weights + scales)
+    "gptq",          # GPTQ quantization (packed int4 weights + scales + zeros)
+    "gptq_marlin",   # GPTQ with Marlin kernel (same weights, different runtime)
+    "awq_marlin",    # AWQ with Marlin kernel (same weights, different runtime)
+}
+
+# Weight dtypes validated for P2P transfer.
+ALLOWED_DTYPES: set[str] = {
+    "bfloat16",
+    "float16",
+    "float32",
+    "float8_e4m3fn",  # FP8 quantized weights
+}
+
+
+def detect_model_features(model_config) -> dict[str, str]:
+    """Detect model features relevant to transfer safety.
+
+    Returns a dict of feature name -> value for logging and validation.
+    """
+    hf_config = model_config.hf_text_config
+    features: dict[str, str] = {}
+
+    features["model_type"] = getattr(hf_config, "model_type", "unknown")
+    features["dtype"] = str(model_config.dtype).replace("torch.", "")
+    features["quantization"] = model_config.quantization or "none"
+
+    # MLA detection
+    mla_model_types = {"deepseek_v2", "deepseek_v3", "deepseek_v32", "deepseek_mtp", "AXK1", "kimi_k2", "kimi_k25"}
+    has_mla = (
+        features["model_type"] in mla_model_types
+        or getattr(hf_config, "kv_lora_rank", None) is not None
+    )
+    features["attention"] = "mla" if has_mla else "standard"
+
+    # MoE
+    num_experts = (
+        getattr(hf_config, "n_routed_experts", None)
+        or getattr(hf_config, "num_local_experts", None)
+    )
+    if num_experts and num_experts > 1:
+        features["moe"] = str(num_experts)
+
+    return features
+
+
+def check_transfer_allowed(model_config) -> tuple[bool, str]:
+    """Check if P2P weight transfer is allowed for this model.
+
+    Uses a strict allow-list approach: only explicitly validated model
+    architectures, quantization methods, and dtypes are permitted.
+    Everything else falls back to disk loading.
+
+    Returns (allowed, reason). If not allowed, reason explains why.
+    """
+    if os.environ.get("MX_SKIP_FEATURE_CHECK", "0") == "1":
+        logger.warning("MX_SKIP_FEATURE_CHECK=1: bypassing feature allow-list")
+        return True, "bypassed"
+
+    features = detect_model_features(model_config)
+    reasons: list[str] = []
+
+    model_type = features["model_type"]
+    if model_type not in ALLOWED_MODEL_TYPES:
+        reasons.append(f"model_type '{model_type}' is not validated for P2P transfer")
+
+    dtype = features["dtype"]
+    if dtype not in ALLOWED_DTYPES:
+        reasons.append(f"dtype '{dtype}' is not validated for P2P transfer")
+
+    quant = model_config.quantization
+    if quant not in ALLOWED_QUANTIZATIONS:
+        reasons.append(f"quantization '{quant}' is not validated for P2P transfer")
+
+    if features["attention"] == "mla":
+        reasons.append("MLA attention creates derived tensors incompatible with P2P transfer")
+
+    if reasons:
+        reason_str = "; ".join(reasons)
+        logger.warning(
+            f"[Transfer Safety] P2P transfer denied: {reason_str}. "
+            f"Features: {features}. "
+            f"Set MX_SKIP_FEATURE_CHECK=1 to bypass."
+        )
+        return False, reason_str
+
+    logger.info(f"[Transfer Safety] P2P transfer allowed. Features: {features}")
+    return True, "allowed"
+
+
+# ---------------------------------------------------------------------------
+# Transfer fingerprint
+# ---------------------------------------------------------------------------
+
+def _get_vllm_version() -> str:
+    try:
+        import vllm
+        return getattr(vllm, "__version__", "unknown")
+    except ImportError:
+        return "unknown"
+
+
+def _get_torch_version() -> str:
+    return torch.__version__
+
+
+def _get_cuda_version() -> str:
+    return getattr(torch.version, "cuda", "unknown") or "unknown"
+
+
+def _get_attention_backend() -> str:
+    """Get the selected attention backend name."""
+    try:
+        from vllm.config import get_current_vllm_config
+        config = get_current_vllm_config()
+        if hasattr(config, "model_config") and config.model_config is not None:
+            cache_config = getattr(config, "cache_config", None)
+            if cache_config is not None:
+                return getattr(cache_config, "attention_backend", "unknown") or "unknown"
+    except Exception:
+        pass
+    return os.environ.get("VLLM_ATTENTION_BACKEND", "auto")
+
+
+def _get_deep_gemm_version() -> str:
+    try:
+        from importlib.metadata import version
+        return version("deep-gemm")
+    except Exception:
+        return "unknown"
+
+
+@dataclass
+class TransferFingerprint:
+    """Captures runtime environment and tensor manifest structure.
+
+    Published by the source alongside tensor metadata. The target computes
+    its own fingerprint and compares. Mismatches cause transfer rejection.
+    """
+    vllm_version: str = ""
+    torch_version: str = ""
+    cuda_version: str = ""
+    deep_gemm_version: str = ""
+    attention_backend: str = ""
+    manifest_hash: str = ""
+    tensor_count: int = 0
+
+    @classmethod
+    def from_environment(cls, tensors: dict[str, torch.Tensor] | None = None) -> TransferFingerprint:
+        """Build a fingerprint from the current runtime environment."""
+        fp = cls(
+            vllm_version=_get_vllm_version(),
+            torch_version=_get_torch_version(),
+            cuda_version=_get_cuda_version(),
+            deep_gemm_version=_get_deep_gemm_version(),
+            attention_backend=_get_attention_backend(),
+        )
+        if tensors is not None:
+            fp.manifest_hash = _compute_manifest_hash(tensors)
+            fp.tensor_count = len(tensors)
+        return fp
+
+    def to_json(self) -> str:
+        """Serialize to JSON string for inclusion in proto metadata."""
+        return json.dumps({
+            "vllm_version": self.vllm_version,
+            "torch_version": self.torch_version,
+            "cuda_version": self.cuda_version,
+            "deep_gemm_version": self.deep_gemm_version,
+            "attention_backend": self.attention_backend,
+            "manifest_hash": self.manifest_hash,
+            "tensor_count": self.tensor_count,
+        }, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, s: str) -> TransferFingerprint:
+        """Deserialize from JSON string."""
+        d = json.loads(s)
+        return cls(**d)
+
+    def validate_against(self, source: TransferFingerprint) -> tuple[bool, list[str]]:
+        """Compare this (target) fingerprint against a source fingerprint.
+
+        Returns (compatible, mismatches). Mismatches is a list of human-readable
+        strings describing each incompatibility.
+        """
+        mismatches: list[str] = []
+
+        # Hard requirements: these MUST match
+        if self.vllm_version != source.vllm_version:
+            mismatches.append(
+                f"vLLM version: source={source.vllm_version}, target={self.vllm_version}"
+            )
+        if self.cuda_version != source.cuda_version:
+            mismatches.append(
+                f"CUDA version: source={source.cuda_version}, target={self.cuda_version}"
+            )
+        if self.attention_backend != source.attention_backend:
+            mismatches.append(
+                f"attention backend: source={source.attention_backend}, target={self.attention_backend}"
+            )
+        if self.deep_gemm_version != source.deep_gemm_version:
+            mismatches.append(
+                f"DeepGemm version: source={source.deep_gemm_version}, target={self.deep_gemm_version}"
+            )
+
+        # Manifest structure: tensor names, sizes, dtypes must match
+        if self.manifest_hash and source.manifest_hash:
+            if self.manifest_hash != source.manifest_hash:
+                mismatches.append(
+                    f"tensor manifest hash: source={source.manifest_hash[:12]}..., "
+                    f"target={self.manifest_hash[:12]}... "
+                    f"(source={source.tensor_count} tensors, target={self.tensor_count} tensors)"
+                )
+
+        return len(mismatches) == 0, mismatches
+
+
+def _compute_manifest_hash(tensors: dict[str, torch.Tensor]) -> str:
+    """Compute a SHA256 hash of the tensor manifest structure.
+
+    Hashes tensor names, sizes, and dtypes (NOT addresses, which are
+    machine-specific). Two identical models with identical post-processing
+    should produce the same hash regardless of GPU memory layout.
+    """
+    entries = []
+    for name in sorted(tensors.keys()):
+        t = tensors[name]
+        entries.append(f"{name}:{list(t.shape)}:{t.dtype}:{t.numel() * t.element_size()}")
+    manifest_str = "\n".join(entries)
+    return hashlib.sha256(manifest_str.encode()).hexdigest()

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -164,7 +164,7 @@ def check_transfer_allowed(model_config) -> tuple[bool, str]:
 # Transfer fingerprint
 # ---------------------------------------------------------------------------
 
-def _get_vllm_version() -> str:
+def get_vllm_version() -> str:
     try:
         import vllm
         return getattr(vllm, "__version__", "unknown")
@@ -172,11 +172,11 @@ def _get_vllm_version() -> str:
         return "unknown"
 
 
-def _get_torch_version() -> str:
+def get_torch_version() -> str:
     return torch.__version__
 
 
-def _get_cuda_version() -> str:
+def get_cuda_version() -> str:
     return getattr(torch.version, "cuda", "unknown") or "unknown"
 
 
@@ -194,7 +194,7 @@ def _get_attention_backend() -> str:
     return os.environ.get("VLLM_ATTENTION_BACKEND", "auto")
 
 
-def _get_deep_gemm_version() -> str:
+def get_deep_gemm_version() -> str:
     try:
         from importlib.metadata import version
         return version("deep-gemm")
@@ -221,10 +221,10 @@ class TransferFingerprint:
     def from_environment(cls, tensors: dict[str, torch.Tensor] | None = None) -> TransferFingerprint:
         """Build a fingerprint from the current runtime environment."""
         fp = cls(
-            vllm_version=_get_vllm_version(),
-            torch_version=_get_torch_version(),
-            cuda_version=_get_cuda_version(),
-            deep_gemm_version=_get_deep_gemm_version(),
+            vllm_version=get_vllm_version(),
+            torch_version=get_torch_version(),
+            cuda_version=get_cuda_version(),
+            deep_gemm_version=get_deep_gemm_version(),
             attention_backend=_get_attention_backend(),
         )
         if tensors is not None:
@@ -258,22 +258,13 @@ class TransferFingerprint:
         """
         mismatches: list[str] = []
 
-        # Hard requirements: these MUST match
-        if self.vllm_version != source.vllm_version:
-            mismatches.append(
-                f"vLLM version: source={source.vllm_version}, target={self.vllm_version}"
-            )
-        if self.cuda_version != source.cuda_version:
-            mismatches.append(
-                f"CUDA version: source={source.cuda_version}, target={self.cuda_version}"
-            )
+        # vllm_version, cuda_version, torch_version, and deep_gemm_version
+        # are checked at source-selection time via extra_parameters in
+        # SourceIdentity (hashed into mx_source_id).
+        # Only runtime-resolved properties are validated here.
         if self.attention_backend != source.attention_backend:
             mismatches.append(
                 f"attention backend: source={source.attention_backend}, target={self.attention_backend}"
-            )
-        if self.deep_gemm_version != source.deep_gemm_version:
-            mismatches.append(
-                f"DeepGemm version: source={source.deep_gemm_version}, target={self.deep_gemm_version}"
             )
 
         # Manifest structure: tensor names, sizes, dtypes must match

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -8,10 +8,10 @@ Two independent safety mechanisms:
 
 1. Feature allow-list: checks model config before attempting P2P transfer.
    Models with unsupported features are rejected early and fall back to
-   disk loading. MLA attention is version-gated: blocked on vLLM < 0.16.0
-   (where process_weights_after_loading runs on a non-Module ABC and derived
-   tensors are invisible to PyTorch), allowed on >= 0.16.0 (where vLLM PR
-   #33284 moved the logic onto nn.Module).
+   disk loading. MLA attention models (DeepSeek, Kimi) are blocked from
+   P2P transfers due to unresolved weight corruption after RDMA receive.
+   The bytes transfer correctly but inference diverges - root cause is
+   under investigation.
 
 2. Transfer fingerprint: captures the runtime environment and tensor
    manifest structure. Source publishes its fingerprint; target computes
@@ -31,90 +31,15 @@ import torch
 logger = logging.getLogger("modelexpress.transfer_safety")
 
 # ---------------------------------------------------------------------------
-# Feature allow-list
+# Feature detection and blocking
 # ---------------------------------------------------------------------------
 
-# Model features that are known to produce correct results via P2P weight transfer.
-# Any feature not on this list causes automatic fallback to disk loading.
-# Add features here only after validating RDMA correctness end-to-end.
-# Model architectures validated for P2P weight transfer.
-# Only models whose model_type is in this set are allowed.
-# Any unknown architecture falls back to disk loading.
-ALLOWED_MODEL_TYPES: set[str] = {
-    "llama",
-    "mistral",
-    "qwen2",
-    "gemma",
-    "gemma2",
-    "phi3",
-    "phi",
-    "starcoder2",
-    "gpt_neox",
-    "gpt2",
-    "opt",
-    "falcon",
-    "codellama",
-    "deepseek_v2",   # MLA - version-gated (requires vLLM >= 0.16.0)
-    "deepseek_v3",   # MLA - version-gated
-    "deepseek_v32",  # MLA - version-gated
-    "deepseek_mtp",  # MLA - version-gated
-    "AXK1",          # MLA variant - version-gated
-    "kimi_k2",       # MLA (Moonshot Kimi K2) - version-gated
-    "kimi_k25",      # MLA (Moonshot Kimi K2.5) - version-gated
-}
+# MLA (Multi-head Latent Attention) is the only feature currently blocked.
+# Bytes transfer correctly via RDMA but inference diverges on all tested
+# vLLM versions (0.12.0 through 0.17.1). Root cause under investigation.
+# Detection is config-based: kv_lora_rank presence in the HF config.
+# Bypass with MX_SKIP_FEATURE_CHECK=1 to test MLA transfers anyway.
 
-# Minimum vLLM version for MLA P2P transfers.
-# vLLM PR #33284 (v0.16.0) moved process_weights_after_loading from
-# MLACommonBaseImpl (ABC, not nn.Module) into MLAAttention (nn.Module).
-# Before this change, derived tensors W_UV and W_UK_T are bare attributes
-# on a non-Module object, invisible to named_buffers() and the
-# nn.Module.__setattr__ patch used for tensor capture.
-MLA_MIN_VLLM_VERSION: tuple[int, ...] = (0, 16, 0)
-
-# Quantization methods validated for P2P transfer.
-ALLOWED_QUANTIZATIONS: set[str | None] = {
-    None,            # No quantization (BF16/FP16/FP32)
-    "",              # Empty string (same as None)
-    "fp8",           # FP8 block quantization (scales are pure data)
-    "awq",           # AWQ quantization (packed int4 weights + scales)
-    "gptq",          # GPTQ quantization (packed int4 weights + scales + zeros)
-    "gptq_marlin",   # GPTQ with Marlin kernel (same weights, different runtime)
-    "awq_marlin",    # AWQ with Marlin kernel (same weights, different runtime)
-}
-
-# Weight dtypes validated for P2P transfer.
-ALLOWED_DTYPES: set[str] = {
-    "bfloat16",
-    "float16",
-    "float32",
-    "float8_e4m3fn",  # FP8 quantized weights
-}
-
-
-def _parse_version(version_str: str) -> tuple[int, ...]:
-    """Parse a version string like '0.16.0' into a comparable tuple.
-
-    Strips dev/rc/post suffixes (e.g. '0.16.0.dev123' -> (0, 16, 0)).
-    Returns (0,) for unparseable strings so comparisons fail safe (deny).
-    """
-    try:
-        # Strip everything after the numeric portion
-        parts = []
-        for part in version_str.split("."):
-            # Stop at first non-numeric segment
-            digits = ""
-            for ch in part:
-                if ch.isdigit():
-                    digits += ch
-                else:
-                    break
-            if digits:
-                parts.append(int(digits))
-            else:
-                break
-        return tuple(parts) if parts else (0,)
-    except Exception:
-        return (0,)
 
 
 def detect_model_features(model_config) -> dict[str, str]:
@@ -129,12 +54,8 @@ def detect_model_features(model_config) -> dict[str, str]:
     features["dtype"] = str(model_config.dtype).replace("torch.", "")
     features["quantization"] = model_config.quantization or "none"
 
-    # MLA detection
-    mla_model_types = {"deepseek_v2", "deepseek_v3", "deepseek_v32", "deepseek_mtp", "AXK1", "kimi_k2", "kimi_k25"}
-    has_mla = (
-        features["model_type"] in mla_model_types
-        or getattr(hf_config, "kv_lora_rank", None) is not None
-    )
+    # MLA detection via HF config attribute
+    has_mla = getattr(hf_config, "kv_lora_rank", None) is not None
     features["attention"] = "mla" if has_mla else "standard"
 
     # MoE
@@ -151,47 +72,28 @@ def detect_model_features(model_config) -> dict[str, str]:
 def check_transfer_allowed(model_config) -> tuple[bool, str]:
     """Check if P2P weight transfer is allowed for this model.
 
-    Uses a strict allow-list approach: only explicitly validated model
-    architectures, quantization methods, and dtypes are permitted.
-    Everything else falls back to disk loading.
+    Currently blocks only MLA attention models (detected via kv_lora_rank
+    in the HF config). All other models are allowed.
 
     Returns (allowed, reason). If not allowed, reason explains why.
     """
     if os.environ.get("MX_SKIP_FEATURE_CHECK", "0") == "1":
-        logger.warning("MX_SKIP_FEATURE_CHECK=1: bypassing feature allow-list")
+        logger.warning("MX_SKIP_FEATURE_CHECK=1: bypassing feature checks")
         return True, "bypassed"
 
     features = detect_model_features(model_config)
-    reasons: list[str] = []
-
-    model_type = features["model_type"]
-    if model_type not in ALLOWED_MODEL_TYPES:
-        reasons.append(f"model_type '{model_type}' is not validated for P2P transfer")
-
-    dtype = features["dtype"]
-    if dtype not in ALLOWED_DTYPES:
-        reasons.append(f"dtype '{dtype}' is not validated for P2P transfer")
-
-    quant = model_config.quantization
-    if quant not in ALLOWED_QUANTIZATIONS:
-        reasons.append(f"quantization '{quant}' is not validated for P2P transfer")
 
     if features["attention"] == "mla":
-        vllm_ver = _parse_version(get_vllm_version())
-        if vllm_ver < MLA_MIN_VLLM_VERSION:
-            reasons.append(
-                f"MLA attention requires vLLM >= {'.'.join(str(v) for v in MLA_MIN_VLLM_VERSION)} "
-                f"for P2P transfer (found {get_vllm_version()})"
-            )
-
-    if reasons:
-        reason_str = "; ".join(reasons)
+        reason = (
+            "MLA attention models are blocked from P2P transfer due to "
+            "unresolved weight corruption (NVBug 6066010)"
+        )
         logger.warning(
-            f"[Transfer Safety] P2P transfer denied: {reason_str}. "
+            f"[Transfer Safety] P2P transfer denied: {reason}. "
             f"Features: {features}. "
             f"Set MX_SKIP_FEATURE_CHECK=1 to bypass."
         )
-        return False, reason_str
+        return False, reason
 
     logger.info(f"[Transfer Safety] P2P transfer allowed. Features: {features}")
     return True, "allowed"

--- a/modelexpress_client/python/modelexpress/types.py
+++ b/modelexpress_client/python/modelexpress/types.py
@@ -6,6 +6,16 @@
 from dataclasses import dataclass
 
 
+class ManifestMismatchError(Exception):
+    """Raised when source and target tensor manifests are incompatible.
+
+    This is NOT a source-side failure - both sides are healthy, but their
+    runtime environments produce different tensor structures. The transfer
+    would silently produce incorrect inference results, so we abort and
+    fall back to disk loading.
+    """
+
+
 @dataclass
 class TensorDescriptor:
     """Descriptor for a tensor in GPU memory."""

--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -59,6 +59,7 @@ from .transfer_safety import (
     detect_model_features,
     get_cuda_version,
     get_deep_gemm_version,
+    get_gpu_capability,
     get_torch_version,
     get_vllm_version,
 )
@@ -387,6 +388,7 @@ def _build_source_identity(
             "runtime.torch_version": get_torch_version(),
             "runtime.cuda_version": get_cuda_version(),
             "runtime.deep_gemm_version": get_deep_gemm_version(),
+            "runtime.gpu_capability": get_gpu_capability(),
         },
     )
 

--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -53,6 +53,11 @@ from vllm.utils.torch_utils import set_default_torch_dtype
 from .gds_loader import MxGdsLoader
 from .gds_transfer import is_gds_available
 from .nixl_transfer import NixlTransferManager, is_nixl_available
+from .transfer_safety import (
+    TransferFingerprint,
+    check_transfer_allowed,
+    detect_model_features,
+)
 from .types import TensorDescriptor
 
 if TYPE_CHECKING:
@@ -124,6 +129,9 @@ class SourceTransferError(Exception):
     (OOM, process_weights_after_loading, warmup) are left as plain exceptions
     so they propagate without poisoning a healthy source.
     """
+
+
+from .types import ManifestMismatchError  # noqa: E402 (after SourceTransferError for grouping)
 
 
 # ---------------------------------------------------------------------------
@@ -369,6 +377,9 @@ def _build_source_identity(
         expert_parallel_size=ep_size,
         dtype=dtype,
         quantization=quantization,
+        extra_parameters={
+            f"feature.{k}": v for k, v in detect_model_features(model_config).items()
+        },
     )
 
 
@@ -613,15 +624,25 @@ class MxModelLoader(BaseModelLoader):
 
         logger.info(f"[Worker {global_rank}] MxModelLoader starting (model={identity.model_name})")
 
+        # Check if model features are safe for RDMA transfer
+        transfer_allowed, allow_reason = check_transfer_allowed(model_config)
+
         with set_default_torch_dtype(model_config.dtype):
             with target_device:
                 model = initialize_model(
                     vllm_config=vllm_config, model_config=model_config
                 )
 
-            loaded_as_target = self._try_load_from_candidates(
-                model, model_config, target_device, global_rank, device_id, identity
-            )
+            loaded_as_target = False
+            if transfer_allowed:
+                loaded_as_target = self._try_load_from_candidates(
+                    model, model_config, target_device, global_rank, device_id, identity
+                )
+            else:
+                logger.info(
+                    f"[Worker {global_rank}] RDMA transfer disabled: {allow_reason}"
+                )
+
             if not loaded_as_target:
                 self._load_as_source(model, model_config, target_device, global_rank, device_id, identity)
 
@@ -722,6 +743,11 @@ class MxModelLoader(BaseModelLoader):
                     f"[Worker {global_rank}] Source transfer failed for worker {worker_id}: {e}. "
                     f"Trying next candidate."
                 )
+            except ManifestMismatchError as e:
+                logger.warning(
+                    f"[Worker {global_rank}] Manifest mismatch with worker {worker_id}: {e}. "
+                    f"Trying next candidate."
+                )
         if candidates:
             tried = min(len(candidates), MAX_SOURCE_RETRIES)
             logger.warning(
@@ -798,6 +824,16 @@ class MxModelLoader(BaseModelLoader):
         # in named_buffers() and get included in the RDMA manifest.
         with _capture_tensor_attrs():
             process_weights_after_loading(model, model_config, target_device)
+
+        # Log transfer fingerprint for debugging environment mismatches.
+        target_fp = TransferFingerprint.from_environment(self._tensors)
+        logger.info(
+            f"[Worker {global_rank}] Transfer fingerprint: "
+            f"vllm={target_fp.vllm_version}, cuda={target_fp.cuda_version}, "
+            f"attn={target_fp.attention_backend}, "
+            f"deepgemm={target_fp.deep_gemm_version}, "
+            f"manifest={target_fp.manifest_hash[:12]}... ({target_fp.tensor_count} tensors)"
+        )
 
         # RDMA receive (fully-processed tensors, no post-processing needed)
         # Raises SourceTransferError on source-side failures
@@ -947,6 +983,17 @@ class MxModelLoader(BaseModelLoader):
 
         # Register tensors + publish metadata
         self._register_tensors(model, global_rank, device_id)
+
+        # Log transfer fingerprint so targets can compare
+        source_fp = TransferFingerprint.from_environment(self._tensors)
+        logger.info(
+            f"[Worker {global_rank}] Source fingerprint: "
+            f"vllm={source_fp.vllm_version}, cuda={source_fp.cuda_version}, "
+            f"attn={source_fp.attention_backend}, "
+            f"deepgemm={source_fp.deep_gemm_version}, "
+            f"manifest={source_fp.manifest_hash[:12]}... ({source_fp.tensor_count} tensors)"
+        )
+
         self._publish_metadata(global_rank, device_id, identity)
 
     def _try_gds_load(

--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -57,6 +57,10 @@ from .transfer_safety import (
     TransferFingerprint,
     check_transfer_allowed,
     detect_model_features,
+    get_cuda_version,
+    get_deep_gemm_version,
+    get_torch_version,
+    get_vllm_version,
 )
 from .types import TensorDescriptor
 
@@ -378,7 +382,11 @@ def _build_source_identity(
         dtype=dtype,
         quantization=quantization,
         extra_parameters={
-            f"feature.{k}": v for k, v in detect_model_features(model_config).items()
+            **{f"feature.{k}": v for k, v in detect_model_features(model_config).items()},
+            "runtime.vllm_version": get_vllm_version(),
+            "runtime.torch_version": get_torch_version(),
+            "runtime.cuda_version": get_cuda_version(),
+            "runtime.deep_gemm_version": get_deep_gemm_version(),
         },
     )
 
@@ -825,7 +833,12 @@ class MxModelLoader(BaseModelLoader):
         with _capture_tensor_attrs():
             process_weights_after_loading(model, model_config, target_device)
 
+        # RDMA receive (fully-processed tensors, no post-processing needed)
+        # Raises SourceTransferError on source-side failures
+        self._receive_from_peer(model, global_rank, device_id, source_worker, mx_source_id)
+
         # Log transfer fingerprint for debugging environment mismatches.
+        # Must be after _receive_from_peer which calls _register_tensors.
         target_fp = TransferFingerprint.from_environment(self._tensors)
         logger.info(
             f"[Worker {global_rank}] Transfer fingerprint: "
@@ -834,10 +847,6 @@ class MxModelLoader(BaseModelLoader):
             f"deepgemm={target_fp.deep_gemm_version}, "
             f"manifest={target_fp.manifest_hash[:12]}... ({target_fp.tensor_count} tensors)"
         )
-
-        # RDMA receive (fully-processed tensors, no post-processing needed)
-        # Raises SourceTransferError on source-side failures
-        self._receive_from_peer(model, global_rank, device_id, source_worker, mx_source_id)
 
         # Publish metadata so future nodes can discover us
         self._publish_metadata(global_rank, device_id, identity)
@@ -933,6 +942,8 @@ class MxModelLoader(BaseModelLoader):
                 coalesce_transfers=coalesce,
                 remote_agent_name=remote_agent_name_override,
             )
+        except ManifestMismatchError:
+            raise
         except Exception as e:
             raise SourceTransferError(f"RDMA receive failed: {e}") from e
         transfer_time = time.perf_counter() - transfer_start

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -11,10 +11,8 @@ import pytest
 import torch
 
 from modelexpress.transfer_safety import (
-    ALLOWED_MODEL_TYPES,
     TransferFingerprint,
     _compute_manifest_hash,
-    _parse_version,
     check_transfer_allowed,
     detect_model_features,
 )
@@ -90,11 +88,11 @@ class TestDetectModelFeatures:
 
 
 # ---------------------------------------------------------------------------
-# Allow-list
+# Feature checks
 # ---------------------------------------------------------------------------
 
 class TestCheckTransferAllowed:
-    def test_llama_bf16_allowed(self):
+    def test_llama_allowed(self):
         config = FakeConfig(
             model_type="llama",
             num_key_value_heads=8,
@@ -103,50 +101,14 @@ class TestCheckTransferAllowed:
         allowed, reason = check_transfer_allowed(config)
         assert allowed
 
-    def test_deepseek_mla_denied_old_vllm(self):
+    def test_unknown_model_type_allowed(self):
         config = FakeConfig(
-            model_type="deepseek_v2",
-            kv_lora_rank=512,
+            model_type="brand_new_architecture",
+            num_key_value_heads=8,
+            num_attention_heads=32,
         )
-        with unittest.mock.patch(
-            "modelexpress.transfer_safety.get_vllm_version", return_value="0.12.0"
-        ):
-            allowed, reason = check_transfer_allowed(config)
-        assert not allowed
-        assert "mla" in reason.lower()
-
-    def test_deepseek_mla_allowed_new_vllm(self):
-        config = FakeConfig(
-            model_type="deepseek_v2",
-            kv_lora_rank=512,
-        )
-        with unittest.mock.patch(
-            "modelexpress.transfer_safety.get_vllm_version", return_value="0.17.1"
-        ):
-            allowed, reason = check_transfer_allowed(config)
+        allowed, reason = check_transfer_allowed(config)
         assert allowed
-
-    def test_kimi_k2_mla_allowed_new_vllm(self):
-        config = FakeConfig(
-            model_type="kimi_k2",
-            kv_lora_rank=512,
-        )
-        with unittest.mock.patch(
-            "modelexpress.transfer_safety.get_vllm_version", return_value="0.16.0"
-        ):
-            allowed, reason = check_transfer_allowed(config)
-        assert allowed
-
-    def test_mla_denied_at_boundary(self):
-        config = FakeConfig(
-            model_type="deepseek_v3",
-            kv_lora_rank=512,
-        )
-        with unittest.mock.patch(
-            "modelexpress.transfer_safety.get_vllm_version", return_value="0.15.9"
-        ):
-            allowed, reason = check_transfer_allowed(config)
-        assert not allowed
 
     def test_fp8_llama_allowed(self):
         config = FakeConfig(
@@ -158,26 +120,39 @@ class TestCheckTransferAllowed:
         allowed, reason = check_transfer_allowed(config)
         assert allowed
 
-    def test_unknown_model_type_denied(self):
+    def test_deepseek_mla_denied(self):
         config = FakeConfig(
-            model_type="brand_new_architecture",
-            num_key_value_heads=8,
-            num_attention_heads=32,
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
         )
         allowed, reason = check_transfer_allowed(config)
         assert not allowed
-        assert "brand_new_architecture" in reason
+        assert "mla" in reason.lower()
 
-    def test_unknown_quantization_denied(self):
+    def test_kimi_mla_denied(self):
         config = FakeConfig(
-            model_type="llama",
-            num_key_value_heads=8,
-            num_attention_heads=32,
-            quantization="some_new_quant",
+            model_type="kimi_k25",
+            kv_lora_rank=512,
         )
         allowed, reason = check_transfer_allowed(config)
         assert not allowed
-        assert "some_new_quant" in reason
+        assert "mla" in reason.lower()
+
+    def test_mla_detected_by_kv_lora_rank(self):
+        config = FakeConfig(
+            model_type="some_future_mla_model",
+            kv_lora_rank=256,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert not allowed
+        assert "mla" in reason.lower()
+
+    def test_no_kv_lora_rank_allowed(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert allowed
 
     def test_bypass_env_var(self):
         config = FakeConfig(
@@ -191,32 +166,6 @@ class TestCheckTransferAllowed:
             assert reason == "bypassed"
         finally:
             del os.environ["MX_SKIP_FEATURE_CHECK"]
-
-
-# ---------------------------------------------------------------------------
-# Version parsing
-# ---------------------------------------------------------------------------
-
-class TestParseVersion:
-    def test_simple_version(self):
-        assert _parse_version("0.16.0") == (0, 16, 0)
-
-    def test_dev_suffix(self):
-        assert _parse_version("0.16.0.dev123") == (0, 16, 0)
-
-    def test_rc_suffix(self):
-        assert _parse_version("0.17.0rc1") == (0, 17, 0)
-
-    def test_comparison(self):
-        assert _parse_version("0.17.1") >= (0, 16, 0)
-        assert _parse_version("0.12.0") < (0, 16, 0)
-        assert _parse_version("0.16.0") >= (0, 16, 0)
-        assert _parse_version("0.15.9") < (0, 16, 0)
-
-    def test_unknown(self):
-        assert _parse_version("unknown") == (0,)
-        # "unknown" should fail safe (< any real version)
-        assert _parse_version("unknown") < (0, 16, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -189,61 +189,6 @@ class TestTransferFingerprint:
         assert fp2.tensor_count == 729
         assert fp2.manifest_hash == "abc123"
 
-    def test_validate_matching(self):
-        fp1 = TransferFingerprint(
-            vllm_version="0.12.0",
-            cuda_version="12.9",
-            attention_backend="CUTLASS_MLA",
-            deep_gemm_version="2.1.0",
-            manifest_hash="abc",
-            tensor_count=729,
-        )
-        fp2 = TransferFingerprint(
-            vllm_version="0.12.0",
-            cuda_version="12.9",
-            attention_backend="CUTLASS_MLA",
-            deep_gemm_version="2.1.0",
-            manifest_hash="abc",
-            tensor_count=729,
-        )
-        compatible, mismatches = fp2.validate_against(fp1)
-        assert compatible
-        assert len(mismatches) == 0
-
-    def test_validate_version_mismatches_ignored(self):
-        # vLLM, CUDA, torch, and deep_gemm version mismatches are caught at
-        # source-selection time via extra_parameters in SourceIdentity, not
-        # by the fingerprint.
-        source = TransferFingerprint(vllm_version="0.17.1", cuda_version="12.9",
-                                     torch_version="2.10.0",
-                                     attention_backend="X", deep_gemm_version="1.0")
-        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.8",
-                                     torch_version="2.9.0",
-                                     attention_backend="X", deep_gemm_version="2.0")
-        compatible, mismatches = target.validate_against(source)
-        assert compatible
-        assert len(mismatches) == 0
-
-    def test_validate_backend_mismatch(self):
-        source = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
-                                     attention_backend="CUTLASS_MLA", deep_gemm_version="1.0")
-        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
-                                     attention_backend="FLASHINFER_MLA", deep_gemm_version="1.0")
-        compatible, mismatches = target.validate_against(source)
-        assert not compatible
-        assert any("attention" in m for m in mismatches)
-
-    def test_validate_manifest_mismatch(self):
-        source = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
-                                     attention_backend="X", deep_gemm_version="1.0",
-                                     manifest_hash="aaa", tensor_count=729)
-        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
-                                     attention_backend="X", deep_gemm_version="1.0",
-                                     manifest_hash="bbb", tensor_count=648)
-        compatible, mismatches = target.validate_against(source)
-        assert not compatible
-        assert any("manifest" in m for m in mismatches)
-
 
 # ---------------------------------------------------------------------------
 # Manifest hash

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -198,14 +198,19 @@ class TestTransferFingerprint:
         assert compatible
         assert len(mismatches) == 0
 
-    def test_validate_vllm_mismatch(self):
+    def test_validate_version_mismatches_ignored(self):
+        # vLLM, CUDA, torch, and deep_gemm version mismatches are caught at
+        # source-selection time via extra_parameters in SourceIdentity, not
+        # by the fingerprint.
         source = TransferFingerprint(vllm_version="0.17.1", cuda_version="12.9",
+                                     torch_version="2.10.0",
                                      attention_backend="X", deep_gemm_version="1.0")
-        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
-                                     attention_backend="X", deep_gemm_version="1.0")
+        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.8",
+                                     torch_version="2.9.0",
+                                     attention_backend="X", deep_gemm_version="2.0")
         compatible, mismatches = target.validate_against(source)
-        assert not compatible
-        assert any("vLLM" in m for m in mismatches)
+        assert compatible
+        assert len(mismatches) == 0
 
     def test_validate_backend_mismatch(self):
         source = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for transfer safety checks."""
+
+import json
+import os
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from modelexpress.transfer_safety import (
+    ALLOWED_MODEL_TYPES,
+    TransferFingerprint,
+    _compute_manifest_hash,
+    check_transfer_allowed,
+    detect_model_features,
+)
+
+
+class FakeHfConfig:
+    """Minimal fake for hf_text_config that returns None for missing attributes."""
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __getattr__(self, name):
+        return None
+
+
+class FakeConfig:
+    """Minimal fake for model_config."""
+    def __init__(self, model_type="llama", dtype=torch.bfloat16, quantization=None, **kwargs):
+        self.dtype = dtype
+        self.quantization = quantization
+        self.hf_text_config = FakeHfConfig(model_type=model_type, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Feature detection
+# ---------------------------------------------------------------------------
+
+class TestDetectModelFeatures:
+    def test_llama_standard_attention(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+        )
+        features = detect_model_features(config)
+        assert features["model_type"] == "llama"
+        assert features["attention"] == "standard"
+
+    def test_deepseek_v2_mla(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
+            num_key_value_heads=1,
+            num_attention_heads=16,
+        )
+        features = detect_model_features(config)
+        assert features["attention"] == "mla"
+
+    def test_fp8_quantization(self):
+        config = FakeConfig(
+            model_type="llama",
+            quantization="fp8",
+        )
+        features = detect_model_features(config)
+        assert features["quantization"] == "fp8"
+
+    def test_moe_detection(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+            n_routed_experts=64,
+        )
+        features = detect_model_features(config)
+        assert features["moe"] == "64"
+
+    def test_unknown_model_type(self):
+        config = FakeConfig(
+            model_type="some_new_architecture",
+        )
+        features = detect_model_features(config)
+        assert features["model_type"] == "some_new_architecture"
+
+
+# ---------------------------------------------------------------------------
+# Allow-list
+# ---------------------------------------------------------------------------
+
+class TestCheckTransferAllowed:
+    def test_llama_bf16_allowed(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_deepseek_mla_denied(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert not allowed
+        assert "mla" in reason.lower()
+
+    def test_fp8_llama_allowed(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+            quantization="fp8",
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_unknown_model_type_denied(self):
+        config = FakeConfig(
+            model_type="brand_new_architecture",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert not allowed
+        assert "brand_new_architecture" in reason
+
+    def test_unknown_quantization_denied(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+            quantization="some_new_quant",
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert not allowed
+        assert "some_new_quant" in reason
+
+    def test_bypass_env_var(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
+        )
+        os.environ["MX_SKIP_FEATURE_CHECK"] = "1"
+        try:
+            allowed, reason = check_transfer_allowed(config)
+            assert allowed
+            assert reason == "bypassed"
+        finally:
+            del os.environ["MX_SKIP_FEATURE_CHECK"]
+
+
+# ---------------------------------------------------------------------------
+# Transfer fingerprint
+# ---------------------------------------------------------------------------
+
+class TestTransferFingerprint:
+    def test_round_trip_json(self):
+        fp = TransferFingerprint(
+            vllm_version="0.17.1",
+            torch_version="2.10.0",
+            cuda_version="12.9",
+            deep_gemm_version="2.3.0",
+            attention_backend="FLASHINFER_MLA",
+            manifest_hash="abc123",
+            tensor_count=729,
+        )
+        json_str = fp.to_json()
+        fp2 = TransferFingerprint.from_json(json_str)
+        assert fp2.vllm_version == "0.17.1"
+        assert fp2.tensor_count == 729
+        assert fp2.manifest_hash == "abc123"
+
+    def test_validate_matching(self):
+        fp1 = TransferFingerprint(
+            vllm_version="0.12.0",
+            cuda_version="12.9",
+            attention_backend="CUTLASS_MLA",
+            deep_gemm_version="2.1.0",
+            manifest_hash="abc",
+            tensor_count=729,
+        )
+        fp2 = TransferFingerprint(
+            vllm_version="0.12.0",
+            cuda_version="12.9",
+            attention_backend="CUTLASS_MLA",
+            deep_gemm_version="2.1.0",
+            manifest_hash="abc",
+            tensor_count=729,
+        )
+        compatible, mismatches = fp2.validate_against(fp1)
+        assert compatible
+        assert len(mismatches) == 0
+
+    def test_validate_vllm_mismatch(self):
+        source = TransferFingerprint(vllm_version="0.17.1", cuda_version="12.9",
+                                     attention_backend="X", deep_gemm_version="1.0")
+        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
+                                     attention_backend="X", deep_gemm_version="1.0")
+        compatible, mismatches = target.validate_against(source)
+        assert not compatible
+        assert any("vLLM" in m for m in mismatches)
+
+    def test_validate_backend_mismatch(self):
+        source = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
+                                     attention_backend="CUTLASS_MLA", deep_gemm_version="1.0")
+        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
+                                     attention_backend="FLASHINFER_MLA", deep_gemm_version="1.0")
+        compatible, mismatches = target.validate_against(source)
+        assert not compatible
+        assert any("attention" in m for m in mismatches)
+
+    def test_validate_manifest_mismatch(self):
+        source = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
+                                     attention_backend="X", deep_gemm_version="1.0",
+                                     manifest_hash="aaa", tensor_count=729)
+        target = TransferFingerprint(vllm_version="0.12.0", cuda_version="12.9",
+                                     attention_backend="X", deep_gemm_version="1.0",
+                                     manifest_hash="bbb", tensor_count=648)
+        compatible, mismatches = target.validate_against(source)
+        assert not compatible
+        assert any("manifest" in m for m in mismatches)
+
+
+# ---------------------------------------------------------------------------
+# Manifest hash
+# ---------------------------------------------------------------------------
+
+class TestManifestHash:
+    def test_same_tensors_same_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32), "b": torch.zeros(20, dtype=torch.bfloat16)}
+        t2 = {"a": torch.ones(10, dtype=torch.float32), "b": torch.ones(20, dtype=torch.bfloat16)}
+        # Same shapes and dtypes, different values -> same hash
+        assert _compute_manifest_hash(t1) == _compute_manifest_hash(t2)
+
+    def test_different_shapes_different_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
+        t2 = {"a": torch.zeros(20, dtype=torch.float32)}
+        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)
+
+    def test_different_names_different_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
+        t2 = {"b": torch.zeros(10, dtype=torch.float32)}
+        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)
+
+    def test_different_dtypes_different_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
+        t2 = {"a": torch.zeros(10, dtype=torch.float16)}
+        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -5,7 +5,7 @@
 
 import json
 import os
-from unittest.mock import MagicMock
+import unittest.mock
 
 import pytest
 import torch
@@ -14,6 +14,7 @@ from modelexpress.transfer_safety import (
     ALLOWED_MODEL_TYPES,
     TransferFingerprint,
     _compute_manifest_hash,
+    _parse_version,
     check_transfer_allowed,
     detect_model_features,
 )
@@ -102,14 +103,50 @@ class TestCheckTransferAllowed:
         allowed, reason = check_transfer_allowed(config)
         assert allowed
 
-    def test_deepseek_mla_denied(self):
+    def test_deepseek_mla_denied_old_vllm(self):
         config = FakeConfig(
             model_type="deepseek_v2",
             kv_lora_rank=512,
         )
-        allowed, reason = check_transfer_allowed(config)
+        with unittest.mock.patch(
+            "modelexpress.transfer_safety.get_vllm_version", return_value="0.12.0"
+        ):
+            allowed, reason = check_transfer_allowed(config)
         assert not allowed
         assert "mla" in reason.lower()
+
+    def test_deepseek_mla_allowed_new_vllm(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
+        )
+        with unittest.mock.patch(
+            "modelexpress.transfer_safety.get_vllm_version", return_value="0.17.1"
+        ):
+            allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_kimi_k2_mla_allowed_new_vllm(self):
+        config = FakeConfig(
+            model_type="kimi_k2",
+            kv_lora_rank=512,
+        )
+        with unittest.mock.patch(
+            "modelexpress.transfer_safety.get_vllm_version", return_value="0.16.0"
+        ):
+            allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_mla_denied_at_boundary(self):
+        config = FakeConfig(
+            model_type="deepseek_v3",
+            kv_lora_rank=512,
+        )
+        with unittest.mock.patch(
+            "modelexpress.transfer_safety.get_vllm_version", return_value="0.15.9"
+        ):
+            allowed, reason = check_transfer_allowed(config)
+        assert not allowed
 
     def test_fp8_llama_allowed(self):
         config = FakeConfig(
@@ -154,6 +191,32 @@ class TestCheckTransferAllowed:
             assert reason == "bypassed"
         finally:
             del os.environ["MX_SKIP_FEATURE_CHECK"]
+
+
+# ---------------------------------------------------------------------------
+# Version parsing
+# ---------------------------------------------------------------------------
+
+class TestParseVersion:
+    def test_simple_version(self):
+        assert _parse_version("0.16.0") == (0, 16, 0)
+
+    def test_dev_suffix(self):
+        assert _parse_version("0.16.0.dev123") == (0, 16, 0)
+
+    def test_rc_suffix(self):
+        assert _parse_version("0.17.0rc1") == (0, 17, 0)
+
+    def test_comparison(self):
+        assert _parse_version("0.17.1") >= (0, 16, 0)
+        assert _parse_version("0.12.0") < (0, 16, 0)
+        assert _parse_version("0.16.0") >= (0, 16, 0)
+        assert _parse_version("0.15.9") < (0, 16, 0)
+
+    def test_unknown(self):
+        assert _parse_version("unknown") == (0,)
+        # "unknown" should fail safe (< any real version)
+        assert _parse_version("unknown") < (0, 16, 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
P2P weight transfer currently has no validation that source and target
environments are compatible. Models using DeepSeek MLA attention produce
garbage inference after transfer, while standard GQA/MHA models transfer
correctly. The exact root cause in MLA post-processing is not yet
identified, but the failure is consistent and reproducible.

This PR adds three safety mechanisms:

- Strict model architecture allow-list gating P2P transfers. Only explicitly
  validated model_types, quantization methods, and dtypes are permitted.
  Unknown architectures fall back to disk loading. Bypass with
  MX_SKIP_FEATURE_CHECK=1.
- Manifest mismatch detection that raises ManifestMismatchError on tensor name
  or size mismatches between source and target. On mismatch, tries the next
  source candidate (important during rolling updates), then falls back to disk.
  Previously mismatches were silently skipped.
- TransferFingerprint logging capturing runtime environment for debugging.

Validated on nScale B200 cluster:

| Model | Architecture | Quantization | P2P Transfer |
|-------|-------------|--------------|--------------|
| Llama-3.1-8B-Instruct | llama (GQA) | none (BF16) | PASS |
| Llama-3.1-8B-Instruct-FP8 | llama (GQA) | fp8 | PASS |
| Llama-3-8B-Instruct-AWQ | llama (GQA) | awq | PASS |
| Llama-3-8B-Instruct-GPTQ | llama (GQA) | gptq | PASS |
| Mistral-7B-Instruct-v0.3 | mistral (GQA) | none (BF16) | PASS |
| Qwen2-7B-Instruct | qwen2 (GQA) | none (BF16) | PASS |
| Phi-3.5-mini-instruct | phi3 (GQA) | none (BF16) | PASS |
| Gemma-2-2b-it | gemma2 (GQA) | none (BF16) | PASS |
| DeepSeek-V2-Lite-Chat-FP8 | deepseek_v2 (MLA) | fp8 | FAIL |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced transfer safety with model feature validation and manifest compatibility checks
  * Added environment-variable controls for transfer behavior tuning
  * Improved transfer fingerprinting to detect incompatible environments

* **Bug Fixes**
  * Better error detection and handling for incompatible transfers between different environments
  * Stricter validation of tensor manifests during weight transfers

* **Documentation**
  * Updated architecture documentation with new 4-stage transfer pipeline and safety mechanisms
  * Added new environment variable reference for deployment configuration

* **Tests**
  * Added comprehensive test coverage for transfer safety validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->