### PR TITLE
refactor: make model requests provider-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/modelexpress_client/src/bin/fallback_test.rs
+++ b/modelexpress_client/src/bin/fallback_test.rs
@@ -4,39 +4,21 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig, ModelProvider};
-use tracing::{error, info};
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logging
     tracing_subscriber::fmt::init();
 
-    info!("Testing model download with server fallback...");
+    info!("Testing smart fallback with unavailable server...");
 
-    let model_name = "google-t5/t5-small";
-
-    // Test smart fallback - this should work whether server is running or not
-    info!("Attempting to download model with smart fallback...");
-
-    match Client::request_model_with_smart_fallback(
-        model_name,
+    Client::request_model_with_smart_fallback(
+        "google-t5/t5-small",
         ModelProvider::HuggingFace,
-        ClientConfig::default(),
+        ClientConfig::for_testing("http://127.0.0.1:54321"),
         false,
     )
-    .await
-    {
-        Ok(()) => {
-            info!("✅ SUCCESS: Model '{model_name}' downloaded successfully!");
-            info!(
-                "The download worked either via server (if running) or direct download (if server unavailable)"
-            );
-        }
-        Err(e) => {
-            error!("❌ FAILED: Could not download model '{model_name}': {e}");
-            return Err(e.into());
-        }
-    }
+    .await?;
 
     Ok(())
 }

--- a/modelexpress_client/src/bin/modules/handlers.rs
+++ b/modelexpress_client/src/bin/modules/handlers.rs
@@ -6,7 +6,10 @@ use super::output::{print_human_readable, print_output};
 use super::payload::read_payload;
 use colored::*;
 use modelexpress_client::{Client, ClientConfig, ModelProvider};
-use modelexpress_common::cache::{CacheConfig, CacheStats, ModelInfo, resolve_model_path};
+use modelexpress_common::{
+    cache::{CacheConfig, CacheStats, ModelInfo, resolve_model_path},
+    download,
+};
 use serde_json::Value;
 use std::io::Write;
 use std::path::PathBuf;
@@ -174,20 +177,13 @@ async fn download_model(
     let result = match strategy {
         DownloadStrategy::SmartFallback => {
             debug!("Using smart fallback strategy");
+            let mut config = config.clone();
             if let Some(cache_config) = cache_config {
-                let mut client = Client::new_with_cache(config.clone(), cache_config).await?;
-                client
-                    .preload_model_to_cache(&model_name, provider, false)
-                    .await
-            } else {
-                Client::request_model_with_smart_fallback(
-                    model_name.clone(),
-                    provider,
-                    config,
-                    false,
-                )
-                .await
+                config.cache = cache_config;
             }
+            Client::request_model_with_smart_fallback(model_name.clone(), provider, config, false)
+                .await
+                .map(|_| ())
         }
         DownloadStrategy::ServerOnly => {
             debug!("Using server-only strategy");
@@ -197,12 +193,23 @@ async fn download_model(
                 Client::new(config.clone()).await?
             };
             client
-                .request_model_with_provider(&model_name, provider, false)
+                .request_model(&model_name, provider, false)
                 .await
+                .map(|_| ())
         }
         DownloadStrategy::Direct => {
             debug!("Using direct download strategy");
-            Client::download_model_directly(model_name.clone(), provider, false).await
+            download::download_model(
+                &model_name,
+                provider,
+                cache_config.map(|config| config.local_path),
+                false,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                modelexpress_common::Error::Generic(format!("Direct download failed: {e}")).into()
+            })
         }
     };
 
@@ -246,7 +253,7 @@ async fn download_model(
                     print_output(&output, format);
                 }
             }
-            return Err(Box::new(e));
+            return Err(e);
         }
     }
 

--- a/modelexpress_client/src/bin/test_client.rs
+++ b/modelexpress_client/src/bin/test_client.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig};
+use modelexpress_common::download;
 use modelexpress_common::models::ModelProvider;
 use std::env;
 use std::time::{Duration, Instant};
@@ -100,7 +101,7 @@ async fn run_concurrent_model_test(model_name: &str) -> Result<(), Box<dyn std::
         info!("Client 1: Requesting model {model_name1}");
         let start = Instant::now();
         client1
-            .request_model(model_name1, false)
+            .request_model(model_name1, ModelProvider::default(), false)
             .await
             .expect("Client 1 failed to download model");
         info!("Client 1: Model downloaded in {:?}", start.elapsed());
@@ -116,7 +117,7 @@ async fn run_concurrent_model_test(model_name: &str) -> Result<(), Box<dyn std::
         info!("Client 2: Requesting model {model_name2}");
         let start = Instant::now();
         client2
-            .request_model(model_name2, false)
+            .request_model(model_name2, ModelProvider::default(), false)
             .await
             .expect("Client 2 failed to download model");
         info!("Client 2: Model downloaded in {:?}", start.elapsed());
@@ -140,7 +141,10 @@ async fn run_single_model_test(model_name: &str) -> Result<(), Box<dyn std::erro
     info!("Client: Requesting model {model_name}");
     let start = Instant::now();
 
-    match client.request_model(model_name.to_string(), false).await {
+    match client
+        .request_model(model_name.to_string(), ModelProvider::default(), false)
+        .await
+    {
         Ok(()) => {
             info!("Client: Model downloaded in {:?}", start.elapsed());
             info!("Client completed in {:?}", start_time.elapsed());
@@ -154,7 +158,7 @@ async fn run_single_model_test(model_name: &str) -> Result<(), Box<dyn std::erro
     }
 }
 
-/// Test fallback functionality including server fallback, direct download, and smart fallback
+/// Test download functionality including server fallback, direct download, and smart fallback
 async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::Error>> {
     info!("Testing fallback functionality (assuming server is running)...");
     let mut client = Client::new(ClientConfig::default()).await?;
@@ -163,7 +167,7 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
 
     // This should work via server since it's running
     match client
-        .request_model_with_provider_and_fallback(model_name, ModelProvider::HuggingFace, false)
+        .request_model(model_name, ModelProvider::HuggingFace, false)
         .await
     {
         Ok(()) => {
@@ -181,8 +185,15 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
     info!("Testing direct download (bypassing server)...");
     let start_direct = Instant::now();
 
-    match Client::download_model_directly(model_name, ModelProvider::HuggingFace, false).await {
-        Ok(()) => {
+    match download::download_model(
+        model_name,
+        ModelProvider::HuggingFace,
+        Some(ClientConfig::default().cache.local_path.clone()),
+        false,
+    )
+    .await
+    {
+        Ok(_) => {
             info!("Model downloaded directly in {:?}", start_direct.elapsed());
         }
         Err(e) => {
@@ -190,12 +201,11 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
         }
     }
 
-    // Test smart fallback (will use server if available, direct download if not)
     info!("Testing smart fallback...");
     let start_smart = Instant::now();
 
     match Client::request_model_with_smart_fallback(
-        model_name,
+        model_name.to_string(),
         ModelProvider::HuggingFace,
         ClientConfig::default(),
         false,
@@ -207,11 +217,12 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
                 "Model downloaded with smart fallback in {:?}",
                 start_smart.elapsed()
             );
-            info!(
-                "FALLBACK TEST PASSED: Server-with-fallback, direct download, and smart fallback all work"
-            );
-            Ok(())
         }
-        Err(e) => Err(format!("Failed to download model with smart fallback: {e}").into()),
+        Err(e) => {
+            return Err(format!("Failed to download model with smart fallback: {e}").into());
+        }
     }
+
+    info!("FALLBACK TEST PASSED: Server, direct download, and smart fallback paths all work");
+    Ok(())
 }

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -144,6 +144,23 @@ async fn create_stream_output_file(file_path: &std::path::Path) -> CommonResult<
         })
 }
 
+struct StreamedFileState {
+    path: PathBuf,
+    file: tokio::fs::File,
+    expected_size: u64,
+    bytes_written: u64,
+    saw_last_chunk: bool,
+}
+
+async fn sync_streamed_file(state: StreamedFileState) -> CommonResult<()> {
+    state.file.sync_all().await.map_err(|e| {
+        modelexpress_common::Error::Io(format!("Failed to sync file to disk {:?}: {e}", state.path))
+    })?;
+    drop(state.file);
+    debug!("Finished writing file: {:?}", state.path);
+    Ok(())
+}
+
 impl Client {
     /// Create a new client with the given configuration
     pub async fn new(config: Config) -> CommonResult<Self> {
@@ -227,32 +244,20 @@ impl Client {
         })
     }
 
-    /// Get the cache directory path for the requested provider, using the
-    /// provider's environment overrides first and then falling back to the
-    /// client's configured cache root.
-    fn get_cache_dir(&self, provider: ModelProvider) -> PathBuf {
-        use std::env;
-        if provider == ModelProvider::HuggingFace
-            && let Ok(cache_path) = env::var("HF_HUB_CACHE")
-        {
-            return PathBuf::from(cache_path);
-        }
-
-        if let Some(cache_config) = self.cache_config.as_ref() {
-            return cache_config.local_path.clone();
-        }
-
-        CacheConfig::discover()
-            .map(|config| config.local_path)
-            .unwrap_or_else(|_| CacheConfig::default().local_path)
-    }
-
     pub async fn get_model_path(
         &self,
         model_name: &str,
         provider: ModelProvider,
     ) -> anyhow::Result<PathBuf> {
-        let cache_dir = self.get_cache_dir(provider);
+        let cache_dir = self
+            .cache_config
+            .as_ref()
+            .map(|config| config.local_path.clone())
+            .unwrap_or_else(|| {
+                CacheConfig::discover()
+                    .map(|config| config.local_path)
+                    .unwrap_or_else(|_| CacheConfig::default().local_path)
+            });
         let model_path = download::get_provider(provider)
             .get_model_path(model_name, cache_dir)
             .await
@@ -260,52 +265,6 @@ impl Client {
 
         debug!("Found model path at {:?}", model_path);
         Ok(model_path)
-    }
-
-    /// Pre-download model to cache
-    /// When shared_storage is disabled, files will be streamed from server to client.
-    pub async fn preload_model_to_cache(
-        &mut self,
-        model_name: &str,
-        provider: ModelProvider,
-        ignore_weights: bool,
-    ) -> CommonResult<()> {
-        info!("Pre-loading model {} to cache", model_name);
-
-        // First try to download via server
-        match self
-            .request_model_with_provider(model_name, provider, ignore_weights)
-            .await
-        {
-            Ok(()) => {
-                info!("Model {} pre-loaded successfully via server", model_name);
-
-                // Check if we need to stream files from server (no shared storage)
-                let needs_streaming = self
-                    .cache_config
-                    .as_ref()
-                    .is_some_and(|c| !c.shared_storage);
-
-                if needs_streaming {
-                    info!(
-                        "Shared storage disabled, streaming files from server for model {}",
-                        model_name
-                    );
-                    self.stream_model_files_from_server(model_name, provider)
-                        .await?;
-                }
-
-                Ok(())
-            }
-            Err(e) => {
-                // Fallback to direct download
-                info!(
-                    "Server unavailable, pre-loading model {} directly. Error: {}",
-                    model_name, e
-                );
-                Self::download_model_directly(model_name, provider, ignore_weights).await
-            }
-        }
     }
 
     /// Get the server health status
@@ -363,76 +322,9 @@ impl Client {
         Ok(data)
     }
 
-    /// Request a model from the server with a specific provider and automatic fallback
-    /// This function will first try to use the server for streaming downloads.
-    /// If the server is unavailable, it will fallback to downloading directly.
-    /// When shared_storage is disabled, files will be streamed from server to client.
-    pub async fn request_model_with_provider_and_fallback(
-        &mut self,
-        model_name: impl Into<String>,
-        provider: ModelProvider,
-        ignore_weights: bool,
-    ) -> CommonResult<()> {
-        let model_name = model_name.into();
-
-        // First try the server-based approach
-        match self
-            .request_model_with_provider(&model_name, provider, ignore_weights)
-            .await
-        {
-            Ok(()) => {
-                info!("Model {} downloaded successfully via server", model_name);
-
-                // Check if we need to stream files from server (no shared storage)
-                let needs_streaming = self
-                    .cache_config
-                    .as_ref()
-                    .is_some_and(|c| !c.shared_storage);
-
-                if needs_streaming {
-                    info!(
-                        "Shared storage disabled, streaming files from server for model {}",
-                        model_name
-                    );
-                    self.stream_model_files_from_server(&model_name, provider)
-                        .await?;
-                }
-
-                Ok(())
-            }
-            Err(e) => {
-                // Check if it's a connection error (server not available)
-                if let modelexpress_common::Error::Transport(_) = *e {
-                    info!(
-                        "Server unavailable, falling back to direct download for model: {}",
-                        model_name
-                    );
-
-                    // Fallback to direct download
-                    let cache_dir = CacheConfig::discover().ok().map(|config| config.local_path);
-                    match download::download_model(&model_name, provider, cache_dir, ignore_weights).await {
-                        Ok(_) => {
-                            info!(
-                                "Model {} downloaded successfully via direct download",
-                                model_name
-                            );
-                            Ok(())
-                        }
-                        Err(download_err) => Err(modelexpress_common::Error::Server(format!(
-                            "Both server and direct download failed. Server error: {e}. Download error: {download_err}"
-                        )).into()),
-                    }
-                } else {
-                    // For other types of errors, don't fallback
-                    Err(e)
-                }
-            }
-        }
-    }
-
-    /// Stream model files from the server to the local cache
-    /// This is used when shared storage is disabled
-    pub async fn stream_model_files_from_server(
+    /// Stream model files from the server to the local cache.
+    /// This is an internal helper used when shared storage is disabled.
+    async fn stream_model_files_from_server(
         &mut self,
         model_name: &str,
         provider: ModelProvider,
@@ -473,12 +365,21 @@ impl Client {
         let mut model_dir: Option<PathBuf> = None;
         let mut canonical_model_dir: Option<PathBuf> = None;
 
-        let mut current_file: Option<(PathBuf, tokio::fs::File)> = None;
+        let mut current_file: Option<StreamedFileState> = None;
         let mut files_received: u64 = 0;
         let mut bytes_received: u64 = 0;
         let mut saw_chunk = false;
+        let mut saw_final_chunk = false;
 
         while let Some(chunk_result) = stream.message().await? {
+            if saw_final_chunk {
+                return Err(modelexpress_common::Error::Validation(format!(
+                    "Received extra file chunk after the final stream marker for model {}",
+                    model_name
+                ))
+                .into());
+            }
+
             saw_chunk = true;
             if model_dir.is_none() {
                 let (dir, canonical_dir) = prepare_stream_model_dir(
@@ -511,6 +412,14 @@ impl Client {
 
             let file_path = model_dir_ref.join(&relative_path);
 
+            if chunk_result.offset > chunk_result.total_size {
+                return Err(modelexpress_common::Error::Validation(format!(
+                    "Received chunk with offset {} beyond total size {} for file {:?}",
+                    chunk_result.offset, chunk_result.total_size, chunk_result.relative_path
+                ))
+                .into());
+            }
+
             // Verify that the resolved path is still within model_dir
             // Create parent directory first if it doesn't exist to enable proper validation
             if let Some(parent) = file_path.parent() {
@@ -539,22 +448,31 @@ impl Client {
             // If this is a new file (different path or first chunk)
             let need_new_file = current_file
                 .as_ref()
-                .is_none_or(|(path, _)| path != &file_path);
+                .is_none_or(|state| state.path != file_path);
 
             if need_new_file {
                 // Close previous file if any
-                if let Some((prev_path, file)) = current_file.take() {
-                    file.sync_all().await.map_err(|e| {
-                        modelexpress_common::Error::Io(format!(
-                            "Failed to sync file to disk {:?}: {e}",
-                            prev_path
+                if let Some(previous_file) = current_file.take() {
+                    if !previous_file.saw_last_chunk
+                        || previous_file.bytes_written != previous_file.expected_size
+                    {
+                        return Err(modelexpress_common::Error::Validation(format!(
+                            "Received new file {:?} before previous file {:?} completed",
+                            chunk_result.relative_path, previous_file.path
                         ))
-                    })?;
-                    drop(file);
-                    debug!("Finished writing file: {:?}", prev_path);
+                        .into());
+                    }
+                    sync_streamed_file(previous_file).await?;
                 }
 
                 // Create new file (parent directory was already created during validation)
+                if chunk_result.offset != 0 {
+                    return Err(modelexpress_common::Error::Validation(format!(
+                        "Received first chunk for file {:?} with non-zero offset {}",
+                        chunk_result.relative_path, chunk_result.offset
+                    ))
+                    .into());
+                }
                 let file = create_stream_output_file(&file_path).await?;
 
                 debug!(
@@ -562,20 +480,80 @@ impl Client {
                     relative_path, chunk_result.total_size
                 );
                 files_received = files_received.saturating_add(1);
-                current_file = Some((file_path.clone(), file));
+                current_file = Some(StreamedFileState {
+                    path: file_path.clone(),
+                    file,
+                    expected_size: chunk_result.total_size,
+                    bytes_written: 0,
+                    saw_last_chunk: false,
+                });
             }
 
             // Write chunk to file
-            if let Some((_, ref mut file)) = current_file {
-                file.write_all(&chunk_result.data).await.map_err(|e| {
-                    modelexpress_common::Error::Io(format!("Failed to write to file: {e}"))
-                })?;
-                bytes_received = bytes_received.saturating_add(chunk_result.data.len() as u64);
+            if let Some(ref mut state) = current_file {
+                if state.saw_last_chunk {
+                    return Err(modelexpress_common::Error::Validation(format!(
+                        "Received extra chunk for completed file {:?}",
+                        chunk_result.relative_path
+                    ))
+                    .into());
+                }
+                if chunk_result.total_size != state.expected_size {
+                    return Err(modelexpress_common::Error::Validation(format!(
+                        "Received inconsistent total size for file {:?}: expected {}, got {}",
+                        chunk_result.relative_path, state.expected_size, chunk_result.total_size
+                    ))
+                    .into());
+                }
+                if chunk_result.offset != state.bytes_written {
+                    return Err(modelexpress_common::Error::Validation(format!(
+                        "Received unexpected offset {} for file {:?}; expected {}",
+                        chunk_result.offset, chunk_result.relative_path, state.bytes_written
+                    ))
+                    .into());
+                }
+
+                let chunk_len = chunk_result.data.len() as u64;
+                let next_size = state.bytes_written.saturating_add(chunk_len);
+                if next_size > state.expected_size {
+                    return Err(modelexpress_common::Error::Validation(format!(
+                        "Received chunk for file {:?} that exceeds the advertised size {}",
+                        chunk_result.relative_path, state.expected_size
+                    ))
+                    .into());
+                }
+
+                state
+                    .file
+                    .write_all(&chunk_result.data)
+                    .await
+                    .map_err(|e| {
+                        modelexpress_common::Error::Io(format!("Failed to write to file: {e}"))
+                    })?;
+                state.bytes_written = next_size;
+                bytes_received = bytes_received.saturating_add(chunk_len);
+
+                if chunk_result.is_last_chunk {
+                    if state.bytes_written != state.expected_size {
+                        return Err(modelexpress_common::Error::Validation(format!(
+                            "Received final chunk for file {:?} with {} bytes written; expected {}",
+                            chunk_result.relative_path, state.bytes_written, state.expected_size
+                        ))
+                        .into());
+                    }
+                    state.saw_last_chunk = true;
+                } else if state.bytes_written == state.expected_size {
+                    return Err(modelexpress_common::Error::Validation(format!(
+                        "Received non-final chunk that completed file {:?}",
+                        chunk_result.relative_path
+                    ))
+                    .into());
+                }
             }
 
             // Check if we're done with all files
             if chunk_result.is_last_file && chunk_result.is_last_chunk {
-                break;
+                saw_final_chunk = true;
             }
         }
 
@@ -587,16 +565,24 @@ impl Client {
             .into());
         }
 
+        if !saw_final_chunk {
+            return Err(modelexpress_common::Error::Server(format!(
+                "Server stream ended before the final file marker for model {}",
+                model_name
+            ))
+            .into());
+        }
+
         // Ensure the last file is properly closed
-        if let Some((path, file)) = current_file.take() {
-            file.sync_all().await.map_err(|e| {
-                modelexpress_common::Error::Io(format!(
-                    "Failed to sync final file to disk {:?}: {e}",
-                    path
+        if let Some(final_file) = current_file.take() {
+            if !final_file.saw_last_chunk || final_file.bytes_written != final_file.expected_size {
+                return Err(modelexpress_common::Error::Validation(format!(
+                    "Final streamed file {:?} ended incomplete",
+                    final_file.path
                 ))
-            })?;
-            drop(file);
-            debug!("Finished writing final file: {:?}", path);
+                .into());
+            }
+            sync_streamed_file(final_file).await?;
         }
 
         info!(
@@ -607,9 +593,8 @@ impl Client {
         Ok(())
     }
 
-    /// Request a model from the server with a specific provider
-    /// This function will wait until the model is downloaded using streaming updates
-    pub async fn request_model_with_provider(
+    /// Request a model on the server.
+    pub async fn request_model_on_server(
         &mut self,
         model_name: impl Into<String>,
         provider: ModelProvider,
@@ -676,34 +661,43 @@ impl Client {
         .into())
     }
 
-    /// Request a model from the server using the default provider (Hugging Face) with automatic fallback
-    /// This function will first try to use the server, then fallback to direct download if needed
+    /// Request a model through the client, using the server as the source of truth.
+    /// When shared_storage is disabled, files will be streamed from server to client.
+    ///
     pub async fn request_model(
         &mut self,
         model_name: impl Into<String>,
+        provider: ModelProvider,
         ignore_weights: bool,
     ) -> CommonResult<()> {
-        self.request_model_with_provider_and_fallback(
-            model_name,
-            ModelProvider::default(),
-            ignore_weights,
-        )
-        .await
+        let model_name = model_name.into();
+
+        self.request_model_on_server(&model_name, provider, ignore_weights)
+            .await?;
+
+        info!("Model {} downloaded successfully via server", model_name);
+
+        // Check if we need to stream files from server (no shared storage)
+        let needs_streaming = self
+            .cache_config
+            .as_ref()
+            .is_some_and(|c| !c.shared_storage);
+
+        if needs_streaming {
+            info!(
+                "Shared storage disabled, streaming files from server for model {}",
+                model_name
+            );
+            self.stream_model_files_from_server(&model_name, provider)
+                .await?;
+        }
+
+        Ok(())
     }
 
-    /// Request a model from the server only (no fallback)
-    /// This function will wait until the model is downloaded using streaming updates from the server
-    pub async fn request_model_server_only(
-        &mut self,
-        model_name: impl Into<String>,
-        ignore_weights: bool,
-    ) -> CommonResult<()> {
-        self.request_model_with_provider(model_name, ModelProvider::default(), ignore_weights)
-            .await
-    }
-
-    /// Request a model with automatic server fallback, creating client connection only if needed
+    /// Request a model with automatic server fallback, creating client connection only if needed.
     /// This function will try to download via server if possible, otherwise download directly
+    /// only if the initial client connection cannot be established.
     pub async fn request_model_with_smart_fallback(
         model_name: impl Into<String>,
         provider: ModelProvider,
@@ -712,46 +706,29 @@ impl Client {
     ) -> CommonResult<()> {
         let model_name = model_name.into();
 
-        // First try to create a client and use server-based download
         match Client::new(config.clone()).await {
             Ok(mut client) => {
                 info!("Server connection established, downloading via server...");
                 client
-                    .request_model_with_provider_and_fallback(&model_name, provider, ignore_weights)
+                    .request_model(&model_name, provider, ignore_weights)
                     .await
             }
             Err(e) => {
-                // If we can't even connect to the server, go straight to direct download
                 info!("Cannot connect to server ({}), downloading directly...", e);
-                Client::download_model_directly(&model_name, provider, ignore_weights).await
+                download::download_model(
+                    &model_name,
+                    provider,
+                    Some(config.cache.local_path.clone()),
+                    ignore_weights,
+                )
+                .await
+                .map(|_| ())
+                .map_err(|e| {
+                    modelexpress_common::Error::Generic(format!("Direct download failed: {e}"))
+                        .into()
+                })
             }
         }
-    }
-
-    /// Download a model directly without using the server
-    /// This bypasses the server entirely and downloads the model using the specified provider
-    pub async fn download_model_directly(
-        model_name: impl Into<String>,
-        provider: ModelProvider,
-        ignore_weights: bool,
-    ) -> CommonResult<()> {
-        let model_name = model_name.into();
-        info!(
-            "Downloading model {} directly using provider: {:?}",
-            model_name, provider
-        );
-
-        // Try to get cache configuration, but don't fail if not available
-        let cache_dir = CacheConfig::discover().ok().map(|config| config.local_path);
-
-        download::download_model(&model_name, provider, cache_dir, ignore_weights)
-            .await
-            .map_err(|e| {
-                modelexpress_common::Error::Server(format!("Direct download failed: {e}"))
-            })?;
-
-        info!("Model {} downloaded successfully", model_name);
-        Ok(())
     }
 }
 
@@ -766,7 +743,6 @@ mod tests {
             FileChunk, ModelDownloadRequest, ModelFileList, ModelFilesRequest, ModelStatusUpdate,
             model_service_server::{ModelService, ModelServiceServer},
         },
-        test_support::{EnvVarGuard, acquire_env_mutex},
     };
     use std::collections::HashMap;
     #[cfg(unix)]
@@ -776,6 +752,11 @@ mod tests {
     use tonic::{Request, Response, Status, transport::Server};
 
     struct EmptyFileStreamModelService;
+    #[derive(Clone)]
+    struct ChunkSequenceModelService {
+        chunks: Vec<FileChunk>,
+    }
+    struct UnavailableModelService;
 
     #[tonic::async_trait]
     impl ModelService for EmptyFileStreamModelService {
@@ -797,6 +778,72 @@ mod tests {
             _request: Request<ModelFilesRequest>,
         ) -> Result<Response<Self::StreamModelFilesStream>, Status> {
             Ok(Response::new(Box::pin(futures::stream::empty())))
+        }
+
+        async fn list_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<ModelFileList>, Status> {
+            Err(Status::unimplemented(
+                "list_model_files is not used in this test",
+            ))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ModelService for UnavailableModelService {
+        type EnsureModelDownloadedStream =
+            Pin<Box<dyn Stream<Item = Result<ModelStatusUpdate, Status>> + Send>>;
+        type StreamModelFilesStream = Pin<Box<dyn Stream<Item = Result<FileChunk, Status>> + Send>>;
+
+        async fn ensure_model_downloaded(
+            &self,
+            _request: Request<ModelDownloadRequest>,
+        ) -> Result<Response<Self::EnsureModelDownloadedStream>, Status> {
+            Err(Status::unavailable("test server unavailable"))
+        }
+
+        async fn stream_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<Self::StreamModelFilesStream>, Status> {
+            Err(Status::unimplemented(
+                "stream_model_files is not used in this test",
+            ))
+        }
+
+        async fn list_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<ModelFileList>, Status> {
+            Err(Status::unimplemented(
+                "list_model_files is not used in this test",
+            ))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ModelService for ChunkSequenceModelService {
+        type EnsureModelDownloadedStream =
+            Pin<Box<dyn Stream<Item = Result<ModelStatusUpdate, Status>> + Send>>;
+        type StreamModelFilesStream = Pin<Box<dyn Stream<Item = Result<FileChunk, Status>> + Send>>;
+
+        async fn ensure_model_downloaded(
+            &self,
+            _request: Request<ModelDownloadRequest>,
+        ) -> Result<Response<Self::EnsureModelDownloadedStream>, Status> {
+            Err(Status::unimplemented(
+                "ensure_model_downloaded is not used in this test",
+            ))
+        }
+
+        async fn stream_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<Self::StreamModelFilesStream>, Status> {
+            Ok(Response::new(Box::pin(futures::stream::iter(
+                self.chunks.clone().into_iter().map(Ok),
+            ))))
         }
 
         async fn list_model_files(
@@ -840,17 +887,6 @@ mod tests {
 
     fn create_test_client_config() -> ClientConfig {
         ClientConfig::for_testing("http://test-endpoint:1234")
-    }
-
-    fn create_test_client(cache_config: Option<CacheConfig>) -> Client {
-        let channel = tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
-
-        Client {
-            health_client: HealthServiceClient::new(channel.clone()),
-            api_client: ApiServiceClient::new(channel.clone()),
-            model_client: ModelServiceClient::new(channel),
-            cache_config,
-        }
     }
 
     #[test]
@@ -904,35 +940,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_get_cache_dir_for_hf_prefers_hf_hub_cache() {
-        let env_lock = acquire_env_mutex();
-        let hf_cache_dir = TempDir::new().expect("Failed to create HF cache dir");
-        let configured_cache_dir = TempDir::new().expect("Failed to create configured cache dir");
-        let _hf_cache_guard = EnvVarGuard::set(
-            &env_lock,
-            "HF_HUB_CACHE",
-            hf_cache_dir
-                .path()
-                .to_str()
-                .expect("Expected HF cache path"),
-        );
-
-        let cache_config = CacheConfig {
-            local_path: configured_cache_dir.path().to_path_buf(),
-            server_endpoint: "http://localhost:8001".to_string(),
-            timeout_secs: None,
-            shared_storage: true,
-            transfer_chunk_size: modelexpress_common::constants::DEFAULT_TRANSFER_CHUNK_SIZE,
-        };
-        let client = create_test_client(Some(cache_config));
-
-        assert_eq!(
-            client.get_cache_dir(ModelProvider::HuggingFace),
-            hf_cache_dir.path()
-        );
-    }
-
     // Note: Most client tests require a running server, so they would be integration tests
     // These unit tests focus on the configuration and setup logic
 
@@ -945,12 +952,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_download_model_directly_invalid_model() {
+    async fn test_direct_download_invalid_model() {
         // This test may fail if network is available and HF is accessible
         // In a real test environment, you might want to mock the download function
-        let result = Client::download_model_directly(
+        let result = download::download_model(
             "definitely-not-a-real-model-name-12345",
             ModelProvider::HuggingFace,
+            Some(ClientConfig::default().cache.local_path.clone()),
             false,
         )
         .await;
@@ -1146,8 +1154,137 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_stream_model_files_from_server_requires_final_marker() {
+        let cache_dir = TempDir::new().expect("Failed to create temp dir");
+        let (addr, server_handle) = spawn_model_service(ChunkSequenceModelService {
+            chunks: vec![FileChunk {
+                relative_path: "config.json".to_string(),
+                data: br#"{}"#.to_vec(),
+                offset: 0,
+                total_size: 2,
+                is_last_chunk: true,
+                is_last_file: false,
+                commit_hash: Some("abc123".to_string()),
+            }],
+        })
+        .await;
+
+        let mut config = ClientConfig::for_testing(format!("http://{addr}"));
+        config.cache.local_path = cache_dir.path().to_path_buf();
+        let mut client = Client::new(config)
+            .await
+            .expect("Expected test client to connect");
+
+        let result = client
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace)
+            .await;
+
+        server_handle.abort();
+        let _ = server_handle.await;
+
+        let err = result.expect_err("Expected missing final marker to fail");
+        assert!(
+            err.to_string().contains("final file marker"),
+            "Unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_model_files_from_server_rejects_unexpected_offsets() {
+        let cache_dir = TempDir::new().expect("Failed to create temp dir");
+        let (addr, server_handle) = spawn_model_service(ChunkSequenceModelService {
+            chunks: vec![
+                FileChunk {
+                    relative_path: "config.json".to_string(),
+                    data: b"{".to_vec(),
+                    offset: 0,
+                    total_size: 2,
+                    is_last_chunk: false,
+                    is_last_file: true,
+                    commit_hash: Some("abc123".to_string()),
+                },
+                FileChunk {
+                    relative_path: "config.json".to_string(),
+                    data: b"}".to_vec(),
+                    offset: 0,
+                    total_size: 2,
+                    is_last_chunk: true,
+                    is_last_file: true,
+                    commit_hash: None,
+                },
+            ],
+        })
+        .await;
+
+        let mut config = ClientConfig::for_testing(format!("http://{addr}"));
+        config.cache.local_path = cache_dir.path().to_path_buf();
+        let mut client = Client::new(config)
+            .await
+            .expect("Expected test client to connect");
+
+        let result = client
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace)
+            .await;
+
+        server_handle.abort();
+        let _ = server_handle.await;
+
+        let err = result.expect_err("Expected invalid offsets to fail");
+        assert!(
+            err.to_string().contains("unexpected offset"),
+            "Unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_model_files_from_server_rejects_incomplete_previous_file() {
+        let cache_dir = TempDir::new().expect("Failed to create temp dir");
+        let (addr, server_handle) = spawn_model_service(ChunkSequenceModelService {
+            chunks: vec![
+                FileChunk {
+                    relative_path: "config.json".to_string(),
+                    data: b"{".to_vec(),
+                    offset: 0,
+                    total_size: 2,
+                    is_last_chunk: false,
+                    is_last_file: false,
+                    commit_hash: Some("abc123".to_string()),
+                },
+                FileChunk {
+                    relative_path: "tokenizer.json".to_string(),
+                    data: b"a".to_vec(),
+                    offset: 0,
+                    total_size: 1,
+                    is_last_chunk: true,
+                    is_last_file: true,
+                    commit_hash: None,
+                },
+            ],
+        })
+        .await;
+
+        let mut config = ClientConfig::for_testing(format!("http://{addr}"));
+        config.cache.local_path = cache_dir.path().to_path_buf();
+        let mut client = Client::new(config)
+            .await
+            .expect("Expected test client to connect");
+
+        let result = client
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace)
+            .await;
+
+        server_handle.abort();
+        let _ = server_handle.await;
+
+        let err = result.expect_err("Expected incomplete previous file to fail");
+        assert!(
+            err.to_string().contains("before previous file"),
+            "Unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_request_model_with_smart_fallback_no_server() {
-        // Test the smart fallback when server is not available
         let config = Config::for_testing("http://127.0.0.1:99999"); // Invalid port
 
         let result = Client::request_model_with_smart_fallback(
@@ -1158,9 +1295,7 @@ mod tests {
         )
         .await;
 
-        // Should fail because the model doesn't exist, but we should get past the connection attempt
         assert!(result.is_err());
-        // The error should indicate it tried to connect to the server but failed
         let error_msg = result.expect_err("Result should be an error").to_string();
         assert!(
             error_msg.contains("Direct download failed")
@@ -1168,6 +1303,37 @@ mod tests {
                 || error_msg.contains("gRPC error")
                 || error_msg.contains("h2 protocol error")
                 || error_msg.contains("connection")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_model_with_smart_fallback_does_not_direct_download_midflight() {
+        let cache_dir = TempDir::new().expect("Failed to create temp dir");
+        let (addr, server_handle) = spawn_model_service(UnavailableModelService).await;
+
+        let mut config = ClientConfig::for_testing(format!("http://{addr}"));
+        config.cache.local_path = cache_dir.path().to_path_buf();
+
+        let result = Client::request_model_with_smart_fallback(
+            "definitely-not-a-real-model-name-12345",
+            ModelProvider::HuggingFace,
+            config,
+            false,
+        )
+        .await;
+
+        server_handle.abort();
+        let _ = server_handle.await;
+
+        let err = result.expect_err("Expected server request failure");
+        let error_msg = err.to_string();
+        assert!(
+            !error_msg.contains("Direct download failed"),
+            "Smart fallback should not switch to direct download after the server path starts: {error_msg}"
+        );
+        assert!(
+            error_msg.contains("gRPC error") || error_msg.contains("unavailable"),
+            "Expected a server-side availability error, got: {error_msg}"
         );
     }
 }
@@ -1242,7 +1408,11 @@ mod integration_tests {
             // Use a very small model for testing to avoid long download times
             // Note: This test might still take time and requires network access
             let result = client
-                .request_model_server_only("sentence-transformers/all-MiniLM-L6-v2", false)
+                .request_model_on_server(
+                    "sentence-transformers/all-MiniLM-L6-v2",
+                    ModelProvider::default(),
+                    false,
+                )
                 .await;
 
             // We don't assert success here because it depends on network availability

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -16,6 +16,11 @@ pub fn get_provider(provider: ModelProvider) -> Box<dyn ModelProviderTrait> {
     }
 }
 
+/// Canonicalize a model name using the provider-specific rules.
+pub fn canonical_model_name(model_name: &str, provider: ModelProvider) -> Result<String> {
+    get_provider(provider).canonical_model_name(model_name)
+}
+
 /// Download a model using the specified provider
 pub async fn download_model(
     model_name: &str,
@@ -102,6 +107,15 @@ mod tests {
         assert_eq!(provider.provider_name(), "Hugging Face");
     }
 
+    #[test]
+    fn test_canonical_model_name_routing() {
+        assert_eq!(
+            canonical_model_name("test/model", ModelProvider::HuggingFace)
+                .expect("Expected canonical model name"),
+            "test/model"
+        );
+    }
+
     #[tokio::test]
     async fn test_mock_provider_success() {
         let temp_dir = TempDir::new().expect("Failed to create temporary directory");
@@ -137,16 +151,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_download_model_routing() {
-        // Test that download_model function properly routes to the provider
-        // Note: This test doesn't actually download from HF to avoid network dependency
-        // In a real scenario, you might want to mock the hf-hub dependency
-
-        let provider = ModelProvider::HuggingFace;
-        let provider_impl = get_provider(provider);
-        assert_eq!(provider_impl.provider_name(), "Hugging Face");
-    }
     #[test]
     fn test_default_trait_implementations() {
         // Create a minimal provider that uses default implementations

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::error::Error as StdError;
 
 pub mod cache;
 pub mod client_config;
@@ -64,10 +65,33 @@ pub enum Error {
     Grpc(#[from] tonic::Status),
 
     #[error("Transport error: {0}")]
-    Transport(#[from] tonic::transport::Error),
+    Transport(String),
 
     #[error("Generic error: {0}")]
     Generic(String),
+}
+
+fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
+    let mut parts = Vec::new();
+    let mut current = Some(err);
+
+    while let Some(error) = current {
+        let part = error.to_string();
+        if !part.is_empty() && parts.last() != Some(&part) {
+            parts.push(part);
+        }
+        current = error.source();
+    }
+
+    if parts.len() > 1 && parts.first().is_some_and(|part| part == "transport error") {
+        parts.remove(0);
+    }
+
+    if parts.is_empty() {
+        "transport error".to_string()
+    } else {
+        parts.join(": ")
+    }
 }
 
 // Implement From traits for Box<Error> to work with the Result<T> type
@@ -77,9 +101,15 @@ impl From<tonic::Status> for Box<Error> {
     }
 }
 
+impl From<tonic::transport::Error> for Error {
+    fn from(err: tonic::transport::Error) -> Self {
+        Error::Transport(format_error_chain(&err))
+    }
+}
+
 impl From<tonic::transport::Error> for Box<Error> {
     fn from(err: tonic::transport::Error) -> Self {
-        Box::new(Error::Transport(err))
+        Box::new(Error::from(err))
     }
 }
 
@@ -204,6 +234,7 @@ impl From<grpc::model::ModelStatusUpdate> for models::ModelStatusResponse {
 mod tests {
     use super::*;
     use std::env;
+    use std::io;
 
     #[test]
     fn test_status_conversion_from_models_to_grpc() {
@@ -218,6 +249,29 @@ mod tests {
         assert_eq!(grpc_response.version, status.version);
         assert_eq!(grpc_response.status, status.status);
         assert_eq!(grpc_response.uptime, status.uptime);
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("outer error")]
+    struct OuterError(#[source] io::Error);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("transport error")]
+    struct TransportWrapper(#[source] io::Error);
+
+    #[test]
+    fn test_format_error_chain_includes_nested_causes() {
+        let err = OuterError(io::Error::other("connection reset by peer"));
+        assert_eq!(
+            format_error_chain(&err),
+            "outer error: connection reset by peer"
+        );
+    }
+
+    #[test]
+    fn test_format_error_chain_skips_repeated_transport_prefix() {
+        let err = TransportWrapper(io::Error::other("underlying cause"));
+        assert_eq!(format_error_chain(&err), "underlying cause");
     }
 
     #[test]
@@ -240,7 +294,6 @@ mod tests {
         let model_provider = models::ModelProvider::HuggingFace;
         let grpc_provider: grpc::model::ModelProvider = model_provider.into();
         let back_to_model: models::ModelProvider = grpc_provider.into();
-
         assert_eq!(model_provider, back_to_model);
     }
 

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -24,6 +24,11 @@ pub trait ModelProviderTrait: Send + Sync {
     /// Returns the path if found, or an error if not found
     async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
 
+    /// Return the canonical model name for this provider.
+    fn canonical_model_name(&self, model_name: &str) -> Result<String> {
+        Ok(model_name.to_string())
+    }
+
     /// Get the provider name for logging
     fn provider_name(&self) -> &'static str;
 
@@ -73,6 +78,8 @@ pub trait ModelProviderTrait: Send + Sync {
             || filename.ends_with(".h5")
             || filename.ends_with(".msgpack")
             || filename.ends_with(".ckpt.index")
+            || filename.ends_with(".iop")
+            || filename.ends_with(".gas")
     }
 }
 
@@ -131,9 +138,23 @@ mod tests {
         assert!(HuggingFaceProvider::is_weight_file("model.h5"));
         assert!(HuggingFaceProvider::is_weight_file("model.msgpack"));
         assert!(HuggingFaceProvider::is_weight_file("model.ckpt.index"));
+        assert!(HuggingFaceProvider::is_weight_file("model.iop"));
+        assert!(HuggingFaceProvider::is_weight_file("model.gas"));
 
         assert!(!HuggingFaceProvider::is_weight_file("tokenizer.json"));
         assert!(!HuggingFaceProvider::is_weight_file("config.json"));
         assert!(!HuggingFaceProvider::is_weight_file("README.md"));
+    }
+
+    #[test]
+    fn test_canonical_model_name_default_preserves_input() {
+        let provider = HuggingFaceProvider;
+        let canonical = provider.canonical_model_name("test/model");
+        assert!(
+            canonical
+                .as_ref()
+                .is_ok_and(|model_name| model_name == "test/model"),
+            "Expected canonical model name, got {canonical:?}"
+        );
     }
 }

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -3,14 +3,15 @@
 
 use crate::database::ModelDatabase;
 use modelexpress_common::{
-    cache::CacheConfig,
+    cache::{CacheConfig, resolve_model_path},
     constants, download,
     grpc::{
         api::{ApiRequest, ApiResponse, api_service_server::ApiService},
         health::{HealthRequest, HealthResponse, health_service_server::HealthService},
         model::{
             FileChunk, ModelDownloadRequest, ModelFileInfo, ModelFileList, ModelFilesRequest,
-            ModelStatusUpdate, model_service_server::ModelService,
+            ModelProvider as GrpcModelProvider, ModelStatusUpdate,
+            model_service_server::ModelService,
         },
     },
     models::{ModelProvider, ModelStatus},
@@ -38,23 +39,6 @@ fn get_server_cache_dir() -> Option<std::path::PathBuf> {
         std::env::var("HF_HUB_CACHE")
             .ok()
             .map(std::path::PathBuf::from)
-    }
-}
-
-/// Convert gRPC provider to internal ModelProvider enum
-///
-/// Falls back to HuggingFace provider if the conversion fails or an invalid
-/// provider value is provided. A warning is logged when fallback occurs.
-fn convert_provider(grpc_provider: i32) -> ModelProvider {
-    match modelexpress_common::grpc::model::ModelProvider::try_from(grpc_provider) {
-        Ok(provider) => provider.into(),
-        Err(_) => {
-            tracing::warn!(
-                "Invalid provider value {}, falling back to HuggingFace",
-                grpc_provider
-            );
-            ModelProvider::HuggingFace
-        }
     }
 }
 
@@ -181,13 +165,17 @@ impl ModelService for ModelServiceImpl {
         info!("Starting model download stream");
         let model_request = request.into_inner();
         let (tx, rx) = tokio::sync::mpsc::channel(4);
-        let model_name = model_request.model_name.clone();
 
         // Convert gRPC provider to our enum
-        let provider: ModelProvider =
-            modelexpress_common::grpc::model::ModelProvider::try_from(model_request.provider)
-                .unwrap_or(modelexpress_common::grpc::model::ModelProvider::HuggingFace)
-                .into();
+        let grpc_provider = GrpcModelProvider::try_from(model_request.provider).map_err(|_| {
+            Status::invalid_argument(format!(
+                "Invalid provider value: {}",
+                model_request.provider
+            ))
+        })?;
+        let provider = ModelProvider::from(grpc_provider);
+        let model_name = download::canonical_model_name(&model_request.model_name, provider)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
         let ignore_weights = model_request.ignore_weights;
 
         // Spawn a task to handle the streaming download updates
@@ -204,8 +192,7 @@ impl ModelService for ModelServiceImpl {
                             Some("Previous download failed - retrying".to_string())
                         }
                     },
-                    provider: modelexpress_common::grpc::model::ModelProvider::from(provider)
-                        as i32,
+                    provider: grpc_provider as i32,
                 };
 
                 if tx.send(Ok(update)).await.is_err() {
@@ -234,7 +221,7 @@ impl ModelService for ModelServiceImpl {
                     ModelStatus::ERROR => Some("Model download failed".to_string()),
                     ModelStatus::DOWNLOADING => Some("Download still in progress".to_string()),
                 },
-                provider: modelexpress_common::grpc::model::ModelProvider::from(provider) as i32,
+                provider: grpc_provider as i32,
             };
 
             let _ = tx.send(Ok(final_update)).await;
@@ -248,7 +235,6 @@ impl ModelService for ModelServiceImpl {
         request: Request<ModelFilesRequest>,
     ) -> Result<Response<Self::StreamModelFilesStream>, Status> {
         let files_request = request.into_inner();
-        let model_name = files_request.model_name.clone();
         let chunk_size = if files_request.chunk_size == 0 {
             constants::DEFAULT_TRANSFER_CHUNK_SIZE
         } else {
@@ -256,7 +242,16 @@ impl ModelService for ModelServiceImpl {
         };
 
         // Convert gRPC provider to our enum
-        let provider = convert_provider(files_request.provider);
+        let grpc_provider = GrpcModelProvider::try_from(files_request.provider).map_err(|_| {
+            Status::invalid_argument(format!(
+                "Invalid provider value: {}",
+                files_request.provider
+            ))
+        })?;
+        let provider = ModelProvider::from(grpc_provider);
+        let model_name = download::canonical_model_name(&files_request.model_name, provider)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        let provider_impl = download::get_provider(provider);
 
         info!(
             "Starting file stream for model: {} with chunk size: {} bytes",
@@ -268,7 +263,6 @@ impl ModelService for ModelServiceImpl {
             .ok_or_else(|| Status::internal("Server cache directory not configured"))?;
 
         // Get the model path using the provider from the request
-        let provider_impl = download::get_provider(provider);
         let model_path = provider_impl
             .get_model_path(&model_name, cache_dir.clone())
             .await
@@ -288,6 +282,23 @@ impl ModelService for ModelServiceImpl {
         if provider == ModelProvider::HuggingFace && commit_hash.is_none() {
             return Err(Status::internal(
                 "Resolved Hugging Face model path did not contain a revision",
+            ));
+        }
+
+        let expected_model_path =
+            resolve_model_path(&cache_dir, provider, &model_name, commit_hash.as_deref()).map_err(
+                |e| Status::internal(format!("Failed to resolve expected cache layout: {e}")),
+            )?;
+
+        if model_path != expected_model_path {
+            error!(
+                "Resolved model path '{}' does not match expected cache layout '{}' for model '{}'",
+                model_path.display(),
+                expected_model_path.display(),
+                model_name
+            );
+            return Err(Status::internal(
+                "Resolved model path does not match expected cache layout",
             ));
         }
 
@@ -332,6 +343,30 @@ impl ModelService for ModelServiceImpl {
 
                 let mut reader = tokio::io::BufReader::new(file);
                 let mut offset: u64 = 0;
+
+                if *total_size == 0 {
+                    let first_chunk = std::mem::replace(&mut is_first_chunk, false);
+                    let chunk = FileChunk {
+                        relative_path: relative_path.to_string_lossy().to_string(),
+                        data: Vec::new(),
+                        offset: 0,
+                        total_size: 0,
+                        is_last_chunk: true,
+                        is_last_file,
+                        commit_hash: if first_chunk {
+                            commit_hash.clone()
+                        } else {
+                            None
+                        },
+                    };
+
+                    if tx.send(Ok(chunk)).await.is_err() {
+                        debug!("Client disconnected during file stream");
+                        return;
+                    }
+
+                    continue;
+                }
 
                 loop {
                     let bytes_read = match reader.read(&mut buffer).await {
@@ -384,10 +419,18 @@ impl ModelService for ModelServiceImpl {
         request: Request<ModelFilesRequest>,
     ) -> Result<Response<ModelFileList>, Status> {
         let files_request = request.into_inner();
-        let model_name = files_request.model_name.clone();
 
         // Convert gRPC provider to our enum
-        let provider = convert_provider(files_request.provider);
+        let grpc_provider = GrpcModelProvider::try_from(files_request.provider).map_err(|_| {
+            Status::invalid_argument(format!(
+                "Invalid provider value: {}",
+                files_request.provider
+            ))
+        })?;
+        let provider = ModelProvider::from(grpc_provider);
+        let model_name = download::canonical_model_name(&files_request.model_name, provider)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        let provider_impl = download::get_provider(provider);
 
         info!("Listing files for model: {}", model_name);
 
@@ -396,7 +439,6 @@ impl ModelService for ModelServiceImpl {
             .ok_or_else(|| Status::internal("Server cache directory not configured"))?;
 
         // Get the model path using the provider from the request
-        let provider_impl = download::get_provider(provider);
         let model_path = provider_impl
             .get_model_path(&model_name, cache_dir)
             .await
@@ -508,7 +550,7 @@ impl ModelDownloadTracker {
                 model_name: model_name.clone(),
                 status: modelexpress_common::grpc::model::ModelStatus::from(status) as i32,
                 message,
-                provider: modelexpress_common::grpc::model::ModelProvider::from(provider) as i32,
+                provider: GrpcModelProvider::from(provider) as i32,
             };
 
             for channel in channels {
@@ -578,8 +620,7 @@ impl ModelDownloadTracker {
                     status: modelexpress_common::grpc::model::ModelStatus::from(ModelStatus::ERROR)
                         as i32,
                     message: Some("Database error occurred".to_string()),
-                    provider: modelexpress_common::grpc::model::ModelProvider::from(provider)
-                        as i32,
+                    provider: GrpcModelProvider::from(provider) as i32,
                 };
                 let _ = tx.send(Ok(error_update)).await;
                 return ModelStatus::ERROR;
@@ -595,7 +636,7 @@ impl ModelDownloadTracker {
                 ModelStatus::DOWNLOADING => Some("Model download in progress".to_string()),
                 ModelStatus::ERROR => Some("Previous download failed - retrying".to_string()),
             },
-            provider: modelexpress_common::grpc::model::ModelProvider::from(provider) as i32,
+            provider: GrpcModelProvider::from(provider) as i32,
         };
 
         let _ = tx.send(Ok(update)).await;
@@ -1143,6 +1184,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_ensure_model_downloaded_rejects_invalid_provider() {
+        let service = ModelServiceImpl;
+
+        let request = Request::new(ModelDownloadRequest {
+            model_name: "test/model".to_string(),
+            provider: 99,
+            ignore_weights: false,
+        });
+
+        let result = service.ensure_model_downloaded(request).await;
+        assert!(result.is_err());
+        let status = result.expect_err("Should return error");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("Invalid provider value"));
+    }
+
+    #[tokio::test]
+    async fn test_list_model_files_rejects_invalid_provider() {
+        let service = ModelServiceImpl;
+
+        let request = Request::new(ModelFilesRequest {
+            model_name: "test/model".to_string(),
+            provider: 99,
+            chunk_size: 0,
+        });
+
+        let result = service.list_model_files(request).await;
+        assert!(result.is_err());
+        let status = result.expect_err("Should return error");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("Invalid provider value"));
+    }
+
+    #[tokio::test]
+    async fn test_stream_model_files_rejects_invalid_provider() {
+        let service = ModelServiceImpl;
+
+        let request = Request::new(ModelFilesRequest {
+            model_name: "test/model".to_string(),
+            provider: 99,
+            chunk_size: 1024,
+        });
+
+        let result = service.stream_model_files(request).await;
+        assert!(result.is_err());
+        let status = result.expect_err("Should return error");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("Invalid provider value"));
+    }
+
+    #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn test_stream_model_files_hf_first_chunk_includes_commit_hash() {
         let env_lock = acquire_env_mutex();
@@ -1178,6 +1270,49 @@ mod tests {
             .expect("Expected first chunk");
 
         assert_eq!(first_chunk.relative_path, "config.json");
+        assert_eq!(first_chunk.commit_hash.as_deref(), Some("abc123"));
+        assert!(first_chunk.is_last_chunk);
+        assert!(first_chunk.is_last_file);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_stream_model_files_hf_emits_chunk_for_zero_byte_file() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let _cache_dir_guard = EnvVarGuard::set(
+            &env_lock,
+            "MODEL_EXPRESS_CACHE_DIRECTORY",
+            temp_dir.path().to_str().expect("Expected temp dir path"),
+        );
+        let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
+
+        let model_dir = temp_dir.path().join("models--test--model/snapshots/abc123");
+        std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+        std::fs::write(model_dir.join("empty.bin"), []).expect("Failed to write empty file");
+
+        let service = ModelServiceImpl;
+        let request = Request::new(ModelFilesRequest {
+            model_name: "test/model".to_string(),
+            provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
+            chunk_size: 1024,
+        });
+
+        let response = service
+            .stream_model_files(request)
+            .await
+            .expect("Expected stream response");
+        let mut stream = response.into_inner();
+        let first_chunk = stream
+            .next()
+            .await
+            .expect("Expected stream item")
+            .expect("Expected first chunk");
+
+        assert_eq!(first_chunk.relative_path, "empty.bin");
+        assert_eq!(first_chunk.total_size, 0);
+        assert_eq!(first_chunk.data.len(), 0);
+        assert_eq!(first_chunk.offset, 0);
         assert_eq!(first_chunk.commit_hash.as_deref(), Some("abc123"));
         assert!(first_chunk.is_last_chunk);
         assert!(first_chunk.is_last_file);

--- a/workspace-tests/tests/integration_tests.rs
+++ b/workspace-tests/tests/integration_tests.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig};
-use modelexpress_common::{constants, models::ModelProvider};
+use modelexpress_common::{constants, download, models::ModelProvider};
 use std::sync::Mutex;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -13,6 +13,24 @@ use tracing::{info, warn};
 /// Mutex to serialize access to HF_HUB_OFFLINE environment variable across tests.
 /// This prevents race conditions when tests run in parallel.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+async fn download_model_directly(
+    model_name: &str,
+    provider: ModelProvider,
+    ignore_weights: bool,
+) -> Result<(), modelexpress_common::Error> {
+    let cache_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+
+    download::download_model(
+        model_name,
+        provider,
+        Some(cache_dir.path().to_path_buf()),
+        ignore_weights,
+    )
+    .await
+    .map(|_| ())
+    .map_err(|e| modelexpress_common::Error::Server(format!("Direct download failed: {e}")))
+}
 
 #[tokio::test]
 #[ignore = "Ignore by default since it requires a running server"]
@@ -79,7 +97,7 @@ async fn test_integration_model_download_fallback() {
 #[tokio::test]
 async fn test_integration_direct_download_invalid_model() {
     // Test direct download with an invalid model name
-    let result = Client::download_model_directly(
+    let result = download_model_directly(
         "definitely-not-a-real-model-name-12345",
         ModelProvider::HuggingFace,
         false,
@@ -98,12 +116,8 @@ async fn test_integration_small_model_download() {
     // Test with a very small, real model (only run this in CI or when explicitly requested)
     // Note: This test requires internet access and may take some time
 
-    let result = Client::download_model_directly(
-        "prajjwal1/bert-tiny", // A very small BERT model for testing
-        ModelProvider::HuggingFace,
-        false,
-    )
-    .await;
+    let result =
+        download_model_directly("prajjwal1/bert-tiny", ModelProvider::HuggingFace, false).await;
 
     match result {
         Ok(()) => info!("Small model download successful"),
@@ -149,7 +163,7 @@ async fn test_integration_offline_mode_without_cache() {
         std::env::set_var("HF_HUB_OFFLINE", "1");
     }
 
-    let result = Client::download_model_directly(
+    let result = download_model_directly(
         "nonexistent-model-for-offline-test",
         ModelProvider::HuggingFace,
         false,


### PR DESCRIPTION
- Require explicit providers for model request flows and unify server-first behavior.
- Consolidate direct-download and smart-fallback paths onto shared common helpers.
- Reject invalid gRPC provider values instead of silently defaulting to Hugging Face.
- Breaking change: `Client::request_model` now requires `provider`; remove `preload_model_to_cache`, `request_model_with_provider_and_fallback`, `request_model_server_only`, and `download_model_directly`; rename `request_model_with_provider` to `request_model_on_server`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model name canonicalization functionality.

* **Bug Fixes**
  * Improved transport error messaging with detailed error chain formatting.
  * Enhanced provider validation to reject invalid values explicitly.
  * Fixed zero-byte file handling in model streaming.

* **Refactor**
  * Simplified public API by removing redundant download methods and consolidating model request workflows. Cache configuration now passed directly for more explicit control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->