### PR TITLE
feat: expose GCS end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"
@@ -331,13 +334,19 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -352,10 +361,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -568,6 +588,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "criterion"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,8 +685,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -666,12 +714,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -701,6 +773,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +790,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -882,10 +965,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.1"
+name = "fd-lock"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1041,9 +1135,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.5+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1051,6 +1159,226 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "google-cloud-auth"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f83bc5c208df4a6b38ad2a8d2b01c0d377811f9efe9b0733171f28dd74db9c3"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "google-cloud-gax",
+ "hex",
+ "hmac",
+ "http",
+ "reqwest 0.13.2",
+ "rustc_version",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188909653b7c484e43695325c0324804b5645d568f8d2e4c8a6f520231d50956"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http",
+ "pin-project",
+ "rand 0.10.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7395094c1dc7284155a48530aa1a49d52c876ce1b392dfcdf7e6b32540d042a2"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "lazy_static",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "reqwest 0.13.2",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-iam-v1"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f436945fb3c581a3ef32f37e47756690006de7177934c6405cc0d4db799c8975"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-longrunning"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767db5d07fff5361d01058764e724c4335b9899aa6c973c3bb2ae8d3bd4eacd8"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-lro"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef3969c85cf6b163c655f7ddcdee5bb5c3241f680ab648951239ef9cd4ffb0f"
+dependencies = [
+ "google-cloud-gax",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd10e97751ca894f9dad6be69fcef1cb72f5bc187329e0254817778fc8235030"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be397108904bd24fb7b1518b68fc26a70589f3718fa8c47e9af5f09c4fc6e88"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-rpc",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "hex",
+ "http",
+ "http-body",
+ "hyper",
+ "lazy_static",
+ "md5",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "google-cloud-type"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9390ac2f3f9882ff42956b25ea65b9f546c8dd44c131726d75a96bf744ec75f6"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ade65b0e4fa9cb4b6f147c8e726803bff453e3190910a53cbd3b0c019f5c2a"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.16",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "h2"
@@ -1064,7 +1392,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1080,6 +1408,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1144,6 +1478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,12 +1496,21 @@ dependencies = [
  "log",
  "num_cpus",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
  "tokio",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1442,6 +1791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,12 +1825,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
+ "serde",
 ]
 
 [[package]]
@@ -1608,10 +1975,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.78"
+name = "jni"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1740,7 +2151,7 @@ dependencies = [
  "http",
  "json-patch",
  "k8s-openapi",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-value",
  "serde_json",
@@ -1753,7 +2164,7 @@ version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37745d8a4076b77e0b1952e94e358726866c8e14ec94baaca677d47dcdb98658"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1794,6 +2205,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1872,6 +2289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +2305,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1983,14 +2416,14 @@ dependencies = [
  "colored",
  "futures",
  "modelexpress-common",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.16",
  "tokio",
  "tokio-test",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
  "tracing",
  "tracing-subscriber",
@@ -2006,12 +2439,17 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "crc32c",
+ "fd-lock",
  "futures",
+ "google-cloud-gax",
+ "google-cloud-storage",
  "hf-hub",
  "jiff",
  "mockall 0.13.1",
- "prost",
- "reqwest",
+ "prost 0.13.5",
+ "reqwest 0.12.23",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2019,7 +2457,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-test",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
  "tracing",
  "wiremock",
@@ -2043,10 +2481,10 @@ dependencies = [
  "mockall 0.14.0",
  "modelexpress-common",
  "once_cell",
- "prost",
+ "prost 0.13.5",
  "redis",
  "rusqlite",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2056,7 +2494,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "toml",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
  "tonic-health",
  "tracing",
@@ -2088,6 +2526,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -2161,6 +2605,22 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "js-sys",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "option-ext"
@@ -2289,23 +2749,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.11.1",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2383,6 +2843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,7 +2909,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -2459,8 +2935,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "regex",
  "syn",
  "tempfile",
@@ -2480,12 +2956,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -2559,6 +3057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +3081,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2616,6 +3131,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -2681,6 +3202,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.16",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2751,9 +3292,50 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -2820,6 +3402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -2883,13 +3474,40 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2940,6 +3558,30 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
  "serde",
  "serde_json",
 ]
@@ -3008,6 +3650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,14 +3719,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3103,12 +3752,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.11.1",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.1",
  "itoa",
  "ryu",
  "serde",
@@ -3122,7 +3802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3139,7 +3819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3338,6 +4018,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,7 +4190,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3531,9 +4242,36 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs 0.8.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -3550,7 +4288,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types",
+ "prost-types 0.13.5",
  "quote",
  "syn",
 ]
@@ -3561,10 +4299,21 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost 0.14.3",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -3575,7 +4324,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.11.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3588,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -3621,9 +4370,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3633,9 +4382,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3644,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3723,6 +4472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3739,6 +4494,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3784,13 +4545,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3852,14 +4613,23 @@ version = "1.0.0+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.45.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3869,26 +4639,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.51"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -3897,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3907,24 +4664,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.1",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3941,10 +4720,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.78"
+name = "wasm-streams"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.1",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3958,6 +4762,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4056,6 +4869,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4088,6 +4910,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4125,6 +4962,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4137,6 +4980,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4146,6 +4995,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4173,6 +5028,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4182,6 +5043,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4197,6 +5064,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4206,6 +5079,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4256,6 +5135,94 @@ name = "wit-bindgen"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.11.1",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.11.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.11.1",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -4377,3 +5344,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,6 +2442,7 @@ dependencies = [
  "crc32c",
  "fd-lock",
  "futures",
+ "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-storage",
  "hf-hub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,11 @@ axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 config = { version = "0.15", features = ["yaml", "toml", "json"] }
+crc32c = "0.6.8"
 colored = "3.0.0"
+fd-lock = "4.0.4"
+google-cloud-gax = "1.8.0"
+google-cloud-storage = { version = "1.9.0", default-features = false }
 hf-hub = { version = "0.4.3", default-features = false, features = [
     "tokio",
     "rustls-tls",
@@ -39,6 +43,7 @@ modelexpress-client = { path = "modelexpress_client", version = "0.3.0" }
 modelexpress-server = { path = "modelexpress_server", version = "0.3.0" }
 once_cell = "1.21.3"
 prost = "0.13"
+rustls = { version = "0.23.37", default-features = false, features = ["ring", "std"] }
 rusqlite = { version = "0.37", features = ["bundled", "chrono"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,13 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 
 # ModelExpress Architecture
 
-Detailed reference document for the ModelExpress codebase. For deployment and configuration, see [`DEPLOYMENT.md`](DEPLOYMENT.md). For contribution guidelines and dev setup, see [`CONTRIBUTING.md`](../CONTRIBUTING.md). For coding standards and AI assistant instructions, see `CLAUDE.md`. For CLI usage, see [`CLI.md`](CLI.md).
+Detailed reference document for the ModelExpress codebase. For deployment and configuration, see [`DEPLOYMENT.md`](DEPLOYMENT.md). For contribution guidelines and dev setup, see [`CONTRIBUTING.md`](../CONTRIBUTING.md). For coding standards and AI assistant instructions, see `CLAUDE.md`. For CLI usage, see [`CLI.md`](CLI.md). For GCS provider internals, see [`GCS_PROVIDER.md`](GCS_PROVIDER.md).
 
 ## Project Overview
 
 ModelExpress is a Rust-based model cache management service and GPU-to-GPU model weight transfer system. It serves two roles:
 
-- **Model Cache Service** - A sidecar alongside inference solutions (vLLM, SGLang, NVIDIA Dynamo) that accelerates model downloads from HuggingFace and NGC with SQLite-backed tracking and LRU cache eviction.
+- **Model Cache Service** - A sidecar alongside inference solutions (vLLM, SGLang, NVIDIA Dynamo) that accelerates model downloads from HuggingFace, NGC, and GCS with SQLite-backed tracking and LRU cache eviction.
 - **P2P Weight Transfer** - GPU-to-GPU model weight transfers between vLLM instances using NVIDIA NIXL over RDMA/InfiniBand, enabling ~15-second transfers for 681GB models.
 
 ### Current Status
@@ -30,6 +30,7 @@ graph TD
         S1 --> DB[(SQLite)]
         S1 --> HF[HuggingFace Hub]
         S1 --> NGC[NVIDIA NGC]
+        S1 --> GCS[Google Cloud Storage]
         S1 --> Cache[Model Cache Dir]
     end
 
@@ -151,8 +152,10 @@ ModelExpress/
 │       ├── config.rs                   # Config trait utilities
 │       ├── download.rs                 # Download orchestration (smart-fallback, direct, server-only)
 │       ├── models.rs                   # Status, ModelProvider, ModelStatus, ModelStatusResponse
-│       ├── providers.rs               # ModelProviderTrait definition, re-exports
+│       ├── providers.rs                # ModelProviderTrait definition, re-exports
 │       └── providers/
+│           ├── gcs.rs                  # GcsProvider implementation
+│           ├── gcs/                    # GCS manifest, cache layout, locking, download helpers
 │           ├── huggingface.rs          # HuggingFaceProvider implementation
 │           └── ngc.rs                  # NgcProvider implementation
 │
@@ -260,7 +263,7 @@ Four proto files define four services, all compiled via `tonic-build` in `modele
 | `StreamModelFiles` | `ModelFilesRequest` | stream `FileChunk` | Stream model file contents (1MB chunks) |
 | `ListModelFiles` | `ModelFilesRequest` | `ModelFileList` | List files with sizes |
 
-Key message types: `ModelProvider` (HuggingFace, NGC), `ModelStatus` (Downloading, Downloaded, Error), `ModelStatusUpdate`, `FileChunk`.
+Key message types: `ModelProvider` (HuggingFace, NGC, GCS), `ModelStatus` (Downloading, Downloaded, Error), `ModelStatusUpdate`, `FileChunk`.
 
 ### p2p.proto - P2pService
 
@@ -418,7 +421,7 @@ Output formats: `--format human` (default), `--format json`, `--format json-pret
 | `config` | Config trait utilities |
 | `download` | Download orchestration with strategy pattern |
 | `models` | `Status`, `ModelProvider`, `ModelStatus`, `ModelStatusResponse` |
-| `providers` | `ModelProviderTrait` + `HuggingFaceProvider` + `NgcProvider` |
+| `providers` | `ModelProviderTrait` + `HuggingFaceProvider` + `NgcProvider` + `GcsProvider` |
 | `grpc` | Generated tonic stubs for all 4 services |
 | `constants` | `DEFAULT_GRPC_PORT` (8001), `DEFAULT_TIMEOUT_SECS` (30), `DEFAULT_TRANSFER_CHUNK_SIZE` (32KB) |
 
@@ -428,7 +431,7 @@ Output formats: `--format human` (default), `--format json`, `--format json-pret
 #[async_trait]
 pub trait ModelProviderTrait: Send + Sync {
     async fn download_model(&self, name: &str, cache_path: Option<PathBuf>, ignore_weights: bool) -> Result<PathBuf>;
-    async fn delete_model(&self, name: &str) -> Result<()>;
+    async fn delete_model(&self, name: &str, cache_dir: PathBuf) -> Result<()>;
     async fn get_model_path(&self, name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
     fn provider_name(&self) -> &'static str;
     fn is_ignored(filename: &str) -> bool;
@@ -437,9 +440,10 @@ pub trait ModelProviderTrait: Send + Sync {
 }
 ```
 
-Two implementations:
-- `HuggingFaceProvider` — uses the `hf-hub` crate with high-CPU download mode.
-- `NgcProvider` — downloads from NVIDIA NGC via the V2 artifact API (Bearer-authenticated `/files/{path}` for team artifacts; presigned S3 URLs for org-level artifacts). Falls back to `checksums.blake3` manifest enumeration when bulk file listing returns 400. Resolves the NGC API key from `NGC_API_KEY`, `NGC_CLI_API_KEY`, or `~/.ngc/config`.
+Three implementations:
+- `HuggingFaceProvider` - uses the `hf-hub` crate with high-CPU download mode.
+- `NgcProvider` - downloads from NVIDIA NGC via the V2 artifact API (Bearer-authenticated `/files/{path}` for team artifacts; presigned S3 URLs for org-level artifacts). Falls back to `checksums.blake3` manifest enumeration when bulk file listing returns 400. Resolves the NGC API key from `NGC_API_KEY`, `NGC_CLI_API_KEY`, or `~/.ngc/config`.
+- `GcsProvider` - downloads objects under a full `gs://<bucket>/<object-prefix>` URL using Google Application Default Credentials. It writes a `.mx/manifest.json` cache manifest, verifies downloaded files with GCS CRC32C checksums, skips dotfiles, README, and images, and stores models under `<cache>/gcs/<bucket>/<object-prefix>`. See [`GCS_PROVIDER.md`](GCS_PROVIDER.md) for the detailed design.
 
 ### ClientConfig / ClientArgs
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -89,6 +89,10 @@ modelexpress-cli model download google-t5/t5-small \
   --provider hugging-face \
   --strategy server-only
 
+# Download from Google Cloud Storage
+modelexpress-cli model download gs://my-bucket/models/qwen/rev-1 \
+  --provider gcs
+
 # Direct download (bypass server)
 modelexpress-cli model download microsoft/DialoGPT-medium \
   --strategy direct
@@ -118,6 +122,9 @@ modelexpress-cli model status
 # Clear specific model from storage
 modelexpress-cli model clear google-t5/t5-small
 
+# Clear a Google Cloud Storage model from storage
+modelexpress-cli model clear --provider gcs gs://my-bucket/models/qwen/rev-1
+
 # Clear all models from storage (with confirmation)
 modelexpress-cli model clear-all
 
@@ -144,6 +151,10 @@ modelexpress-cli model stats --detailed
 
 **Providers:**
 - `hugging-face`: Hugging Face model hub (default)
+- `ngc`: NVIDIA NGC catalog
+- `gcs`: Google Cloud Storage object prefix. The model name must be a full `gs://<bucket>/<path>` URL. See [`GCS_PROVIDER.md`](GCS_PROVIDER.md) for cache layout and provider behavior.
+
+For GCS downloads, configure Google Application Default Credentials on the process that performs the download: the server for `server-only`, the client for `direct`, and either process for `smart-fallback`. Common options are `GOOGLE_APPLICATION_CREDENTIALS`, `gcloud auth application-default login`, or Workload Identity on GKE.
 
 **Model Commands:**
 - `download`: Download model with automatic storage (use `--strategy` and `--provider` for options)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -135,6 +135,8 @@ Cache directory resolution for HuggingFace: `MODEL_EXPRESS_CACHE_DIRECTORY` -> `
 
 Cache directory resolution for NGC: `MODEL_EXPRESS_CACHE_DIRECTORY` -> `~/.cache/ngc`.
 
+GCS uses the configured/default ModelExpress cache root; `MODEL_EXPRESS_CACHE_DIRECTORY` overrides it. Cached GCS models are stored under `<cache>/gcs/<bucket>/<object-prefix>`. See [`GCS_PROVIDER.md`](GCS_PROVIDER.md) for provider internals.
+
 See [`CLI.md`](CLI.md) for full CLI usage documentation.
 
 ## Docker
@@ -203,6 +205,25 @@ kubectl create secret generic ngc-api-key-secret \
 ```
 
 Pass it to the server pod via `envFrom` or individual `env` entries in your deployment manifest.
+
+### Google Cloud Storage Credentials
+
+To download models from Google Cloud Storage with the direct `gcs` provider, use a full `gs://<bucket>/<object-prefix>` model name and configure Google Application Default Credentials for the process doing the download. The identity needs permission to list and read objects under the model prefix, for example `storage.objects.list` and `storage.objects.get`.
+
+Common credential options:
+
+1. Set `GOOGLE_APPLICATION_CREDENTIALS` to a mounted service account JSON key.
+2. Use `gcloud auth application-default login` for local development.
+3. Use GKE Workload Identity or another platform-provided ADC source in Kubernetes.
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/var/secrets/google/service-account.json
+kubectl create secret generic gcs-service-account-key \
+  --from-file=service-account.json=/path/to/service-account.json \
+  -n ${NAMESPACE}
+```
+
+Mount the secret into the server or client pod and set `GOOGLE_APPLICATION_CREDENTIALS` to the mounted file path. When using Workload Identity, no key secret is needed. For cache layout, manifest behavior, and failure modes, see [`GCS_PROVIDER.md`](GCS_PROVIDER.md).
 
 ### Helm Chart
 

--- a/docs/GCS_PROVIDER.md
+++ b/docs/GCS_PROVIDER.md
@@ -1,0 +1,162 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# GCS Provider
+
+This document describes the Rust `GcsProvider`, which lets ModelExpress download and cache model files from Google Cloud Storage with the same provider abstraction used by Hugging Face and NGC.
+
+This is separate from the Python ModelStreamer path. ModelStreamer can stream `gs://` URIs directly into a vLLM load path when `MX_MODEL_URI` is set; `GcsProvider` is the ModelExpress model provider used by the CLI, server, cache listing, cache clearing, and gRPC file streaming paths.
+
+## Entry Points
+
+The provider is selected with `ModelProvider::Gcs`, exposed in the CLI as `--provider gcs`.
+
+```bash
+modelexpress-cli model download gs://my-bucket/models/qwen/rev-1 --provider gcs
+modelexpress-cli model clear --provider gcs gs://my-bucket/models/qwen/rev-1
+```
+
+In `server-only` mode, the ModelExpress server performs the GCS download and therefore needs GCS credentials. In `direct` mode, the client performs the download and needs credentials. In `smart-fallback` mode, the client tries the server path first and then falls back to direct download.
+
+## Model Names
+
+GCS model names must be full URLs:
+
+```text
+gs://<bucket>/<object-prefix>
+```
+
+The provider canonicalizes names by removing a trailing slash from the object prefix. It rejects empty names, missing buckets, missing object prefixes, empty path segments, and `.` or `..` path segments. The bucket component must be a single path segment.
+
+Examples:
+
+```text
+gs://model-bucket/deepseek-ai/DeepSeek-V3/rev-1
+gs://model-bucket/org/model/snapshots/2026-04-29
+```
+
+## Authentication
+
+The provider uses Google Application Default Credentials through the Google Cloud Storage Rust client. Common options are:
+
+- `GOOGLE_APPLICATION_CREDENTIALS` pointing to a service account JSON key file
+- local ADC from `gcloud auth application-default login`
+- GKE Workload Identity or another platform-provided ADC source
+
+The identity needs permission to list and read objects under the model prefix, for example `storage.objects.list` and `storage.objects.get`.
+
+Credentials are local to the process doing the download. They are not sent through ModelExpress gRPC.
+
+## Cache Layout
+
+GCS models are stored under the configured ModelExpress cache root:
+
+```text
+<cache-root>/gcs/<bucket>/<object-prefix>/
+```
+
+For `gs://model-bucket/deepseek-ai/DeepSeek-V3/rev-1`, the cache path is:
+
+```text
+<cache-root>/gcs/model-bucket/deepseek-ai/DeepSeek-V3/rev-1/
+```
+
+Provider-private metadata lives under `.mx/` inside the model directory:
+
+```text
+<model-dir>/
+  config.json
+  tokenizer.json
+  weights/model.safetensors
+  .mx/
+    manifest.json
+    manifest.lock
+    locks/<relative-file>.lock
+    parts/<relative-file>.part
+```
+
+The `.mx/locks` and `.mx/parts` paths mirror the remote relative object paths so nested model files can be locked and resumed independently.
+
+## Manifest
+
+Before downloading files, the provider lists objects under the requested prefix and writes a cache manifest:
+
+```json
+{
+  "version": 1,
+  "model": "gs://model-bucket/deepseek-ai/DeepSeek-V3/rev-1",
+  "files": [
+    {
+      "path": "config.json",
+      "size": 128,
+      "crc32c": "00000000",
+      "generation": 123456789
+    }
+  ]
+}
+```
+
+The manifest is written to `.mx/manifest.json` under an exclusive `.mx/manifest.lock`. It records each downloadable file's relative path, expected size, CRC32C checksum, and GCS generation when available.
+
+An existing manifest is reused if it is parseable, has the expected version/model, has at least one file, has safe relative paths, and has valid CRC32C fields. The provider does not re-list GCS while a valid manifest exists. To force a fresh listing after changing remote objects, clear the cached model or remove its manifest.
+
+## Download Flow
+
+The high-level download flow is:
+
+1. Parse and canonicalize the `gs://` model name.
+2. Resolve the cache path under `<cache-root>/gcs/<bucket>/<object-prefix>`.
+3. If the manifest is valid and all requested files already exist, return the cached path.
+4. Check that this model prefix does not overlap an existing cached ancestor or descendant model.
+5. Build or load `.mx/manifest.json` by listing GCS objects under the prefix.
+6. Convert manifest entries into download tasks, applying `ignore_weights` when requested.
+7. Download files in parallel, with one lock and temp file per destination file.
+8. Verify each completed temp file and atomically promote it into the model directory.
+9. Recheck cache completeness before reporting success.
+
+Object listing uses pages of up to 1000 objects. Downloads run with up to 8 concurrent workers.
+
+## File Filtering
+
+The manifest includes downloadable objects below the requested prefix, excluding:
+
+- directory marker objects
+- dotfiles
+- `README.md`
+- common image files such as `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, `ico`, `bmp`, `tiff`, and `tif`
+
+Unsafe relative paths and paths under the reserved `.mx` metadata directory are rejected instead of cached.
+
+When `ignore_weights` is true, weight files are skipped for that request. Weight detection matches extensions such as `.bin`, `.safetensors`, `.h5`, `.msgpack`, `.ckpt.index`, `.iop`, and `.gas`.
+
+## Concurrency and Resume
+
+The provider uses file locks from the `fd-lock` crate:
+
+- `.mx/manifest.lock` serializes manifest creation.
+- `.mx/locks/<relative-file>.lock` serializes each file download.
+
+If another process is already downloading the same file, later processes wait and then reuse the completed file if it exists.
+
+Partial downloads are written to `.mx/parts/<relative-file>.part`. If a partial file is smaller than the expected size and the GCS generation is known, the provider resumes with a range read from the existing byte offset and pins the read to that generation. If the generation is not known, partial files are discarded instead of resumed. Oversized partial files are also discarded.
+
+## Integrity Checks
+
+The provider records remote size and CRC32C in the manifest. Newly downloaded temp files are checked before promotion:
+
+- final byte length must match the manifest size
+- local CRC32C must match the manifest CRC32C
+
+Only verified temp files are moved into the model directory. If verification fails, the temp file is removed and the download fails.
+
+Cache hits are cheaper: a valid manifest plus the presence of requested files is enough to satisfy the request. Existing cached files are not re-hashed on every access.
+
+## Cache Listing and Clearing
+
+The shared cache layer delegates GCS operations to `GcsProviderCache`.
+
+Listing walks `<cache-root>/gcs/` by bucket and reports directories that contain a valid manifest and all files required by that manifest. Clearing requires the same full `gs://` model name and removes the corresponding cache directory when it is safe to do so.
+
+The provider refuses to create or delete ambiguous overlapping cache entries. For example, a cached `gs://bucket/a/b` model blocks treating `gs://bucket/a` or `gs://bucket/a/b/c` as a separate cached model until the overlap is removed.

--- a/modelexpress_client/src/bin/cli.rs
+++ b/modelexpress_client/src/bin/cli.rs
@@ -115,7 +115,7 @@ async fn main() {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::modules::args::{Cli, Commands};
-    use clap::Parser;
+    use clap::{Parser, ValueEnum};
     use modelexpress_client::ModelProvider;
 
     #[test]
@@ -137,6 +137,16 @@ mod tests {
             panic!("Expected download subcommand");
         };
         assert_eq!(provider, ModelProvider::HuggingFace);
+    }
+
+    #[test]
+    fn test_cli_model_provider_value_enum() {
+        let parsed = ModelProvider::from_str("hugging-face", false)
+            .expect("Failed to parse hugging-face provider");
+        assert_eq!(parsed, ModelProvider::HuggingFace);
+
+        let parsed = ModelProvider::from_str("gcs", false).expect("Failed to parse gcs provider");
+        assert_eq!(parsed, ModelProvider::Gcs);
     }
 
     #[test]
@@ -200,20 +210,40 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_model_clear_defaults_to_hugging_face_provider() {
+    fn test_cli_model_clear_parses_explicit_provider() {
         let parsed = Cli::try_parse_from([
             "modelexpress-cli",
             "model",
             "clear",
             "--provider",
-            "hugging-face",
-            "dev/bake/qwen/rev123",
-        ]);
-        assert!(parsed.is_ok());
+            "gcs",
+            "gs://bucket/dev/bake/qwen/rev123",
+        ])
+        .expect("Expected clear command to parse with explicit provider");
 
-        let missing_provider =
-            Cli::try_parse_from(["modelexpress-cli", "model", "clear", "dev/bake/qwen/rev123"])
-                .expect("Expected clear command to parse without provider");
+        let Commands::Model { command } = parsed.command else {
+            panic!("Expected model command");
+        };
+        let super::modules::args::ModelCommands::Clear {
+            provider,
+            model_name,
+        } = command
+        else {
+            panic!("Expected clear subcommand");
+        };
+        assert_eq!(provider, ModelProvider::Gcs);
+        assert_eq!(model_name, "gs://bucket/dev/bake/qwen/rev123");
+    }
+
+    #[test]
+    fn test_cli_model_clear_defaults_to_hugging_face_provider() {
+        let missing_provider = Cli::try_parse_from([
+            "modelexpress-cli",
+            "model",
+            "clear",
+            "gs://bucket/dev/bake/qwen/rev123",
+        ])
+        .expect("Expected clear command to parse without provider");
 
         let Commands::Model { command } = missing_provider.command else {
             panic!("Expected model command");
@@ -226,6 +256,6 @@ mod tests {
             panic!("Expected clear subcommand");
         };
         assert_eq!(provider, ModelProvider::HuggingFace);
-        assert_eq!(model_name, "dev/bake/qwen/rev123");
+        assert_eq!(model_name, "gs://bucket/dev/bake/qwen/rev123");
     }
 }

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -748,6 +748,7 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
     use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
     use tonic::{Request, Response, Status, transport::Server};
 
@@ -757,6 +758,10 @@ mod tests {
         chunks: Vec<FileChunk>,
     }
     struct UnavailableModelService;
+    struct RecordingModelService {
+        seen_model_name: Arc<Mutex<Option<String>>>,
+    }
+    struct ZeroByteGcsMarkerStreamModelService;
 
     #[tonic::async_trait]
     impl ModelService for EmptyFileStreamModelService {
@@ -844,6 +849,102 @@ mod tests {
             Ok(Response::new(Box::pin(futures::stream::iter(
                 self.chunks.clone().into_iter().map(Ok),
             ))))
+        }
+
+        async fn list_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<ModelFileList>, Status> {
+            Err(Status::unimplemented(
+                "list_model_files is not used in this test",
+            ))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ModelService for RecordingModelService {
+        type EnsureModelDownloadedStream =
+            Pin<Box<dyn Stream<Item = Result<ModelStatusUpdate, Status>> + Send>>;
+        type StreamModelFilesStream = Pin<Box<dyn Stream<Item = Result<FileChunk, Status>> + Send>>;
+
+        async fn ensure_model_downloaded(
+            &self,
+            request: Request<ModelDownloadRequest>,
+        ) -> Result<Response<Self::EnsureModelDownloadedStream>, Status> {
+            let request = request.into_inner();
+            *self
+                .seen_model_name
+                .lock()
+                .expect("Failed to lock seen_model_name") = Some(request.model_name);
+            let update = ModelStatusUpdate {
+                model_name: "gs://envbucket/dev/bake/qwen/rev123".to_string(),
+                status: modelexpress_common::grpc::model::ModelStatus::Downloaded as i32,
+                message: None,
+                provider: modelexpress_common::grpc::model::ModelProvider::Gcs as i32,
+            };
+            Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
+                update,
+            )]))))
+        }
+
+        async fn stream_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<Self::StreamModelFilesStream>, Status> {
+            Err(Status::unimplemented(
+                "stream_model_files is not used in this test",
+            ))
+        }
+
+        async fn list_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<ModelFileList>, Status> {
+            Err(Status::unimplemented(
+                "list_model_files is not used in this test",
+            ))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ModelService for ZeroByteGcsMarkerStreamModelService {
+        type EnsureModelDownloadedStream =
+            Pin<Box<dyn Stream<Item = Result<ModelStatusUpdate, Status>> + Send>>;
+        type StreamModelFilesStream = Pin<Box<dyn Stream<Item = Result<FileChunk, Status>> + Send>>;
+
+        async fn ensure_model_downloaded(
+            &self,
+            request: Request<ModelDownloadRequest>,
+        ) -> Result<Response<Self::EnsureModelDownloadedStream>, Status> {
+            let request = request.into_inner();
+            let update = ModelStatusUpdate {
+                model_name: request.model_name,
+                status: modelexpress_common::grpc::model::ModelStatus::Downloaded as i32,
+                message: None,
+                provider: request.provider,
+            };
+            Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
+                update,
+            )]))))
+        }
+
+        async fn stream_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<Self::StreamModelFilesStream>, Status> {
+            let chunk = FileChunk {
+                relative_path: ".mx-model".to_string(),
+                data: vec![],
+                offset: 0,
+                total_size: 0,
+                is_last_chunk: true,
+                is_last_file: true,
+                commit_hash: None,
+            };
+
+            Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
+                chunk,
+            )]))))
         }
 
         async fn list_model_files(
@@ -972,6 +1073,9 @@ mod tests {
         let provider = ModelProvider::HuggingFace;
         assert_eq!(provider, ModelProvider::HuggingFace);
 
+        let provider = ModelProvider::Gcs;
+        assert_eq!(provider, ModelProvider::Gcs);
+
         let default_provider = ModelProvider::default();
         assert_eq!(default_provider, ModelProvider::HuggingFace);
     }
@@ -1084,6 +1188,22 @@ mod tests {
             matches!(err.as_ref(), modelexpress_common::Error::Validation(message) if message.contains("outside cache root")),
             "Unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_prepare_stream_model_dir_uses_gcs_layout_without_commit_hash() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let cache_root = temp_dir.path();
+
+        let (dir, _) = prepare_stream_model_dir(
+            cache_root,
+            ModelProvider::Gcs,
+            "gs://envbucket/dev/bake/qwen/rev123",
+            None,
+        )
+        .expect("Expected GCS cache layout");
+
+        assert_eq!(dir, cache_root.join("gcs/envbucket/dev/bake/qwen/rev123"));
     }
 
     #[cfg(unix)]
@@ -1284,6 +1404,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_request_model_streaming_creates_zero_byte_gcs_marker() {
+        let cache_dir = TempDir::new().expect("Failed to create temp dir");
+        let (addr, server_handle) = spawn_model_service(ZeroByteGcsMarkerStreamModelService).await;
+
+        let mut config = ClientConfig::for_testing(format!("http://{addr}"));
+        config.cache.local_path = cache_dir.path().to_path_buf();
+        config.cache.shared_storage = false;
+
+        let model_name = "gs://test-bucket/org/model/rev-1";
+        let mut client = Client::new(config)
+            .await
+            .expect("Expected test client to connect");
+
+        client
+            .request_model(model_name, ModelProvider::Gcs, false)
+            .await
+            .expect("Expected streamed model request to succeed");
+
+        server_handle.abort();
+        let _ = server_handle.await;
+
+        let model_dir = resolve_model_path(cache_dir.path(), ModelProvider::Gcs, model_name, None)
+            .expect("Expected resolved GCS model dir");
+        let marker_path = model_dir.join(".mx-model");
+        assert!(
+            marker_path.is_file(),
+            "Expected marker file at {:?}",
+            marker_path
+        );
+        assert_eq!(
+            std::fs::metadata(&marker_path)
+                .expect("Expected marker metadata")
+                .len(),
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn test_request_model_with_smart_fallback_no_server() {
         let config = Config::for_testing("http://127.0.0.1:99999"); // Invalid port
 
@@ -1334,6 +1492,39 @@ mod tests {
         assert!(
             error_msg.contains("gRPC error") || error_msg.contains("unavailable"),
             "Expected a server-side availability error, got: {error_msg}"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_request_model_with_smart_fallback_accepts_full_gcs_url() {
+        let seen_model_name = Arc::new(Mutex::new(None));
+        let (addr, server_handle) = spawn_model_service(RecordingModelService {
+            seen_model_name: Arc::clone(&seen_model_name),
+        })
+        .await;
+
+        let mut config = ClientConfig::for_testing(format!("http://{addr}"));
+        config.cache.shared_storage = true;
+
+        Client::request_model_with_smart_fallback(
+            "gs://envbucket/dev/bake/qwen/rev123",
+            ModelProvider::Gcs,
+            config,
+            false,
+        )
+        .await
+        .expect("Expected smart fallback request to succeed");
+
+        server_handle.abort();
+        let _ = server_handle.await;
+
+        assert_eq!(
+            seen_model_name
+                .lock()
+                .expect("Failed to lock seen_model_name")
+                .clone(),
+            "gs://envbucket/dev/bake/qwen/rev123".to_string().into()
         );
     }
 }

--- a/modelexpress_common/Cargo.toml
+++ b/modelexpress_common/Cargo.toml
@@ -33,10 +33,15 @@ config = { workspace = true }
 futures = { workspace = true }
 jiff = { workspace = true }
 reqwest = { workspace = true }
+google-cloud-storage = { workspace = true }
+rustls = { workspace = true }
+crc32c = { workspace = true }
+fd-lock = { workspace = true }
 
 [dev-dependencies]
+google-cloud-gax = { workspace = true }
 mockall = "0.13"
-tempfile = "3.20"
+tempfile = { workspace = true }
 tokio-test = "0.4"
 wiremock = "0.6.5"
 

--- a/modelexpress_common/Cargo.toml
+++ b/modelexpress_common/Cargo.toml
@@ -39,6 +39,7 @@ crc32c = { workspace = true }
 fd-lock = { workspace = true }
 
 [dev-dependencies]
+google-cloud-auth = { version = "1.7.0", default-features = false }
 google-cloud-gax = { workspace = true }
 mockall = "0.13"
 tempfile = { workspace = true }

--- a/modelexpress_common/proto/model.proto
+++ b/modelexpress_common/proto/model.proto
@@ -44,6 +44,7 @@ enum ModelStatus {
 enum ModelProvider {
   HUGGING_FACE = 0;
   NGC = 1;
+  GCS = 2;
 }
 
 // Request for streaming model files

--- a/modelexpress_common/src/cache.rs
+++ b/modelexpress_common/src/cache.rs
@@ -4,7 +4,9 @@
 use crate::{
     Utils, constants,
     models::ModelProvider,
-    providers::{huggingface::HuggingFaceProviderCache, ngc::NgcProviderCache},
+    providers::{
+        gcs::GcsProviderCache, huggingface::HuggingFaceProviderCache, ngc::NgcProviderCache,
+    },
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -230,7 +232,11 @@ impl CacheConfig {
             });
         }
 
-        for provider in [ModelProvider::HuggingFace, ModelProvider::Ngc] {
+        for provider in [
+            ModelProvider::HuggingFace,
+            ModelProvider::Ngc,
+            ModelProvider::Gcs,
+        ] {
             models.extend(cache_for_provider(provider).list_models(&self.local_path)?);
         }
 
@@ -338,6 +344,7 @@ pub(crate) fn cache_for_provider(provider: ModelProvider) -> &'static dyn Provid
     match provider {
         ModelProvider::HuggingFace => &HuggingFaceProviderCache,
         ModelProvider::Ngc => &NgcProviderCache,
+        ModelProvider::Gcs => &GcsProviderCache,
     }
 }
 
@@ -371,6 +378,7 @@ fn provider_sort_key(provider: ModelProvider) -> u8 {
     match provider {
         ModelProvider::HuggingFace => 0,
         ModelProvider::Ngc => 1,
+        ModelProvider::Gcs => 2,
     }
 }
 
@@ -437,8 +445,8 @@ mod tests {
                     path: PathBuf::from("/test/model1"),
                 },
                 ModelInfo {
-                    provider: ModelProvider::HuggingFace,
-                    name: "model2".to_string(),
+                    provider: ModelProvider::Gcs,
+                    name: "gs://bucket/model2".to_string(),
                     size: 1024 * 1024 * 3, // 3 MB
                     path: PathBuf::from("/test/model2"),
                 },
@@ -499,6 +507,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_resolve_model_path_gcs_uses_full_url_layout() {
+        let cache_root = Path::new("/tmp/cache");
+
+        assert_eq!(
+            resolve_model_path(
+                cache_root,
+                ModelProvider::Gcs,
+                "gs://envbucket/dev/bake/qwen/rev123",
+                None,
+            )
+            .expect("Expected GCS model path"),
+            PathBuf::from("/tmp/cache/gcs/envbucket/dev/bake/qwen/rev123")
+        );
+    }
+
+    #[test]
+    fn test_resolve_model_path_gcs_full_url_trailing_slash_normalizes() {
+        let cache_root = Path::new("/tmp/cache");
+
+        assert_eq!(
+            resolve_model_path(
+                cache_root,
+                ModelProvider::Gcs,
+                "gs://sourcebucket/dev/bake/qwen/rev123/",
+                None,
+            )
+            .expect("Expected GCS model path"),
+            PathBuf::from("/tmp/cache/gcs/sourcebucket/dev/bake/qwen/rev123")
+        );
+    }
+
     fn create_test_cache_config(local_path: PathBuf) -> CacheConfig {
         CacheConfig {
             local_path,
@@ -510,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_cache_stats_supports_hf_layout() {
+    fn test_get_cache_stats_supports_hf_and_gcs_layouts() {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let cache_path = temp_dir.path().join("cache");
         fs::create_dir_all(&cache_path).expect("Failed to create cache directory");
@@ -518,6 +558,28 @@ mod tests {
         let hf_model_dir = cache_path.join("models--google--t5-small");
         fs::create_dir_all(&hf_model_dir).expect("Failed to create HF model directory");
         fs::write(hf_model_dir.join("config.json"), b"{}").expect("Failed to write HF file");
+
+        let gcs_model_dir = resolve_model_path(
+            &cache_path,
+            ModelProvider::Gcs,
+            "gs://envbucket/dev/bake/qwen/rev123",
+            None,
+        )
+        .expect("Failed to resolve GCS path");
+        fs::create_dir_all(gcs_model_dir.join("weights"))
+            .expect("Failed to create GCS model directory");
+        fs::write(gcs_model_dir.join("tokenizer.json"), b"{}")
+            .expect("Failed to write GCS tokenizer");
+        fs::write(gcs_model_dir.join("weights/model.bin"), b"abcd")
+            .expect("Failed to write GCS weights");
+        let gcs_metadata_dir = gcs_model_dir.join(".mx");
+        fs::create_dir_all(&gcs_metadata_dir).expect("Failed to create GCS metadata directory");
+        fs::write(
+            gcs_metadata_dir.join("manifest.json"),
+            r#"{"version":1,"model":"gs://envbucket/dev/bake/qwen/rev123","files":[{"path":"tokenizer.json","size":2,"crc32c":"00000000","generation":null},{"path":"weights/model.bin","size":4,"crc32c":"00000000","generation":null}]}
+"#,
+        )
+        .expect("Failed to write GCS manifest");
 
         let ignored_dir = cache_path.join("tmp");
         fs::create_dir_all(&ignored_dir).expect("Failed to create ignored directory");
@@ -528,14 +590,18 @@ mod tests {
             .get_cache_stats()
             .expect("Failed to get cache stats");
 
-        assert_eq!(stats.total_models, 1);
-        assert_eq!(stats.total_size, 2);
-        assert_eq!(stats.models.len(), 1);
+        assert_eq!(stats.total_models, 2);
+        assert_eq!(stats.total_size, 8);
+        assert_eq!(stats.models.len(), 2);
 
         assert_eq!(stats.models[0].provider, ModelProvider::HuggingFace);
         assert_eq!(stats.models[0].name, "google/t5-small");
         assert_eq!(stats.models[0].size, 2);
         assert_eq!(stats.models[0].path, hf_model_dir);
+        assert_eq!(stats.models[1].provider, ModelProvider::Gcs);
+        assert_eq!(stats.models[1].name, "gs://envbucket/dev/bake/qwen/rev123");
+        assert_eq!(stats.models[1].size, 6);
+        assert_eq!(stats.models[1].path, gcs_model_dir);
         assert!(stats.models.iter().all(|model| model.name != "tmp"));
     }
 
@@ -549,7 +615,23 @@ mod tests {
         fs::create_dir_all(&hf_model_dir).expect("Failed to create HF model directory");
         fs::write(hf_model_dir.join("config.json"), b"{}").expect("Failed to write HF file");
 
+        let gcs_model_dir = resolve_model_path(
+            &cache_path,
+            ModelProvider::Gcs,
+            "gs://envbucket/org/model/rev1",
+            None,
+        )
+        .expect("Failed to resolve GCS path");
+        fs::create_dir_all(&gcs_model_dir).expect("Failed to create GCS model directory");
+        fs::write(gcs_model_dir.join("tokenizer.json"), b"{}").expect("Failed to write GCS file");
+
         let config = create_test_cache_config(cache_path);
+
+        config
+            .clear_model("gs://envbucket/org/model/rev1", ModelProvider::Gcs)
+            .expect("Failed to clear GCS model");
+        assert!(hf_model_dir.exists(), "HF model should remain");
+        assert!(!gcs_model_dir.exists(), "GCS model should be removed");
 
         config
             .clear_model("google/t5-small", ModelProvider::HuggingFace)

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::models::ModelProvider;
-use crate::providers::{HuggingFaceProvider, ModelProviderTrait, NgcProvider};
+use crate::providers::{GcsProvider, HuggingFaceProvider, ModelProviderTrait, NgcProvider};
 use anyhow::Result;
 use std::path::PathBuf;
 use tracing::{info, warn};
@@ -13,6 +13,7 @@ pub fn get_provider(provider: ModelProvider) -> Box<dyn ModelProviderTrait> {
     match provider {
         ModelProvider::HuggingFace => Box::new(HuggingFaceProvider),
         ModelProvider::Ngc => Box::new(NgcProvider),
+        ModelProvider::Gcs => Box::new(GcsProvider),
     }
 }
 
@@ -105,6 +106,12 @@ mod tests {
     fn test_get_provider() {
         let provider = get_provider(ModelProvider::HuggingFace);
         assert_eq!(provider.provider_name(), "Hugging Face");
+
+        let provider = get_provider(ModelProvider::Ngc);
+        assert_eq!(provider.provider_name(), "NGC");
+
+        let provider = get_provider(ModelProvider::Gcs);
+        assert_eq!(provider.provider_name(), "GCS");
     }
 
     #[test]
@@ -113,6 +120,11 @@ mod tests {
             canonical_model_name("test/model", ModelProvider::HuggingFace)
                 .expect("Expected canonical model name"),
             "test/model"
+        );
+        assert_eq!(
+            canonical_model_name("gs://test-bucket/org/model/rev-1/", ModelProvider::Gcs)
+                .expect("Expected canonical model name"),
+            "gs://test-bucket/org/model/rev-1"
         );
     }
 

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -172,6 +172,7 @@ impl From<models::ModelProvider> for grpc::model::ModelProvider {
         match provider {
             models::ModelProvider::HuggingFace => grpc::model::ModelProvider::HuggingFace,
             models::ModelProvider::Ngc => grpc::model::ModelProvider::Ngc,
+            models::ModelProvider::Gcs => grpc::model::ModelProvider::Gcs,
         }
     }
 }
@@ -181,6 +182,7 @@ impl From<grpc::model::ModelProvider> for models::ModelProvider {
         match provider {
             grpc::model::ModelProvider::HuggingFace => models::ModelProvider::HuggingFace,
             grpc::model::ModelProvider::Ngc => models::ModelProvider::Ngc,
+            grpc::model::ModelProvider::Gcs => models::ModelProvider::Gcs,
         }
     }
 }
@@ -291,10 +293,15 @@ mod tests {
 
     #[test]
     fn test_model_provider_conversion_both_ways() {
-        let model_provider = models::ModelProvider::HuggingFace;
-        let grpc_provider: grpc::model::ModelProvider = model_provider.into();
-        let back_to_model: models::ModelProvider = grpc_provider.into();
-        assert_eq!(model_provider, back_to_model);
+        for model_provider in [
+            models::ModelProvider::HuggingFace,
+            models::ModelProvider::Ngc,
+            models::ModelProvider::Gcs,
+        ] {
+            let grpc_provider: grpc::model::ModelProvider = model_provider.into();
+            let back_to_model: models::ModelProvider = grpc_provider.into();
+            assert_eq!(model_provider, back_to_model);
+        }
     }
 
     #[test]

--- a/modelexpress_common/src/models.rs
+++ b/modelexpress_common/src/models.rs
@@ -32,6 +32,8 @@ pub enum ModelProvider {
     HuggingFace,
     /// NVIDIA NGC catalog
     Ngc,
+    /// Google Cloud Storage
+    Gcs,
 }
 
 impl ModelProvider {
@@ -40,6 +42,7 @@ impl ModelProvider {
         match self {
             Self::HuggingFace => "hugging-face",
             Self::Ngc => "ngc",
+            Self::Gcs => "gcs",
         }
     }
 }
@@ -52,7 +55,7 @@ impl Display for ModelProvider {
 
 impl ValueEnum for ModelProvider {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::HuggingFace, Self::Ngc]
+        &[Self::HuggingFace, Self::Ngc, Self::Gcs]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
@@ -84,12 +87,17 @@ mod tests {
 
     #[test]
     fn test_model_provider_serialization() {
-        let provider = ModelProvider::HuggingFace;
-        let serialized =
-            serde_json::to_string(&provider).expect("Failed to serialize ModelProvider");
-        let deserialized: ModelProvider =
-            serde_json::from_str(&serialized).expect("Failed to deserialize ModelProvider");
-        assert_eq!(provider, deserialized);
+        for provider in [
+            ModelProvider::HuggingFace,
+            ModelProvider::Ngc,
+            ModelProvider::Gcs,
+        ] {
+            let serialized =
+                serde_json::to_string(&provider).expect("Failed to serialize ModelProvider");
+            let deserialized: ModelProvider =
+                serde_json::from_str(&serialized).expect("Failed to deserialize ModelProvider");
+            assert_eq!(provider, deserialized);
+        }
     }
 
     #[test]
@@ -102,25 +110,20 @@ mod tests {
     fn test_model_provider_display() {
         assert_eq!(ModelProvider::HuggingFace.to_string(), "hugging-face");
         assert_eq!(ModelProvider::Ngc.to_string(), "ngc");
+        assert_eq!(ModelProvider::Gcs.to_string(), "gcs");
     }
 
     #[test]
     fn test_model_provider_value_enum_matches_display() {
-        for provider in [ModelProvider::HuggingFace, ModelProvider::Ngc] {
+        for provider in [
+            ModelProvider::HuggingFace,
+            ModelProvider::Ngc,
+            ModelProvider::Gcs,
+        ] {
             let parsed = ModelProvider::from_str(provider.as_str(), false)
                 .expect("Failed to parse ModelProvider from clap value");
             assert_eq!(parsed, provider);
         }
-    }
-
-    #[test]
-    fn test_model_provider_ngc_serialization() {
-        let provider = ModelProvider::Ngc;
-        let serialized =
-            serde_json::to_string(&provider).expect("Failed to serialize ModelProvider");
-        let deserialized: ModelProvider =
-            serde_json::from_str(&serialized).expect("Failed to deserialize ModelProvider");
-        assert_eq!(provider, deserialized);
     }
 
     #[test]

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -83,9 +83,11 @@ pub trait ModelProviderTrait: Send + Sync {
     }
 }
 
+pub mod gcs;
 pub mod huggingface;
 pub mod ngc;
 
+pub use gcs::GcsProvider;
 pub use huggingface::HuggingFaceProvider;
 pub use ngc::NgcProvider;
 
@@ -154,6 +156,18 @@ mod tests {
             canonical
                 .as_ref()
                 .is_ok_and(|model_name| model_name == "test/model"),
+            "Expected canonical model name, got {canonical:?}"
+        );
+    }
+
+    #[test]
+    fn test_canonical_model_name_gcs_trims_trailing_slash() {
+        let provider = GcsProvider;
+        let canonical = provider.canonical_model_name("gs://test-bucket/org/model/rev-1/");
+        assert!(
+            canonical
+                .as_ref()
+                .is_ok_and(|model_name| model_name == "gs://test-bucket/org/model/rev-1"),
             "Expected canonical model name, got {canonical:?}"
         );
     }

--- a/modelexpress_common/src/providers/gcs.rs
+++ b/modelexpress_common/src/providers/gcs.rs
@@ -1,0 +1,571 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::providers::ModelProviderTrait;
+use anyhow::{Context, Result};
+use google_cloud_storage::client::{Storage, StorageControl};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+mod cache_manifest;
+mod download_progress;
+mod download_task;
+mod downloader;
+mod lock_file;
+mod model_dir;
+mod model_name;
+mod path_ext;
+mod provider_cache;
+
+use downloader::Downloader;
+use model_dir::ModelDir;
+use model_name::ModelName;
+
+pub use provider_cache::GcsProviderCache;
+
+fn ensure_crypto_provider() -> Result<()> {
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        return Ok(());
+    }
+
+    match rustls::crypto::ring::default_provider().install_default() {
+        Ok(()) => Ok(()),
+        Err(_) if rustls::crypto::CryptoProvider::get_default().is_some() => Ok(()),
+        Err(_) => anyhow::bail!("Failed to install rustls ring CryptoProvider for GCS"),
+    }
+}
+
+pub struct GcsProvider;
+
+impl GcsProvider {
+    fn is_downloadable_path(path: &Path) -> bool {
+        !Self::is_ignored(path.to_string_lossy().as_ref()) && !Self::is_image(path)
+    }
+
+    fn matches_request_path(path: &Path, ignore_weights: bool) -> bool {
+        !ignore_weights || !Self::is_weight_file(path.to_string_lossy().as_ref())
+    }
+}
+
+#[async_trait::async_trait]
+impl ModelProviderTrait for GcsProvider {
+    async fn download_model(
+        &self,
+        model_name: &str,
+        cache_dir: Option<PathBuf>,
+        ignore_weights: bool,
+    ) -> Result<PathBuf> {
+        let cache_dir = cache_dir
+            .ok_or_else(|| anyhow::anyhow!("GCS download requires cache_dir to be provided"))?;
+        fs::create_dir_all(&cache_dir).with_context(|| {
+            format!("Failed to create cache directory: {}", cache_dir.display())
+        })?;
+
+        let model = ModelName::parse(model_name)?;
+
+        let model_dir = model.model_dir(&cache_dir);
+        let current_model_dir = ModelDir::new(&cache_dir, &model_dir);
+        if current_model_dir.cache_satisfies_request(ignore_weights)? {
+            info!(
+                "Using cached GCS model '{}' from '{}'",
+                model,
+                model_dir.display()
+            );
+            return Ok(model_dir);
+        }
+
+        (ModelDir::new(&cache_dir, &model_dir)).ensure_available()?;
+
+        ensure_crypto_provider()?;
+        let storage = Storage::builder()
+            .build()
+            .await
+            .context("Failed to initialize Google Cloud Storage data client")?;
+        let control = StorageControl::builder()
+            .build()
+            .await
+            .context("Failed to initialize Google Cloud Storage control client")?;
+        let downloader = Downloader::new(&storage, &control, &model, current_model_dir);
+        let manifest = current_model_dir
+            .ensure_manifest(&model, &downloader)
+            .await?;
+
+        if current_model_dir.cache_satisfies_request(ignore_weights)? {
+            info!(
+                "Using cached GCS model '{}' from '{}'",
+                model,
+                model_dir.display()
+            );
+            return Ok(model_dir);
+        }
+
+        let download_tasks = downloader.download_tasks_from_manifest(&manifest, ignore_weights)?;
+
+        if download_tasks.is_empty() {
+            anyhow::bail!("No downloadable files found in {}", model);
+        }
+
+        downloader
+            .download_tasks_in_parallel(&download_tasks)
+            .await?;
+
+        if !current_model_dir.cache_satisfies_request(ignore_weights)? {
+            anyhow::bail!(
+                "Downloaded GCS model '{}' is still incomplete for the requested file set",
+                model
+            );
+        }
+
+        info!(
+            "Downloaded {} files for model '{}'",
+            download_tasks.len(),
+            model
+        );
+
+        Ok(model_dir)
+    }
+
+    async fn delete_model(&self, model_name: &str, cache_dir: PathBuf) -> Result<()> {
+        let model = ModelName::parse(model_name)?;
+        let model_dir = model.model_dir(&cache_dir);
+        let model_dir_state = ModelDir::new(&cache_dir, &model_dir);
+
+        if !model_dir_state.is_removable()? {
+            info!(
+                "GCS model '{}' not found in cache, skipping delete",
+                model_name
+            );
+            return Ok(());
+        }
+
+        model_dir_state.remove()?;
+        info!(
+            "Deleted cached GCS model '{}' from '{}'",
+            model_name,
+            model_dir.display()
+        );
+        Ok(())
+    }
+
+    async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf> {
+        let model = ModelName::parse(model_name)?;
+        let model_dir = model.model_dir(&cache_dir);
+        let model_dir_state = ModelDir::new(&cache_dir, &model_dir);
+        if !model_dir_state.cache_satisfies_request(false)? {
+            anyhow::bail!("GCS model '{model_name}' not found in cache");
+        }
+
+        Ok(model_dir)
+    }
+
+    fn canonical_model_name(&self, model_name: &str) -> Result<String> {
+        Ok(ModelName::parse(model_name)?.to_string())
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "GCS"
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod test_support {
+    use super::{
+        cache_manifest::{CacheManifest, ManifestEntry},
+        model_dir::{INTERNAL_METADATA_DIR_NAME, ModelDir},
+        model_name::ModelName,
+    };
+    use google_cloud_gax::{options::RequestOptions as ControlRequestOptions, response::Response};
+    use google_cloud_storage::{
+        model::{
+            ListObjectsRequest, ListObjectsResponse, Object, ObjectChecksums, ReadObjectRequest,
+        },
+        model_ext::ObjectHighlights,
+        read_object::ReadObjectResponse,
+        request_options::RequestOptions as StorageRequestOptions,
+    };
+    use std::{
+        collections::{HashMap, VecDeque},
+        fs,
+        future::Future,
+        path::{Path, PathBuf},
+        sync::{Arc, Mutex},
+    };
+
+    pub fn expected_model_dir(cache_dir: &Path, model_name: &str) -> PathBuf {
+        ModelName::parse(model_name)
+            .expect("Expected model parsing")
+            .model_dir(cache_dir)
+    }
+
+    pub fn expected_internal_dir(cache_dir: &Path, model_name: &str) -> PathBuf {
+        expected_model_dir(cache_dir, model_name).join(INTERNAL_METADATA_DIR_NAME)
+    }
+
+    pub fn manifest_entry_with_generation(
+        relative_path: &str,
+        contents: &[u8],
+        generation: u64,
+    ) -> ManifestEntry {
+        ManifestEntry {
+            path: relative_path.to_string(),
+            size: contents.len() as u64,
+            crc32c: format!("{:08x}", crc32c::crc32c(contents)),
+            generation: Some(generation),
+        }
+    }
+
+    pub fn manifest_entry(relative_path: &str, contents: &[u8]) -> ManifestEntry {
+        manifest_entry_with_generation(relative_path, contents, 42)
+    }
+
+    pub fn gcs_object(object_name: &str, contents: &[u8], generation: i64) -> Object {
+        Object::new()
+            .set_name(object_name)
+            .set_size(contents.len() as i64)
+            .set_generation(generation)
+            .set_checksums(ObjectChecksums::new().set_crc32c(crc32c::crc32c(contents)))
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct TestStorageStub {
+        objects: Arc<HashMap<String, String>>,
+        requests: Arc<Mutex<Vec<ReadObjectRequest>>>,
+    }
+
+    impl TestStorageStub {
+        pub fn new<I, K, V>(objects: I) -> Self
+        where
+            I: IntoIterator<Item = (K, V)>,
+            K: Into<String>,
+            V: Into<String>,
+        {
+            Self {
+                objects: Arc::new(
+                    objects
+                        .into_iter()
+                        .map(|(name, contents)| (name.into(), contents.into()))
+                        .collect(),
+                ),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        pub fn read_requests(&self) -> Vec<ReadObjectRequest> {
+            self.requests
+                .lock()
+                .expect("Failed to lock read requests")
+                .clone()
+        }
+    }
+
+    impl google_cloud_storage::stub::Storage for TestStorageStub {
+        fn read_object(
+            &self,
+            req: ReadObjectRequest,
+            _options: StorageRequestOptions,
+        ) -> impl Future<Output = google_cloud_storage::Result<ReadObjectResponse>> + Send {
+            let objects = Arc::clone(&self.objects);
+            let requests = Arc::clone(&self.requests);
+            async move {
+                requests
+                    .lock()
+                    .expect("Failed to lock read requests")
+                    .push(req.clone());
+
+                let payload = objects
+                    .get(&req.object)
+                    .expect("Expected test object payload")
+                    .clone();
+                let start = usize::try_from(req.read_offset.max(0))
+                    .expect("Expected non-negative read offset");
+                let resumed = payload
+                    .get(start..)
+                    .expect("Expected resume offset to be within payload")
+                    .to_string();
+
+                Ok(ReadObjectResponse::from_source(
+                    ObjectHighlights::default(),
+                    resumed,
+                ))
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct TestStorageControlStub {
+        responses: Arc<Mutex<VecDeque<Response<ListObjectsResponse>>>>,
+        requests: Arc<Mutex<Vec<ListObjectsRequest>>>,
+    }
+
+    impl TestStorageControlStub {
+        pub fn new<I>(responses: I) -> Self
+        where
+            I: IntoIterator<Item = ListObjectsResponse>,
+        {
+            Self {
+                responses: Arc::new(Mutex::new(
+                    responses.into_iter().map(Response::from).collect(),
+                )),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        pub fn list_requests(&self) -> Vec<ListObjectsRequest> {
+            self.requests
+                .lock()
+                .expect("Failed to lock list requests")
+                .clone()
+        }
+    }
+
+    impl google_cloud_storage::stub::StorageControl for TestStorageControlStub {
+        fn list_objects(
+            &self,
+            req: ListObjectsRequest,
+            _options: ControlRequestOptions,
+        ) -> impl Future<Output = google_cloud_storage::Result<Response<ListObjectsResponse>>> + Send
+        {
+            let responses = Arc::clone(&self.responses);
+            let requests = Arc::clone(&self.requests);
+            async move {
+                requests
+                    .lock()
+                    .expect("Failed to lock list requests")
+                    .push(req);
+                Ok(responses
+                    .lock()
+                    .expect("Failed to lock list responses")
+                    .pop_front()
+                    .expect("Expected test list_objects response"))
+            }
+        }
+    }
+
+    fn write_payload(cache_dir: &Path, model_name: &str, relative_path: &str, contents: &[u8]) {
+        let model_dir = expected_model_dir(cache_dir, model_name);
+        let payload_path = model_dir.join(relative_path);
+        if let Some(parent) = payload_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create model payload directory");
+        }
+        fs::write(&payload_path, contents).expect("Failed to write model payload");
+    }
+
+    fn write_manifest(cache_dir: &Path, model_name: &str, entries: Vec<ManifestEntry>) {
+        let model = ModelName::parse(model_name).expect("Expected model name parse");
+        let model_dir = expected_model_dir(cache_dir, model_name);
+        (ModelDir::new(cache_dir, &model_dir))
+            .write_manifest(&CacheManifest::new(&model, entries))
+            .expect("Failed to write manifest");
+    }
+
+    pub fn write_cached_model(
+        cache_dir: &Path,
+        model_name: &str,
+        relative_path: &str,
+        contents: &[u8],
+    ) {
+        write_payload(cache_dir, model_name, relative_path, contents);
+        write_manifest(
+            cache_dir,
+            model_name,
+            vec![manifest_entry(relative_path, contents)],
+        );
+    }
+
+    pub fn write_manifest_with_payloads(
+        cache_dir: &Path,
+        model_name: &str,
+        payloads: &[(&str, &[u8])],
+        manifest_entries: Vec<ManifestEntry>,
+    ) {
+        for (relative_path, contents) in payloads {
+            write_payload(cache_dir, model_name, relative_path, contents);
+        }
+        write_manifest(cache_dir, model_name, manifest_entries);
+    }
+
+    pub fn write_incomplete_cached_model(
+        cache_dir: &Path,
+        model_name: &str,
+        relative_path: &str,
+        contents: &[u8],
+    ) {
+        let model_dir = expected_model_dir(cache_dir, model_name);
+        let payload_path = model_dir.join(relative_path);
+        if let Some(parent) = payload_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create model payload directory");
+        }
+        fs::write(&payload_path, contents).expect("Failed to write model payload");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::test_support::{
+        expected_model_dir, manifest_entry, write_cached_model, write_incomplete_cached_model,
+        write_manifest_with_payloads,
+    };
+    use super::*;
+    use crate::providers::ModelProviderTrait;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_download_model_validation_cases() {
+        let provider = GcsProvider;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create runtime");
+
+        for (name, model_name, cache_dir, expected_error) in [
+            (
+                "missing_cache_dir",
+                "gs://test-bucket/test/model/rev-1",
+                None,
+                "requires cache_dir",
+            ),
+            (
+                "relative_path",
+                "org/model/rev-2",
+                Some(TempDir::new().expect("Failed to create temp dir")),
+                "full gs://<bucket>/<path> URL",
+            ),
+        ] {
+            let result = runtime.block_on(provider.download_model(
+                model_name,
+                cache_dir.as_ref().map(|dir| dir.path().to_path_buf()),
+                false,
+            ));
+            assert!(
+                result
+                    .expect_err("Expected validation failure")
+                    .to_string()
+                    .contains(expected_error),
+                "scenario={name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_download_model_cached_cases() {
+        let provider = GcsProvider;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create runtime");
+        let cases = [
+            (
+                "full",
+                "gs://test-bucket/org/model/rev-1",
+                false,
+                vec![("weights/model.bin", b"weights".as_slice())],
+                vec![manifest_entry("weights/model.bin", b"weights")],
+            ),
+            (
+                "metadata_subset",
+                "gs://test-bucket/org/model/rev-meta",
+                true,
+                vec![("tokenizer.json", b"{}".as_slice())],
+                vec![
+                    manifest_entry("tokenizer.json", b"{}"),
+                    manifest_entry("weights/model.bin", b"weights"),
+                ],
+            ),
+        ];
+
+        for (name, model_name, ignore_weights, payloads, manifest_entries) in cases {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let model_dir = expected_model_dir(temp_dir.path(), model_name);
+            write_manifest_with_payloads(temp_dir.path(), model_name, &payloads, manifest_entries);
+
+            let result = runtime
+                .block_on(provider.download_model(
+                    model_name,
+                    Some(temp_dir.path().to_path_buf()),
+                    ignore_weights,
+                ))
+                .expect("Expected cached model reuse");
+
+            assert_eq!(result, model_dir, "scenario={name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_model_path_scenarios() {
+        let provider = GcsProvider;
+        for scenario in ["missing", "partial_manifest", "complete"] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let model_name = match scenario {
+                "missing" => "gs://test-bucket/org/model/rev-3",
+                "partial_manifest" => "gs://test-bucket/org/model/rev-partial",
+                "complete" => "gs://test-bucket/org/model/rev-5",
+                _ => unreachable!("unexpected scenario"),
+            };
+
+            match scenario {
+                "partial_manifest" => write_manifest_with_payloads(
+                    temp_dir.path(),
+                    model_name,
+                    &[("tokenizer.json", b"{}")],
+                    vec![
+                        manifest_entry("tokenizer.json", b"{}"),
+                        manifest_entry("weights/model.bin", b"weights"),
+                    ],
+                ),
+                "complete" => {
+                    write_cached_model(temp_dir.path(), model_name, "tokenizer.json", b"{}");
+                }
+                "missing" => {}
+                _ => unreachable!("unexpected scenario"),
+            }
+
+            let result = provider
+                .get_model_path(model_name, temp_dir.path().to_path_buf())
+                .await;
+            match scenario {
+                "complete" => assert_eq!(
+                    result.expect("Expected model path"),
+                    expected_model_dir(temp_dir.path(), model_name)
+                ),
+                _ => assert!(
+                    result
+                        .expect_err("Expected cache miss")
+                        .to_string()
+                        .contains("not found in cache")
+                ),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_model_scenarios() {
+        let provider = GcsProvider;
+        for scenario in ["complete", "incomplete"] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let model_name = "gs://test-bucket/org/model/rev-1";
+            let model_dir = expected_model_dir(temp_dir.path(), model_name);
+            match scenario {
+                "complete" => {
+                    write_cached_model(temp_dir.path(), model_name, "tokenizer.json", b"{}");
+                }
+                "incomplete" => {
+                    write_incomplete_cached_model(
+                        temp_dir.path(),
+                        model_name,
+                        "tokenizer.json",
+                        b"{}",
+                    );
+                }
+                _ => unreachable!("unexpected scenario"),
+            }
+            provider
+                .delete_model(model_name, temp_dir.path().to_path_buf())
+                .await
+                .expect("Expected successful delete");
+            assert!(!model_dir.exists());
+        }
+    }
+}

--- a/modelexpress_common/src/providers/gcs.rs
+++ b/modelexpress_common/src/providers/gcs.rs
@@ -5,6 +5,7 @@ use crate::providers::ModelProviderTrait;
 use anyhow::{Context, Result};
 use google_cloud_storage::client::{Storage, StorageControl};
 use std::fs;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use tracing::info;
 
@@ -46,16 +47,19 @@ impl GcsProvider {
     fn matches_request_path(path: &Path, ignore_weights: bool) -> bool {
         !ignore_weights || !Self::is_weight_file(path.to_string_lossy().as_ref())
     }
-}
 
-#[async_trait::async_trait]
-impl ModelProviderTrait for GcsProvider {
-    async fn download_model(
+    async fn download_with_clients<BuildClients, BuildFuture, S>(
         &self,
         model_name: &str,
         cache_dir: Option<PathBuf>,
         ignore_weights: bool,
-    ) -> Result<PathBuf> {
+        build_clients: BuildClients,
+    ) -> Result<PathBuf>
+    where
+        BuildClients: FnOnce() -> BuildFuture,
+        BuildFuture: Future<Output = Result<(Storage<S>, StorageControl)>>,
+        S: google_cloud_storage::stub::Storage + 'static,
+    {
         let cache_dir = cache_dir
             .ok_or_else(|| anyhow::anyhow!("GCS download requires cache_dir to be provided"))?;
         fs::create_dir_all(&cache_dir).with_context(|| {
@@ -75,17 +79,9 @@ impl ModelProviderTrait for GcsProvider {
             return Ok(model_dir);
         }
 
-        (ModelDir::new(&cache_dir, &model_dir)).ensure_available()?;
+        current_model_dir.ensure_available()?;
 
-        ensure_crypto_provider()?;
-        let storage = Storage::builder()
-            .build()
-            .await
-            .context("Failed to initialize Google Cloud Storage data client")?;
-        let control = StorageControl::builder()
-            .build()
-            .await
-            .context("Failed to initialize Google Cloud Storage control client")?;
+        let (storage, control) = build_clients().await?;
         let downloader = Downloader::new(&storage, &control, &model, current_model_dir);
         let manifest = current_model_dir
             .ensure_manifest(&model, &downloader)
@@ -124,6 +120,30 @@ impl ModelProviderTrait for GcsProvider {
         );
 
         Ok(model_dir)
+    }
+}
+
+#[async_trait::async_trait]
+impl ModelProviderTrait for GcsProvider {
+    async fn download_model(
+        &self,
+        model_name: &str,
+        cache_dir: Option<PathBuf>,
+        ignore_weights: bool,
+    ) -> Result<PathBuf> {
+        self.download_with_clients(model_name, cache_dir, ignore_weights, || async {
+            ensure_crypto_provider()?;
+            let storage = Storage::builder()
+                .build()
+                .await
+                .context("Failed to initialize Google Cloud Storage data client")?;
+            let control = StorageControl::builder()
+                .build()
+                .await
+                .context("Failed to initialize Google Cloud Storage control client")?;
+            Ok((storage, control))
+        })
+        .await
     }
 
     async fn delete_model(&self, model_name: &str, cache_dir: PathBuf) -> Result<()> {
@@ -405,12 +425,38 @@ mod test_support {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::test_support::{
-        expected_model_dir, manifest_entry, write_cached_model, write_incomplete_cached_model,
-        write_manifest_with_payloads,
+        TestStorageControlStub, expected_model_dir, gcs_object, manifest_entry, write_cached_model,
+        write_incomplete_cached_model, write_manifest_with_payloads,
     };
     use super::*;
     use crate::providers::ModelProviderTrait;
+    use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_storage::model::ListObjectsResponse;
     use tempfile::TempDir;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn mount_gcs_read_object(
+        server: &MockServer,
+        object_name: &str,
+        generation: i64,
+        body: &'static [u8],
+    ) {
+        let encoded_object_name = object_name.replace('/', "%2F");
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/b/test-bucket/o/{encoded_object_name}"
+            )))
+            .and(query_param("alt", "media"))
+            .and(query_param("generation", generation.to_string()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body)
+                    .insert_header("x-goog-generation", generation.to_string()),
+            )
+            .mount(server)
+            .await;
+    }
 
     #[test]
     fn test_download_model_validation_cases() {
@@ -567,5 +613,89 @@ mod tests {
                 .expect("Expected successful delete");
             assert!(!model_dir.exists());
         }
+    }
+
+    #[tokio::test]
+    async fn test_download_model_with_wiremock_gcs_data_client() {
+        let provider = GcsProvider;
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let server = MockServer::start().await;
+        let model_name = "gs://test-bucket/org/model/rev123";
+        let object_prefix = "org/model/rev123";
+
+        mount_gcs_read_object(&server, &format!("{object_prefix}/config.json"), 21, b"{}").await;
+        mount_gcs_read_object(
+            &server,
+            &format!("{object_prefix}/tokenizer.json"),
+            22,
+            b"{\"tokenizer\":true}",
+        )
+        .await;
+        mount_gcs_read_object(
+            &server,
+            &format!("{object_prefix}/weights/model.bin"),
+            23,
+            b"weights",
+        )
+        .await;
+
+        let control_stub = TestStorageControlStub::new([ListObjectsResponse::new().set_objects([
+            gcs_object(&format!("{object_prefix}/config.json"), b"{}", 21),
+            gcs_object(
+                &format!("{object_prefix}/tokenizer.json"),
+                b"{\"tokenizer\":true}",
+                22,
+            ),
+            gcs_object(
+                &format!("{object_prefix}/weights/model.bin"),
+                b"weights",
+                23,
+            ),
+            gcs_object(&format!("{object_prefix}/README.md"), b"ignored", 24),
+            gcs_object(&format!("{object_prefix}/image.png"), b"ignored", 25),
+        ])]);
+        let control = StorageControl::from_stub(control_stub.clone());
+
+        let result = provider
+            .download_with_clients(
+                model_name,
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                || async {
+                    ensure_crypto_provider()?;
+                    let storage = Storage::builder()
+                        .with_endpoint(server.uri())
+                        .with_credentials(Anonymous::new().build())
+                        .build()
+                        .await
+                        .context("Failed to initialize WireMock GCS data client")?;
+                    Ok((storage, control))
+                },
+            )
+            .await
+            .expect("Expected WireMock GCS download to succeed");
+
+        let model_dir = expected_model_dir(temp_dir.path(), model_name);
+        assert_eq!(result, model_dir);
+        assert_eq!(
+            fs::read(model_dir.join("config.json")).expect("Expected config.json"),
+            b"{}"
+        );
+        assert_eq!(
+            fs::read(model_dir.join("tokenizer.json")).expect("Expected tokenizer.json"),
+            b"{\"tokenizer\":true}"
+        );
+        assert_eq!(
+            fs::read(model_dir.join("weights/model.bin")).expect("Expected weights/model.bin"),
+            b"weights"
+        );
+        assert!(!model_dir.join("README.md").exists());
+        assert!(!model_dir.join("image.png").exists());
+        assert!(model_dir.join(".mx/manifest.json").is_file());
+
+        let list_requests = control_stub.list_requests();
+        assert_eq!(list_requests.len(), 1);
+        assert_eq!(list_requests[0].parent, "projects/_/buckets/test-bucket");
+        assert_eq!(list_requests[0].prefix, format!("{object_prefix}/"));
     }
 }

--- a/modelexpress_common/src/providers/gcs/cache_manifest.rs
+++ b/modelexpress_common/src/providers/gcs/cache_manifest.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::model_name::ModelName;
+use serde::{Deserialize, Serialize};
+
+pub const MANIFEST_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheManifest {
+    pub version: u32,
+    pub model: String,
+    pub files: Vec<ManifestEntry>,
+}
+
+impl CacheManifest {
+    pub fn new(model: &ModelName, mut files: Vec<ManifestEntry>) -> Self {
+        files.sort_by(|left, right| left.path.cmp(&right.path));
+        Self {
+            version: MANIFEST_VERSION,
+            model: model.to_string(),
+            files,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    pub path: String,
+    pub size: u64,
+    pub crc32c: String,
+    pub generation: Option<u64>,
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::super::model_name::{BucketName, ModelName};
+    use super::*;
+
+    #[test]
+    fn test_cache_manifest_new_sorts_files_and_sets_metadata() {
+        let model = ModelName::new(
+            BucketName::parse("test-bucket").expect("Expected bucket parse"),
+            "org/model/rev",
+        )
+        .expect("Expected model name");
+
+        let manifest = CacheManifest::new(
+            &model,
+            vec![
+                ManifestEntry {
+                    path: "weights/model.bin".to_string(),
+                    size: 7,
+                    crc32c: "00000001".to_string(),
+                    generation: Some(2),
+                },
+                ManifestEntry {
+                    path: "config.json".to_string(),
+                    size: 2,
+                    crc32c: "00000002".to_string(),
+                    generation: Some(1),
+                },
+            ],
+        );
+
+        assert_eq!(manifest.version, MANIFEST_VERSION);
+        assert_eq!(manifest.model, "gs://test-bucket/org/model/rev");
+        assert_eq!(
+            manifest
+                .files
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["config.json", "weights/model.bin"]
+        );
+    }
+}

--- a/modelexpress_common/src/providers/gcs/download_progress.rs
+++ b/modelexpress_common/src/providers/gcs/download_progress.rs
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::download_task::DownloadTask;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Instant;
+use tracing::info;
+
+const PROGRESS_LOG_INTERVAL_BYTES: u64 = 128 * 1024 * 1024;
+
+pub struct DownloadProgress {
+    total_files: usize,
+    total_bytes: Option<u64>,
+    completed_files: AtomicUsize,
+    downloaded_bytes: AtomicU64,
+    next_log_bytes: AtomicU64,
+    started_at: Instant,
+}
+
+impl DownloadProgress {
+    pub fn new(tasks: &[DownloadTask]) -> Self {
+        let mut total_bytes = Some(0u64);
+        for task in tasks {
+            total_bytes = match (total_bytes, task.expected_size) {
+                (Some(acc), Some(size)) => acc.checked_add(size),
+                _ => None,
+            };
+        }
+
+        Self {
+            total_files: tasks.len(),
+            total_bytes,
+            completed_files: AtomicUsize::new(0),
+            downloaded_bytes: AtomicU64::new(0),
+            next_log_bytes: AtomicU64::new(PROGRESS_LOG_INTERVAL_BYTES),
+            started_at: Instant::now(),
+        }
+    }
+
+    pub fn log_start(&self, max_parallel_downloads: usize) {
+        let total_size = self
+            .total_bytes
+            .map(Self::format_bytes)
+            .unwrap_or_else(|| "unknown".to_string());
+        info!(
+            "Starting GCS parallel download: {} files ({} total) with {} workers",
+            self.total_files, total_size, max_parallel_downloads
+        );
+    }
+
+    pub fn record_downloaded_bytes(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+
+        let previous = self.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+        let current = previous.saturating_add(bytes);
+        self.maybe_log_threshold_progress(current);
+    }
+
+    pub fn mark_file_completed(&self, object_name: &str) {
+        let previous = self.completed_files.fetch_add(1, Ordering::Relaxed);
+        let completed = previous.saturating_add(1);
+        self.log_progress(&format!(
+            "Completed '{}' ({}/{})",
+            object_name, completed, self.total_files
+        ));
+    }
+
+    pub fn log_finish(&self) {
+        let elapsed = self.started_at.elapsed();
+        self.log_progress(&format!(
+            "Finished GCS download in {:.1}s",
+            elapsed.as_secs_f64()
+        ));
+    }
+
+    fn maybe_log_threshold_progress(&self, current_bytes: u64) {
+        let mut threshold = self.next_log_bytes.load(Ordering::Relaxed);
+        while current_bytes >= threshold {
+            match self.next_log_bytes.compare_exchange(
+                threshold,
+                threshold.saturating_add(PROGRESS_LOG_INTERVAL_BYTES),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    self.log_progress("GCS download progress");
+                    break;
+                }
+                Err(observed) => threshold = observed,
+            }
+        }
+    }
+
+    fn log_progress(&self, prefix: &str) {
+        let completed = self.completed_files.load(Ordering::Relaxed);
+        let downloaded = self.downloaded_bytes.load(Ordering::Relaxed);
+        match self.total_bytes {
+            Some(total) if total > 0 => {
+                let percent = ((downloaded as f64) * 100.0 / (total as f64)).min(100.0);
+                info!(
+                    "{}: files {}/{}, bytes {}/{} ({:.1}%)",
+                    prefix,
+                    completed,
+                    self.total_files,
+                    Self::format_bytes(downloaded),
+                    Self::format_bytes(total),
+                    percent
+                );
+            }
+            Some(_) | None => {
+                info!(
+                    "{}: files {}/{}, bytes {}",
+                    prefix,
+                    completed,
+                    self.total_files,
+                    Self::format_bytes(downloaded)
+                );
+            }
+        }
+    }
+
+    fn format_bytes(bytes: u64) -> String {
+        const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+        let mut value = bytes as f64;
+        let mut unit_idx = 0usize;
+        let last_unit_idx = UNITS.len().saturating_sub(1);
+        while value >= 1024.0 && unit_idx < last_unit_idx {
+            value /= 1024.0;
+            unit_idx = unit_idx.saturating_add(1);
+        }
+        format!("{value:.1} {}", UNITS[unit_idx])
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::super::{
+        download_task::DownloadTask, model_dir::INTERNAL_METADATA_DIR_NAME, model_name::BucketName,
+        path_ext::PathExt,
+    };
+    use super::*;
+    use std::{fs, path::PathBuf, sync::atomic::Ordering};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_progress_and_crc_helpers() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let checksum_path = temp_dir.path().join("weights.bin");
+        fs::write(&checksum_path, b"weights").expect("Failed to write checksum payload");
+        assert_eq!(
+            checksum_path
+                .as_path()
+                .calculate_file_crc32c()
+                .expect("Expected checksum calculation"),
+            crc32c::crc32c(b"weights")
+        );
+
+        let tasks = vec![
+            DownloadTask {
+                object_name: "org/model/rev123/tokenizer.json".to_string(),
+                relative_path: PathBuf::from("tokenizer.json"),
+                destination_path: temp_dir.path().join("tokenizer.json"),
+                internal_dir: temp_dir.path().join(INTERNAL_METADATA_DIR_NAME),
+                expected_size: Some(2),
+                generation: Some(51),
+                expected_crc32c: Some(crc32c::crc32c(b"{}")),
+            },
+            DownloadTask {
+                object_name: "org/model/rev123/weights/model.bin".to_string(),
+                relative_path: PathBuf::from("weights/model.bin"),
+                destination_path: temp_dir.path().join("weights/model.bin"),
+                internal_dir: temp_dir.path().join(INTERNAL_METADATA_DIR_NAME),
+                expected_size: Some(7),
+                generation: Some(52),
+                expected_crc32c: Some(crc32c::crc32c(b"weights")),
+            },
+        ];
+        let progress = DownloadProgress::new(&tasks);
+        assert_eq!(progress.total_bytes, Some(9));
+        progress.record_downloaded_bytes(2);
+        progress.mark_file_completed("tokenizer.json");
+        assert_eq!(progress.completed_files.load(Ordering::Relaxed), 1);
+        assert_eq!(progress.downloaded_bytes.load(Ordering::Relaxed), 2);
+        progress.log_start(8);
+        progress.log_finish();
+
+        assert_eq!(DownloadProgress::format_bytes(0), "0.0 B");
+        assert_eq!(DownloadProgress::format_bytes(1536), "1.5 KiB");
+        assert_eq!(
+            BucketName::parse("gs://bucket-name/")
+                .expect("Expected bucket parse")
+                .resource_name(),
+            "projects/_/buckets/bucket-name"
+        );
+    }
+}

--- a/modelexpress_common/src/providers/gcs/download_task.rs
+++ b/modelexpress_common/src/providers/gcs/download_task.rs
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::path_ext::PathExt;
+use anyhow::{Context, Result};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+const LOCKS_DIR_NAME: &str = "locks";
+const PARTS_DIR_NAME: &str = "parts";
+
+#[derive(Debug, Clone)]
+pub struct DownloadTask {
+    pub object_name: String,
+    pub relative_path: PathBuf,
+    pub destination_path: PathBuf,
+    pub internal_dir: PathBuf,
+    pub expected_size: Option<u64>,
+    pub generation: Option<i64>,
+    pub expected_crc32c: Option<u32>,
+}
+
+impl DownloadTask {
+    fn sidecar_path(&self, subdir: &str, suffix: &str) -> PathBuf {
+        let mut suffixed_name = self
+            .relative_path
+            .file_name()
+            .map(|value| value.to_os_string())
+            .unwrap_or_else(|| OsStr::new("download").to_os_string());
+        suffixed_name.push(suffix);
+
+        let suffixed_relative_path = self.relative_path.with_file_name(suffixed_name);
+        self.internal_dir.join(subdir).join(suffixed_relative_path)
+    }
+
+    pub fn lock_path(&self) -> PathBuf {
+        self.sidecar_path(LOCKS_DIR_NAME, ".lock")
+    }
+
+    pub fn temp_path(&self) -> PathBuf {
+        self.sidecar_path(PARTS_DIR_NAME, ".part")
+    }
+
+    async fn verify_file_crc32c(&self, path: &Path) -> Result<()> {
+        let Some(expected_crc32c) = self.expected_crc32c else {
+            anyhow::bail!(
+                "Cannot verify file '{}' for '{}': remote CRC32C is unavailable",
+                path.display(),
+                self.object_name
+            );
+        };
+
+        let verify_path = path.to_path_buf();
+        let actual_crc32c =
+            tokio::task::spawn_blocking(move || verify_path.calculate_file_crc32c())
+                .await
+                .with_context(|| {
+                    format!("CRC32C verification task panicked for '{}'", path.display())
+                })??;
+
+        if actual_crc32c != expected_crc32c {
+            anyhow::bail!(
+                "CRC32C mismatch for file '{}' for '{}': expected {:08x}, got {:08x}",
+                path.display(),
+                self.object_name,
+                expected_crc32c,
+                actual_crc32c
+            );
+        }
+
+        Ok(())
+    }
+
+    pub async fn has_cached_destination_file(&self) -> Result<bool> {
+        let metadata = match tokio::fs::metadata(&self.destination_path).await {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(err) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to inspect destination '{}': {}",
+                    self.destination_path.display(),
+                    err
+                ));
+            }
+        };
+
+        if !metadata.is_file() {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    pub async fn remove_temp_file_if_present(&self, temp_path: &Path) -> Result<()> {
+        match tokio::fs::remove_file(temp_path).await {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(anyhow::anyhow!(
+                "Failed to remove stale temp file '{}': {}",
+                temp_path.display(),
+                err
+            )),
+        }
+    }
+
+    pub async fn promote_verified_temp_file(&self, temp_path: &Path) -> Result<()> {
+        if let Err(err) = self.verify_file_crc32c(temp_path).await {
+            if let Err(remove_err) = tokio::fs::remove_file(temp_path).await {
+                return Err(anyhow::anyhow!(
+                    "{}; also failed to discard unverified temp file '{}': {}",
+                    err,
+                    temp_path.display(),
+                    remove_err
+                ));
+            }
+            return Err(err);
+        }
+
+        tokio::fs::rename(temp_path, &self.destination_path)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to move '{}' to '{}'",
+                    temp_path.display(),
+                    self.destination_path.display()
+                )
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::super::model_dir::INTERNAL_METADATA_DIR_NAME;
+    use super::*;
+    use std::{fs, path::Path};
+    use tempfile::TempDir;
+
+    fn test_download_task(
+        root: &Path,
+        relative_path: &str,
+        expected_crc32c: Option<u32>,
+    ) -> DownloadTask {
+        let relative_path = PathBuf::from(relative_path);
+        DownloadTask {
+            object_name: format!("org/model/rev/{}", relative_path.display()),
+            relative_path: relative_path.clone(),
+            destination_path: root.join(&relative_path),
+            internal_dir: root.join(INTERNAL_METADATA_DIR_NAME),
+            expected_size: None,
+            generation: Some(42),
+            expected_crc32c,
+        }
+    }
+
+    #[test]
+    fn test_download_task_sidecar_paths() {
+        for (relative_path, expected_temp, expected_lock) in [
+            (
+                "weights/model.bin",
+                "/tmp/cache/model/.mx/parts/weights/model.bin.part",
+                "/tmp/cache/model/.mx/locks/weights/model.bin.lock",
+            ),
+            (
+                "weights/model.mlir",
+                "/tmp/cache/model/.mx/parts/weights/model.mlir.part",
+                "/tmp/cache/model/.mx/locks/weights/model.mlir.lock",
+            ),
+            (
+                "weights/model",
+                "/tmp/cache/model/.mx/parts/weights/model.part",
+                "/tmp/cache/model/.mx/locks/weights/model.lock",
+            ),
+        ] {
+            let task = test_download_task(Path::new("/tmp/cache/model"), relative_path, None);
+            assert_eq!(task.temp_path(), PathBuf::from(expected_temp));
+            assert_eq!(task.lock_path(), PathBuf::from(expected_lock));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_download_task_file_verification_cases() {
+        struct PromoteCase {
+            name: &'static str,
+            temp_payload: &'static [u8],
+            expected_crc32c: Option<u32>,
+            expect_error_substr: Option<&'static str>,
+        }
+
+        for case in [
+            PromoteCase {
+                name: "match",
+                temp_payload: b"weights",
+                expected_crc32c: Some(crc32c::crc32c(b"weights")),
+                expect_error_substr: None,
+            },
+            PromoteCase {
+                name: "mismatch",
+                temp_payload: b"weights",
+                expected_crc32c: Some(crc32c::crc32c(b"different")),
+                expect_error_substr: Some("CRC32C mismatch"),
+            },
+            PromoteCase {
+                name: "missing_crc",
+                temp_payload: b"weights",
+                expected_crc32c: None,
+                expect_error_substr: Some("remote CRC32C is unavailable"),
+            },
+        ] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let temp_path = temp_dir.path().join("weights.bin.tmp");
+            fs::write(&temp_path, case.temp_payload).expect("Failed to write temp file");
+
+            let task = test_download_task(temp_dir.path(), "weights.bin", case.expected_crc32c);
+            let destination_path = task.destination_path.clone();
+
+            match case.expect_error_substr {
+                None => {
+                    task.promote_verified_temp_file(&temp_path)
+                        .await
+                        .expect("Expected checksum verification");
+                    assert!(!temp_path.exists(), "scenario={}", case.name);
+                    assert_eq!(
+                        fs::read(&destination_path).expect("Expected promoted destination file"),
+                        case.temp_payload,
+                        "scenario={}",
+                        case.name
+                    );
+                }
+                Some(error_substr) => {
+                    let err = task
+                        .promote_verified_temp_file(&temp_path)
+                        .await
+                        .expect_err("Expected promote failure");
+                    assert!(
+                        err.to_string().contains(error_substr),
+                        "scenario={} err={err}",
+                        case.name
+                    );
+                    assert!(!temp_path.exists(), "scenario={}", case.name);
+                    assert!(!destination_path.exists(), "scenario={}", case.name);
+                }
+            }
+        }
+
+        for (name, setup, expected_match) in [
+            ("file", "file", true),
+            ("missing", "missing", false),
+            ("directory", "directory", false),
+        ] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let task = test_download_task(
+                temp_dir.path(),
+                "weights.bin",
+                Some(crc32c::crc32c(b"weights")),
+            );
+
+            match setup {
+                "file" => {
+                    fs::write(&task.destination_path, b"weights")
+                        .expect("Failed to create destination file");
+                }
+                "missing" => {}
+                "directory" => {
+                    fs::create_dir_all(&task.destination_path)
+                        .expect("Failed to create destination directory");
+                }
+                _ => unreachable!("unexpected setup"),
+            }
+
+            assert_eq!(
+                task.has_cached_destination_file()
+                    .await
+                    .expect("Expected destination inspection"),
+                expected_match,
+                "scenario={name}"
+            );
+        }
+    }
+}

--- a/modelexpress_common/src/providers/gcs/downloader.rs
+++ b/modelexpress_common/src/providers/gcs/downloader.rs
@@ -1,0 +1,727 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    GcsProvider,
+    cache_manifest::{CacheManifest, ManifestEntry},
+    download_progress::DownloadProgress,
+    download_task::DownloadTask,
+    lock_file::LockFile,
+    model_dir::{INTERNAL_METADATA_DIR_NAME, ModelDir},
+    model_name::{BucketName, ModelName},
+};
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use futures::stream;
+use google_cloud_storage::client::{Storage, StorageControl};
+use google_cloud_storage::model::{ListObjectsRequest, Object};
+use google_cloud_storage::model_ext::ReadRange;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
+use tracing::warn;
+
+const MAX_GCS_LIST_RESULTS: i32 = 1000;
+const MAX_PARALLEL_DOWNLOADS: usize = 8;
+
+pub struct Downloader<'a, S = google_cloud_storage::stub::DefaultStorage>
+where
+    S: google_cloud_storage::stub::Storage + 'static,
+{
+    storage: &'a Storage<S>,
+    control: &'a StorageControl,
+    bucket: &'a BucketName,
+    model: &'a ModelName,
+    model_dir: ModelDir<'a>,
+    bucket_resource_name: String,
+    list_prefix: String,
+}
+
+impl<'a, S> Downloader<'a, S>
+where
+    S: google_cloud_storage::stub::Storage + 'static,
+{
+    pub fn new(
+        storage: &'a Storage<S>,
+        control: &'a StorageControl,
+        model: &'a ModelName,
+        model_dir: ModelDir<'a>,
+    ) -> Self {
+        Self {
+            storage,
+            control,
+            bucket: &model.bucket,
+            model,
+            model_dir,
+            bucket_resource_name: model.bucket.resource_name(),
+            list_prefix: format!("{}/", model.object_prefix),
+        }
+    }
+
+    fn build_list_request(&self, page_token: Option<String>) -> ListObjectsRequest {
+        let mut request = ListObjectsRequest::new()
+            .set_parent(self.bucket_resource_name.clone())
+            .set_prefix(self.list_prefix.clone())
+            .set_page_size(MAX_GCS_LIST_RESULTS);
+
+        if let Some(page_token) = page_token {
+            request = request.set_page_token(page_token);
+        }
+
+        request
+    }
+
+    fn ensure_parent_directory(path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory '{}'", parent.display()))?;
+        }
+        Ok(())
+    }
+
+    fn candidate_relative_key<'b>(&self, object: &'b Object) -> Option<&'b str> {
+        object
+            .name
+            .strip_prefix(&self.list_prefix)
+            .filter(|suffix| !suffix.is_empty() && !suffix.ends_with('/'))
+    }
+
+    fn build_download_task(
+        &self,
+        relative_path: PathBuf,
+        expected_size: u64,
+        generation: Option<u64>,
+        expected_crc32c: u32,
+    ) -> Result<DownloadTask> {
+        let destination_path = self.model_dir.model_dir.join(&relative_path);
+
+        Ok(DownloadTask {
+            object_name: format!("{}/{}", self.model.object_prefix, relative_path.display()),
+            relative_path,
+            destination_path,
+            internal_dir: self.model_dir.model_dir.join(INTERNAL_METADATA_DIR_NAME),
+            expected_size: Some(expected_size),
+            generation: generation.and_then(|value| i64::try_from(value).ok()),
+            expected_crc32c: Some(expected_crc32c),
+        })
+    }
+
+    fn manifest_entry_if_downloadable(&self, object: &Object) -> Result<Option<ManifestEntry>> {
+        let Some(relative_key) = self.candidate_relative_key(object) else {
+            return Ok(None);
+        };
+        let relative_path = self.model_dir.parse_relative_object_path(relative_key)?;
+        if !GcsProvider::is_downloadable_path(&relative_path) {
+            return Ok(None);
+        }
+
+        let expected_size = u64::try_from(object.size).with_context(|| {
+            format!(
+                "Object '{}' for model '{}' has an invalid size '{}'",
+                object.name, self.model, object.size
+            )
+        })?;
+        let expected_crc32c = object
+            .checksums
+            .as_ref()
+            .and_then(|checksums| checksums.crc32c)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cannot record manifest entry for '{}': remote CRC32C is unavailable",
+                    object.name
+                )
+            })?;
+
+        Ok(Some(ManifestEntry {
+            path: relative_path.to_string_lossy().into_owned(),
+            size: expected_size,
+            crc32c: format!("{expected_crc32c:08x}"),
+            generation: (object.generation > 0)
+                .then_some(object.generation)
+                .and_then(|generation| u64::try_from(generation).ok()),
+        }))
+    }
+
+    pub async fn collect_manifest_entries(&self) -> Result<Vec<ManifestEntry>> {
+        let mut page_token: Option<String> = None;
+        let mut entries = Vec::new();
+
+        loop {
+            let response = self
+                .control
+                .list_objects()
+                .with_request(self.build_list_request(page_token.clone()))
+                .send()
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to list objects in gs://{}/{}",
+                        self.bucket, self.model.object_prefix
+                    )
+                })?;
+
+            for object in response.objects {
+                if let Some(entry) = self.manifest_entry_if_downloadable(&object)? {
+                    entries.push(entry);
+                }
+            }
+
+            if response.next_page_token.is_empty() {
+                break;
+            }
+            page_token = Some(response.next_page_token);
+        }
+
+        Ok(entries)
+    }
+
+    pub fn download_tasks_from_manifest(
+        &self,
+        manifest: &CacheManifest,
+        ignore_weights: bool,
+    ) -> Result<Vec<DownloadTask>> {
+        let mut tasks = Vec::new();
+        for entry in &manifest.files {
+            let relative_path = self.model_dir.parse_relative_object_path(&entry.path)?;
+            if !GcsProvider::matches_request_path(&relative_path, ignore_weights) {
+                continue;
+            }
+
+            let expected_crc32c = u32::from_str_radix(&entry.crc32c, 16).with_context(|| {
+                format!(
+                    "Manifest for '{}' contains invalid CRC32C '{}'",
+                    self.model, entry.crc32c
+                )
+            })?;
+
+            tasks.push(self.build_download_task(
+                relative_path,
+                entry.size,
+                entry.generation,
+                expected_crc32c,
+            )?);
+        }
+
+        Ok(tasks)
+    }
+
+    pub async fn download_tasks_in_parallel(&self, tasks: &[DownloadTask]) -> Result<()> {
+        let task_count = tasks.len();
+        if task_count == 0 {
+            return Ok(());
+        }
+        let progress = Arc::new(DownloadProgress::new(tasks));
+        progress.log_start(MAX_PARALLEL_DOWNLOADS);
+
+        let download_stream = stream::iter(tasks.iter().cloned().map(|task| {
+            let progress = Arc::clone(&progress);
+            async move {
+                self.download_task_once(&task, progress.as_ref()).await?;
+                progress.mark_file_completed(&task.object_name);
+                Ok::<(), anyhow::Error>(())
+            }
+        }))
+        .buffer_unordered(MAX_PARALLEL_DOWNLOADS);
+
+        tokio::pin!(download_stream);
+
+        while let Some(result) = download_stream.next().await {
+            result?;
+        }
+        progress.log_finish();
+
+        Ok(())
+    }
+
+    async fn download_task_once(
+        &self,
+        task: &DownloadTask,
+        progress: &DownloadProgress,
+    ) -> Result<()> {
+        Self::ensure_parent_directory(&task.destination_path)?;
+        let temp_path = task.temp_path();
+        Self::ensure_parent_directory(&temp_path)?;
+
+        LockFile::with_exclusive(&task.lock_path(), || async move {
+            let Some(resume_offset) = self.prepare_task_download(task).await? else {
+                return Ok(());
+            };
+            self.stream_task_to_temp(task, resume_offset, progress)
+                .await?;
+            self.finalize_task_download(task).await
+        })
+        .await
+    }
+
+    async fn prepare_task_download(&self, task: &DownloadTask) -> Result<Option<u64>> {
+        let temp_path = task.temp_path();
+        if task.has_cached_destination_file().await? {
+            task.remove_temp_file_if_present(&temp_path).await?;
+            return Ok(None);
+        }
+
+        let mut resume_offset = match tokio::fs::metadata(&temp_path).await {
+            Ok(metadata) => metadata.len(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(err) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to inspect '{}': {}",
+                    temp_path.display(),
+                    err
+                ));
+            }
+        };
+        if let Some(expected_size) = task.expected_size {
+            if resume_offset > expected_size {
+                tokio::fs::remove_file(&temp_path).await.with_context(|| {
+                    format!(
+                        "Failed to clear oversized temp file '{}'",
+                        temp_path.display()
+                    )
+                })?;
+                resume_offset = 0;
+            } else if resume_offset == expected_size && resume_offset > 0 {
+                match task.promote_verified_temp_file(&temp_path).await {
+                    Ok(()) => return Ok(None),
+                    Err(err) => {
+                        warn!("{err}");
+                        resume_offset = 0;
+                    }
+                }
+            }
+        }
+
+        if resume_offset > 0 && task.generation.is_none() {
+            warn!(
+                "Discarding partial temp file '{}' for '{}' because remote generation is unavailable",
+                temp_path.display(),
+                task.object_name
+            );
+            tokio::fs::remove_file(&temp_path).await.with_context(|| {
+                format!(
+                    "Failed to discard temp file '{}' without a known remote generation",
+                    temp_path.display()
+                )
+            })?;
+            resume_offset = 0;
+        }
+
+        Ok(Some(resume_offset))
+    }
+
+    async fn stream_task_to_temp(
+        &self,
+        task: &DownloadTask,
+        resume_offset: u64,
+        progress: &DownloadProgress,
+    ) -> Result<()> {
+        let temp_path = task.temp_path();
+        let bucket = self.bucket;
+        let read_range = if resume_offset == 0 {
+            ReadRange::all()
+        } else {
+            ReadRange::offset(resume_offset)
+        };
+
+        let mut request = self
+            .storage
+            .read_object(self.bucket_resource_name.clone(), task.object_name.clone())
+            .set_read_range(read_range);
+        if let Some(generation) = task.generation {
+            request = request.set_generation(generation);
+        }
+
+        let mut stream = request.send().await.with_context(|| {
+            format!(
+                "Failed to start download for gs://{bucket}/{}",
+                task.object_name
+            )
+        })?;
+
+        let mut file = if resume_offset == 0 {
+            tokio::fs::File::create(&temp_path)
+                .await
+                .with_context(|| format!("Failed to create '{}'", temp_path.display()))?
+        } else {
+            tokio::fs::OpenOptions::new()
+                .append(true)
+                .open(&temp_path)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to open '{}' for resume at byte {}",
+                        temp_path.display(),
+                        resume_offset
+                    )
+                })?
+        };
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| {
+                format!("Failed while streaming gs://{bucket}/{}", task.object_name)
+            })?;
+            file.write_all(&chunk)
+                .await
+                .with_context(|| format!("Failed to write '{}'", temp_path.display()))?;
+            progress.record_downloaded_bytes(chunk.len() as u64);
+        }
+
+        file.flush()
+            .await
+            .with_context(|| format!("Failed to flush '{}'", temp_path.display()))?;
+        drop(file);
+
+        Ok(())
+    }
+
+    async fn finalize_task_download(&self, task: &DownloadTask) -> Result<()> {
+        let temp_path = task.temp_path();
+        if let Some(expected_size) = task.expected_size {
+            let final_size = tokio::fs::metadata(&temp_path)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to inspect completed temp file '{}'",
+                        temp_path.display()
+                    )
+                })?
+                .len();
+            if final_size != expected_size {
+                anyhow::bail!(
+                    "Incomplete download for '{}': expected {} bytes, got {} bytes",
+                    task.object_name,
+                    expected_size,
+                    final_size
+                );
+            }
+        }
+
+        task.promote_verified_temp_file(&temp_path).await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::super::{
+        cache_manifest::{CacheManifest, ManifestEntry},
+        model_dir::ModelDir,
+        model_name::ModelName,
+        test_support::{
+            TestStorageControlStub, TestStorageStub, gcs_object, manifest_entry_with_generation,
+        },
+    };
+    use super::*;
+    use google_cloud_storage::{
+        client::{Storage, StorageControl},
+        model::ListObjectsResponse,
+    };
+    use std::{fs, path::PathBuf};
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_downloader_collect_manifest_entries_paginates_and_filters_downloadables() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model =
+            ModelName::parse("gs://test-bucket/org/model/rev123").expect("Expected model parsing");
+        let model_dir_path = model.model_dir(temp_dir.path());
+        let model_dir = ModelDir::new(temp_dir.path(), &model_dir_path);
+        let object_prefix = model.object_prefix.clone();
+
+        let storage_stub = TestStorageStub::new(Vec::<(String, String)>::new());
+        let storage = Storage::from_stub(storage_stub);
+        let control_stub = TestStorageControlStub::new([
+            ListObjectsResponse::new()
+                .set_objects([
+                    gcs_object(&format!("{object_prefix}/tokenizer.json"), b"{}", 11),
+                    gcs_object(&format!("{object_prefix}/README.md"), b"readme", 12),
+                    gcs_object(&format!("{object_prefix}/image.png"), b"png", 13),
+                    gcs_object(&format!("{object_prefix}/"), b"", 14),
+                    gcs_object("other/prefix/file.bin", b"other", 15),
+                ])
+                .set_next_page_token("page-2"),
+            ListObjectsResponse::new().set_objects([gcs_object(
+                &format!("{object_prefix}/weights/model.bin"),
+                b"weights",
+                16,
+            )]),
+        ]);
+        let control = StorageControl::from_stub(control_stub.clone());
+        let downloader = Downloader::new(&storage, &control, &model, model_dir);
+
+        let mut entries = downloader
+            .collect_manifest_entries()
+            .await
+            .expect("Expected manifest entry collection");
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+
+        assert_eq!(
+            entries,
+            vec![
+                manifest_entry_with_generation("tokenizer.json", b"{}", 11),
+                manifest_entry_with_generation("weights/model.bin", b"weights", 16),
+            ]
+        );
+
+        let requests = control_stub.list_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].parent, model.bucket.resource_name());
+        assert_eq!(requests[0].prefix, format!("{object_prefix}/"));
+        assert_eq!(requests[0].page_size, MAX_GCS_LIST_RESULTS);
+        assert!(requests[0].page_token.is_empty());
+        assert_eq!(requests[1].page_token, "page-2");
+    }
+
+    #[test]
+    fn test_download_tasks_from_manifest_filters_weights_and_validates_crc() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model =
+            ModelName::parse("gs://test-bucket/org/model/rev123").expect("Expected model parsing");
+        let model_dir_path = model.model_dir(temp_dir.path());
+        let model_dir = ModelDir::new(temp_dir.path(), &model_dir_path);
+        let storage = Storage::from_stub(TestStorageStub::new(Vec::<(String, String)>::new()));
+        let control = StorageControl::from_stub(TestStorageControlStub::new(Vec::<
+            ListObjectsResponse,
+        >::new()));
+        let downloader = Downloader::new(&storage, &control, &model, model_dir);
+
+        let manifest = CacheManifest::new(
+            &model,
+            vec![
+                manifest_entry_with_generation("tokenizer.json", b"{}", 21),
+                manifest_entry_with_generation("weights/model.bin", b"weights", 22),
+            ],
+        );
+
+        let metadata_only = downloader
+            .download_tasks_from_manifest(&manifest, true)
+            .expect("Expected task generation");
+        assert_eq!(metadata_only.len(), 1);
+        assert_eq!(
+            metadata_only[0].relative_path,
+            PathBuf::from("tokenizer.json")
+        );
+        assert_eq!(
+            metadata_only[0].destination_path,
+            model_dir_path.join("tokenizer.json")
+        );
+        assert_eq!(metadata_only[0].generation, Some(21));
+
+        let full_request = downloader
+            .download_tasks_from_manifest(&manifest, false)
+            .expect("Expected full task generation");
+        assert_eq!(full_request.len(), 2);
+        assert_eq!(
+            full_request[1].relative_path,
+            PathBuf::from("weights/model.bin")
+        );
+        assert_eq!(
+            full_request[1].object_name,
+            format!("{}/weights/model.bin", model.object_prefix)
+        );
+
+        let invalid_crc_manifest = CacheManifest::new(
+            &model,
+            vec![ManifestEntry {
+                path: "tokenizer.json".to_string(),
+                size: 2,
+                crc32c: "not-hex".to_string(),
+                generation: Some(23),
+            }],
+        );
+        assert!(
+            downloader
+                .download_tasks_from_manifest(&invalid_crc_manifest, false)
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_tasks_in_parallel_resumes_partial_downloads_and_skips_cached_files() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model =
+            ModelName::parse("gs://test-bucket/org/model/rev123").expect("Expected model parsing");
+        let model_dir_path = model.model_dir(temp_dir.path());
+        let model_dir = ModelDir::new(temp_dir.path(), &model_dir_path);
+        let tokenizer_object = format!("{}/tokenizer.json", model.object_prefix);
+        let weights_object = format!("{}/weights/model.bin", model.object_prefix);
+
+        let storage_stub = TestStorageStub::new([(weights_object.clone(), "weights".to_string())]);
+        let storage = Storage::from_stub(storage_stub.clone());
+        let control = StorageControl::from_stub(TestStorageControlStub::new(Vec::<
+            ListObjectsResponse,
+        >::new()));
+        let downloader = Downloader::new(&storage, &control, &model, model_dir);
+        let manifest = CacheManifest::new(
+            &model,
+            vec![
+                manifest_entry_with_generation("tokenizer.json", b"{}", 31),
+                manifest_entry_with_generation("weights/model.bin", b"weights", 32),
+            ],
+        );
+        let tasks = downloader
+            .download_tasks_from_manifest(&manifest, false)
+            .expect("Expected download tasks");
+
+        let cached_task = tasks
+            .iter()
+            .find(|task| task.object_name == tokenizer_object)
+            .expect("Expected cached tokenizer task");
+        if let Some(parent) = cached_task.destination_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create cached destination dir");
+        }
+        fs::write(&cached_task.destination_path, b"{}")
+            .expect("Failed to write cached destination");
+        if let Some(parent) = cached_task.temp_path().parent() {
+            fs::create_dir_all(parent).expect("Failed to create cached temp dir");
+        }
+        fs::write(cached_task.temp_path(), b"stale").expect("Failed to write stale temp");
+
+        let resumed_task = tasks
+            .iter()
+            .find(|task| task.object_name == weights_object)
+            .expect("Expected resumable weights task");
+        if let Some(parent) = resumed_task.temp_path().parent() {
+            fs::create_dir_all(parent).expect("Failed to create resume temp dir");
+        }
+        fs::write(resumed_task.temp_path(), b"we").expect("Failed to write partial temp");
+
+        downloader
+            .download_tasks_in_parallel(&tasks)
+            .await
+            .expect("Expected parallel download");
+
+        assert_eq!(
+            fs::read(&cached_task.destination_path).expect("Expected cached destination payload"),
+            b"{}"
+        );
+        assert!(
+            !cached_task.temp_path().exists(),
+            "Expected stale temp file to be removed"
+        );
+        assert_eq!(
+            fs::read(&resumed_task.destination_path).expect("Expected resumed destination payload"),
+            b"weights"
+        );
+        assert!(
+            !resumed_task.temp_path().exists(),
+            "Expected resumed temp file to be promoted"
+        );
+
+        let requests = storage_stub.read_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].bucket, model.bucket.resource_name());
+        assert_eq!(requests[0].object, weights_object);
+        assert_eq!(requests[0].read_offset, 2);
+        assert_eq!(requests[0].generation, 32);
+    }
+
+    #[tokio::test]
+    async fn test_prepare_and_finalize_task_download_edge_cases() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model =
+            ModelName::parse("gs://test-bucket/org/model/rev123").expect("Expected model parsing");
+        let model_dir_path = model.model_dir(temp_dir.path());
+        let model_dir = ModelDir::new(temp_dir.path(), &model_dir_path);
+        let storage = Storage::from_stub(TestStorageStub::new(Vec::<(String, String)>::new()));
+        let control = StorageControl::from_stub(TestStorageControlStub::new(Vec::<
+            ListObjectsResponse,
+        >::new()));
+        let downloader = Downloader::new(&storage, &control, &model, model_dir);
+
+        let mismatch_task = downloader
+            .build_download_task(
+                PathBuf::from("weights/checksum.bin"),
+                7,
+                Some(41),
+                crc32c::crc32c(b"different"),
+            )
+            .expect("Expected mismatch task");
+        if let Some(parent) = mismatch_task.temp_path().parent() {
+            fs::create_dir_all(parent).expect("Failed to create mismatch temp dir");
+        }
+        fs::write(mismatch_task.temp_path(), b"weights").expect("Failed to write mismatch temp");
+        assert_eq!(
+            downloader
+                .prepare_task_download(&mismatch_task)
+                .await
+                .expect("Expected mismatch temp handling"),
+            Some(0)
+        );
+        assert!(
+            !mismatch_task.temp_path().exists(),
+            "Expected mismatched temp file to be discarded"
+        );
+
+        let oversized_task = downloader
+            .build_download_task(
+                PathBuf::from("weights/oversized.bin"),
+                3,
+                Some(42),
+                crc32c::crc32c(b"abc"),
+            )
+            .expect("Expected oversized task");
+        if let Some(parent) = oversized_task.temp_path().parent() {
+            fs::create_dir_all(parent).expect("Failed to create oversized temp dir");
+        }
+        fs::write(oversized_task.temp_path(), b"toolong").expect("Failed to write oversized temp");
+        assert_eq!(
+            downloader
+                .prepare_task_download(&oversized_task)
+                .await
+                .expect("Expected oversized temp handling"),
+            Some(0)
+        );
+        assert!(
+            !oversized_task.temp_path().exists(),
+            "Expected oversized temp file to be discarded"
+        );
+
+        let generationless_task = DownloadTask {
+            generation: None,
+            ..downloader
+                .build_download_task(
+                    PathBuf::from("weights/generationless.bin"),
+                    7,
+                    Some(43),
+                    crc32c::crc32c(b"weights"),
+                )
+                .expect("Expected generationless task")
+        };
+        if let Some(parent) = generationless_task.temp_path().parent() {
+            fs::create_dir_all(parent).expect("Failed to create generationless temp dir");
+        }
+        fs::write(generationless_task.temp_path(), b"we")
+            .expect("Failed to write generationless temp");
+        assert_eq!(
+            downloader
+                .prepare_task_download(&generationless_task)
+                .await
+                .expect("Expected generationless temp handling"),
+            Some(0)
+        );
+        assert!(
+            !generationless_task.temp_path().exists(),
+            "Expected generationless temp file to be discarded"
+        );
+
+        let incomplete_task = downloader
+            .build_download_task(
+                PathBuf::from("weights/incomplete.bin"),
+                7,
+                Some(44),
+                crc32c::crc32c(b"weights"),
+            )
+            .expect("Expected incomplete task");
+        if let Some(parent) = incomplete_task.temp_path().parent() {
+            fs::create_dir_all(parent).expect("Failed to create incomplete temp dir");
+        }
+        fs::write(incomplete_task.temp_path(), b"w").expect("Failed to write incomplete temp");
+        let err = downloader
+            .finalize_task_download(&incomplete_task)
+            .await
+            .expect_err("Expected finalize to reject incomplete temp");
+        assert!(err.to_string().contains("Incomplete download"));
+    }
+}

--- a/modelexpress_common/src/providers/gcs/lock_file.rs
+++ b/modelexpress_common/src/providers/gcs/lock_file.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use fd_lock::{RwLock as FileRwLock, RwLockWriteGuard as FileWriteGuard};
+use futures::Future;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+
+const FILE_LOCK_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+pub struct LockFile;
+
+impl LockFile {
+    fn try_acquire<'a>(
+        lock: &'a mut FileRwLock<fs::File>,
+        lock_path: &Path,
+    ) -> Result<Option<FileWriteGuard<'a, fs::File>>> {
+        match lock.try_write() {
+            Ok(guard) => Ok(Some(guard)),
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+                ) =>
+            {
+                Ok(None)
+            }
+            Err(err) => Err(anyhow::anyhow!(
+                "Failed to acquire lock file '{}': {}",
+                lock_path.display(),
+                err
+            )),
+        }
+    }
+
+    fn open(path: &Path) -> Result<FileRwLock<fs::File>> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create lock directory '{}'", parent.display())
+            })?;
+        }
+
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .with_context(|| format!("Failed to create lock file '{}'", path.display()))?;
+
+        Ok(FileRwLock::new(file))
+    }
+
+    pub async fn with_exclusive<T, F, Fut>(lock_path: &Path, op: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        let mut lock_file = Self::open(lock_path)?;
+        let _lock = loop {
+            if let Some(lock) = Self::try_acquire(&mut lock_file, lock_path)? {
+                break lock;
+            }
+            tokio::time::sleep(FILE_LOCK_POLL_INTERVAL).await;
+        };
+
+        op().await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::sync::{Mutex, oneshot};
+
+    #[tokio::test]
+    async fn test_with_exclusive_creates_parent_directories_and_lock_file() {
+        let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+        let lock_path = temp_dir.path().join("nested/locks/model.lock");
+
+        let result = LockFile::with_exclusive(&lock_path, || async { Ok(7usize) })
+            .await
+            .expect("Expected lock acquisition");
+
+        assert_eq!(result, 7);
+        assert!(lock_path.is_file());
+    }
+
+    #[tokio::test]
+    async fn test_with_exclusive_serializes_concurrent_access() {
+        let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+        let lock_path = Arc::new(temp_dir.path().join("model.lock"));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (release_first_tx, release_first_rx) = oneshot::channel();
+
+        let first_lock_path = Arc::clone(&lock_path);
+        let first_events = Arc::clone(&events);
+        let first = tokio::spawn(async move {
+            LockFile::with_exclusive(&first_lock_path, || async move {
+                first_events.lock().await.push("first-start");
+                first_started_tx
+                    .send(())
+                    .expect("Expected first-start notification");
+                release_first_rx
+                    .await
+                    .expect("Expected release notification");
+                first_events.lock().await.push("first-end");
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        });
+
+        first_started_rx
+            .await
+            .expect("Expected first lock to be acquired");
+
+        let second_lock_path = Arc::clone(&lock_path);
+        let second_events = Arc::clone(&events);
+        let second = tokio::spawn(async move {
+            LockFile::with_exclusive(&second_lock_path, || async move {
+                second_events.lock().await.push("second");
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        });
+
+        tokio::time::sleep(FILE_LOCK_POLL_INTERVAL + FILE_LOCK_POLL_INTERVAL).await;
+        assert_eq!(
+            *events.lock().await,
+            vec!["first-start"],
+            "second task should wait while the first task holds the lock"
+        );
+
+        release_first_tx
+            .send(())
+            .expect("Expected first lock release signal");
+        first
+            .await
+            .expect("Expected first task to join")
+            .expect("Expected first lock task to succeed");
+        second
+            .await
+            .expect("Expected second task to join")
+            .expect("Expected second lock task to succeed");
+
+        assert_eq!(
+            *events.lock().await,
+            vec!["first-start", "first-end", "second"]
+        );
+    }
+}

--- a/modelexpress_common/src/providers/gcs/model_dir.rs
+++ b/modelexpress_common/src/providers/gcs/model_dir.rs
@@ -1,0 +1,921 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    GcsProvider,
+    cache_manifest::{CacheManifest, MANIFEST_VERSION},
+    downloader::Downloader,
+    lock_file::LockFile,
+    model_name::{BucketName, CACHE_ROOT_DIR_NAME, ModelName},
+    path_ext::PathExt,
+};
+use crate::providers::ModelProviderTrait;
+use anyhow::{Context, Result};
+use std::{
+    collections::HashSet,
+    ffi::OsStr,
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+use tracing::warn;
+
+pub const INTERNAL_METADATA_DIR_NAME: &str = ".mx";
+const MANIFEST_FILE_NAME: &str = "manifest.json";
+const MANIFEST_LOCK_FILE_NAME: &str = "manifest.lock";
+
+#[derive(Debug, Clone, Copy)]
+pub struct ModelDir<'a> {
+    cache_dir: &'a Path,
+    pub model_dir: &'a Path,
+}
+
+impl<'a> ModelDir<'a> {
+    pub fn new(cache_dir: &'a Path, model_dir: &'a Path) -> Self {
+        Self {
+            cache_dir,
+            model_dir,
+        }
+    }
+
+    fn metadata_dir(&self) -> PathBuf {
+        self.model_dir.join(INTERNAL_METADATA_DIR_NAME)
+    }
+
+    fn manifest_path(&self) -> PathBuf {
+        self.metadata_dir().join(MANIFEST_FILE_NAME)
+    }
+
+    fn manifest_temp_path(&self) -> PathBuf {
+        self.metadata_dir()
+            .join(format!("{MANIFEST_FILE_NAME}.tmp"))
+    }
+
+    fn manifest_lock_path(&self) -> PathBuf {
+        self.metadata_dir().join(MANIFEST_LOCK_FILE_NAME)
+    }
+
+    pub fn has_manifest_file(&self) -> bool {
+        self.manifest_path().is_file()
+    }
+
+    pub fn write_manifest(&self, manifest: &CacheManifest) -> Result<()> {
+        let manifest_path = self.manifest_path();
+        let temp_path = self.manifest_temp_path();
+        fs::create_dir_all(self.metadata_dir()).with_context(|| {
+            format!(
+                "Failed to create GCS metadata directory '{}'",
+                self.metadata_dir().display()
+            )
+        })?;
+
+        let mut payload = serde_json::to_vec_pretty(manifest).with_context(|| {
+            format!(
+                "Failed to serialize manifest for '{}'",
+                self.model_dir.display()
+            )
+        })?;
+        payload.push(b'\n');
+
+        fs::write(&temp_path, payload)
+            .with_context(|| format!("Failed to write manifest '{}'", temp_path.display()))?;
+        if let Err(err) = fs::rename(&temp_path, &manifest_path).with_context(|| {
+            format!(
+                "Failed to move manifest '{}' into '{}'",
+                temp_path.display(),
+                manifest_path.display()
+            )
+        }) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    pub async fn ensure_manifest(
+        &self,
+        model: &ModelName,
+        downloader: &Downloader<'_, impl google_cloud_storage::stub::Storage + 'static>,
+    ) -> Result<CacheManifest> {
+        if let Some(manifest) = self.load_manifest()? {
+            return Ok(manifest);
+        }
+
+        LockFile::with_exclusive(&self.manifest_lock_path(), || async move {
+            if let Some(manifest) = self.load_manifest()? {
+                return Ok(manifest);
+            }
+
+            let manifest = CacheManifest::new(model, downloader.collect_manifest_entries().await?);
+            self.write_manifest(&manifest)?;
+            Ok(manifest)
+        })
+        .await
+    }
+
+    fn load_manifest(&self) -> Result<Option<CacheManifest>> {
+        let manifest_path = self.manifest_path();
+        if !manifest_path.is_file() {
+            return Ok(None);
+        }
+
+        let contents = fs::read(&manifest_path)
+            .with_context(|| format!("Failed to read manifest '{}'", manifest_path.display()));
+        let manifest = contents.and_then(|contents| {
+            serde_json::from_slice::<CacheManifest>(&contents)
+                .with_context(|| format!("Failed to parse manifest '{}'", manifest_path.display()))
+        });
+        let Some(manifest) = (match manifest {
+            Ok(manifest) => Some(manifest),
+            Err(err) => {
+                warn!(
+                    "Ignoring unreadable GCS manifest '{}': {}",
+                    manifest_path.display(),
+                    err
+                );
+                return Ok(None);
+            }
+        }) else {
+            return Ok(None);
+        };
+
+        let expected_model = self.model_name()?.to_string();
+        let mut seen_paths = HashSet::new();
+        let manifest_is_valid = manifest.version == MANIFEST_VERSION
+            && manifest.model == expected_model
+            && !manifest.files.is_empty()
+            && manifest.files.iter().all(|entry| {
+                let relative_path = Path::new(&entry.path);
+                !entry.path.is_empty()
+                    && relative_path.is_safe_relative()
+                    && !Self::is_internal_artifact(relative_path)
+                    && u32::from_str_radix(&entry.crc32c, 16).is_ok()
+                    && seen_paths.insert(entry.path.clone())
+            });
+
+        if !manifest_is_valid {
+            warn!(
+                "Ignoring invalid GCS manifest '{}'",
+                manifest_path.display(),
+            );
+            return Ok(None);
+        }
+
+        Ok(Some(manifest))
+    }
+
+    pub fn model_name(&self) -> Result<ModelName> {
+        let gcs_root = self.cache_dir.join(CACHE_ROOT_DIR_NAME);
+        let relative = self.model_dir.strip_prefix(&gcs_root).with_context(|| {
+            format!(
+                "GCS model directory '{}' is outside cache directory '{}'",
+                self.model_dir.display(),
+                gcs_root.display()
+            )
+        })?;
+        let mut components = relative.components();
+        let bucket_component = components.next().ok_or_else(|| {
+            anyhow::anyhow!(
+                "GCS model directory '{}' is missing bucket and object path",
+                self.model_dir.display()
+            )
+        })?;
+        let bucket_name = match bucket_component {
+            Component::Normal(component) => component.to_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "GCS bucket component in '{}' is not valid UTF-8",
+                    self.model_dir.display()
+                )
+            })?,
+            _ => {
+                anyhow::bail!(
+                    "GCS model directory '{}' has invalid bucket component",
+                    self.model_dir.display()
+                )
+            }
+        };
+        let bucket = BucketName::parse(bucket_name)?;
+
+        let mut object_prefix_components = Vec::new();
+        for component in components {
+            let component = match component {
+                Component::Normal(component) => component.to_str().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "GCS object path component in '{}' is not valid UTF-8",
+                        self.model_dir.display()
+                    )
+                })?,
+                _ => {
+                    anyhow::bail!(
+                        "GCS model directory '{}' has invalid object path component",
+                        self.model_dir.display()
+                    )
+                }
+            };
+            object_prefix_components.push(component);
+        }
+
+        if object_prefix_components.is_empty() {
+            anyhow::bail!(
+                "GCS model directory '{}' is missing object path",
+                self.model_dir.display()
+            );
+        }
+
+        ModelName::new(bucket, &object_prefix_components.join("/"))
+    }
+
+    pub fn parse_relative_object_path(&self, relative_key: &str) -> Result<PathBuf> {
+        if relative_key.split('/').any(str::is_empty) {
+            anyhow::bail!(
+                "Unsafe object path '{relative_key}' for model '{}': empty path segments are not allowed",
+                self.model_name()?
+            );
+        }
+
+        let path = Path::new(relative_key);
+        if !path.is_safe_relative() {
+            anyhow::bail!(
+                "Unsafe object path '{relative_key}' for model '{}'",
+                self.model_name()?
+            );
+        }
+        if Self::is_internal_artifact(path) {
+            anyhow::bail!(
+                "GCS model '{}' contains reserved internal path '{}'",
+                self.model_name()?,
+                relative_key
+            );
+        }
+
+        Ok(path.to_path_buf())
+    }
+
+    pub fn cache_satisfies_request(&self, ignore_weights: bool) -> Result<bool> {
+        let Some(manifest) = self.load_manifest()? else {
+            return Ok(false);
+        };
+        let mut matched_entry = false;
+        for entry in &manifest.files {
+            if ignore_weights && GcsProvider::is_weight_file(&entry.path) {
+                continue;
+            }
+
+            matched_entry = true;
+            let file_path = self.model_dir.join(&entry.path);
+            let metadata = match fs::metadata(&file_path) {
+                Ok(metadata) => metadata,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(false),
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to inspect manifest file '{}': {}",
+                        file_path.display(),
+                        err
+                    ));
+                }
+            };
+            if !metadata.is_file() {
+                return Ok(false);
+            }
+        }
+        Ok(matched_entry)
+    }
+
+    fn find_overlap(&self) -> Result<Option<(&'static str, ModelName)>> {
+        let model = self.model_name()?;
+        let bucket_dir = model.bucket_dir(self.cache_dir);
+        let mut current = self.model_dir.parent();
+        while let Some(ancestor) = current {
+            if !ancestor.starts_with(&bucket_dir) {
+                break;
+            }
+
+            let ancestor_model_dir = ModelDir::new(self.cache_dir, ancestor);
+            if ancestor_model_dir.has_manifest_file() {
+                return Ok(Some(("ancestor", ancestor_model_dir.model_name()?)));
+            }
+
+            if ancestor == bucket_dir {
+                break;
+            }
+            current = ancestor.parent();
+        }
+
+        if !self.model_dir.is_dir() {
+            return Ok(None);
+        }
+
+        let mut pending = vec![self.model_dir.to_path_buf()];
+        while let Some(current_dir) = pending.pop() {
+            for entry in fs::read_dir(&current_dir)
+                .with_context(|| format!("Failed to read directory '{}'", current_dir.display()))?
+            {
+                let entry = entry?;
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+
+                let child_model_dir = ModelDir::new(self.cache_dir, &path);
+                if child_model_dir.has_manifest_file() {
+                    return Ok(Some(("descendant", child_model_dir.model_name()?)));
+                }
+
+                pending.push(path);
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn is_removable(&self) -> Result<bool> {
+        if self.has_manifest_file() {
+            self.model_name()?;
+            return Ok(true);
+        }
+
+        if !self.model_dir.exists() {
+            return Ok(false);
+        }
+
+        Ok(self.find_overlap()?.is_none())
+    }
+
+    pub fn remove(&self) -> Result<()> {
+        if !self.is_removable()? {
+            anyhow::bail!(
+                "GCS model directory '{}' is not removable",
+                self.model_dir.display()
+            );
+        }
+
+        if self.model_dir.is_dir() {
+            fs::remove_dir_all(self.model_dir).with_context(|| {
+                format!(
+                    "Failed to remove cached GCS model directory '{}'",
+                    self.model_dir.display()
+                )
+            })?;
+        } else {
+            fs::remove_file(self.model_dir).with_context(|| {
+                format!(
+                    "Failed to remove cached GCS model file '{}'",
+                    self.model_dir.display()
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    pub fn ensure_available(&self) -> Result<()> {
+        let model = self.model_name()?;
+
+        if let Some((kind, overlap)) = self.find_overlap()? {
+            anyhow::bail!(
+                "GCS model '{}' overlaps cached {} model '{}'",
+                model,
+                kind,
+                overlap
+            );
+        }
+
+        Ok(())
+    }
+
+    fn is_internal_artifact(relative: &Path) -> bool {
+        matches!(
+            relative.components().next(),
+            Some(Component::Normal(component)) if component == OsStr::new(INTERNAL_METADATA_DIR_NAME)
+        )
+    }
+
+    pub fn size(&self) -> Result<u64> {
+        let mut size = 0u64;
+        let mut pending = vec![self.model_dir.to_path_buf()];
+
+        while let Some(current_dir) = pending.pop() {
+            for entry in fs::read_dir(&current_dir)
+                .with_context(|| format!("Failed to read directory '{}'", current_dir.display()))?
+            {
+                let entry = entry?;
+                let path = entry.path();
+                let relative = path
+                    .strip_prefix(self.model_dir)
+                    .with_context(|| format!("Failed to make '{}' relative", path.display()))?;
+
+                if Self::is_internal_artifact(relative) {
+                    continue;
+                }
+
+                if path.is_file() {
+                    size = size.saturating_add(fs::metadata(&path)?.len());
+                } else if path.is_dir() {
+                    pending.push(path);
+                }
+            }
+        }
+
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::super::{
+        GcsProvider,
+        cache_manifest::{CacheManifest, MANIFEST_VERSION},
+        model_name::{BucketName, ModelName},
+        path_ext::PathExt,
+        test_support::{
+            expected_internal_dir, expected_model_dir, manifest_entry, write_cached_model,
+            write_manifest_with_payloads,
+        },
+    };
+    use super::*;
+    use crate::providers::ModelProviderTrait;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_manifest_rejects_invalid_entries() {
+        let model_name = "gs://test-bucket/org/model/rev-1";
+        for (scenario, files) in [
+            (
+                "duplicate_paths",
+                serde_json::json!([
+                    {
+                        "path": "tokenizer.json",
+                        "size": 2,
+                        "crc32c": format!("{:08x}", crc32c::crc32c(b"{}")),
+                        "generation": 11
+                    },
+                    {
+                        "path": "tokenizer.json",
+                        "size": 7,
+                        "crc32c": format!("{:08x}", crc32c::crc32c(b"weights")),
+                        "generation": 12
+                    }
+                ]),
+            ),
+            (
+                "reserved_internal_path",
+                serde_json::json!([{
+                    "path": ".mx/manifest.json",
+                    "size": 2,
+                    "crc32c": format!("{:08x}", crc32c::crc32c(b"{}")),
+                    "generation": 13
+                }]),
+            ),
+            (
+                "invalid_crc",
+                serde_json::json!([{
+                    "path": "tokenizer.json",
+                    "size": 2,
+                    "crc32c": "not-hex",
+                    "generation": 14
+                }]),
+            ),
+            (
+                "wrong_model_name",
+                serde_json::json!([{
+                    "path": "tokenizer.json",
+                    "size": 2,
+                    "crc32c": format!("{:08x}", crc32c::crc32c(b"{}")),
+                    "generation": 15
+                }]),
+            ),
+        ] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let model_dir = expected_model_dir(temp_dir.path(), model_name);
+            let internal_dir = expected_internal_dir(temp_dir.path(), model_name);
+            fs::create_dir_all(&internal_dir).expect("Failed to create metadata dir");
+
+            let manifest = serde_json::json!({
+                "version": MANIFEST_VERSION,
+                "model": if scenario == "wrong_model_name" {
+                    "gs://other-bucket/org/model/rev-1"
+                } else {
+                    model_name
+                },
+                "files": files
+            });
+            fs::write(
+                internal_dir.join(MANIFEST_FILE_NAME),
+                serde_json::to_vec(&manifest).expect("Expected manifest serialization"),
+            )
+            .expect("Failed to write manifest");
+
+            let model_dir = ModelDir::new(temp_dir.path(), &model_dir);
+            assert!(
+                model_dir
+                    .load_manifest()
+                    .expect("Expected manifest read to succeed")
+                    .is_none(),
+                "scenario={scenario}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_write_manifest_scenarios() {
+        let model_name = "gs://testbucket/dev/bake/qwen/rev123";
+        let model = ModelName::parse(model_name).expect("Expected model parse");
+        let cases = [
+            (
+                "create",
+                None,
+                CacheManifest::new(&model, vec![manifest_entry("tokenizer.json", b"{}")]),
+            ),
+            (
+                "replace",
+                Some(CacheManifest::new(
+                    &model,
+                    vec![manifest_entry("tokenizer.json", b"{}")],
+                )),
+                CacheManifest::new(&model, vec![manifest_entry("config.json", br#"{"a":1}"#)]),
+            ),
+            (
+                "expand",
+                Some(CacheManifest::new(
+                    &model,
+                    vec![manifest_entry("tokenizer.json", b"{}")],
+                )),
+                CacheManifest::new(
+                    &model,
+                    vec![
+                        manifest_entry("tokenizer.json", b"{}"),
+                        manifest_entry("weights/model.bin", b"weights"),
+                    ],
+                ),
+            ),
+        ];
+
+        for (name, initial_manifest, final_manifest) in cases {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let model_dir = expected_model_dir(temp_dir.path(), model_name);
+            let model_dir_state = ModelDir::new(temp_dir.path(), &model_dir);
+
+            if let Some(initial_manifest) = initial_manifest {
+                model_dir_state
+                    .write_manifest(&initial_manifest)
+                    .expect("Expected initial manifest write");
+            }
+
+            model_dir_state
+                .write_manifest(&final_manifest)
+                .expect("Expected manifest write");
+
+            let parsed: CacheManifest = serde_json::from_slice(
+                &fs::read(model_dir_state.manifest_path()).expect("Expected manifest contents"),
+            )
+            .expect("Expected manifest JSON");
+            assert_eq!(parsed, final_manifest, "scenario={name}");
+            assert!(
+                !model_dir_state.manifest_temp_path().exists(),
+                "scenario={name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mx_path_layout_tables() {
+        assert_eq!(GcsProvider.provider_name(), "GCS");
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model_name = "gs://testbucket/dev/bake/qwen/rev123";
+        let model_dir = expected_model_dir(temp_dir.path(), model_name);
+        let model_dir = ModelDir::new(temp_dir.path(), &model_dir);
+
+        for (path, expected) in [
+            (
+                model_dir.manifest_path(),
+                expected_internal_dir(temp_dir.path(), model_name).join(MANIFEST_FILE_NAME),
+            ),
+            (
+                model_dir.manifest_temp_path(),
+                expected_internal_dir(temp_dir.path(), model_name).join("manifest.json.tmp"),
+            ),
+            (
+                model_dir.manifest_lock_path(),
+                expected_internal_dir(temp_dir.path(), model_name).join(MANIFEST_LOCK_FILE_NAME),
+            ),
+        ] {
+            assert_eq!(path, expected);
+        }
+
+        for (path, expected_reserved) in [
+            (".mx/manifest.json", true),
+            (".mx/parts/weights/model.bin.part", true),
+            ("weights/model.bin", false),
+        ] {
+            assert_eq!(
+                ModelDir::is_internal_artifact(Path::new(path)),
+                expected_reserved,
+                "path={path}"
+            );
+        }
+
+        let root = temp_dir.path().join("size-case");
+        fs::create_dir_all(root.join("nested")).expect("Failed to create nested dirs");
+        fs::create_dir_all(root.join(".mx/parts/nested")).expect("Failed to create parts dir");
+        fs::create_dir_all(root.join(".mx/locks/nested")).expect("Failed to create locks dir");
+        fs::write(root.join("nested/model.bin"), b"weights").expect("Failed to create model file");
+        fs::write(root.join(".mx/parts/nested/model.bin.part"), b"partial")
+            .expect("Failed to create temp file");
+        fs::write(root.join(".mx/locks/nested/model.bin.lock"), b"lock")
+            .expect("Failed to create lock file");
+        assert_eq!(
+            (ModelDir::new(&root, &root))
+                .size()
+                .expect("Expected model dir size"),
+            7
+        );
+    }
+
+    #[test]
+    fn test_model_name_tables_cover_normalization_paths_and_cache_roundtrip() {
+        let valid_cases = [
+            (
+                "gs://testbucket/dev/bake/qwen/rev123",
+                "gs://testbucket/dev/bake/qwen/rev123",
+                PathBuf::from("/tmp/cache/gcs/testbucket/dev/bake/qwen/rev123"),
+            ),
+            (
+                "gs://testbucket/dev/bake/qwen/rev123/",
+                "gs://testbucket/dev/bake/qwen/rev123",
+                PathBuf::from("/tmp/cache/gcs/testbucket/dev/bake/qwen/rev123"),
+            ),
+            (
+                "gs://sourcebucket/dev/bake/qwen/rev123",
+                "gs://sourcebucket/dev/bake/qwen/rev123",
+                PathBuf::from("/tmp/cache/gcs/sourcebucket/dev/bake/qwen/rev123"),
+            ),
+            (
+                "gs://sourcebucket/dev/bake/qwen/rev123/",
+                "gs://sourcebucket/dev/bake/qwen/rev123",
+                PathBuf::from("/tmp/cache/gcs/sourcebucket/dev/bake/qwen/rev123"),
+            ),
+        ];
+
+        for (input, canonical, expected_model_dir) in valid_cases {
+            let model = ModelName::parse(input).expect("Expected model parsing");
+            assert_eq!(model.to_string(), canonical, "input={input}");
+            assert_eq!(
+                model.model_dir(Path::new("/tmp/cache")),
+                expected_model_dir,
+                "input={input}"
+            );
+        }
+
+        for invalid in [
+            "",
+            "gs://bucket-only",
+            "gs://bucket-only/",
+            "dev/bake/qwen/rev123",
+        ] {
+            assert!(ModelName::parse(invalid).is_err(), "input={invalid}");
+        }
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model_name = "gs://testbucket/dev/bake/qwen/rev123";
+        let model_dir = expected_model_dir(temp_dir.path(), model_name);
+        write_cached_model(temp_dir.path(), model_name, "tokenizer.json", b"{}");
+        let model = ModelDir::new(temp_dir.path(), &model_dir)
+            .model_name()
+            .expect("Expected cached model name");
+        assert_eq!(model.to_string(), model_name);
+    }
+
+    #[test]
+    fn test_bucket_name_parse_table() {
+        let valid_cases = [("gs://example-bucket/", "example-bucket")];
+        for (input, expected) in valid_cases {
+            assert_eq!(
+                BucketName::parse(input)
+                    .expect("Expected bucket normalization")
+                    .to_string(),
+                expected,
+                "input={input}"
+            );
+        }
+
+        for invalid in ["example-bucket/path", "..", ".", "gs://../"] {
+            assert!(BucketName::parse(invalid).is_err(), "input={invalid}");
+        }
+    }
+
+    #[test]
+    fn test_relative_object_path_tables_cover_safety_downloadability_and_weight_matching() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model_path = expected_model_dir(temp_dir.path(), "gs://test-bucket/org/model/rev-1");
+        let model_dir = ModelDir::new(temp_dir.path(), &model_path);
+        let relative_path_cases = [
+            ("README.md", false, true, true, false),
+            ("nested/README.md", false, true, true, false),
+            (".gitattributes", false, true, true, false),
+            ("image.png", false, true, true, false),
+            ("nested/image.webp", false, true, true, false),
+            ("config.json", true, true, true, false),
+            ("tokenizer.json", true, true, true, false),
+            ("foo.mlir", true, true, true, false),
+            ("compile_summary.json", true, true, true, false),
+            ("manifest.json", true, true, true, false),
+            ("nested/preset.json", true, true, true, false),
+            ("model.safetensors", true, false, true, true),
+            ("weights/model.bin", true, false, true, true),
+            ("weights/model.iop", true, false, true, true),
+            ("weights/model.gas", true, false, true, true),
+            ("weights/model.h5", true, false, true, true),
+            ("weights/model.msgpack", true, false, true, true),
+            ("weights/model.ckpt.index", true, false, true, true),
+        ];
+
+        for (
+            relative_path,
+            expected_downloadable,
+            expected_metadata_match,
+            expected_safe,
+            expected_weight,
+        ) in relative_path_cases
+        {
+            let relative = model_dir
+                .parse_relative_object_path(relative_path)
+                .expect("Expected valid relative object path");
+            assert_eq!(
+                relative.is_safe_relative(),
+                expected_safe,
+                "safe check for {relative_path}"
+            );
+            assert_eq!(
+                GcsProvider::is_downloadable_path(&relative),
+                expected_downloadable,
+                "downloadable check for {relative_path}"
+            );
+            assert_eq!(
+                GcsProvider::matches_request_path(&relative, true),
+                expected_metadata_match,
+                "metadata match for {relative_path}"
+            );
+            assert!(
+                GcsProvider::matches_request_path(&relative, false),
+                "full request match for {relative_path}"
+            );
+            assert_eq!(
+                GcsProvider::is_weight_file(relative.to_string_lossy().as_ref()),
+                expected_weight,
+                "weight check for {relative_path}"
+            );
+        }
+
+        for path in ["weights/model.safetensors", "tokenizer.json"] {
+            assert!(
+                Path::new(path).is_safe_relative(),
+                "expected safe relative path: {path}"
+            );
+        }
+        for path in ["../model.safetensors", "/etc/passwd"] {
+            assert!(
+                !Path::new(path).is_safe_relative(),
+                "expected unsafe relative path: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_relative_path_validation_tables() {
+        fn candidate<'a>(object_name: &'a str, list_prefix: &str) -> Option<&'a str> {
+            object_name
+                .strip_prefix(list_prefix)
+                .filter(|suffix| !suffix.is_empty() && !suffix.ends_with('/'))
+        }
+
+        assert!(candidate("other/model/file.bin", "org/model/rev123/").is_none());
+        assert!(candidate("org/model/rev123/", "org/model/rev123/").is_none());
+        assert!(candidate("org/model/rev123/subdir/", "org/model/rev123/").is_none());
+        assert_eq!(
+            candidate("org/model/rev123/tokenizer.json", "org/model/rev123/"),
+            Some("tokenizer.json")
+        );
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let model_path = expected_model_dir(temp_dir.path(), "gs://test-bucket/org/model/rev-1");
+        let model_dir = ModelDir::new(temp_dir.path(), &model_path);
+        for invalid in ["../secret.bin", "a//b.bin", "/a/b.bin", "a/b//c.bin"] {
+            assert!(
+                model_dir.parse_relative_object_path(invalid).is_err(),
+                "input={invalid}"
+            );
+        }
+
+        for (path, expected_valid) in [
+            ("weights/model.bin", true),
+            ("", false),
+            ("/etc/passwd", false),
+            ("../escape", false),
+        ] {
+            let path = Path::new(path);
+            let is_valid_relative = !path.as_os_str().is_empty() && path.is_safe_relative();
+            assert_eq!(is_valid_relative, expected_valid, "path={:?}", path);
+        }
+    }
+
+    #[test]
+    fn test_request_is_satisfied_scenarios() {
+        for scenario in ["metadata_only_payload", "invalid_manifest"] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let model_name = match scenario {
+                "metadata_only_payload" => "gs://bucket/foo/bar/baz",
+                "invalid_manifest" => "gs://bucket/foo/bar/bad",
+                _ => unreachable!("unexpected scenario"),
+            };
+            let model_dir = expected_model_dir(temp_dir.path(), model_name);
+
+            match scenario {
+                "metadata_only_payload" => write_manifest_with_payloads(
+                    temp_dir.path(),
+                    model_name,
+                    &[("tokenizer.json", b"{}")],
+                    vec![
+                        manifest_entry("tokenizer.json", b"{}"),
+                        manifest_entry("weights/model.bin", b"weights"),
+                    ],
+                ),
+                "invalid_manifest" => {
+                    let internal_dir = expected_internal_dir(temp_dir.path(), model_name);
+                    fs::create_dir_all(&internal_dir).expect("Failed to create metadata dir");
+                    let invalid_manifest = serde_json::json!({
+                        "version": MANIFEST_VERSION + 1,
+                        "model": model_name,
+                        "files": [{
+                            "path": "tokenizer.json",
+                            "size": 2,
+                            "crc32c": format!("{:08x}", crc32c::crc32c(b"{}")),
+                            "generation": 42
+                        }]
+                    });
+                    fs::write(
+                        internal_dir.join(MANIFEST_FILE_NAME),
+                        serde_json::to_vec(&invalid_manifest)
+                            .expect("Expected manifest serialization"),
+                    )
+                    .expect("Failed to write invalid manifest");
+                    fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+                    fs::write(model_dir.join("tokenizer.json"), b"{}")
+                        .expect("Failed to write payload");
+                }
+                _ => unreachable!("unexpected scenario"),
+            }
+
+            let model_dir = ModelDir::new(temp_dir.path(), &model_dir);
+            match scenario {
+                "metadata_only_payload" => {
+                    assert!(
+                        model_dir
+                            .cache_satisfies_request(true)
+                            .expect("Expected metadata request to be satisfied")
+                    );
+                    assert!(
+                        !model_dir
+                            .cache_satisfies_request(false)
+                            .expect("Expected full request to remain incomplete")
+                    );
+                }
+                "invalid_manifest" => {
+                    assert!(
+                        !model_dir
+                            .cache_satisfies_request(false)
+                            .expect("Expected invalid manifest to be ignored")
+                    );
+                }
+                _ => unreachable!("unexpected scenario"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_ensure_model_dir_available_rejects_ancestor_descendant_overlap() {
+        for (cached_model, requested_model) in [
+            ("gs://bucket/foo/bar/baz", "gs://bucket/foo/bar"),
+            ("gs://bucket/foo/.mx/bar", "gs://bucket/foo"),
+        ] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            write_cached_model(temp_dir.path(), cached_model, "tokenizer.json", b"{}");
+
+            let model = ModelName::parse(requested_model).expect("Expected model parse");
+            let model_dir = model.model_dir(temp_dir.path());
+
+            let err = (ModelDir::new(temp_dir.path(), &model_dir))
+                .ensure_available()
+                .expect_err("Expected overlap rejection");
+
+            assert!(
+                err.to_string().contains("overlaps cached descendant model"),
+                "cached_model={cached_model} requested_model={requested_model} err={err}"
+            );
+        }
+    }
+}

--- a/modelexpress_common/src/providers/gcs/model_name.rs
+++ b/modelexpress_common/src/providers/gcs/model_name.rs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+pub const CACHE_ROOT_DIR_NAME: &str = "gcs";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelName {
+    pub bucket: BucketName,
+    pub object_prefix: String,
+}
+
+impl ModelName {
+    pub fn parse(model_name: &str) -> Result<Self> {
+        if model_name.is_empty() {
+            anyhow::bail!("Model name must not be empty");
+        }
+
+        let Some(full_url) = model_name.strip_prefix("gs://") else {
+            anyhow::bail!("GCS model name must be a full gs://<bucket>/<path> URL");
+        };
+        let (bucket_raw, object_prefix) = full_url
+            .split_once('/')
+            .ok_or_else(|| anyhow::anyhow!("GCS model URL must include bucket and object path"))?;
+        if object_prefix.is_empty() {
+            anyhow::bail!("GCS model URL must include a non-empty object path");
+        }
+
+        let bucket = BucketName::parse(bucket_raw)?;
+        Self::new(bucket, object_prefix)
+    }
+
+    pub fn new(bucket: BucketName, object_prefix: &str) -> Result<Self> {
+        let normalized_object_prefix = object_prefix.trim_end_matches('/');
+        if normalized_object_prefix.is_empty() {
+            anyhow::bail!("GCS model path must not be empty");
+        }
+
+        let mut components = Vec::new();
+        for component in normalized_object_prefix.split('/') {
+            if component.is_empty() {
+                anyhow::bail!("GCS model path must not contain empty path segments");
+            }
+            if component == "." || component == ".." {
+                anyhow::bail!("GCS model path must not contain '.' or '..' segments");
+            }
+            components.push(component);
+        }
+
+        if components.is_empty() {
+            anyhow::bail!("GCS model path must not be empty");
+        }
+
+        Ok(Self {
+            bucket,
+            object_prefix: components.join("/"),
+        })
+    }
+
+    pub fn model_dir(&self, cache_dir: &Path) -> PathBuf {
+        let mut path = self.bucket_dir(cache_dir);
+        for component in self.object_prefix.split('/') {
+            path = path.join(component);
+        }
+        path
+    }
+
+    pub fn bucket_dir(&self, cache_dir: &Path) -> PathBuf {
+        cache_dir
+            .join(CACHE_ROOT_DIR_NAME)
+            .join(self.bucket.as_str())
+    }
+}
+
+impl std::fmt::Display for ModelName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "gs://{}/{}", self.bucket, self.object_prefix)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketName {
+    normalized: String,
+}
+
+impl BucketName {
+    pub fn parse(raw: &str) -> Result<Self> {
+        use std::path::{Component, Path};
+
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("bucket name must not be empty");
+        }
+
+        let without_scheme = trimmed.strip_prefix("gs://").unwrap_or(trimmed);
+        let without_trailing = without_scheme.trim_end_matches('/');
+        if without_trailing.is_empty() {
+            anyhow::bail!("trimmed bucket name must not be empty");
+        }
+
+        if without_trailing.contains('/') {
+            anyhow::bail!("bucket name must contain only the bucket name (no object path)");
+        }
+
+        let mut components = Path::new(without_trailing).components();
+        match (components.next(), components.next()) {
+            (Some(Component::Normal(_)), None) => {}
+            _ => anyhow::bail!("bucket name must be a single normal path segment"),
+        }
+
+        Ok(Self {
+            normalized: without_trailing.to_string(),
+        })
+    }
+
+    fn as_str(&self) -> &str {
+        &self.normalized
+    }
+
+    pub fn resource_name(&self) -> String {
+        format!("projects/_/buckets/{}", self.as_str())
+    }
+}
+
+impl std::fmt::Display for BucketName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/modelexpress_common/src/providers/gcs/path_ext.rs
+++ b/modelexpress_common/src/providers/gcs/path_ext.rs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use crc32c::Crc32cReader;
+use std::fs;
+use std::io;
+use std::path::{Component, Path};
+
+pub trait PathExt {
+    fn calculate_file_crc32c(&self) -> Result<u32>;
+    fn is_safe_relative(&self) -> bool;
+}
+
+impl PathExt for Path {
+    fn calculate_file_crc32c(&self) -> Result<u32> {
+        let file = fs::File::open(self).with_context(|| {
+            format!(
+                "Failed to open '{}' for CRC32C verification",
+                self.display()
+            )
+        })?;
+        let mut reader = Crc32cReader::new(file);
+        io::copy(&mut reader, &mut io::sink()).with_context(|| {
+            format!(
+                "Failed to read '{}' for CRC32C verification",
+                self.display()
+            )
+        })?;
+        Ok(reader.crc32c())
+    }
+
+    fn is_safe_relative(&self) -> bool {
+        if self.is_absolute() {
+            return false;
+        }
+
+        self.components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_is_safe_relative_path_cases() {
+        for (path, expected) in [
+            ("tokenizer.json", true),
+            ("weights/model.bin", true),
+            (".", false),
+            ("..", false),
+            ("weights/../model.bin", false),
+            ("/tmp/model.bin", false),
+        ] {
+            assert_eq!(Path::new(path).is_safe_relative(), expected, "path={path}");
+        }
+    }
+
+    #[test]
+    fn test_calculate_file_crc32c() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let path = temp_dir.path().join("weights.bin");
+        fs::write(&path, b"weights").expect("Failed to write checksum payload");
+
+        assert_eq!(
+            path.as_path()
+                .calculate_file_crc32c()
+                .expect("Expected checksum calculation"),
+            crc32c::crc32c(b"weights")
+        );
+    }
+}

--- a/modelexpress_common/src/providers/gcs/provider_cache.rs
+++ b/modelexpress_common/src/providers/gcs/provider_cache.rs
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    model_dir::ModelDir,
+    model_name::{BucketName, CACHE_ROOT_DIR_NAME, ModelName},
+};
+use crate::cache::{ModelInfo, ProviderCache};
+use crate::models::ModelProvider;
+use anyhow::{Context, Result};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use tracing::{info, warn};
+
+pub struct GcsProviderCache;
+
+impl GcsProviderCache {
+    fn collect_cached_models(
+        cache_dir: &Path,
+        current_dir: &Path,
+        models: &mut Vec<ModelInfo>,
+    ) -> Result<()> {
+        let current_model_dir = ModelDir::new(cache_dir, current_dir);
+        if current_model_dir.has_manifest_file() {
+            match current_model_dir.model_name() {
+                Ok(model) => {
+                    if current_model_dir.cache_satisfies_request(false)? {
+                        models.push(ModelInfo {
+                            provider: ModelProvider::Gcs,
+                            name: model.to_string(),
+                            size: current_model_dir.size()?,
+                            path: current_dir.to_path_buf(),
+                        });
+                    }
+                    return Ok(());
+                }
+                Err(err) => {
+                    warn!(
+                        "Skipping invalid GCS cache entry '{}': {}",
+                        current_dir.display(),
+                        err
+                    );
+                }
+            }
+        }
+
+        for entry in fs::read_dir(current_dir)
+            .with_context(|| format!("Failed to read directory '{}'", current_dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                Self::collect_cached_models(cache_dir, &path, models)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ProviderCache for GcsProviderCache {
+    fn clear_model(&self, cache_dir: &Path, model_name: &str) -> Result<()> {
+        let model = ModelName::parse(model_name)?;
+        let model_dir = model.model_dir(cache_dir);
+        let model_dir_state = ModelDir::new(cache_dir, &model_dir);
+
+        if !model_dir_state.is_removable()? {
+            info!(
+                "Model not found in cache: {} ({:?})",
+                model_name,
+                ModelProvider::Gcs
+            );
+            return Ok(());
+        }
+
+        model_dir_state.remove()?;
+        info!("Cleared model: {} ({:?})", model_name, ModelProvider::Gcs);
+
+        Ok(())
+    }
+
+    fn resolve_model_path(
+        &self,
+        cache_dir: &Path,
+        model_name: &str,
+        _revision: Option<&str>,
+    ) -> Result<PathBuf> {
+        Ok(ModelName::parse(model_name)?.model_dir(cache_dir))
+    }
+
+    fn list_models(&self, cache_dir: &Path) -> Result<Vec<ModelInfo>> {
+        let mut models = Vec::new();
+        let root = cache_dir.join(CACHE_ROOT_DIR_NAME);
+
+        if !root.exists() {
+            return Ok(models);
+        }
+
+        for bucket_entry in fs::read_dir(&root)? {
+            let bucket_entry = bucket_entry?;
+            let bucket_path = bucket_entry.path();
+            if !bucket_path.is_dir() {
+                continue;
+            }
+
+            let Some(bucket_name) = bucket_path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+
+            if BucketName::parse(bucket_name).is_err() {
+                warn!(
+                    "Skipping invalid GCS bucket cache entry '{}'",
+                    bucket_path.display()
+                );
+                continue;
+            }
+
+            Self::collect_cached_models(cache_dir, &bucket_path, &mut models)?;
+        }
+
+        Ok(models)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::super::test_support::{
+        expected_model_dir, manifest_entry, write_cached_model, write_incomplete_cached_model,
+        write_manifest_with_payloads,
+    };
+    use super::*;
+    use crate::cache::ProviderCache;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_list_models_scenarios() {
+        let cache = GcsProviderCache;
+        for scenario in [
+            "partial_manifest",
+            "recursive_siblings",
+            "model_path_contains_internal_segment",
+        ] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            match scenario {
+                "partial_manifest" => write_manifest_with_payloads(
+                    temp_dir.path(),
+                    "gs://bucket/foo/bar/baz",
+                    &[("tokenizer.json", b"{}")],
+                    vec![
+                        manifest_entry("tokenizer.json", b"{}"),
+                        manifest_entry("weights/model.bin", b"weights"),
+                    ],
+                ),
+                "recursive_siblings" => {
+                    write_cached_model(
+                        temp_dir.path(),
+                        "gs://bucket/foo/bar/baz",
+                        "tokenizer.json",
+                        b"{}",
+                    );
+                    write_cached_model(
+                        temp_dir.path(),
+                        "gs://bucket/foo/bar/buz",
+                        "weights/model.bin",
+                        b"abcd",
+                    );
+                }
+                "model_path_contains_internal_segment" => {
+                    write_cached_model(
+                        temp_dir.path(),
+                        "gs://bucket/foo/.mx/bar",
+                        "tokenizer.json",
+                        b"{}",
+                    );
+                }
+                _ => unreachable!("unexpected scenario"),
+            }
+
+            let mut models = cache
+                .list_models(temp_dir.path())
+                .expect("Expected model listing");
+            models.sort_by(|left, right| left.name.cmp(&right.name));
+
+            match scenario {
+                "partial_manifest" => {
+                    assert!(models.is_empty(), "partial manifest should not be listed");
+                }
+                "recursive_siblings" => {
+                    assert_eq!(models.len(), 2);
+                    assert_eq!(models[0].name, "gs://bucket/foo/bar/baz");
+                    assert_eq!(models[0].size, 2);
+                    assert_eq!(models[1].name, "gs://bucket/foo/bar/buz");
+                    assert_eq!(models[1].size, 4);
+                }
+                "model_path_contains_internal_segment" => {
+                    assert_eq!(models.len(), 1);
+                    assert_eq!(models[0].name, "gs://bucket/foo/.mx/bar");
+                    assert_eq!(models[0].size, 2);
+                }
+                _ => unreachable!("unexpected scenario"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_clear_model_scenarios() {
+        let cache = GcsProviderCache;
+        for scenario in [
+            "ancestor_keeps_descendant",
+            "incomplete_removed",
+            "descendant_keeps_cached_ancestor",
+        ] {
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            match scenario {
+                "ancestor_keeps_descendant" => {
+                    let ancestor_name = "gs://bucket/foo/bar";
+                    let descendant_name = "gs://bucket/foo/bar/baz";
+                    write_cached_model(temp_dir.path(), descendant_name, "tokenizer.json", b"{}");
+                    cache
+                        .clear_model(temp_dir.path(), ancestor_name)
+                        .expect("Expected clear to succeed");
+                    assert!(expected_model_dir(temp_dir.path(), descendant_name).exists());
+                }
+                "incomplete_removed" => {
+                    let model_name = "gs://bucket/foo/bar";
+                    let model_dir = expected_model_dir(temp_dir.path(), model_name);
+                    write_incomplete_cached_model(
+                        temp_dir.path(),
+                        model_name,
+                        "tokenizer.json",
+                        b"{}",
+                    );
+                    cache
+                        .clear_model(temp_dir.path(), model_name)
+                        .expect("Expected clear to succeed");
+                    assert!(!model_dir.exists());
+                }
+                "descendant_keeps_cached_ancestor" => {
+                    let ancestor_name = "gs://bucket/foo/bar";
+                    let descendant_name = "gs://bucket/foo/bar/baz";
+                    let ancestor_dir = expected_model_dir(temp_dir.path(), ancestor_name);
+                    let descendant_dir = expected_model_dir(temp_dir.path(), descendant_name);
+                    write_cached_model(temp_dir.path(), ancestor_name, "tokenizer.json", b"{}");
+                    fs::create_dir_all(&descendant_dir).expect("Failed to create descendant dir");
+                    fs::write(descendant_dir.join("partial.bin"), b"partial")
+                        .expect("Failed to create descendant payload");
+                    cache
+                        .clear_model(temp_dir.path(), descendant_name)
+                        .expect("Expected clear to succeed");
+                    assert!(ancestor_dir.exists());
+                    assert!(ancestor_dir.join("tokenizer.json").exists());
+                    assert!(descendant_dir.exists());
+                }
+                _ => unreachable!("unexpected scenario"),
+            }
+        }
+    }
+}

--- a/modelexpress_server/src/database.rs
+++ b/modelexpress_server/src/database.rs
@@ -108,7 +108,8 @@ impl ModelDatabase {
             let provider = match provider_str.as_str() {
                 "HuggingFace" => ModelProvider::HuggingFace,
                 "Ngc" => ModelProvider::Ngc,
-                _ => ModelProvider::HuggingFace,
+                "Gcs" => ModelProvider::Gcs,
+                _ => ModelProvider::HuggingFace, // Default fallback
             };
 
             let status = match status_str.as_str() {
@@ -169,6 +170,7 @@ impl ModelDatabase {
         let provider_str = match provider {
             ModelProvider::HuggingFace => "HuggingFace",
             ModelProvider::Ngc => "Ngc",
+            ModelProvider::Gcs => "Gcs",
         };
 
         let status_str = match status {
@@ -240,6 +242,7 @@ impl ModelDatabase {
             let provider = match provider_str.as_str() {
                 "HuggingFace" => ModelProvider::HuggingFace,
                 "Ngc" => ModelProvider::Ngc,
+                "Gcs" => ModelProvider::Gcs,
                 _ => ModelProvider::HuggingFace,
             };
 
@@ -332,6 +335,7 @@ impl ModelDatabase {
         let provider_str = match provider {
             ModelProvider::HuggingFace => "HuggingFace",
             ModelProvider::Ngc => "Ngc",
+            ModelProvider::Gcs => "Gcs",
         };
 
         // Use INSERT OR IGNORE to atomically create the record only if it doesn't exist
@@ -621,6 +625,20 @@ mod tests {
             .expect("Failed to get record")
             .expect("Record should be present");
         assert_eq!(record.provider, ModelProvider::HuggingFace);
+
+        db.set_status(
+            "test-model-gcs",
+            ModelProvider::Gcs,
+            ModelStatus::DOWNLOADED,
+            None,
+        )
+        .expect("Failed to set status");
+
+        let record = db
+            .get_model_record("test-model-gcs")
+            .expect("Failed to get record")
+            .expect("Record should be present");
+        assert_eq!(record.provider, ModelProvider::Gcs);
     }
 
     #[test]

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -958,6 +958,44 @@ mod tests {
         MODEL_TRACKER.delete_status(&model_name);
     }
 
+    #[tokio::test]
+    async fn test_model_service_already_downloaded_gcs_trailing_slash_uses_canonical_name() {
+        let service = ModelServiceImpl;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos();
+        let canonical_model_name = format!("gs://test-bucket-{timestamp}/org/model/rev-1");
+
+        MODEL_TRACKER.set_status(
+            canonical_model_name.clone(),
+            ModelStatus::DOWNLOADED,
+            ModelProvider::Gcs,
+        );
+
+        let request = Request::new(ModelDownloadRequest {
+            model_name: format!("{canonical_model_name}/"),
+            provider: modelexpress_common::grpc::model::ModelProvider::Gcs as i32,
+            ignore_weights: false,
+        });
+
+        let response = service.ensure_model_downloaded(request).await;
+        assert!(response.is_ok());
+
+        let mut stream = response.expect("Response should be ok").into_inner();
+        let update = stream.next().await.expect("Update should be present");
+        assert!(update.is_ok());
+
+        let status_update = update.expect("Status update should be ok");
+        assert_eq!(status_update.model_name, canonical_model_name);
+        assert_eq!(
+            status_update.status,
+            modelexpress_common::grpc::model::ModelStatus::Downloaded as i32
+        );
+
+        MODEL_TRACKER.delete_status(&canonical_model_name);
+    }
+
     #[test]
     fn test_model_download_tracker_set_status_and_notify() {
         let _temp_dir = TempDir::new().expect("Failed to create temp dir");


### PR DESCRIPTION
- Wire GCS through client, CLI, and server request and streaming flows.
- Validate streamed cache layouts on the server.
- Expose `gcs` provider selection in the CLI and client-facing request paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud Storage (GCS) as a supported model provider alongside HuggingFace.
  * Implemented enhanced streaming validation for model file downloads with stricter error checking.
  * Improved smart fallback mechanism for reliable model downloads across different providers.

* **Improvements**
  * Strengthened error handling and provider validation throughout download workflows.
  * Extended cache discovery to support multiple storage providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->