### PR TITLE
fix: revert "fix:only start NIXL listener when P2P metadata is enabled (#210)"

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -609,7 +609,7 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 | `MX_METADATA_BACKEND` | (required) | Metadata backend: `redis` or `kubernetes` |
 | `MX_CONTIGUOUS_REG` | `0` | Enable contiguous region registration (experimental) |
 | `MX_P2P_METADATA` | `0` | Enable P2P metadata exchange on source workers |
-| `MX_METADATA_PORT` | `5555` | Base NIXL listen port used only when `MX_P2P_METADATA=1`; effective port is `MX_METADATA_PORT + device_id` |
+| `MX_METADATA_PORT` | `5555` | Base NIXL listen port; effective port is `MX_METADATA_PORT + device_id` |
 | `MX_WORKER_GRPC_PORT` | `0` | Worker gRPC port for P2P tensor manifest serving |
 | `MX_WORKER_HOST` | (auto-detect) | Override worker IP/hostname for P2P endpoints |
 | `MX_HEARTBEAT_INTERVAL_SECS` | `30` | Client heartbeat frequency |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -229,7 +229,7 @@ ModelExpress supports GPU-to-GPU model weight transfers between vLLM instances u
 | `MX_REGISTER_LOADERS` | `1` | Auto-register the mx loader with vLLM |
 | `MX_CONTIGUOUS_REG` | `0` | Contiguous region registration (experimental) |
 | `MX_P2P_METADATA` | `0` | Enable P2P metadata exchange (source workers only) |
-| `MX_METADATA_PORT` | `0` | NIXL listen thread port for P2P metadata exchange |
+| `MX_METADATA_PORT` | `5555` | Base NIXL listen port; effective port is `MX_METADATA_PORT + device_id` |
 | `MX_WORKER_GRPC_PORT` | `0` | Worker gRPC port for P2P tensor manifest serving |
 | `MX_WORKER_HOST` | (auto-detect) | Override worker IP/hostname for P2P endpoints |
 | `MX_STATUS_TTL_SECS` | `3600` | TTL for Redis metadata keys (seconds) |

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -18,7 +18,7 @@ import torch.nn as nn
 from ..client import MxClient
 from ..nixl_transfer import is_nixl_available
 from ..tensor_utils import collect_module_tensors, log_tensor_summary
-from ..metadata import is_p2p_metadata_enabled, publish_metadata_and_ready
+from ..metadata import publish_metadata_and_ready
 from .. import p2p_pb2
 
 if TYPE_CHECKING:
@@ -86,19 +86,14 @@ class LoadStrategy(ABC):
 # ---------------------------------------------------------------------------
 
 
-def _init_nixl_manager(global_rank: int, device_id: int, role: str) -> NixlTransferManager:
+def _init_nixl_manager(
+    global_rank: int, device_id: int, role: str, listen_port: int = 0,
+) -> NixlTransferManager:
     """Create and initialize a NIXL transfer manager."""
     from ..nixl_transfer import NixlTransferManager
 
     agent_name = f"mx-{role}-worker{global_rank}-{uuid.uuid4().hex[:8]}"
     logger.debug(f"[Worker {global_rank}] Initializing NIXL manager with agent_name={agent_name}")
-
-    listen_port = None
-    if is_p2p_metadata_enabled():
-        base_port = int(os.environ.get("MX_METADATA_PORT", "5555"))
-        listen_port = base_port + device_id
-        logger.info(f"[Worker {global_rank}] P2P metadata exchange enabled, listening on port {listen_port}")
-
     manager = NixlTransferManager(
         agent_name=agent_name,
         device_id=device_id,
@@ -119,7 +114,13 @@ def register_tensors(model: nn.Module, ctx: LoadContext) -> None:
     log_tensor_summary(ctx.tensors, ctx.global_rank, "Registering tensors")
 
     if ctx.nixl_manager is None:
-        ctx.nixl_manager = _init_nixl_manager(ctx.global_rank, ctx.device_id, "auto")
+        # Always enable the NIXL listen thread: targets need it to call
+        # fetch_remote_metadata on P2P sources, and every node becomes a
+        # source after receiving weights. Each worker needs a unique port
+        # (base + device_id) to avoid collisions in multi-GPU setups.
+        base_port = int(os.environ.get("MX_METADATA_PORT", "5555"))
+        listen_port = base_port + ctx.device_id
+        ctx.nixl_manager = _init_nixl_manager(ctx.global_rank, ctx.device_id, "auto", listen_port)
 
     if not ctx.nixl_manager.tensor_descriptors:
         logger.debug(f"[Worker {ctx.global_rank}] Registering tensors with NIXL...")

--- a/modelexpress_client/python/modelexpress/metadata.py
+++ b/modelexpress_client/python/modelexpress/metadata.py
@@ -125,14 +125,8 @@ def publish_metadata_and_ready(
         nixl_manager, tensors, device_id, global_rank,
     )
 
-    if is_p2p_metadata_enabled():
+    if _is_p2p_metadata_enabled():
         from .worker_server import WorkerGrpcServer
-
-        if nixl_manager._listen_port is None:
-            raise RuntimeError(
-                "P2P metadata exchange requires a NIXL listen port, "
-                "but the NIXL manager was initialized without one."
-            )
 
         host = _get_worker_host()
 
@@ -244,7 +238,7 @@ def _publish_metadata_to_server(
     raise RuntimeError(f"{message}: {last_error}") from last_error
 
 
-def is_p2p_metadata_enabled() -> bool:
+def _is_p2p_metadata_enabled() -> bool:
     """Check if P2P metadata exchange is enabled via env var."""
     return os.environ.get("MX_P2P_METADATA", "0") == "1"
 

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -11,7 +11,6 @@ import torch
 import torch.nn as nn
 
 from modelexpress import p2p_pb2
-from modelexpress.nixl_transfer import NixlTransferManager
 
 
 # ---------------------------------------------------------------------------
@@ -204,37 +203,6 @@ class TestAbstractMethodCompleteness:
         with patch("modelexpress.vllm_loader.DefaultModelLoader") as mock_cls:
             loader.load_weights(model, cfg)
             mock_cls.return_value.load_weights.assert_called_once_with(model, cfg)
-
-
-# ---------------------------------------------------------------------------
-# register_tensors (load_strategy.base)
-# ---------------------------------------------------------------------------
-
-
-class TestInitNixlManager:
-    """Verify _init_nixl_manager computes listen_port from MX_P2P_METADATA."""
-
-    def test_centralized_mode_skips_listen_port(self):
-        from modelexpress.load_strategy.base import _init_nixl_manager
-
-        with patch.dict("os.environ", {"MX_P2P_METADATA": "0"}, clear=False), \
-             patch.object(NixlTransferManager, "initialize"):
-            mgr = _init_nixl_manager(global_rank=0, device_id=0, role="auto")
-
-        assert mgr._listen_port is None
-
-    def test_p2p_mode_sets_listen_port_with_device_offset(self):
-        from modelexpress.load_strategy.base import _init_nixl_manager
-
-        with patch.dict(
-            "os.environ",
-            {"MX_P2P_METADATA": "1", "MX_METADATA_PORT": "6000"},
-            clear=False,
-        ), \
-             patch.object(NixlTransferManager, "initialize"):
-            mgr = _init_nixl_manager(global_rank=0, device_id=2, role="auto")
-
-        assert mgr._listen_port == 6002  # base port 6000 + device_id 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This reverts commit 049e9f440018c1e808d94a88565dabbdbbca9047.

The NIXL listen thread must always be enabled by default. MX_P2P_METADATA only controls whether the source starts the worker gRPC service for P2P metadata exchange vs using centralized storage for all blobs. It should not gate the NIXL listener.

Keeps the doc fix for MX_METADATA_PORT default (5555, not 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and deployment documentation to clarify `MX_METADATA_PORT` environment variable behavior, effective port calculation as base port plus device ID, and revised default port configuration.

* **Bug Fixes**
  * Streamlined metadata network listener initialization to ensure consistent behavior across all worker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->