### PR TITLE
feat: add ModelStreamer load strategy for S3 object storage streaming

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,6 +122,7 @@ ModelExpress/
 │       │   ├── __init__.py             # LoadStrategyChain.run()
 │       │   ├── base.py                 # LoadStrategy ABC, LoadContext, shared helpers
 │       │   ├── rdma_strategy.py        # RdmaStrategy (P2P GPU transfer via NIXL)
+│       │   ├── model_streamer_strategy.py # ModelStreamerStrategy (S3 streaming)
 │       │   ├── gds_strategy.py         # GdsStrategy (GPUDirect Storage)
 │       │   └── default_strategy.py     # DefaultStrategy (vLLM DefaultModelLoader)
 │       ├── tensor_utils.py             # Tensor collection, checksums, storage views
@@ -447,7 +448,7 @@ Loading precedence: CLI args > environment variables > config file > defaults.
 | `gds_transfer.py` | GPUDirect Storage availability check and transfer utilities |
 | `gds_loader.py` | `MxGdsLoader` - GDS-based model loader (direct file-to-GPU) |
 | `vllm_loader.py` | `MxModelLoader` - thin orchestration, delegates to `LoadStrategyChain` |
-| `load_strategy/` | Loading strategy chain package (see below) |
+| `load_strategy/` | Loading strategy chain: `RdmaStrategy`, `ModelStreamerStrategy` (S3), `GdsStrategy`, `DefaultStrategy` |
 | `tensor_utils.py` | Tensor collection, checksums, storage views, `capture_tensor_attrs` |
 | `metadata.py` | `build_source_identity`, `publish_metadata_and_ready`, retry logic |
 | `rank_utils.py` | `get_global_rank`, `get_worker_rank` |
@@ -494,10 +495,11 @@ Auto-detects the best loading strategy with a prioritized chain. Each strategy i
 | Priority | Strategy | `is_available()` | Behavior |
 |---|---|---|---|
 | p0 | `RdmaStrategy` | NIXL available | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). On `SourceTransferError`, try next. |
-| p1 | `GdsStrategy` | GDS hardware available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. |
-| p2 | `DefaultStrategy` | Always | vLLM `DefaultModelLoader` (CPU-staged, auto-downloads from HF Hub). |
+| p1 | `ModelStreamerStrategy` | `MX_S3_URI` set + `runai_model_streamer` installed | Stream safetensors from S3 to GPU via CPU staging buffer (no disk writes). |
+| p2 | `GdsStrategy` | GDS hardware available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. |
+| p3 | `DefaultStrategy` | Always | vLLM `DefaultModelLoader` (CPU-staged, auto-downloads from HF Hub). |
 
-Each strategy is fully self-contained: it handles weight loading, post-processing (`process_weights_after_loading`), NIXL tensor registration, and metadata publishing. New strategies (e.g., ModelStreamer for S3) can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
+Each strategy is fully self-contained: it handles weight loading, post-processing (`process_weights_after_loading`), NIXL tensor registration, and metadata publishing. New strategies can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
 
 After loading by any strategy, the worker starts a `HeartbeatThread` that periodically sends `UpdateStatus(READY)` to keep `updated_at` fresh. On clean shutdown, the heartbeat sends `UpdateStatus(STALE)` via an `atexit` handler. Metadata publish failures are logged but do not crash the worker.
 
@@ -586,7 +588,7 @@ graph TD
 
 ### Flow
 
-1. **Source loads**: Loads weights from disk (or GDS), runs `process_weights_after_loading()`
+1. **Source loads**: Loads weights from disk, GDS, or S3 (via ModelStreamer), runs `process_weights_after_loading()`
 2. **Source publishes**: Registers tensors with NIXL, calls `PublishMetadata(identity, worker, worker_id)` -> gets `mx_source_id` (status=INITIALIZING). In P2P mode (`MX_P2P_METADATA=1`), publishes only lightweight endpoint pointers and starts a `WorkerGrpcServer` for tensor manifest serving.
 3. **Heartbeat starts**: `HeartbeatThread` sends `UpdateStatus(READY)` every 30s, refreshing `updated_at`
 4. **Target discovers**: Calls `ListSources(identity, status=READY)`, filters by `worker_rank`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -252,6 +252,24 @@ Targets auto-detect which mode a source is using based on whether `worker_grpc_e
 
 Set `MX_METADATA_PORT` and `MX_WORKER_GRPC_PORT` to fixed ports when running in K8s (port 0 picks an ephemeral port). Set `MX_WORKER_HOST` if the pod IP auto-detection doesn't produce a routable address.
 
+### ModelStreamer (S3 Object Storage)
+
+ModelStreamer enables streaming safetensors directly from S3/S3-compatible storage to GPU memory without writing to disk. The first pod streams from S3; subsequent pods use P2P RDMA from the first pod's GPU memory.
+
+**Prerequisites:** Install `pip install modelexpress[streamer]` (adds `runai-model-streamer[s3]`).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MX_S3_URI` | (none) | S3 model location (e.g., `s3://bucket/path/to/model`). When set, enables the ModelStreamer strategy. |
+| `AWS_ACCESS_KEY_ID` | (none) | S3 credentials (read by boto3 and runai-model-streamer) |
+| `AWS_SECRET_ACCESS_KEY` | (none) | S3 credentials |
+| `AWS_DEFAULT_REGION` | (none) | AWS region (required by some backends) |
+| `AWS_ENDPOINT_URL` | (none) | Custom endpoint for S3-compatible storage (MinIO, Ceph, etc.) |
+| `RUNAI_STREAMER_CONCURRENCY` | `8` | Number of concurrent read threads |
+| `RUNAI_STREAMER_MEMORY_LIMIT` | (default) | CPU staging buffer size. `0` reuses a single-tensor buffer. |
+
+Credentials are injected via standard AWS mechanisms (EKS Pod Identity, IRSA, or K8s secrets mounted as env vars). No credentials flow through the MX server or gRPC.
+
 ### UCX/NIXL Tuning
 
 | Variable | Recommended | Description |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -256,7 +256,7 @@ Set `MX_METADATA_PORT` and `MX_WORKER_GRPC_PORT` to fixed ports when running in 
 
 ModelStreamer enables streaming safetensors directly from S3/S3-compatible storage to GPU memory without writing to disk. The first pod streams from S3; subsequent pods use P2P RDMA from the first pod's GPU memory.
 
-**Prerequisites:** Install `pip install modelexpress[streamer]` (adds `runai-model-streamer[s3]`).
+`runai-model-streamer[s3]` is included as a core dependency of the `modelexpress` package — no extra install step needed. Set `MX_S3_URI` to enable the ModelStreamer strategy.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -266,7 +266,7 @@ ModelStreamer enables streaming safetensors directly from S3/S3-compatible stora
 | `AWS_DEFAULT_REGION` | (none) | AWS region (required by some backends) |
 | `AWS_ENDPOINT_URL` | (none) | Custom endpoint for S3-compatible storage (MinIO, Ceph, etc.) |
 | `RUNAI_STREAMER_CONCURRENCY` | `8` | Number of concurrent read threads |
-| `RUNAI_STREAMER_MEMORY_LIMIT` | (default) | CPU staging buffer size. `0` reuses a single-tensor buffer. |
+| `RUNAI_STREAMER_MEMORY_LIMIT` | (none) | CPU staging buffer size in bytes. `0` reuses a single-tensor buffer (most memory efficient). When unset, runai-model-streamer allocates based on file size — see [runai-model-streamer docs](https://github.com/run-ai/model-streamer). |
 
 Credentials are injected via standard AWS mechanisms (EKS Pod Identity, IRSA, or K8s secrets mounted as env vars). No credentials flow through the MX server or gRPC.
 

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-s3.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-s3.yaml
@@ -64,6 +64,9 @@ spec:
               value: "us-west-2"
             - name: VLLM_PLUGINS
               value: "modelexpress"
+            # ModelStreamer tuning: more parallel S3 reads (default 8)
+            - name: RUNAI_STREAMER_CONCURRENCY
+              value: "32"
             # Optional: enable P2P serving after S3 load (requires MX server + RDMA)
             # - name: MX_SERVER_ADDRESS
             #   value: "modelexpress-server:8001"

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-s3.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-s3.yaml
@@ -53,6 +53,8 @@ spec:
               add:
                 - IPC_LOCK
           env:
+            - name: VLLM_RPC_TIMEOUT
+              value: "7200000"
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-V3"
             # Update to your S3 bucket and region

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-s3.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-s3.yaml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Single-node vLLM deployment with ModelExpress ModelStreamer (S3).
+# Streams weights from S3 via runai-model-streamer — no disk, no PVC.
+#
+# Prerequisites:
+#   - Model weights uploaded to S3 bucket
+#   - kubectl create secret generic aws-creds \
+#       --from-literal=AWS_ACCESS_KEY_ID=<key> \
+#       --from-literal=AWS_SECRET_ACCESS_KEY=<secret> \
+#       --from-literal=AWS_SESSION_TOKEN=<token>
+#
+# For P2P RDMA serving after S3 load, also set MX_SERVER_ADDRESS
+# and add RDMA resources (rdma/ib), UCX env vars — see vllm-single-node-p2p.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mx-vllm-s3
+  labels:
+    app: mx-vllm-s3
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+  selector:
+    app: mx-vllm-s3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mx-vllm-s3
+  labels:
+    app: mx-vllm-s3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mx-vllm-s3
+  template:
+    metadata:
+      labels:
+        app: mx-vllm-s3
+    spec:
+      containers:
+        - name: vllm
+          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:latest
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+          env:
+            - name: MODEL_NAME
+              value: "deepseek-ai/DeepSeek-V3"
+            # Update to your S3 bucket and region
+            - name: MX_S3_URI
+              value: "s3://my-bucket/deepseek-ai/DeepSeek-V3"
+            - name: AWS_DEFAULT_REGION
+              value: "us-west-2"
+            - name: VLLM_PLUGINS
+              value: "modelexpress"
+            # Optional: enable P2P serving after S3 load (requires MX server + RDMA)
+            # - name: MX_SERVER_ADDRESS
+            #   value: "modelexpress-server:8001"
+          # AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
+          envFrom:
+            - secretRef:
+                name: aws-creds
+          args:
+            - --model
+            - $(MODEL_NAME)
+            - --load-format
+            - mx
+            - --tensor-parallel-size
+            - "8"
+            - --enable-expert-parallel
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+              # Optional: uncomment for P2P RDMA serving
+              # rdma/ib: "8"
+            requests:
+              nvidia.com/gpu: "8"
+              # rdma/ib: "8"
+              memory: "200Gi"
+              cpu: "16"
+          volumeMounts:
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+      imagePullSecrets:
+        - name: nvcr-imagepullsecret

--- a/modelexpress_client/python/modelexpress/load_strategy/__init__.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/__init__.py
@@ -48,11 +48,13 @@ class LoadStrategyChain:
         Raises RuntimeError if no strategy succeeds.
         """
         from .rdma_strategy import RdmaStrategy
+        from .model_streamer_strategy import ModelStreamerStrategy
         from .gds_strategy import GdsStrategy
         from .default_strategy import DefaultStrategy
 
         all_strategies: list[LoadStrategy] = [
             RdmaStrategy(),
+            ModelStreamerStrategy(),
             GdsStrategy(),
             DefaultStrategy(),
         ]
@@ -61,8 +63,14 @@ class LoadStrategyChain:
 
         for strategy in eligible:
             logger.info(f"[Worker {ctx.global_rank}] Trying strategy: {strategy.name}")
-            if strategy.load(model, ctx):
-                return
+            try:
+                if strategy.load(model, ctx):
+                    return
+            except Exception as e:
+                logger.warning(
+                    f"[Worker {ctx.global_rank}] Strategy {strategy.name} "
+                    f"raised unexpected error, trying next: {e}"
+                )
 
         raise RuntimeError(
             f"[Worker {ctx.global_rank}] No loading strategy succeeded "

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -143,6 +143,12 @@ def publish_metadata(ctx: LoadContext) -> None:
             f"[Worker {ctx.global_rank}] No NIXL manager, skipping metadata publish"
         )
         return
+    server_addr = os.environ.get("MODEL_EXPRESS_URL") or os.environ.get("MX_SERVER_ADDRESS")
+    if not server_addr:
+        logger.info(
+            f"[Worker {ctx.global_rank}] No MX server configured, skipping metadata publish"
+        )
+        return
     try:
         publish_metadata_and_ready(
             ctx.mx_client, ctx.nixl_manager, ctx.tensors,

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -105,31 +105,44 @@ def _init_nixl_manager(
 
 
 def register_tensors(model: nn.Module, ctx: LoadContext) -> None:
-    """Collect model tensors and register them with NIXL."""
+    """Collect model tensors and register them with NIXL.
+
+    Failures are logged but do not raise — the worker continues without
+    P2P serving capability.
+    """
     if not is_nixl_available():
         logger.warning(f"[Worker {ctx.global_rank}] NIXL not available, skipping registration")
         return
 
-    ctx.tensors = collect_module_tensors(model)
-    log_tensor_summary(ctx.tensors, ctx.global_rank, "Registering tensors")
+    try:
+        ctx.tensors = collect_module_tensors(model)
+        log_tensor_summary(ctx.tensors, ctx.global_rank, "Registering tensors")
 
-    if ctx.nixl_manager is None:
-        # Always enable the NIXL listen thread: targets need it to call
-        # fetch_remote_metadata on P2P sources, and every node becomes a
-        # source after receiving weights. Each worker needs a unique port
-        # (base + device_id) to avoid collisions in multi-GPU setups.
-        base_port = int(os.environ.get("MX_METADATA_PORT", "5555"))
-        listen_port = base_port + ctx.device_id
-        ctx.nixl_manager = _init_nixl_manager(ctx.global_rank, ctx.device_id, "auto", listen_port)
+        if ctx.nixl_manager is None:
+            base_port = int(os.environ.get("MX_METADATA_PORT", "5555"))
+            listen_port = base_port + ctx.device_id
+            ctx.nixl_manager = _init_nixl_manager(
+                ctx.global_rank, ctx.device_id, "auto", listen_port
+            )
 
-    if not ctx.nixl_manager.tensor_descriptors:
-        logger.debug(f"[Worker {ctx.global_rank}] Registering tensors with NIXL...")
-        ctx.nixl_manager.register_tensors(ctx.tensors)
-        logger.debug(f"[Worker {ctx.global_rank}] Tensors registered with NIXL")
+        if not ctx.nixl_manager.tensor_descriptors:
+            logger.debug(f"[Worker {ctx.global_rank}] Registering tensors with NIXL...")
+            ctx.nixl_manager.register_tensors(ctx.tensors)
+            logger.debug(f"[Worker {ctx.global_rank}] Tensors registered with NIXL")
+    except Exception as e:
+        logger.warning(
+            f"[Worker {ctx.global_rank}] NIXL registration failed, "
+            f"worker will continue without P2P serving: {e}"
+        )
 
 
 def publish_metadata(ctx: LoadContext) -> None:
     """Publish metadata to the MX server. Failures are logged but do not raise."""
+    if ctx.nixl_manager is None:
+        logger.info(
+            f"[Worker {ctx.global_rank}] No NIXL manager, skipping metadata publish"
+        )
+        return
     try:
         publish_metadata_and_ready(
             ctx.mx_client, ctx.nixl_manager, ctx.tensors,

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ModelStreamer loading strategy: stream safetensors from S3 to GPU via runai-model-streamer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import os
+import time
+from typing import Iterator
+
+import torch
+import torch.nn as nn
+
+from .base import LoadContext, LoadStrategy, register_tensors, publish_metadata
+from ..tensor_utils import capture_tensor_attrs
+
+logger = logging.getLogger("modelexpress.strategy_model_streamer")
+
+_LOG_INTERVAL_SECS = 30
+
+
+class ModelStreamerStrategy(LoadStrategy):
+    """Load weights by streaming safetensors from S3 via runai-model-streamer."""
+
+    name = "model_streamer"
+
+    def is_available(self, ctx: LoadContext) -> bool:
+        s3_uri = os.environ.get("MX_S3_URI", "")
+        if not s3_uri:
+            logger.info(f"[Worker {ctx.global_rank}] MX_S3_URI not set, skipping model streamer")
+            return False
+        if importlib.util.find_spec("runai_model_streamer") is None:
+            logger.info(
+                f"[Worker {ctx.global_rank}] runai_model_streamer not installed, skipping"
+            )
+            return False
+        return True
+
+    def load(self, model: nn.Module, ctx: LoadContext) -> bool:
+        from vllm.model_executor.model_loader.utils import process_weights_after_loading
+
+        s3_uri = os.environ.get("MX_S3_URI", "")
+        if not s3_uri:
+            logger.warning(f"[Worker {ctx.global_rank}] MX_S3_URI not set")
+            return False
+        logger.info(f"[Worker {ctx.global_rank}] Attempting model streamer loading from {s3_uri}")
+        try:
+            weights_iter = self._stream_weights(s3_uri, ctx)
+            model.load_weights(weights_iter)
+            logger.info(f"[Worker {ctx.global_rank}] Model streamer weight loading complete")
+        except Exception as e:
+            logger.warning(
+                f"[Worker {ctx.global_rank}] Model streamer loading failed, falling through: {e}"
+            )
+            return False
+
+        with capture_tensor_attrs():
+            process_weights_after_loading(model, ctx.model_config, ctx.target_device)
+
+        register_tensors(model, ctx)
+        publish_metadata(ctx)
+        return True
+
+    def _stream_weights(
+        self, s3_uri: str, ctx: LoadContext
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        from runai_model_streamer import SafetensorsStreamer
+
+        file_uris = self._resolve_s3_safetensors(s3_uri)
+        logger.info(
+            f"[Worker {ctx.global_rank}] Streaming {len(file_uris)} safetensors files "
+            f"from {s3_uri}"
+        )
+
+        start = time.perf_counter()
+        with SafetensorsStreamer() as streamer:
+            streamer.stream_files(file_uris)
+            total_tensors = sum(
+                len(meta) for meta in streamer.files_to_tensors_metadata.values()
+            )
+            count = 0
+            last_log = start
+            for name, tensor in streamer.get_tensors():
+                count += 1
+                now = time.perf_counter()
+                if now - last_log >= _LOG_INTERVAL_SECS or count == total_tensors:
+                    pct = count / total_tensors * 100 if total_tensors else 0
+                    elapsed = now - start
+                    logger.info(
+                        f"[Worker {ctx.global_rank}] S3 streaming: "
+                        f"{count}/{total_tensors} tensors ({pct:.0f}%) "
+                        f"in {elapsed:.0f}s"
+                    )
+                    last_log = now
+                yield name, tensor.clone()
+        elapsed = time.perf_counter() - start
+        logger.info(f"[Worker {ctx.global_rank}] Streamed all weights in {elapsed:.1f}s")
+
+    @staticmethod
+    def _resolve_s3_safetensors(s3_uri: str) -> list[str]:
+        """Resolve safetensors file URIs from an S3 prefix.
+
+        Tries model.safetensors.index.json first, then falls back to
+        listing all .safetensors files under the prefix.
+        """
+        if not s3_uri.startswith("s3://"):
+            raise ValueError(f"Expected s3:// URI, got: {s3_uri}")
+
+        import boto3
+        from botocore.exceptions import ClientError
+
+        path = s3_uri[5:]
+        bucket, _, prefix = path.partition("/")
+        prefix = prefix.rstrip("/")
+
+        s3 = boto3.client("s3")
+
+        index_key = f"{prefix}/model.safetensors.index.json"
+        try:
+            resp = s3.get_object(Bucket=bucket, Key=index_key)
+            index = json.loads(resp["Body"].read())
+            weight_map = index.get("weight_map", {})
+            filenames = sorted(set(weight_map.values()))
+            if filenames:
+                return [f"s3://{bucket}/{prefix}/{fn}" for fn in filenames]
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("NoSuchKey", "404"):
+                pass
+            else:
+                raise
+
+        paginator = s3.get_paginator("list_objects_v2")
+        uris: list[str] = []
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith(".safetensors"):
+                    uris.append(f"s3://{bucket}/{key}")
+
+        if not uris:
+            raise FileNotFoundError(f"No .safetensors files found at {s3_uri}")
+
+        return sorted(uris)

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -41,12 +41,7 @@ class ModelStreamerStrategy(LoadStrategy):
         return True
 
     def load(self, model: nn.Module, ctx: LoadContext) -> bool:
-        from vllm.model_executor.model_loader.utils import process_weights_after_loading
-
-        s3_uri = os.environ.get("MX_S3_URI", "")
-        if not s3_uri:
-            logger.warning(f"[Worker {ctx.global_rank}] MX_S3_URI not set")
-            return False
+        s3_uri = os.environ["MX_S3_URI"]
         logger.info(f"[Worker {ctx.global_rank}] Attempting model streamer loading from {s3_uri}")
         try:
             weights_iter = self._stream_weights(s3_uri, ctx)
@@ -58,6 +53,7 @@ class ModelStreamerStrategy(LoadStrategy):
             )
             return False
 
+        from vllm.model_executor.model_loader.utils import process_weights_after_loading
         with capture_tensor_attrs():
             process_weights_after_loading(model, ctx.model_config, ctx.target_device)
 
@@ -113,7 +109,7 @@ class ModelStreamerStrategy(LoadStrategy):
         import boto3
         from botocore.exceptions import ClientError
 
-        path = s3_uri[5:]
+        path = s3_uri.removeprefix("s3://")
         bucket, _, prefix = path.partition("/")
         prefix = prefix.rstrip("/")
 

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -92,6 +92,8 @@ class ModelStreamerStrategy(LoadStrategy):
                         f"in {elapsed:.0f}s"
                     )
                     last_log = now
+                # clone() ensures safety when RUNAI_STREAMER_MEMORY_LIMIT=0
+                # (single-buffer mode reuses memory on next iteration)
                 yield name, tensor.clone()
         elapsed = time.perf_counter() - start
         logger.info(f"[Worker {ctx.global_rank}] Streamed all weights in {elapsed:.1f}s")

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -35,7 +35,13 @@ class RdmaStrategy(LoadStrategy):
     name = "rdma"
 
     def is_available(self, ctx: LoadContext) -> bool:
-        return is_nixl_available()
+        if not is_nixl_available():
+            return False
+        server_addr = os.environ.get("MODEL_EXPRESS_URL") or os.environ.get("MX_SERVER_ADDRESS")
+        if not server_addr:
+            logger.info(f"[Worker {ctx.global_rank}] No MX server configured, skipping RDMA")
+            return False
+        return True
 
     def load(self, model: nn.Module, ctx: LoadContext) -> bool:
         candidates = self._find_source_instances(ctx)

--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -18,7 +18,7 @@ Uses LoadStrategyChain to auto-detect the best loading strategy:
     4. Default (vLLM DefaultModelLoader) - standard CPU-staged loading
 
 Usage:
-    --load-format mx  (auto-detect: RDMA -> GDS -> default)
+    --load-format mx  (auto-detect: RDMA -> ModelStreamer -> GDS -> default)
 """
 
 from __future__ import annotations

--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -13,8 +13,9 @@ are auto-promoted to non-persistent buffers via capture_tensor_attrs().
 
 Uses LoadStrategyChain to auto-detect the best loading strategy:
     1. RDMA (P2P GPU transfer via NIXL) - if a source is already serving
-    2. GDS (GPUDirect Storage) - direct file-to-GPU, bypassing CPU
-    3. Default (vLLM DefaultModelLoader) - standard CPU-staged loading
+    2. ModelStreamer (S3 streaming via runai-model-streamer) - stream to GPU, no disk
+    3. GDS (GPUDirect Storage) - direct file-to-GPU, bypassing CPU
+    4. Default (vLLM DefaultModelLoader) - standard CPU-staged loading
 
 Usage:
     --load-format mx  (auto-detect: RDMA -> GDS -> default)

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "protobuf>=5.27.0,<6.0.0", # protobuf 5.x compatibility
     "pydantic>=2.0.0",
     "torch>=2.6.0",
+    "runai-model-streamer[s3]",
 ]
 
 [project.optional-dependencies]
@@ -40,8 +41,6 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
 ]
-# All optional features (none currently needed — client uses gRPC only)
-all = []
 
 [project.urls]
 Homepage = "https://github.com/ai-dynamo/modelexpress"

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -125,12 +125,6 @@ class TestModelStreamerLoad:
         mock_capture.return_value.__enter__ = MagicMock()
         mock_capture.return_value.__exit__ = MagicMock(return_value=False)
 
-        mock_streamer_instance = MagicMock()
-        mock_streamer_instance.get_tensors.return_value = [
-            ("layer.0.weight", torch.randn(4, 4)),
-            ("layer.1.weight", torch.randn(4, 4)),
-        ]
-
         model = MagicMock()
         ctx = _make_load_context()
         strategy = self._make_strategy()
@@ -168,10 +162,7 @@ class TestModelStreamerLoad:
                 "ModelStreamerStrategy._stream_weights",
                 side_effect=RuntimeError("S3 connection failed"),
             ):
-                with patch(
-                    "vllm.model_executor.model_loader.utils.process_weights_after_loading"
-                ):
-                    result = strategy.load(model, ctx)
+                result = strategy.load(model, ctx)
 
         assert result is False
         mock_register.assert_not_called()
@@ -265,7 +256,7 @@ class TestResolveS3Safetensors:
         modules["boto3"].client.return_value = mock_client
 
         with patch.dict(sys.modules, modules):
-            with pytest.raises(FileNotFoundError, match="No .safetensors files found"):
+            with pytest.raises(FileNotFoundError, match=r"No \.safetensors files found"):
                 strategy._resolve_s3_safetensors("s3://my-bucket/models/llama")
 
     def test_rejects_non_s3_uri(self):
@@ -328,3 +319,48 @@ class TestChainOrder:
             LoadStrategyChain.run(model, ctx)
 
         assert call_order == ["rdma", "model_streamer", "gds", "default"]
+
+    @patch(
+        "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.is_available",
+        return_value=True,
+    )
+    @patch(
+        "modelexpress.load_strategy.model_streamer_strategy."
+        "ModelStreamerStrategy.is_available",
+        return_value=False,
+    )
+    @patch(
+        "modelexpress.load_strategy.gds_strategy.GdsStrategy.is_available",
+        return_value=True,
+    )
+    @patch(
+        "modelexpress.load_strategy.default_strategy.DefaultStrategy.is_available",
+        return_value=True,
+    )
+    def test_skips_unavailable_strategy(self, _d, _g, _ms, _r):
+        from modelexpress.load_strategy import LoadStrategyChain
+
+        call_order: list[str] = []
+
+        def track_load(strategy_name):
+            def _load(self_or_model, *args, **kwargs):
+                call_order.append(strategy_name)
+                return strategy_name == "default"
+            return _load
+
+        model = MagicMock()
+        ctx = _make_load_context()
+
+        with patch(
+            "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.load",
+            track_load("rdma"),
+        ), patch(
+            "modelexpress.load_strategy.gds_strategy.GdsStrategy.load",
+            track_load("gds"),
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.load",
+            track_load("default"),
+        ):
+            LoadStrategyChain.run(model, ctx)
+
+        assert call_order == ["rdma", "gds", "default"]

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ModelStreamerStrategy."""
+
+import json
+import sys
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from modelexpress import p2p_pb2
+
+
+# ---------------------------------------------------------------------------
+# boto3 / botocore mock helpers (not installed in dev environment)
+# ---------------------------------------------------------------------------
+
+
+class _MockClientError(Exception):
+    """Stand-in for botocore.exceptions.ClientError."""
+
+    def __init__(self, error_response, operation_name):
+        self.response = error_response
+        self.operation_name = operation_name
+        super().__init__(f"{operation_name}: {error_response}")
+
+
+def _boto3_modules():
+    """Return a dict of mock modules to inject into sys.modules for boto3/botocore."""
+    mock_boto3 = MagicMock()
+    mock_botocore = MagicMock()
+    mock_botocore_exceptions = MagicMock()
+    mock_botocore_exceptions.ClientError = _MockClientError
+    mock_botocore.exceptions = mock_botocore_exceptions
+    return {
+        "boto3": mock_boto3,
+        "botocore": mock_botocore,
+        "botocore.exceptions": mock_botocore_exceptions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_load_context(**overrides):
+    """Return a LoadContext with mocked dependencies."""
+    from modelexpress.load_strategy import LoadContext
+
+    defaults = dict(
+        vllm_config=MagicMock(),
+        model_config=MagicMock(),
+        load_config=MagicMock(),
+        target_device=torch.device("cpu"),
+        global_rank=0,
+        device_id=0,
+        identity=p2p_pb2.SourceIdentity(model_name="test-model"),
+        mx_client=MagicMock(),
+        worker_id="test-worker",
+    )
+    defaults.update(overrides)
+    return LoadContext(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# TestModelStreamerIsAvailable
+# ---------------------------------------------------------------------------
+
+
+class TestModelStreamerIsAvailable:
+    def _make_strategy(self):
+        from modelexpress.load_strategy.model_streamer_strategy import ModelStreamerStrategy
+        return ModelStreamerStrategy()
+
+    def test_available_when_env_and_package(self):
+        ctx = _make_load_context()
+        strategy = self._make_strategy()
+        with patch.dict("os.environ", {"MX_S3_URI": "s3://bucket/model"}):
+            with patch("importlib.util.find_spec", return_value=MagicMock()):
+                assert strategy.is_available(ctx) is True
+
+    def test_unavailable_no_env(self):
+        ctx = _make_load_context()
+        strategy = self._make_strategy()
+        with patch.dict("os.environ", {}, clear=True):
+            assert strategy.is_available(ctx) is False
+
+    def test_unavailable_empty_env(self):
+        ctx = _make_load_context()
+        strategy = self._make_strategy()
+        with patch.dict("os.environ", {"MX_S3_URI": ""}):
+            assert strategy.is_available(ctx) is False
+
+    def test_unavailable_no_package(self):
+        ctx = _make_load_context()
+        strategy = self._make_strategy()
+        with patch.dict("os.environ", {"MX_S3_URI": "s3://bucket/model"}):
+            with patch("importlib.util.find_spec", return_value=None):
+                assert strategy.is_available(ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# TestModelStreamerLoad
+# ---------------------------------------------------------------------------
+
+
+class TestModelStreamerLoad:
+    def _make_strategy(self):
+        from modelexpress.load_strategy.model_streamer_strategy import ModelStreamerStrategy
+        return ModelStreamerStrategy()
+
+    @patch("modelexpress.load_strategy.model_streamer_strategy.publish_metadata")
+    @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
+    @patch("modelexpress.load_strategy.model_streamer_strategy.capture_tensor_attrs")
+    @patch(
+        "modelexpress.load_strategy.model_streamer_strategy."
+        "ModelStreamerStrategy._resolve_s3_safetensors"
+    )
+    def test_success_path(self, mock_resolve, mock_capture, mock_register, mock_publish):
+        mock_resolve.return_value = ["s3://bucket/model/shard-00001.safetensors"]
+        mock_capture.return_value.__enter__ = MagicMock()
+        mock_capture.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_streamer_instance = MagicMock()
+        mock_streamer_instance.get_tensors.return_value = [
+            ("layer.0.weight", torch.randn(4, 4)),
+            ("layer.1.weight", torch.randn(4, 4)),
+        ]
+
+        model = MagicMock()
+        ctx = _make_load_context()
+        strategy = self._make_strategy()
+
+        with patch.dict("os.environ", {"MX_S3_URI": "s3://bucket/model"}):
+            with patch.dict("sys.modules", {"runai_model_streamer": MagicMock()}):
+                with patch(
+                    "modelexpress.load_strategy.model_streamer_strategy."
+                    "ModelStreamerStrategy._stream_weights"
+                ) as mock_stream:
+                    mock_stream.return_value = iter([
+                        ("layer.0.weight", torch.randn(4, 4)),
+                        ("layer.1.weight", torch.randn(4, 4)),
+                    ])
+                    with patch(
+                        "vllm.model_executor.model_loader.utils.process_weights_after_loading"
+                    ):
+                        result = strategy.load(model, ctx)
+
+        assert result is True
+        model.load_weights.assert_called_once()
+        mock_register.assert_called_once_with(model, ctx)
+        mock_publish.assert_called_once_with(ctx)
+
+    @patch("modelexpress.load_strategy.model_streamer_strategy.publish_metadata")
+    @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
+    def test_returns_false_on_error(self, mock_register, mock_publish):
+        model = MagicMock()
+        ctx = _make_load_context()
+        strategy = self._make_strategy()
+
+        with patch.dict("os.environ", {"MX_S3_URI": "s3://bucket/model"}):
+            with patch(
+                "modelexpress.load_strategy.model_streamer_strategy."
+                "ModelStreamerStrategy._stream_weights",
+                side_effect=RuntimeError("S3 connection failed"),
+            ):
+                with patch(
+                    "vllm.model_executor.model_loader.utils.process_weights_after_loading"
+                ):
+                    result = strategy.load(model, ctx)
+
+        assert result is False
+        mock_register.assert_not_called()
+        mock_publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestResolveS3Safetensors
+# ---------------------------------------------------------------------------
+
+
+class TestResolveS3Safetensors:
+    def _make_strategy(self):
+        from modelexpress.load_strategy.model_streamer_strategy import ModelStreamerStrategy
+        return ModelStreamerStrategy()
+
+    def test_resolves_from_index(self):
+        strategy = self._make_strategy()
+
+        index_data = {
+            "weight_map": {
+                "model.layer.0.weight": "model-00001-of-00002.safetensors",
+                "model.layer.1.weight": "model-00001-of-00002.safetensors",
+                "model.layer.2.weight": "model-00002-of-00002.safetensors",
+            }
+        }
+        body = BytesIO(json.dumps(index_data).encode())
+
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {"Body": body}
+
+        modules = _boto3_modules()
+        modules["boto3"].client.return_value = mock_client
+
+        with patch.dict(sys.modules, modules):
+            result = strategy._resolve_s3_safetensors("s3://my-bucket/models/llama")
+
+        assert result == [
+            "s3://my-bucket/models/llama/model-00001-of-00002.safetensors",
+            "s3://my-bucket/models/llama/model-00002-of-00002.safetensors",
+        ]
+        mock_client.get_object.assert_called_once_with(
+            Bucket="my-bucket",
+            Key="models/llama/model.safetensors.index.json",
+        )
+
+    def test_fallback_to_listing(self):
+        strategy = self._make_strategy()
+
+        error_response = {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}
+
+        mock_client = MagicMock()
+        mock_client.get_object.side_effect = _MockClientError(error_response, "GetObject")
+
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "models/llama/model-00001.safetensors"},
+                    {"Key": "models/llama/model-00002.safetensors"},
+                    {"Key": "models/llama/config.json"},
+                ]
+            }
+        ]
+        mock_client.get_paginator.return_value = mock_paginator
+
+        modules = _boto3_modules()
+        modules["boto3"].client.return_value = mock_client
+
+        with patch.dict(sys.modules, modules):
+            result = strategy._resolve_s3_safetensors("s3://my-bucket/models/llama")
+
+        assert result == [
+            "s3://my-bucket/models/llama/model-00001.safetensors",
+            "s3://my-bucket/models/llama/model-00002.safetensors",
+        ]
+
+    def test_raises_no_files(self):
+        strategy = self._make_strategy()
+
+        error_response = {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}
+
+        mock_client = MagicMock()
+        mock_client.get_object.side_effect = _MockClientError(error_response, "GetObject")
+
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{"Contents": []}]
+        mock_client.get_paginator.return_value = mock_paginator
+
+        modules = _boto3_modules()
+        modules["boto3"].client.return_value = mock_client
+
+        with patch.dict(sys.modules, modules):
+            with pytest.raises(FileNotFoundError, match="No .safetensors files found"):
+                strategy._resolve_s3_safetensors("s3://my-bucket/models/llama")
+
+    def test_rejects_non_s3_uri(self):
+        strategy = self._make_strategy()
+        with pytest.raises(ValueError, match="Expected s3:// URI"):
+            strategy._resolve_s3_safetensors("gs://bucket/model")
+
+
+# ---------------------------------------------------------------------------
+# TestChainOrder
+# ---------------------------------------------------------------------------
+
+
+class TestChainOrder:
+    @patch(
+        "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.is_available",
+        return_value=True,
+    )
+    @patch(
+        "modelexpress.load_strategy.model_streamer_strategy."
+        "ModelStreamerStrategy.is_available",
+        return_value=True,
+    )
+    @patch(
+        "modelexpress.load_strategy.gds_strategy.GdsStrategy.is_available",
+        return_value=True,
+    )
+    @patch(
+        "modelexpress.load_strategy.default_strategy.DefaultStrategy.is_available",
+        return_value=True,
+    )
+    def test_model_streamer_in_chain(self, _d, _g, _ms, _r):
+        from modelexpress.load_strategy import LoadStrategyChain
+
+        call_order: list[str] = []
+
+        def track_load(strategy_name):
+            def _load(self_or_model, *args, **kwargs):
+                call_order.append(strategy_name)
+                return strategy_name == "default"
+            return _load
+
+        model = MagicMock()
+        ctx = _make_load_context()
+
+        with patch(
+            "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.load",
+            track_load("rdma"),
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.load",
+            track_load("model_streamer"),
+        ), patch(
+            "modelexpress.load_strategy.gds_strategy.GdsStrategy.load",
+            track_load("gds"),
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.load",
+            track_load("default"),
+        ):
+            LoadStrategyChain.run(model, ctx)
+
+        assert call_order == ["rdma", "model_streamer", "gds", "default"]

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -11,6 +11,7 @@ import torch
 import torch.nn as nn
 
 from modelexpress import p2p_pb2
+from modelexpress.nixl_transfer import NixlTransferManager
 
 
 # ---------------------------------------------------------------------------
@@ -203,6 +204,166 @@ class TestAbstractMethodCompleteness:
         with patch("modelexpress.vllm_loader.DefaultModelLoader") as mock_cls:
             loader.load_weights(model, cfg)
             mock_cls.return_value.load_weights.assert_called_once_with(model, cfg)
+
+
+# ---------------------------------------------------------------------------
+# register_tensors (load_strategy.base)
+# ---------------------------------------------------------------------------
+
+
+class TestInitNixlManager:
+    """Verify _init_nixl_manager passes listen_port to NixlTransferManager."""
+
+    def test_default_listen_port_is_zero(self):
+        from modelexpress.load_strategy.base import _init_nixl_manager
+
+        with patch.object(NixlTransferManager, "initialize"):
+            mgr = _init_nixl_manager(global_rank=0, device_id=0, role="auto")
+
+        assert mgr._listen_port == 0
+
+    def test_explicit_listen_port(self):
+        from modelexpress.load_strategy.base import _init_nixl_manager
+
+        with patch.object(NixlTransferManager, "initialize"):
+            mgr = _init_nixl_manager(global_rank=0, device_id=2, role="auto", listen_port=6002)
+
+        assert mgr._listen_port == 6002
+
+
+class TestRegisterTensorsErrorHandling:
+    """Verify register_tensors never raises — failures are logged as warnings."""
+
+    @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=False)
+    def test_skips_when_nixl_unavailable(self, _mock):
+        from modelexpress.load_strategy.base import register_tensors
+        ctx = _make_load_context()
+        model = MagicMock()
+        register_tensors(model, ctx)
+        assert ctx.nixl_manager is None
+
+    @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
+    @patch("modelexpress.load_strategy.base.collect_module_tensors", return_value={})
+    @patch(
+        "modelexpress.load_strategy.base._init_nixl_manager",
+        side_effect=RuntimeError("NIXL_ERR_BACKEND"),
+    )
+    def test_nixl_init_failure_does_not_raise(self, _init, _collect, _avail):
+        from modelexpress.load_strategy.base import register_tensors
+        ctx = _make_load_context()
+        model = MagicMock()
+        register_tensors(model, ctx)
+        assert ctx.nixl_manager is None
+
+    @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
+    @patch("modelexpress.load_strategy.base.collect_module_tensors", return_value={"t": MagicMock()})
+    @patch("modelexpress.load_strategy.base._init_nixl_manager")
+    def test_tensor_registration_failure_does_not_raise(self, mock_init, _collect, _avail):
+        from modelexpress.load_strategy.base import register_tensors
+        mock_mgr = MagicMock()
+        mock_mgr.tensor_descriptors = []
+        mock_mgr.register_tensors.side_effect = RuntimeError("memory registration failed")
+        mock_init.return_value = mock_mgr
+        ctx = _make_load_context()
+        model = MagicMock()
+        register_tensors(model, ctx)
+
+
+class TestPublishMetadataErrorHandling:
+    """Verify publish_metadata never raises."""
+
+    def test_skips_when_no_nixl_manager(self):
+        from modelexpress.load_strategy.base import publish_metadata
+        ctx = _make_load_context()
+        ctx.nixl_manager = None
+        publish_metadata(ctx)
+
+    @patch("modelexpress.load_strategy.base.publish_metadata_and_ready", side_effect=RuntimeError("gRPC fail"))
+    def test_publish_failure_does_not_raise(self, _mock):
+        from modelexpress.load_strategy.base import publish_metadata
+        ctx = _make_load_context()
+        ctx.nixl_manager = MagicMock()
+        publish_metadata(ctx)
+
+
+class TestLoadStrategyChainRunErrorHandling:
+    """Verify LoadStrategyChain.run catches exceptions from strategy.load()."""
+
+    def test_strategy_exception_falls_through_to_next(self):
+        from modelexpress.load_strategy import LoadStrategyChain
+
+        call_order = []
+
+        def exploding_load(self_or_model, *args, **kwargs):
+            call_order.append("exploding")
+            raise RuntimeError("unexpected crash")
+
+        def fallback_load(self_or_model, *args, **kwargs):
+            call_order.append("fallback")
+            return True
+
+        ctx = _make_load_context()
+        model = MagicMock()
+
+        with patch(
+            "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.load",
+            exploding_load,
+        ), patch(
+            "modelexpress.load_strategy.gds_strategy.GdsStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.load",
+            fallback_load,
+        ):
+            LoadStrategyChain.run(model, ctx)
+
+        assert call_order == ["exploding", "fallback"]
+
+
+class TestRdmaStrategyAvailability:
+    """Verify RdmaStrategy.is_available checks for MX server config."""
+
+    def _make_strategy(self):
+        from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
+        return RdmaStrategy()
+
+    @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True)
+    def test_unavailable_when_no_server_address(self, _mock):
+        strategy = self._make_strategy()
+        ctx = _make_load_context()
+        with patch.dict("os.environ", {}, clear=True):
+            assert strategy.is_available(ctx) is False
+
+    @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True)
+    def test_available_when_mx_server_address_set(self, _mock):
+        strategy = self._make_strategy()
+        ctx = _make_load_context()
+        with patch.dict("os.environ", {"MX_SERVER_ADDRESS": "server:8001"}):
+            assert strategy.is_available(ctx) is True
+
+    @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True)
+    def test_available_when_model_express_url_set(self, _mock):
+        strategy = self._make_strategy()
+        ctx = _make_load_context()
+        with patch.dict("os.environ", {"MODEL_EXPRESS_URL": "server:8001"}):
+            assert strategy.is_available(ctx) is True
+
+    @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=False)
+    def test_unavailable_when_nixl_not_available(self, _mock):
+        strategy = self._make_strategy()
+        ctx = _make_load_context()
+        assert strategy.is_available(ctx) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Integrate [Run:AI ModelStreamer](https://github.com/run-ai/model-streamer) (`runai-model-streamer`) as a new load strategy that streams safetensors from S3/S3-compatible object storage directly to GPU memory — no disk writes, no PVC required. This is Phase 1 of the [ModelStreamer integration design](docs/tmp/2026-04-02-model-streamer-integration-design.md).

- **New `ModelStreamerStrategy`** — slots between RDMA (p0) and GDS (p2) as priority p1 in `LoadStrategyChain`
- **S3 file resolution** — parses `model.safetensors.index.json` for shard discovery, falls back to S3 listing
- **Error handling hardening** — `register_tensors()` and `publish_metadata()` never crash vLLM; `LoadStrategyChain.run()` catches unexpected strategy exceptions; RDMA strategy and metadata publish skip when no MX server is configured
- **22 new unit tests** — ModelStreamer strategy (12), error handling (6), RDMA availability (4)
- **Example K8s manifest** — `vllm-single-node-s3.yaml` with streamer tuning (`RUNAI_STREAMER_CONCURRENCY=32`)

### How it works

```
First pod:
  LoadStrategyChain.run() -> [RDMA, ModelStreamer, GDS, Default]
  - RDMA: no MX server configured, skip
  - ModelStreamer: MX_S3_URI set, stream S3 -> CPU -> GPU
  - Register NIXL + publish metadata (if RDMA available)

Subsequent pods:
  - RDMA: source found, P2P transfer from GPU memory (~15s)
```

### Configuration

| Variable | Description |
|----------|-------------|
| `MX_S3_URI` | S3 model location (e.g., `s3://bucket/deepseek-ai/DeepSeek-V3`) |
| `AWS_DEFAULT_REGION` | S3 bucket region |
| `AWS_ACCESS_KEY_ID` | S3 credentials (via K8s secret) |
| `AWS_SECRET_ACCESS_KEY` | S3 credentials (via K8s secret) |
| `RUNAI_STREAMER_CONCURRENCY` | Parallel S3 read threads (default 8, recommend 32) |

## E2E Testing

### Qwen3.5-0.8B (1 GPU, single shard) — nscale cluster
- S3 bucket: `model-express-dev-models` (us-west-2)
- Streamed 488 tensors in **5.7s**
- NIXL registration failed gracefully (no RDMA on test node) — logged warning, continued serving
- vLLM API server started, inference verified

### DeepSeek-V3 (8x H100, 163 shards, 688 GB) — nscale cluster
- S3 bucket: `model-express-dev-models` (us-west-2, cross-region)
- Streamed 91,991 tensors across 8 workers in **~18 min** (~630 MB/s aggregate)
- vLLM API server started, inference verified

### DeepSeek-V3 (4x GB200, TP=4) — AWS us-east-1 cluster
- S3 bucket: `model-express-models` (us-east-1, same-region)
- Streamed at **1.9 GB/s** aggregate (3x faster than cross-region)
- `RUNAI_STREAMER_DIST=auto` confirmed: distributed mode auto-enabled with NCCL
- RDMA/publish gracefully skipped when no MX server configured
- `.clone()` removal tested: no perf difference (S3 I/O is bottleneck), restored for buffer safety

### Unit tests
```
76 passed, 8 skipped (CUDA-dependent)
4 pre-existing failures (vLLM abstract method changes, unrelated)
```

## Changes

| File | Change |
|------|--------|
| `load_strategy/model_streamer_strategy.py` | **New** — ModelStreamerStrategy implementation |
| `load_strategy/__init__.py` | Register ModelStreamerStrategy in chain, catch strategy exceptions |
| `load_strategy/base.py` | Wrap `register_tensors()` in try-except, skip `publish_metadata()` when no NIXL manager or no MX server |
| `load_strategy/rdma_strategy.py` | Skip when `MX_SERVER_ADDRESS` / `MODEL_EXPRESS_URL` not set |
| `vllm_loader.py` | Update docstring with 4-tier chain |
| `pyproject.toml` | Add `runai-model-streamer[s3]` as core dependency |
| `vllm-single-node-s3.yaml` | **New** — K8s example manifest for S3-only deployment |
| `tests/test_model_streamer_strategy.py` | **New** — 12 tests for strategy, S3 resolution, chain order |
| `tests/test_vllm_loader.py` | 10 new tests for error handling and RDMA availability |
| `docs/ARCHITECTURE.md` | File tree, module table, 4-tier strategy chain |
| `docs/DEPLOYMENT.md` | ModelStreamer section with env var reference |

## Test plan

- [x] Unit tests pass (76 passed, 0 new failures)
- [x] E2E: Qwen3.5-0.8B streamed from S3 on 1 GPU (nscale)
- [x] E2E: DeepSeek-V3 streamed from S3 on 8x H100 (nscale, cross-region)
- [x] E2E: DeepSeek-V3 S3 streaming on 4x GB200 (AWS, same-region, 1.9 GB/s)
- [x] NIXL init failure handled gracefully (no crash)
- [x] Metadata publish skipped when no NIXL manager or no MX server
- [x] RDMA strategy skipped when no MX server configured
- [x] Fallback to default strategy works when ModelStreamer fails
- [x] .clone() vs no-clone perf comparison (no difference, kept for safety)
- [ ] P2P transfer from S3-loaded source to second pod (needs RDMA node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)