### PR TITLE
feat: add safety checks for P2P weight transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ cargo bench
 
 ## Known Issues
 
+- **MLA models blocked from P2P transfer** — Models using Multi-head Latent Attention (DeepSeek-V2/V3, Kimi K2/K2.5) are automatically blocked from GPU-to-GPU transfer and fall back to disk loading. Bytes transfer correctly but inference produces corrupted output. Set `MX_SKIP_FEATURE_CHECK=1` to bypass for debugging. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 - **NIXL_ERR_REMOTE_DISCONNECT** — Source restarts invalidate rkeys. Flush Redis, redeploy.
 - **Long source warmup** — DeepSeek-V3 (DeepGemm, CUDA graphs) can take significant time; targets wait via coordination.
 - **Large model gRPC stream** — May not close automatically; use client timeout.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,6 +125,7 @@ ModelExpress/
 │       │   ├── gds_strategy.py         # GdsStrategy (GPUDirect Storage)
 │       │   └── default_strategy.py     # DefaultStrategy (vLLM DefaultModelLoader)
 │       ├── tensor_utils.py             # Tensor collection, checksums, storage views
+│       ├── transfer_safety.py          # MLA feature gate, TransferFingerprint
 │       ├── metadata.py                 # Metadata building and publishing
 │       ├── rank_utils.py               # Rank detection utilities
 │       ├── worker_server.py            # WorkerGrpcServer (P2P tensor manifest)
@@ -493,11 +494,19 @@ Auto-detects the best loading strategy with a prioritized chain. Each strategy i
 
 | Priority | Strategy | `is_available()` | Behavior |
 |---|---|---|---|
-| p0 | `RdmaStrategy` | NIXL available | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). On `SourceTransferError`, try next. |
+| p0 | `RdmaStrategy` | NIXL available + MLA check passes | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). On `SourceTransferError` or `ManifestMismatchError`, try next. |
 | p1 | `GdsStrategy` | GDS hardware available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. |
 | p2 | `DefaultStrategy` | Always | vLLM `DefaultModelLoader` (CPU-staged, auto-downloads from HF Hub). |
 
 Each strategy is fully self-contained: it handles weight loading, post-processing (`process_weights_after_loading`), NIXL tensor registration, and metadata publishing. New strategies (e.g., ModelStreamer for S3) can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
+
+### Transfer Safety
+
+`RdmaStrategy.is_available()` checks `transfer_safety.check_transfer_allowed()` before attempting P2P transfer. Currently the only blocked feature is MLA (Multi-head Latent Attention), detected via `kv_lora_rank` in the HF model config. MLA models (DeepSeek-V2/V3, Kimi K2/K2.5, GLM-5.1, and any future model using MLA) fall back to GDS or disk loading automatically.
+
+MLA models produce correct inference when loaded from disk but corrupted inference after RDMA weight transfer. The bytes transfer correctly (checksums match), but inference diverges. This has been reproduced across all tested vLLM versions (0.12.0 through 0.17.1). Root cause is under investigation. Set `MX_SKIP_FEATURE_CHECK=1` to bypass the block for debugging.
+
+During transfer, `ManifestMismatchError` is raised if source and target tensor names or sizes don't match. This triggers trying the next source candidate rather than marking the source as stale, which is important during rolling updates where pods may run different image versions.
 
 After loading by any strategy, the worker starts a `HeartbeatThread` that periodically sends `UpdateStatus(READY)` to keep `updated_at` fresh. On clean shutdown, the heartbeat sends `UpdateStatus(STALE)` via an `atexit` handler. Metadata publish failures are logged but do not crash the worker.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -228,6 +228,7 @@ ModelExpress supports GPU-to-GPU model weight transfers between vLLM instances u
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
 | `MX_REGISTER_LOADERS` | `1` | Auto-register the mx loader with vLLM |
 | `MX_CONTIGUOUS_REG` | `0` | Contiguous region registration (experimental) |
+| `MX_SKIP_FEATURE_CHECK` | `0` | Bypass the MLA feature gate for P2P transfer (testing only) |
 | `MX_P2P_METADATA` | `0` | Enable P2P metadata exchange (source workers only) |
 | `MX_METADATA_PORT` | `5555` | Base NIXL listen port; effective port is `MX_METADATA_PORT + device_id` |
 | `MX_WORKER_GRPC_PORT` | `0` | Worker gRPC port for P2P tensor manifest serving |

--- a/examples/p2p_transfer_k8s/client/README.md
+++ b/examples/p2p_transfer_k8s/client/README.md
@@ -6,8 +6,8 @@ vLLM instances with ModelExpress P2P weight transfer support.
 
 | Topology | Manifest | Model | Configuration |
 |----------|----------|-------|---------------|
-| **Single-node** | [`vllm/vllm-single-node.yaml`](vllm/vllm-single-node.yaml) | DeepSeek-V3 | TP=8, 1 node (8 GPUs) |
-| **Multi-node** | [`vllm/vllm-multi-node.yaml`](vllm/vllm-multi-node.yaml) | Kimi-K2.5 | TP=8, PP=2, 2 nodes (16 GPUs) |
+| **Single-node** | [`vllm/vllm-single-node.yaml`](vllm/vllm-single-node.yaml) | Llama-3.1-405B-Instruct | TP=8, 1 node (8 GPUs) |
+| **Multi-node** | [`vllm/vllm-multi-node.yaml`](vllm/vllm-multi-node.yaml) | Llama-3.1-405B-Instruct | TP=4, PP=2, 2 nodes (8 GPUs) |
 
 ## How It Works
 

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -3,10 +3,9 @@
 
 # Multi-node vLLM StatefulSet with ModelExpress P2P weight transfer.
 #
-# Deploys Kimi-K2.5 as a single StatefulSet across 2 nodes (8 GPUs total):
+# Deploys Llama-3.1-405B-Instruct as a single StatefulSet across 2 nodes (8 GPUs total):
 #   - tensor-parallel-size=4 (within each node)
 #   - pipeline-parallel-size=2 (across nodes)
-#   - expert-parallel enabled
 #
 # Pod roles are determined by ordinal index:
 #   - pod-0: Ray head node + vLLM API server
@@ -93,7 +92,7 @@ spec:
             - name: HF_HUB_CACHE
               value: "/models"
             - name: MODEL_NAME
-              value: "moonshotai/Kimi-K2.5"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             - name: VLLM_PLUGINS
               value: "modelexpress"
             - name: MX_SERVER_ADDRESS
@@ -142,7 +141,6 @@ spec:
                   --load-format mx \
                   --tensor-parallel-size 4 \
                   --pipeline-parallel-size 2 \
-                  --enable-expert-parallel \
                   --trust-remote-code \
                   --distributed-executor-backend ray
               else

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -59,7 +59,7 @@ spec:
             - name: HF_HUB_CACHE
               value: "/models"
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             - name: VLLM_PLUGINS
               value: "modelexpress"
             - name: MX_SERVER_ADDRESS

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Single-node vLLM deployment with ModelExpress P2P weight transfer.
-# Deploys DeepSeek-V3 on 1 node (8 GPUs, TP=8).
+# Deploys Llama-3.1-405B-Instruct on 1 node (8 GPUs, TP=8).
 #
 # Prerequisites:
 #   - ModelExpress server deployed (see ../../server/)
@@ -61,7 +61,7 @@ spec:
             - name: HF_HUB_CACHE
               value: "/models"
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             # Register ModelExpress loaders via vLLM plugin system
             - name: VLLM_PLUGINS
               value: "modelexpress"

--- a/examples/p2p_transfer_k8s/model-download.yaml
+++ b/examples/p2p_transfer_k8s/model-download.yaml
@@ -45,7 +45,7 @@ spec:
             - name: HF_HUB_CACHE
               value: /models
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
+              value: "meta-llama/Llama-3.1-405B-Instruct"
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/examples/p2p_transfer_k8s/server/kubernetes_backend/crd-modelmetadata.yaml
+++ b/examples/p2p_transfer_k8s/server/kubernetes_backend/crd-modelmetadata.yaml
@@ -29,7 +29,7 @@ spec:
               properties:
                 modelName:
                   type: string
-                  description: Full model name (e.g., deepseek-ai/DeepSeek-V3)
+                  description: Full model name (e.g., meta-llama/Llama-3.1-405B-Instruct)
             status:
               type: object
               properties:

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -17,7 +17,8 @@ import torch.nn as nn
 from .base import LoadContext, LoadStrategy, SourceTransferError, register_tensors, publish_metadata
 from ..nixl_transfer import is_nixl_available
 from ..tensor_utils import capture_tensor_attrs
-from ..types import TensorDescriptor
+from ..transfer_safety import check_transfer_allowed
+from ..types import ManifestMismatchError, TensorDescriptor
 from .. import p2p_pb2
 
 logger = logging.getLogger("modelexpress.strategy_rdma")
@@ -35,7 +36,15 @@ class RdmaStrategy(LoadStrategy):
     name = "rdma"
 
     def is_available(self, ctx: LoadContext) -> bool:
-        return is_nixl_available()
+        if not is_nixl_available():
+            return False
+        allowed, reason = check_transfer_allowed(ctx.model_config)
+        if not allowed:
+            logger.info(
+                f"[Worker {ctx.global_rank}] RDMA transfer disabled: {reason}"
+            )
+            return False
+        return True
 
     def load(self, model: nn.Module, ctx: LoadContext) -> bool:
         candidates = self._find_source_instances(ctx)
@@ -72,6 +81,11 @@ class RdmaStrategy(LoadStrategy):
             except SourceTransferError as e:
                 logger.warning(
                     f"[Worker {ctx.global_rank}] Source transfer failed for worker {worker_id}: {e}. "
+                    f"Trying next candidate."
+                )
+            except ManifestMismatchError as e:
+                logger.warning(
+                    f"[Worker {ctx.global_rank}] Manifest mismatch with worker {worker_id}: {e}. "
                     f"Trying next candidate."
                 )
 

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Transfer safety checks for ModelExpress GPU-to-GPU weight transfer.
+
+Two independent safety mechanisms:
+
+1. Feature allow-list: checks model config before attempting P2P transfer.
+   Models with unsupported features are rejected early and fall back to
+   disk loading. MLA attention models (DeepSeek, Kimi) are blocked from
+   P2P transfers due to unresolved weight corruption after RDMA receive.
+   The bytes transfer correctly but inference diverges - root cause is
+   under investigation.
+
+2. Transfer fingerprint: captures the runtime environment and tensor
+   manifest structure. Source publishes its fingerprint; target computes
+   its own and rejects the transfer if they don't match.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+
+import torch
+
+logger = logging.getLogger("modelexpress.transfer_safety")
+
+# ---------------------------------------------------------------------------
+# Feature detection and blocking
+# ---------------------------------------------------------------------------
+
+# MLA (Multi-head Latent Attention) is the only feature currently blocked.
+# Bytes transfer correctly via RDMA but inference diverges on all tested
+# vLLM versions (0.12.0 through 0.17.1). Root cause under investigation.
+# Detection is config-based: kv_lora_rank presence in the HF config.
+# Bypass with MX_SKIP_FEATURE_CHECK=1 to test MLA transfers anyway.
+
+
+
+def detect_model_features(model_config) -> dict[str, str]:
+    """Detect model features relevant to transfer safety.
+
+    Returns a dict of feature name -> value for logging and validation.
+    """
+    hf_config = model_config.hf_text_config
+    features: dict[str, str] = {}
+
+    features["model_type"] = getattr(hf_config, "model_type", "unknown")
+    features["dtype"] = str(model_config.dtype).replace("torch.", "")
+    features["quantization"] = model_config.quantization or "none"
+
+    # MLA detection via HF config attribute
+    has_mla = getattr(hf_config, "kv_lora_rank", None) is not None
+    features["attention"] = "mla" if has_mla else "standard"
+
+    # MoE
+    num_experts = (
+        getattr(hf_config, "n_routed_experts", None)
+        or getattr(hf_config, "num_local_experts", None)
+    )
+    if num_experts and num_experts > 1:
+        features["moe"] = str(num_experts)
+
+    return features
+
+
+def check_transfer_allowed(model_config) -> tuple[bool, str]:
+    """Check if P2P weight transfer is allowed for this model.
+
+    Currently blocks only MLA attention models (detected via kv_lora_rank
+    in the HF config). All other models are allowed.
+
+    Returns (allowed, reason). If not allowed, reason explains why.
+    """
+    if os.environ.get("MX_SKIP_FEATURE_CHECK", "0") == "1":
+        logger.warning("MX_SKIP_FEATURE_CHECK=1: bypassing feature checks")
+        return True, "bypassed"
+
+    features = detect_model_features(model_config)
+
+    if features["attention"] == "mla":
+        reason = (
+            "MLA attention models are blocked from P2P transfer due to "
+            "unresolved weight corruption after RDMA receive"
+        )
+        logger.warning(
+            f"[Transfer Safety] P2P transfer denied: {reason}. "
+            f"Features: {features}. "
+            f"Set MX_SKIP_FEATURE_CHECK=1 to bypass."
+        )
+        return False, reason
+
+    logger.info(f"[Transfer Safety] P2P transfer allowed. Features: {features}")
+    return True, "allowed"
+
+
+# ---------------------------------------------------------------------------
+# Transfer fingerprint
+# ---------------------------------------------------------------------------
+
+def get_vllm_version() -> str:
+    try:
+        import vllm
+        return getattr(vllm, "__version__", "unknown")
+    except ImportError:
+        return "unknown"
+
+
+def get_torch_version() -> str:
+    return torch.__version__
+
+
+def get_cuda_version() -> str:
+    return getattr(torch.version, "cuda", "unknown") or "unknown"
+
+
+def _get_attention_backend() -> str:
+    """Get the selected attention backend name."""
+    try:
+        from vllm.config import get_current_vllm_config
+        config = get_current_vllm_config()
+        if hasattr(config, "model_config") and config.model_config is not None:
+            cache_config = getattr(config, "cache_config", None)
+            if cache_config is not None:
+                return getattr(cache_config, "attention_backend", "unknown") or "unknown"
+    except Exception:
+        pass
+    return os.environ.get("VLLM_ATTENTION_BACKEND", "auto")
+
+
+def get_deep_gemm_version() -> str:
+    try:
+        from importlib.metadata import version
+        return version("deep-gemm")
+    except Exception:
+        return "unknown"
+
+
+def get_gpu_capability() -> str:
+    """Get the GPU compute capability as 'major.minor' (e.g. '9.0', '10.0').
+
+    Different GPU architectures can trigger different post-processing paths
+    (e.g. DeepGemm TMA scale packing differs between SM90 and SM100).
+    Including this in SourceIdentity ensures heterogeneous clusters don't
+    attempt cross-architecture transfers.
+
+    Returns 'unknown' if CUDA is not available.
+    """
+    try:
+        if torch.cuda.is_available():
+            props = torch.cuda.get_device_properties(0)
+            return f"{props.major}.{props.minor}"
+    except Exception:
+        pass
+    return "unknown"
+
+
+@dataclass
+class TransferFingerprint:
+    """Captures runtime environment and tensor manifest structure.
+
+    Published by the source alongside tensor metadata. The target computes
+    its own fingerprint and compares. Mismatches cause transfer rejection.
+    """
+    vllm_version: str = ""
+    torch_version: str = ""
+    cuda_version: str = ""
+    deep_gemm_version: str = ""
+    gpu_capability: str = ""
+    attention_backend: str = ""
+    manifest_hash: str = ""
+    tensor_count: int = 0
+
+    @classmethod
+    def from_environment(cls, tensors: dict[str, torch.Tensor] | None = None) -> TransferFingerprint:
+        """Build a fingerprint from the current runtime environment."""
+        fp = cls(
+            vllm_version=get_vllm_version(),
+            torch_version=get_torch_version(),
+            cuda_version=get_cuda_version(),
+            deep_gemm_version=get_deep_gemm_version(),
+            gpu_capability=get_gpu_capability(),
+            attention_backend=_get_attention_backend(),
+        )
+        if tensors is not None:
+            fp.manifest_hash = _compute_manifest_hash(tensors)
+            fp.tensor_count = len(tensors)
+        return fp
+
+    def to_json(self) -> str:
+        """Serialize to JSON string for inclusion in proto metadata."""
+        return json.dumps({
+            "vllm_version": self.vllm_version,
+            "torch_version": self.torch_version,
+            "cuda_version": self.cuda_version,
+            "deep_gemm_version": self.deep_gemm_version,
+            "gpu_capability": self.gpu_capability,
+            "attention_backend": self.attention_backend,
+            "manifest_hash": self.manifest_hash,
+            "tensor_count": self.tensor_count,
+        }, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, s: str) -> TransferFingerprint:
+        """Deserialize from JSON string."""
+        d = json.loads(s)
+        return cls(**d)
+
+
+
+def _compute_manifest_hash(tensors: dict[str, torch.Tensor]) -> str:
+    """Compute a SHA256 hash of the tensor manifest structure.
+
+    Hashes tensor names, sizes, and dtypes (NOT addresses, which are
+    machine-specific). Two identical models with identical post-processing
+    should produce the same hash regardless of GPU memory layout.
+    """
+    entries = []
+    for name in sorted(tensors.keys()):
+        t = tensors[name]
+        entries.append(f"{name}:{list(t.shape)}:{t.dtype}:{t.numel() * t.element_size()}")
+    manifest_str = "\n".join(entries)
+    return hashlib.sha256(manifest_str.encode()).hexdigest()

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -55,7 +55,8 @@ def detect_model_features(model_config) -> dict[str, str]:
     features["quantization"] = model_config.quantization or "none"
 
     # MLA detection via HF config attribute
-    has_mla = getattr(hf_config, "kv_lora_rank", None) is not None
+    kv_lora_rank = getattr(hf_config, "kv_lora_rank", None)
+    has_mla = isinstance(kv_lora_rank, int)
     features["attention"] = "mla" if has_mla else "standard"
 
     # MoE
@@ -63,7 +64,7 @@ def detect_model_features(model_config) -> dict[str, str]:
         getattr(hf_config, "n_routed_experts", None)
         or getattr(hf_config, "num_local_experts", None)
     )
-    if num_experts and num_experts > 1:
+    if isinstance(num_experts, int) and num_experts > 1:
         features["moe"] = str(num_experts)
 
     return features

--- a/modelexpress_client/python/modelexpress/types.py
+++ b/modelexpress_client/python/modelexpress/types.py
@@ -34,3 +34,13 @@ class GetMetadataResponse:
     """Response from GetMetadata RPC."""
     found: bool
     workers: list[WorkerMetadata]
+
+
+class ManifestMismatchError(Exception):
+    """Source and target tensor manifests are incompatible.
+
+    Raised during RDMA transfer when tensor names or sizes don't match.
+    The caller should try the next source candidate rather than marking
+    the source as stale (the mismatch may be due to a rolling update,
+    not a source-side failure).
+    """

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for transfer safety checks."""
+
+import json
+import os
+import unittest.mock
+
+import pytest
+import torch
+
+from modelexpress.transfer_safety import (
+    TransferFingerprint,
+    _compute_manifest_hash,
+    check_transfer_allowed,
+    detect_model_features,
+)
+
+
+class FakeHfConfig:
+    """Minimal fake for hf_text_config that returns None for missing attributes."""
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __getattr__(self, name):
+        return None
+
+
+class FakeConfig:
+    """Minimal fake for model_config."""
+    def __init__(self, model_type="llama", dtype=torch.bfloat16, quantization=None, **kwargs):
+        self.dtype = dtype
+        self.quantization = quantization
+        self.hf_text_config = FakeHfConfig(model_type=model_type, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Feature detection
+# ---------------------------------------------------------------------------
+
+class TestDetectModelFeatures:
+    def test_llama_standard_attention(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+        )
+        features = detect_model_features(config)
+        assert features["model_type"] == "llama"
+        assert features["attention"] == "standard"
+
+    def test_deepseek_v2_mla(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
+            num_key_value_heads=1,
+            num_attention_heads=16,
+        )
+        features = detect_model_features(config)
+        assert features["attention"] == "mla"
+
+    def test_fp8_quantization(self):
+        config = FakeConfig(
+            model_type="llama",
+            quantization="fp8",
+        )
+        features = detect_model_features(config)
+        assert features["quantization"] == "fp8"
+
+    def test_moe_detection(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+            n_routed_experts=64,
+        )
+        features = detect_model_features(config)
+        assert features["moe"] == "64"
+
+    def test_unknown_model_type(self):
+        config = FakeConfig(
+            model_type="some_new_architecture",
+        )
+        features = detect_model_features(config)
+        assert features["model_type"] == "some_new_architecture"
+
+
+# ---------------------------------------------------------------------------
+# Feature checks
+# ---------------------------------------------------------------------------
+
+class TestCheckTransferAllowed:
+    def test_llama_allowed(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_unknown_model_type_allowed(self):
+        config = FakeConfig(
+            model_type="brand_new_architecture",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_fp8_llama_allowed(self):
+        config = FakeConfig(
+            model_type="llama",
+            num_key_value_heads=8,
+            num_attention_heads=32,
+            quantization="fp8",
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_deepseek_mla_denied(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert not allowed
+        assert "mla" in reason.lower()
+
+    def test_kimi_mla_denied(self):
+        config = FakeConfig(
+            model_type="kimi_k25",
+            kv_lora_rank=512,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert not allowed
+        assert "mla" in reason.lower()
+
+    def test_mla_detected_by_kv_lora_rank(self):
+        config = FakeConfig(
+            model_type="some_future_mla_model",
+            kv_lora_rank=256,
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert not allowed
+        assert "mla" in reason.lower()
+
+    def test_no_kv_lora_rank_allowed(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+        )
+        allowed, reason = check_transfer_allowed(config)
+        assert allowed
+
+    def test_bypass_env_var(self):
+        config = FakeConfig(
+            model_type="deepseek_v2",
+            kv_lora_rank=512,
+        )
+        os.environ["MX_SKIP_FEATURE_CHECK"] = "1"
+        try:
+            allowed, reason = check_transfer_allowed(config)
+            assert allowed
+            assert reason == "bypassed"
+        finally:
+            del os.environ["MX_SKIP_FEATURE_CHECK"]
+
+
+# ---------------------------------------------------------------------------
+# Transfer fingerprint
+# ---------------------------------------------------------------------------
+
+class TestTransferFingerprint:
+    def test_round_trip_json(self):
+        fp = TransferFingerprint(
+            vllm_version="0.17.1",
+            torch_version="2.10.0",
+            cuda_version="12.9",
+            deep_gemm_version="2.3.0",
+            attention_backend="FLASHINFER_MLA",
+            manifest_hash="abc123",
+            tensor_count=729,
+        )
+        json_str = fp.to_json()
+        fp2 = TransferFingerprint.from_json(json_str)
+        assert fp2.vllm_version == "0.17.1"
+        assert fp2.tensor_count == 729
+        assert fp2.manifest_hash == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# Manifest hash
+# ---------------------------------------------------------------------------
+
+class TestManifestHash:
+    def test_same_tensors_same_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32), "b": torch.zeros(20, dtype=torch.bfloat16)}
+        t2 = {"a": torch.ones(10, dtype=torch.float32), "b": torch.ones(20, dtype=torch.bfloat16)}
+        # Same shapes and dtypes, different values -> same hash
+        assert _compute_manifest_hash(t1) == _compute_manifest_hash(t2)
+
+    def test_different_shapes_different_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
+        t2 = {"a": torch.zeros(20, dtype=torch.float32)}
+        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)
+
+    def test_different_names_different_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
+        t2 = {"b": torch.zeros(10, dtype=torch.float32)}
+        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)
+
+    def test_different_dtypes_different_hash(self):
+        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
+        t2 = {"a": torch.zeros(10, dtype=torch.float16)}
+        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)


### PR DESCRIPTION
Port of #199 (release/0.3.0) to main, adapted for the LoadStrategyChain architecture.

- MLA feature gate in RdmaStrategy.is_available() - blocks MLA models from P2P, detected via kv_lora_rank in HF config
- ManifestMismatchError for tensor name/size mismatches during transfer
- TransferFingerprint for runtime environment logging
- Replace MLA models with Llama-3.1-405B-Instruct in P2P examples
- MLA limitation documented in README, ARCHITECTURE.md, DEPLOYMENT.md
- Bypass with MX_SKIP_FEATURE_CHECK=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic P2P transfer safety checks that block Multi-head Latent Attention (MLA) models from GPU-to-GPU transfer and fallback to disk loading.
  * Introduced manifest validation to detect tensor incompatibilities during transfer.
  * Added `MX_SKIP_FEATURE_CHECK` environment variable for testing.

* **Documentation**
  * Updated deployment and architecture documentation with transfer safety details and known MLA transfer issues.
  * Updated example configurations to use supported model architectures.

* **Tests**
  * Added comprehensive transfer safety validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->