### PR TITLE
fix: use correct grpc-health-probe image in Helm test template (#213)

### DIFF
--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
   - name: grpc-health-probe
-    image: registry.k8s.io/grpc-health-probe:v0.4.35
-    command: ['grpc_health_probe']
+    image: ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.35
+    command: ['/ko-app/grpc-health-probe']
     args: ['-addr={{ include "modelexpress.fullname" . }}:{{ .Values.service.port | default 8001 }}']
   restartPolicy: Never


### PR DESCRIPTION
Cherry-pick of PR #213 