### PR TITLE
fix: propagate vLLM log handlers to modelexpress loggers

### DIFF
--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -24,6 +24,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import os
 import time
 import uuid
 
@@ -64,7 +65,10 @@ def _configure_vllm_logging():
     vllm_logger = logging.getLogger("vllm")
     for handler in vllm_logger.handlers:
         mx_root.addHandler(handler)
-    if vllm_logger.level != logging.NOTSET:
+    mx_level = os.environ.get("MODEL_EXPRESS_LOG_LEVEL", "").upper()
+    if mx_level and hasattr(logging, mx_level):
+        mx_root.setLevel(getattr(logging, mx_level))
+    elif vllm_logger.level != logging.NOTSET:
         mx_root.setLevel(vllm_logger.level)
 
 

--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -47,6 +47,27 @@ from vllm.utils.torch_utils import set_default_torch_dtype
 logger = logging.getLogger("modelexpress.vllm_loader")
 
 
+def _configure_vllm_logging():
+    """Ensure modelexpress loggers are visible in vLLM's EngineCore subprocess.
+
+    vLLM 0.19.0+ only attaches log handlers to the "vllm" namespace.
+    Without this, all "modelexpress.*" output is silently dropped because
+    the root logger in the subprocess has no handler.
+
+    Copies vLLM's handlers onto the "modelexpress" parent logger so every
+    child logger (client, metadata, heartbeat, nixl_transfer, etc.)
+    inherits them via propagation.
+    """
+    mx_root = logging.getLogger("modelexpress")
+    if mx_root.handlers:
+        return
+    vllm_logger = logging.getLogger("vllm")
+    for handler in vllm_logger.handlers:
+        mx_root.addHandler(handler)
+    if vllm_logger.level != logging.NOTSET:
+        mx_root.setLevel(vllm_logger.level)
+
+
 # Global storage for tensor metadata, keyed by device_id (local CUDA ordinal).
 _tensor_registry: dict[int, dict[str, torch.Tensor]] = {}
 _nixl_managers: dict[int, NixlTransferManager] = {}
@@ -65,6 +86,7 @@ class MxModelLoader(BaseModelLoader):
 
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
+        _configure_vllm_logging()
         self._mx_client = MxClient()
         self._worker_id = uuid.uuid4().hex[:8]
         self._ctx: LoadContext | None = None

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -5,6 +5,7 @@
 
 import logging
 import logging.handlers
+import os
 from unittest.mock import MagicMock, patch, call
 
 import grpc
@@ -871,7 +872,7 @@ class TestConfigureVllmLogging:
     def test_no_duplicate_handlers_on_repeated_calls(self):
         from modelexpress.vllm_loader import _configure_vllm_logging
 
-        vllm_logger, handler = self._simulate_vllm_enginecore_logging()
+        vllm_logger, _handler = self._simulate_vllm_enginecore_logging()
         try:
             _configure_vllm_logging()
             _configure_vllm_logging()
@@ -901,4 +902,30 @@ class TestConfigureVllmLogging:
             assert buf.buffer[0].name == "modelexpress.heartbeat"
         finally:
             vllm_logger.removeHandler(buf)
+            self._cleanup(vllm_logger)
+
+    def test_model_express_log_level_overrides_vllm(self):
+        from modelexpress.vllm_loader import _configure_vllm_logging
+
+        vllm_logger, _handler = self._simulate_vllm_enginecore_logging()
+        try:
+            assert vllm_logger.level == logging.DEBUG
+            with patch.dict("os.environ", {"MODEL_EXPRESS_LOG_LEVEL": "WARNING"}):
+                _configure_vllm_logging()
+            mx_root = logging.getLogger("modelexpress")
+            assert mx_root.level == logging.WARNING
+        finally:
+            self._cleanup(vllm_logger)
+
+    def test_falls_back_to_vllm_level_when_env_unset(self):
+        from modelexpress.vllm_loader import _configure_vllm_logging
+
+        vllm_logger, _handler = self._simulate_vllm_enginecore_logging()
+        try:
+            with patch.dict("os.environ", {}, clear=False):
+                os.environ.pop("MODEL_EXPRESS_LOG_LEVEL", None)
+                _configure_vllm_logging()
+            mx_root = logging.getLogger("modelexpress")
+            assert mx_root.level == logging.DEBUG
+        finally:
             self._cleanup(vllm_logger)

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -3,6 +3,8 @@
 
 """Tests for tensor utilities, metadata publishing, and loading strategies."""
 
+import logging
+import logging.handlers
 from unittest.mock import MagicMock, patch, call
 
 import grpc
@@ -809,3 +811,94 @@ class TestCollectModuleTensorsStorageViews:
         source = collect_module_tensors(make_model())
         target = collect_module_tensors(make_model())
         assert set(source.keys()) == set(target.keys())
+
+
+# ---------------------------------------------------------------------------
+# _configure_vllm_logging
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureVllmLogging:
+    """Verify modelexpress loggers inherit vLLM handlers in EngineCore subprocess."""
+
+    def _reset_mx_logger(self):
+        """Clear any handlers/level from the modelexpress root logger."""
+        mx_root = logging.getLogger("modelexpress")
+        mx_root.handlers.clear()
+        mx_root.setLevel(logging.NOTSET)
+
+    def _simulate_vllm_enginecore_logging(self):
+        """Reproduce vLLM 0.19.0 EngineCore: only "vllm" gets a handler."""
+        self._reset_mx_logger()
+
+        vllm_logger = logging.getLogger("vllm")
+        self._saved_vllm_handlers = list(vllm_logger.handlers)
+        self._saved_vllm_level = vllm_logger.level
+        self._saved_vllm_propagate = vllm_logger.propagate
+
+        vllm_logger.handlers.clear()
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(name)s %(levelname)s %(message)s"))
+        vllm_logger.addHandler(handler)
+        vllm_logger.setLevel(logging.DEBUG)
+        vllm_logger.propagate = False
+        return vllm_logger, handler
+
+    def _cleanup(self, vllm_logger):
+        self._reset_mx_logger()
+        vllm_logger.handlers.clear()
+        for h in self._saved_vllm_handlers:
+            vllm_logger.addHandler(h)
+        vllm_logger.setLevel(self._saved_vllm_level)
+        vllm_logger.propagate = self._saved_vllm_propagate
+
+    def test_child_loggers_visible_after_configure(self):
+        from modelexpress.vllm_loader import _configure_vllm_logging
+
+        vllm_logger, handler = self._simulate_vllm_enginecore_logging()
+        try:
+            _configure_vllm_logging()
+
+            mx_root = logging.getLogger("modelexpress")
+            assert len(mx_root.handlers) == 1
+            assert mx_root.handlers[0] is handler
+
+            child = logging.getLogger("modelexpress.metadata")
+            assert child.getEffectiveLevel() == logging.DEBUG
+        finally:
+            self._cleanup(vllm_logger)
+
+    def test_no_duplicate_handlers_on_repeated_calls(self):
+        from modelexpress.vllm_loader import _configure_vllm_logging
+
+        vllm_logger, handler = self._simulate_vllm_enginecore_logging()
+        try:
+            _configure_vllm_logging()
+            _configure_vllm_logging()
+
+            mx_root = logging.getLogger("modelexpress")
+            assert len(mx_root.handlers) == 1
+        finally:
+            self._cleanup(vllm_logger)
+
+    def test_log_output_actually_captured(self):
+        from modelexpress.vllm_loader import _configure_vllm_logging
+
+        vllm_logger, _ = self._simulate_vllm_enginecore_logging()
+        try:
+            buf = logging.handlers.MemoryHandler(capacity=100)
+            vllm_logger.handlers.clear()
+            vllm_logger.addHandler(buf)
+
+            self._reset_mx_logger()
+            _configure_vllm_logging()
+
+            child = logging.getLogger("modelexpress.heartbeat")
+            child.info("Heartbeat started")
+
+            assert len(buf.buffer) == 1
+            assert "Heartbeat started" in buf.buffer[0].getMessage()
+            assert buf.buffer[0].name == "modelexpress.heartbeat"
+        finally:
+            vllm_logger.removeHandler(buf)
+            self._cleanup(vllm_logger)


### PR DESCRIPTION
## Summary

- vLLM 0.19.0's EngineCore subprocess only attaches log handlers to the `"vllm"` namespace. All `"modelexpress.*"` loggers propagate to the root logger which has no handler, silently dropping all MxModelLoader output (startup, metadata publish, heartbeat, retry warnings, errors).
- Copies vLLM's handlers onto the `"modelexpress"` parent logger in `MxModelLoader.__init__()` so all child loggers inherit them via propagation. Idempotent guard prevents duplicate handlers.

Bug: https://nvbugspro.nvidia.com/bug/6071055

## Test plan

- [x] Unit tests added in `TestConfigureVllmLogging` (3 tests):
  - Handler propagation from `"vllm"` to `"modelexpress"` parent logger
  - Idempotency (no duplicate handlers on repeated calls)
  - Log output actually captured through vLLM's handler
- [x] All 50 existing tests in `test_vllm_loader.py` pass