### PR TITLE
fix: remove --enable-expert-parallel from vLLM example manifests

### DIFF
--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -110,7 +110,6 @@ spec:
             - mx
             - --tensor-parallel-size
             - "8"
-            - --enable-expert-parallel
           resources:
             limits:
               nvidia.com/gpu: "8"

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -108,7 +108,6 @@ spec:
             - mx
             - --tensor-parallel-size
             - "8"
-            - --enable-expert-parallel
           resources:
             limits:
               nvidia.com/gpu: "8"


### PR DESCRIPTION
The flag is not needed for the current vLLM configurations and was causing issues. Remove it from multi-node, single-node, and single-node-p2p example YAML files.