### PR TITLE
fix: re-initialize model after failed RDMA target attempt (FP8 disk fallback crash)

### DIFF
--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -654,6 +654,28 @@ class MxModelLoader(BaseModelLoader):
                 )
 
             if not loaded_as_target:
+                if transfer_allowed:
+                    # A failed RDMA target attempt runs
+                    # process_weights_after_loading() to establish the tensor
+                    # layout for receive buffers.  That mutates the model
+                    # in-place (e.g. FP8 post-processing strips weight_loader
+                    # from QuantizedParameters), leaving it in a state
+                    # incompatible with a fresh disk load.  It also registers
+                    # stale tensors with NIXL.  Clean up and re-initialize.
+                    self._tensors = {}
+                    self._nixl_manager = None
+                    _tensor_registry.pop(device_id, None)
+                    _nixl_managers.pop(device_id, None)
+                    del model
+                    torch.cuda.empty_cache()
+                    logger.info(
+                        f"[Worker {global_rank}] Re-initializing model after "
+                        f"failed RDMA attempt"
+                    )
+                    with target_device:
+                        model = initialize_model(
+                            vllm_config=vllm_config, model_config=model_config
+                        )
                 self._load_as_source(model, model_config, target_device, global_rank, device_id, identity)
 
         total_time = time.perf_counter() - load_start


### PR DESCRIPTION
When P2P transfer fails and the loader falls back to disk, the model is left in a post-processed state from the target path. `process_weights_after_loading()` (which must run before RDMA to establish tensor layout) strips `weight_loader` attributes from FP8/modelopt `QuantizedParameter`s. The disk fallback then crashes with `AttributeError: 'Parameter' object has no attribute 'weight_loader'`.

Re-initialization is the correct fix because:
- `process_weights_after_loading()` cannot be deferred past RDMA receive; the target path needs the final tensor layout to allocate matching receive buffers
- Restoring `weight_loader` attributes after post-processing would require re-running the quantization pipeline setup, tightly coupled to vLLM internals
- `initialize_model()` only builds the module tree (no weight I/O), so the cost is negligible compared to the disk load that follows

- Delete the mutated model and free CUDA memory before re-initializing
- Clear stale NIXL tensor registrations and manager state so the source path re-registers against the new model's tensors
- Only runs when `transfer_allowed` (i.e. an RDMA attempt may have been made)

Fixes: NVBugs 6071387