### PR TITLE
fix: re-initialize model after failed strategy mutates it (FP8 disk fallback crash)

### DIFF
--- a/modelexpress_client/python/modelexpress/load_strategy/__init__.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/__init__.py
@@ -79,14 +79,7 @@ class LoadStrategyChain:
                     f"raised unexpected error, trying next: {e}"
                 )
 
-            # A failed strategy may have mutated the model (e.g. RDMA runs
-            # process_weights_after_loading() before the transfer attempt,
-            # stripping weight_loader from FP8 QuantizedParameters).  Detect
-            # this via stale NIXL state and re-initialize so the next
-            # strategy gets a clean model.
-            if ctx.tensors or ctx.nixl_manager is not None:
-                ctx.tensors = {}
-                ctx.nixl_manager = None
+            if strategy.rollback(ctx):
                 del model
                 torch.cuda.empty_cache()
                 logger.info(

--- a/modelexpress_client/python/modelexpress/load_strategy/__init__.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/__init__.py
@@ -39,6 +39,30 @@ __all__ = [
 logger = logging.getLogger("modelexpress.load_strategy")
 
 
+def _reset_vllm_compilation_state(compilation_config) -> None:
+    """Reset per-model mutable state on vLLM's CompilationConfig.
+
+    vLLM registers attention / MLA / Mamba / FusedMoE layers and accumulates
+    compile stats into dicts / sets / counters on ``compilation_config``
+    during ``initialize_model()``. These live on the config object, not the
+    model, so they survive ``del model`` and either crash the next
+    ``initialize_model()`` (``static_forward_context`` has an explicit
+    duplicate-name guard) or silently corrupt subsequent state (MoE layer
+    list, custom op counters, traced files, compilation time).
+
+    Called from the chain's re-init path so the next strategy sees a clean
+    config. Audited against vLLM 0.17.1; newer vLLM versions may add
+    additional ``init=False`` fields on ``CompilationConfig`` that need
+    similar treatment.
+    """
+    compilation_config.static_forward_context.clear()
+    compilation_config.static_all_moe_layers.clear()
+    compilation_config.enabled_custom_ops.clear()
+    compilation_config.disabled_custom_ops.clear()
+    compilation_config.traced_files.clear()
+    compilation_config.compilation_time = 0.0
+
+
 class LoadStrategyChain:
     """Prioritized chain of model loading strategies.
 
@@ -82,6 +106,7 @@ class LoadStrategyChain:
             if strategy.rollback(ctx):
                 del model
                 torch.cuda.empty_cache()
+                _reset_vllm_compilation_state(ctx.vllm_config.compilation_config)
                 logger.info(
                     f"[Worker {ctx.global_rank}] Re-initializing model after "
                     f"failed strategy '{strategy.name}'"

--- a/modelexpress_client/python/modelexpress/load_strategy/__init__.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 
+import torch
 import torch.nn as nn
 
 from .base import (
@@ -46,11 +47,13 @@ class LoadStrategyChain:
     """
 
     @staticmethod
-    def run(model: nn.Module, ctx: LoadContext) -> None:
+    def run(model: nn.Module, ctx: LoadContext) -> nn.Module:
         """Build the chain and execute strategies until one succeeds.
 
+        Returns the (possibly re-initialized) model on success.
         Raises RuntimeError if no strategy succeeds.
         """
+        from vllm.model_executor.model_loader.utils import initialize_model
         from .rdma_strategy import RdmaStrategy
         from .model_streamer_strategy import ModelStreamerStrategy
         from .gds_strategy import GdsStrategy
@@ -69,12 +72,32 @@ class LoadStrategyChain:
             logger.info(f"[Worker {ctx.global_rank}] Trying strategy: {strategy.name}")
             try:
                 if strategy.load(model, ctx):
-                    return
+                    return model
             except Exception as e:
                 logger.warning(
                     f"[Worker {ctx.global_rank}] Strategy {strategy.name} "
                     f"raised unexpected error, trying next: {e}"
                 )
+
+            # A failed strategy may have mutated the model (e.g. RDMA runs
+            # process_weights_after_loading() before the transfer attempt,
+            # stripping weight_loader from FP8 QuantizedParameters).  Detect
+            # this via stale NIXL state and re-initialize so the next
+            # strategy gets a clean model.
+            if ctx.tensors or ctx.nixl_manager is not None:
+                ctx.tensors = {}
+                ctx.nixl_manager = None
+                del model
+                torch.cuda.empty_cache()
+                logger.info(
+                    f"[Worker {ctx.global_rank}] Re-initializing model after "
+                    f"failed strategy '{strategy.name}'"
+                )
+                with ctx.target_device:
+                    model = initialize_model(
+                        vllm_config=ctx.vllm_config,
+                        model_config=ctx.model_config,
+                    )
 
         raise RuntimeError(
             f"[Worker {ctx.global_rank}] No loading strategy succeeded "

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -119,6 +119,19 @@ class LoadStrategy(ABC):
     def load(self, model: nn.Module, ctx: LoadContext) -> bool:
         """Attempt to load weights. Return True on success, False to try next."""
 
+    def rollback(self, ctx: LoadContext) -> bool:
+        """Clean up after a failed load attempt.
+
+        Called by the chain when load() returns False or raises. Strategies
+        that mutate the model before their failure point (e.g. RDMA runs
+        process_weights_after_loading before the transfer) should override
+        this to clean up their state and return True so the chain can
+        re-initialize the model for the next strategy.
+
+        Returns True if the model was mutated and needs re-initialization.
+        """
+        return False
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers (used by strategy implementations)

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -35,6 +35,20 @@ class RdmaStrategy(LoadStrategy):
 
     name = "rdma"
 
+    def rollback(self, ctx: LoadContext) -> bool:
+        """Clean up NIXL state from a failed RDMA target attempt.
+
+        Returns True if _load_as_target() ran (and thus
+        process_weights_after_loading mutated the model).  Detected by
+        checking whether register_tensors() populated ctx during the
+        attempt.
+        """
+        if ctx.tensors or ctx.nixl_manager is not None:
+            ctx.tensors = {}
+            ctx.nixl_manager = None
+            return True
+        return False
+
     def is_available(self, ctx: LoadContext) -> bool:
         if not is_nixl_available():
             return False

--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -81,7 +81,7 @@ class MxModelLoader(BaseModelLoader):
                     vllm_config=vllm_config, model_config=model_config
                 )
 
-            LoadStrategyChain.run(model, ctx)
+            model = LoadStrategyChain.run(model, ctx)
 
             # Update global registries
             _tensor_registry[ctx.device_id] = ctx.tensors


### PR DESCRIPTION
Same root cause as #231 (release/0.3.0), adapted for the strategy chain architecture on main.

When RdmaStrategy enters _load_as_target(), it runs process_weights_after_loading() before the RDMA receive to establish tensor layout for receive buffers. For FP8/modelopt models, this strips weight_loader from QuantizedParameters. If RDMA then fails, subsequent strategies (DefaultStrategy) crash on model.load_weights() because weight_loader is gone.

- LoadStrategyChain.run() detects stale NIXL state after a failed strategy, cleans up, and re-initializes the model before trying the next strategy
- run() returns the (possibly re-initialized) model so the caller uses the correct object
- Detection is precise: RDMA is the only strategy that runs process_weights_after_loading() before its failure point, and NIXL state is only set when _load_as_target() actually ran

Fixes: NVBugs 6071387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved model loading resilience with enhanced error recovery for failed initialization strategies
  * Fixed model state corruption by automatically reinitializing models when partial mutations are detected during strategy failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->