### PR TITLE
fix: default coalesce_transfers to False in receive_from_source

### DIFF
--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -311,7 +311,7 @@ class NixlTransferManager:
         source_metadata: bytes,
         source_tensors: list[TensorDescriptor],
         timeout_seconds: float | None = None,
-        coalesce_transfers: bool = True,
+        coalesce_transfers: bool = False,
         remote_agent_name: str | None = None,
     ) -> tuple[int, int, float]:
         """


### PR DESCRIPTION
## Summary

- Change `coalesce_transfers` default from `True` to `False` in `NixlTransferManager.receive_from_source()`

## Problem

When `MX_CONTIGUOUS_REG=0` (the default), the source registers individual tensors with NIXL. However, `receive_from_source()` defaults to `coalesce_transfers=True`, which merges adjacent tensor descriptors into larger memory regions before calling `prep_xfer_dlist`. NIXL requires the requested address range to exactly match a registered region on the source side, so the coalesced requests fail with `NIXL_ERR_NOT_FOUND`:

```
prepXferDlist: failed to prepare the descriptors for any of the
specified or potential backends for agent 'sglang-seed-rank0-...'
nixl_cu12._bindings.nixlNotFoundError: NIXL_ERR_NOT_FOUND
```

The vLLM loader already handles this correctly by passing `coalesce_transfers=False` when `MX_CONTIGUOUS_REG=0`. But any caller that omits the parameter (e.g., SGLang) gets the broken default.

## Fix

Default `coalesce_transfers` to `False` so individual tensor transfers (the safe path) are used unless explicitly opted in. Coalescing is only valid when the source also registers coalesced regions (`MX_CONTIGUOUS_REG=1`).
