### PR TITLE
fix: update example manifests and Helm docs to public 0.3.0 image URI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -74,7 +74,9 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: vllm
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:0.3.0
+          # Build a vLLM + ModelExpress client image using
+          # examples/p2p_transfer_k8s/Dockerfile.client
+          image: <your-registry>/modelexpress-client:latest
           imagePullPolicy: IfNotPresent
           # IPC_LOCK required for RDMA memory pinning (NIXL/UCX GPUDirect)
           securityContext:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -74,7 +74,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: vllm
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:latest
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-client:0.3.0
           imagePullPolicy: IfNotPresent
           # IPC_LOCK required for RDMA memory pinning (NIXL/UCX GPUDirect)
           securityContext:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -74,7 +74,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: vllm
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-client:0.3.0
+          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:0.3.0
           imagePullPolicy: IfNotPresent
           # IPC_LOCK required for RDMA memory pinning (NIXL/UCX GPUDirect)
           securityContext:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-client:0.3.0
+          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:0.3.0
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -47,7 +47,9 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:0.3.0
+          # Build a vLLM + ModelExpress client image using
+          # examples/p2p_transfer_k8s/Dockerfile.client
+          image: <your-registry>/modelexpress-client:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:latest
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-client:0.3.0
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:latest
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-client:0.3.0
           imagePullPolicy: IfNotPresent
           # Needed for GPUDirect RDMA to work.
           securityContext:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-client:0.3.0
+          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:0.3.0
           imagePullPolicy: IfNotPresent
           # Needed for GPUDirect RDMA to work.
           securityContext:

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -47,7 +47,9 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-client:0.3.0
+          # Build a vLLM + ModelExpress client image using
+          # examples/p2p_transfer_k8s/Dockerfile.client
+          image: <your-registry>/modelexpress-client:latest
           imagePullPolicy: IfNotPresent
           # Needed for GPUDirect RDMA to work.
           securityContext:

--- a/examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml
+++ b/examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: modelexpress
       containers:
         - name: modelexpress-server
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-server:latest
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8001

--- a/examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml
+++ b/examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml
@@ -75,7 +75,7 @@ spec:
 
       containers:
         - name: modelexpress-server
-          image: nvcr.io/nvidian/dynamo-dev/modelexpress-server:latest
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8001

--- a/helm/README.md
+++ b/helm/README.md
@@ -294,7 +294,7 @@ The Helm chart uses the official NVIDIA ModelExpress image from the NVIDIA Conta
 docker login nvcr.io -u '$oauthtoken' -p 'YOUR_NVCR_API_KEY'
 
 # Pull the image
-docker pull nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.2.0
+docker pull nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
 ```
 
 **Note:** The default image requires authentication. See the [Installation](#installation) section for creating the required Kubernetes secret.


### PR DESCRIPTION
## Summary

- Update server example manifests from internal `nvcr.io/nvidian/dynamo-dev/modelexpress-server:latest` to public `nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0`
- Replace private `nvcr.io/nvidian/dynamo-dev/modelexpress-client` image in vLLM client manifests with a `<your-registry>` placeholder, pointing users to `examples/p2p_transfer_k8s/Dockerfile.client` to build their own image
- Update Helm README docker pull example from `0.2.0` to `0.3.0`

### Files changed

| File | Change |
|------|--------|
| `examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml` | server image → public `nvidia/ai-dynamo` registry, `0.3.0` |
| `examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml` | server image → public `nvidia/ai-dynamo` registry, `0.3.0` |
| `examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml` | client image → `<your-registry>` placeholder + Dockerfile.client comment |
| `examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml` | client image → `<your-registry>` placeholder + Dockerfile.client comment |
| `examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml` | client image → `<your-registry>` placeholder + Dockerfile.client comment |
| `helm/README.md` | docker pull version bump `0.2.0` → `0.3.0` |

## Test plan

- [ ] Verify no remaining internal registry references in example manifests
- [ ] YAML manifests pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)