### PR TITLE
fix: only re-initialize model when RDMA target load was actually attempted

### DIFF
--- a/modelexpress_client/python/modelexpress/vllm_loader.py
+++ b/modelexpress_client/python/modelexpress/vllm_loader.py
@@ -669,8 +669,9 @@ class MxModelLoader(BaseModelLoader):
                 )
 
             loaded_as_target = False
+            rdma_attempted = False
             if transfer_allowed:
-                loaded_as_target = self._try_load_from_candidates(
+                loaded_as_target, rdma_attempted = self._try_load_from_candidates(
                     model, model_config, target_device, global_rank, device_id, identity
                 )
             else:
@@ -679,7 +680,7 @@ class MxModelLoader(BaseModelLoader):
                 )
 
             if not loaded_as_target:
-                if transfer_allowed:
+                if rdma_attempted:
                     # A failed RDMA target attempt runs
                     # process_weights_after_loading() to establish the tensor
                     # layout for receive buffers.  That mutates the model
@@ -758,16 +759,16 @@ class MxModelLoader(BaseModelLoader):
         global_rank: int,
         device_id: int,
         identity: p2p_pb2.SourceIdentity,
-    ) -> bool:
+    ) -> tuple[bool, bool]:
         """Try RDMA load from each candidate source instance in order.
 
-        Returns True if a load succeeded. Only marks an instance STALE when a
-        SourceTransferError is raised, which indicates a proven source-side failure
-        (RDMA receive, missing remote tensors). Target-local errors (OOM, weight
-        processing) propagate normally without poisoning a healthy source.
-        Falls back to disk and returns False if all candidates are exhausted.
+        Returns (loaded, attempted) where loaded is True if a load succeeded
+        and attempted is True if _load_as_target() was called on at least one
+        candidate (meaning the model may have been mutated by post-processing).
+        Falls back to disk and returns (False, ...) if all candidates are exhausted.
         """
         candidates = self._find_source_instances(identity, global_rank)
+        rdma_attempted = False
         for instance in candidates[:MAX_SOURCE_RETRIES]:
             mx_source_id = instance.mx_source_id
             worker_id = instance.worker_id
@@ -790,11 +791,12 @@ class MxModelLoader(BaseModelLoader):
             )
 
             try:
+                rdma_attempted = True
                 self._load_as_target(
                     model, model_config, target_device,
                     global_rank, device_id, identity, source_worker, mx_source_id, worker_id,
                 )
-                return True
+                return True, True
             except SourceTransferError as e:
                 logger.warning(
                     f"[Worker {global_rank}] Source transfer failed for worker {worker_id}: {e}. "
@@ -813,7 +815,7 @@ class MxModelLoader(BaseModelLoader):
             )
         else:
             logger.info(f"[Worker {global_rank}] No source worker found - loading from disk")
-        return False
+        return False, rdma_attempted
 
     def _find_source_instances(
         self, identity: p2p_pb2.SourceIdentity, global_rank: int

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -327,7 +327,7 @@ class TestTryLoadFromCandidates:
                 MagicMock(), MagicMock(), MagicMock(), 0, 0, _make_identity()
             )
 
-        assert result is True
+        assert result == (True, True)
         assert attempts == ["w-1"]
 
     def test_marks_stale_on_source_transfer_error_and_tries_next(self):
@@ -349,7 +349,7 @@ class TestTryLoadFromCandidates:
                 MagicMock(), MagicMock(), MagicMock(), 0, 0, _make_identity()
             )
 
-        assert result is True
+        assert result == (True, True)
         assert attempts == ["w-1", "w-2"]
         # Target no longer marks sources STALE — that's owned by heartbeat + reaper
         loader._mx_client.update_status.assert_not_called()
@@ -360,7 +360,7 @@ class TestTryLoadFromCandidates:
             result = loader._try_load_from_candidates(
                 MagicMock(), MagicMock(), MagicMock(), 0, 0, _make_identity()
             )
-        assert result is False
+        assert result == (False, False)
 
     def test_returns_false_when_all_fail(self):
         loader = _make_loader()
@@ -377,7 +377,7 @@ class TestTryLoadFromCandidates:
                 MagicMock(), MagicMock(), MagicMock(), 0, 0, _make_identity()
             )
 
-        assert result is False
+        assert result == (False, True)
         # Target no longer marks sources STALE — that's owned by heartbeat + reaper
         loader._mx_client.update_status.assert_not_called()
 


### PR DESCRIPTION
The re-initialization added in PR #231 triggers on transfer_allowed,
which is true whenever P2P is configured. On the very first source pod
startup (no existing sources), no RDMA attempt is made and the model is
never mutated, but the re-init path runs anyway and calls
initialize_model() a second time, crashing vLLM with
"Duplicate layer name".

- Return (loaded, attempted) tuple from _try_load_from_candidates()
- Track whether _load_as_target() was actually called
- Gate re-initialization on rdma_attempted instead of transfer_allowed