### PR TITLE
feat(examples): add single-node disaggregated variant for dynamo P2P …

### DIFF
--- a/examples/dynamo_p2p_transfer_k8s/Dockerfile
+++ b/examples/dynamo_p2p_transfer_k8s/Dockerfile
@@ -20,9 +20,9 @@ FROM nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
 # Copy and install ModelExpress Python client
 # Proto stubs (p2p_pb2.py, p2p_pb2_grpc.py) are checked-in source artifacts;
 # regenerate them with grpcio-tools when p2p.proto changes.
-COPY modelexpress_client/python /opt/modelexpress/client
+COPY --chown=dynamo:dynamo modelexpress_client/python /opt/modelexpress/client
 WORKDIR /opt/modelexpress/client
-RUN pip install --break-system-packages .
+RUN uv pip install .
 
 # Back to default workdir
 WORKDIR /workspace

--- a/examples/dynamo_p2p_transfer_k8s/Dockerfile
+++ b/examples/dynamo_p2p_transfer_k8s/Dockerfile
@@ -9,9 +9,9 @@
 # Alternatively, build from the dynamo repo with MX integrated:
 #   cd path/to/dynamo
 #   python container/render.py --framework vllm --target runtime \
-#       --platform amd64 --cuda-version 12.9 --show-result
+#       --platform amd64 --cuda-version 12.9 --output-short-filename
 #   docker build --platform linux/amd64 \
-#       -f container/vllm-runtime-cuda12.9-amd64-rendered.Dockerfile \
+#       -f container/rendered.Dockerfile \
 #       --build-arg ENABLE_MODELEXPRESS_P2P=true \
 #       --build-arg MODELEXPRESS_REF=main \
 #       -t <your-tag> .

--- a/examples/dynamo_p2p_transfer_k8s/README.md
+++ b/examples/dynamo_p2p_transfer_k8s/README.md
@@ -1,38 +1,71 @@
 # Dynamo P2P Weight Transfer Example
 
-Deploys ModelExpress P2P RDMA weight transfer using [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) DynamoGraphDeployment on Kubernetes.
+Deploys [ModelExpress](https://github.com/ai-dynamo/modelexpress) P2P RDMA weight transfer on top of [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) using the `DynamoGraphDeployment` custom resource on Kubernetes.
 
-## Architecture
+New worker replicas pull model weights over RDMA from other running replicas instead of loading from disk or object storage — dramatically cutting warm-up time when scaling out large models.
+
+## Deployment Variants
+
+| YAML | Topology | Description |
+|---|---|---|
+| [`vllm/vllm-multi-node-aggregated.yaml`](vllm/vllm-multi-node-aggregated.yaml) | Multi-node, TP=4 PP=2 per replica | Single `VllmWorker` service running both prefill and decode. Use for large models that don't fit on a single node. |
+| [`vllm/vllm-single-node-disaggregated.yaml`](vllm/vllm-single-node-disaggregated.yaml) | Single-node, TP=4 PP=1 per replica | Separate `VllmPrefillWorker` and `VllmDecodeWorker` services with NIXL KV transfer between them. |
+
+## Architecture — aggregated
 
 ```mermaid
 graph LR
     Client -->|HTTP| Frontend
-    Frontend -->|round-robin| Worker0[VllmWorker replica 0<br/>TP=4, PP=2<br/>disk load]
-    Frontend -->|round-robin| Worker1[VllmWorker replica 1<br/>TP=4, PP=2<br/>P2P RDMA]
+    Frontend -->|round-robin| Worker0[VllmWorker replica 0<br/>disk load]
+    Frontend -->|round-robin| Worker1[VllmWorker replica 1<br/>P2P RDMA]
     Worker0 -->|publish metadata| MX[ModelExpress Server]
     Worker1 -->|discover source| MX
     Worker0 -.->|RDMA via NIXL| Worker1
 ```
 
-- **ModelExpress**: P2P metadata server (kubernetes CRD backend). Manages source discovery, heartbeats, and stale reaping.
-- **Frontend**: Dynamo HTTP frontend, routes requests to worker replicas via round-robin.
-- **VllmWorker**: Multi-node vLLM workers (TP=4, PP=2 per replica). First replica loads from disk, subsequent replicas receive weights via RDMA.
+## Architecture — disaggregated
+
+```mermaid
+graph LR
+    Client -->|HTTP| Frontend
+    Frontend --> DecodeWorker
+    DecodeWorker -.->|NIXL KV pull| PrefillWorker
+    subgraph "decode replicas"
+        DecodeWorker[VllmDecodeWorker<br/>replicas=N]
+    end
+    subgraph "prefill replicas"
+        PrefillWorker[VllmPrefillWorker<br/>replicas=M]
+    end
+    DecodeWorker -->|publish metadata| MX[ModelExpress Server]
+    PrefillWorker -->|publish metadata| MX
+    DecodeWorker -.->|MX weights RDMA| PrefillWorker
+```
+
+- **ModelExpress server** (Kubernetes CRD backend): tracks which workers have the model Ready, handles heartbeats, and reaps stale entries. Decode and prefill publish under the same `source_id` (derived from model identity), so any worker of either service can serve as an RDMA source for any other worker of either service.
+- **Frontend**: Dynamo's HTTP entry point; routes to decode workers round-robin.
+- **Workers**: `--load-format mx` means the first replica loads from disk and publishes metadata; every subsequent replica receives weights from a Ready source over RDMA.
 
 ## Prerequisites
 
-1. **Dynamo operator** installed (DynamoGraphDeployment CRD)
-2. **ModelMetadata CRD** installed (one-time, requires cluster-admin):
+1. **Dynamo operator** installed (provides the `DynamoGraphDeployment` CRD).
+2. **ModelMetadata CRD** installed — one-time, cluster-admin:
    ```bash
-   kubectl apply -f examples/p2p_transfer_k8s/server/kubernetes_backend/crd-modelmetadata.yaml
+   kubectl apply -f vllm/crd-modelmetadata.yaml
    ```
-3. **PVC** with model weights pre-downloaded (`shared-model-cache`)
-4. **HuggingFace token secret**: `kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token>`
-
-Note: RBAC (ServiceAccount, Role, RoleBinding) is included in the aggregated YAML and applied automatically.
+3. **RBAC** for the ModelExpress server to manage ModelMetadata CRs:
+   ```bash
+   kubectl apply -f vllm/rbac-modelmetadata.yaml -n <namespace>
+   ```
+4. **PVC** with the model weights pre-downloaded (the YAMLs expect a PVC named `shared-model-cache`; change `spec.pvcs` and `volumeMounts` to match your setup).
+5. **HuggingFace token** for gated models:
+   ```bash
+   kubectl create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN=<your-token> -n <namespace>
+   ```
 
 ## Building the Image
 
-Option A: Layer MX client on dynamo runtime (fast, for dev iteration):
+**Option A — Layer the ModelExpress client on top of the official Dynamo runtime** (fast, good for iteration):
 
 ```bash
 docker build --platform linux/amd64 \
@@ -40,56 +73,84 @@ docker build --platform linux/amd64 \
   -t <your-registry>/mx-vllm-runtime:<tag> .
 ```
 
-Option B: Build from dynamo repo with MX integrated (recommended for CI):
+Uses the public `nvcr.io/nvidia/ai-dynamo/vllm-runtime` base and adds the ModelExpress Python client. Builds in a couple of minutes.
+
+**Option B — Rebuild from the Dynamo repo with ModelExpress integrated** (slower; needed if you want a newer vLLM than the base image ships with):
 
 ```bash
-cd path/to/dynamo
+git clone https://github.com/ai-dynamo/dynamo && cd dynamo
 python container/render.py --framework vllm --target runtime \
-    --platform amd64 --cuda-version 12.9 --show-result
+    --platform amd64 --cuda-version 12.9 --output-short-filename
 docker build --platform linux/amd64 \
-    -f container/vllm-runtime-cuda12.9-amd64-rendered.Dockerfile \
-    --build-arg ENABLE_MODELEXPRESS_P2P=true \
-    --build-arg MODELEXPRESS_REF=main \
-    -t <your-registry>/mx-vllm-runtime:<tag> .
+  -f container/rendered.Dockerfile \
+  --build-arg VLLM_REF=<vllm-tag-or-commit> \
+  --build-arg ENABLE_MODELEXPRESS_P2P=true \
+  --build-arg MODELEXPRESS_REF=main \
+  -t <your-registry>/mx-vllm-runtime:<tag> .
 ```
+
+Recompiles vLLM from source and installs the ModelExpress client directly from GitHub. The build is memory-heavy — plan for a host with several tens of GB of RAM and expect a long first build.
+
+Either way, push the resulting image to a registry reachable from your Kubernetes cluster.
 
 ## Usage
 
-1. Update image tags in `vllm/vllm-multi-node-aggregated.yaml` (search for `# REPLACE`)
+### Aggregated
 
-2. Apply CRD, RBAC, and DGD:
+1. Replace the image placeholder (`<your-registry>/modelexpress-vllm-runtime:latest`) in [`vllm/vllm-multi-node-aggregated.yaml`](vllm/vllm-multi-node-aggregated.yaml) with your pushed tag.
+2. Apply:
    ```bash
-   kubectl apply -f vllm/crd-modelmetadata.yaml            # one-time, cluster-admin
+   kubectl apply -f vllm/crd-modelmetadata.yaml
    kubectl apply -f vllm/rbac-modelmetadata.yaml -n <namespace>
    kubectl apply -f vllm/vllm-multi-node-aggregated.yaml -n <namespace>
    ```
-
-3. Wait for DGD to become READY:
+3. Once the DGD is Ready, scale to validate P2P transfer:
    ```bash
-   kubectl get dgd mx-vllm -n <namespace> -w
-   ```
-
-4. Scale to 2 replicas for P2P transfer:
-   ```bash
-   # Edit replicas in the YAML and re-apply, or:
    kubectl patch dgd mx-vllm -n <namespace> --type merge \
      -p '{"spec":{"services":{"VllmWorker":{"replicas":2}}}}'
    ```
-
-5. Verify P2P transfer in target worker logs:
+4. Confirm P2P in the new replica's logs:
    ```bash
-   kubectl logs -n <namespace> <target-leader-pod> | grep "Transfer complete"
+   kubectl logs -n <namespace> <new-worker-leader-pod> -c main | grep "Transfer complete"
    ```
 
-## Cluster-Specific Configuration
+### Disaggregated (single-node)
 
-- **UCX_NET_DEVICES**: Commented out by default. Uncomment and set to your cluster's IB HCA devices if UCX auto-detection picks wrong devices.
-- **Tolerations**: Not included. Add under `extraPodSpec.tolerations` if your GPU nodes have taints.
-- **PVC name**: Default `shared-model-cache`. Change in `spec.pvcs` and `volumeMounts`.
+1. Replace image placeholders in [`vllm/vllm-single-node-disaggregated.yaml`](vllm/vllm-single-node-disaggregated.yaml).
+2. Apply the same CRD + RBAC from above, then:
+   ```bash
+   kubectl apply -f vllm/vllm-single-node-disaggregated.yaml -n <namespace>
+   ```
+3. Scale either service (or both) to validate that new replicas pull weights via RDMA:
+   ```bash
+   kubectl patch dgd mx-vllm-disagg-sn -n <namespace> --type merge \
+     -p '{"spec":{"services":{"VllmDecodeWorker":{"replicas":2}}}}'
+   ```
+4. Send a request to confirm end-to-end inference through the prefill→decode KV transfer:
+   ```bash
+   kubectl run curl-test --rm -i --image=curlimages/curl:8.9.1 \
+     --restart=Never -n <namespace> -- \
+     curl -sS http://mx-vllm-disagg-sn-frontend:8000/v1/chat/completions \
+       -H "Content-Type: application/json" \
+       -d '{"model":"<your-model>","messages":[{"role":"user","content":"hi"}],"max_tokens":20}'
+   ```
 
 ## Debugging
 
-Set `MODEL_EXPRESS_LOG_LEVEL=DEBUG` in VllmWorker envs to see:
-- Per-tensor checksums during registration
-- Each adopted hidden tensor with source object type
-- Detailed RDMA transfer logging
+Set `MODEL_EXPRESS_LOG_LEVEL=DEBUG` in the worker env to get:
+- Per-tensor checksums during NIXL registration
+- Per-adopted hidden tensor details (source object, shape, dtype)
+- Verbose RDMA transfer logs
+
+Useful grep patterns on the worker pod:
+
+```bash
+# Confirm weights were transferred over RDMA (not loaded from disk)
+kubectl logs -n <namespace> <pod> -c main | grep "Transfer complete"
+
+# Confirm ModelExpress discovered post-processing tensors during load
+kubectl logs -n <namespace> <pod> -c main | grep "Adopted .* hidden"
+
+# vLLM's disagg KV-transfer metrics on the decode side
+kubectl logs -n <namespace> <decode-pod> -c main | grep -E "KV Transfer metrics|prefix cache"
+```

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -123,7 +123,8 @@ spec:
           value: "INFO"
         - name: UCX_TLS
           value: "rc_x,rc,dc_x,dc,cuda_copy"
-        # Uncomment and set to your cluster's IB HCA devices if needed:
+        # Optional: pin UCX to specific compute-fabric HCAs if your cluster
+        # exposes multiple IB fabrics. Device list is cluster-specific.
         # - name: UCX_NET_DEVICES
         #   value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1"
         - name: UCX_RNDV_SCHEME

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Single-node vLLM DynamoGraphDeployment with disaggregated prefill/decode
+# AND ModelExpress P2P weight transfer.
+#
+# Each worker replica fits on ONE node with TP=8, PP=1. This avoids the known
+# vLLM bug where PP>1 + disaggregated NixlConnector trips a block_lens
+# IndexError in `_validate_remote_agent_handshake` (see
+# https://github.com/vllm-project/vllm/issues/22430).
+#
+# Shape follows dynamo's canonical disagg example
+# (https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/deploy/disagg.yaml):
+#   - subComponentType: decode / prefill for service-level labeling
+#   - `--disaggregation-mode {decode,prefill}` on workers
+#   - engine_id omitted (dynamo's service discovery resolves peer ids)
+# This lets replicas>1 work without manual per-replica engine_id templating.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: mx-vllm-disagg-sn
+spec:
+  backendFramework: vllm
+  pvcs:
+    - create: false
+      name: shared-model-cache
+  services:
+    # ModelExpress P2P metadata server (kubernetes CRD backend).
+    # Shared by both prefill and decode workers — a single pool of sources.
+    ModelExpress:
+      componentType: frontend
+      replicas: 1
+      livenessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      extraPodSpec:
+        serviceAccountName: modelexpress
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - exec /app/modelexpress-server --port 8000
+          env:
+            - name: MX_METADATA_BACKEND
+              value: "kubernetes"
+            - name: MX_METADATA_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /models
+
+    # Dynamo Frontend: HTTP API server, routes to decode workers which
+    # internally coordinate with prefill workers via NIXL KV transfer.
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: <your-registry>/modelexpress-vllm-runtime:latest
+          command:
+            - python3
+            - -m
+            - dynamo.frontend
+          args:
+            - --router-mode
+            - round-robin
+            - --http-port
+            - "8000"
+
+    # Decode workers: run token generation after receiving KV from prefill.
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      sharedMemory:
+        size: 179Gi
+      resources:
+        limits:
+          gpu: "4"
+          custom:
+            rdma/ib: "4"
+      envs:
+        - name: VLLM_RPC_TIMEOUT
+          value: "7200000"
+        - name: HF_HOME
+          value: "/models"
+        - name: MODEL_NAME
+          value: "nvidia/Kimi-K2.5-NVFP4"
+        - name: VLLM_PLUGINS
+          value: "modelexpress"
+        - name: MX_SERVER_ADDRESS
+          value: "mx-vllm-disagg-sn-modelexpress:8000"
+        - name: MX_CONTIGUOUS_REG
+          value: "0"
+        - name: MX_SKIP_FEATURE_CHECK
+          value: "1"
+        - name: NIXL_LOG_LEVEL
+          value: "INFO"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: UCX_TLS
+          value: "rc_x,rc,dc_x,dc,cuda_copy"
+        # Optional: pin UCX to specific compute-fabric HCAs if your cluster
+        # exposes multiple IB fabrics. Device list is cluster-specific.
+        # - name: UCX_NET_DEVICES
+        #   value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1"
+        - name: UCX_RNDV_SCHEME
+          value: "get_zcopy"
+        - name: UCX_RNDV_THRESH
+          value: "0"
+      extraPodSpec:
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          - key: dra
+            operator: Exists
+            effect: NoSchedule
+        # Keep decode replicas on distinct nodes so each replica uses a full
+        # 8-GPU node's worth of RDMA bandwidth.
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    nvidia.com/dynamo-component: VllmDecodeWorker
+                topologyKey: kubernetes.io/hostname
+        mainContainer:
+          image: <your-registry>/modelexpress-vllm-runtime:latest
+          securityContext:
+            capabilities:
+              add:
+              - IPC_LOCK
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - nvidia/Kimi-K2.5-NVFP4
+            - --load-format
+            - mx
+            - --tensor-parallel-size
+            - "4"
+            - --max-model-len
+            - "32768"
+            - --trust-remote-code
+            - --disaggregation-mode
+            - decode
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /models
+
+    # Prefill workers: compute KV cache, ship it to decode via NIXL.
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      sharedMemory:
+        size: 179Gi
+      resources:
+        limits:
+          gpu: "4"
+          custom:
+            rdma/ib: "4"
+      envs:
+        - name: VLLM_RPC_TIMEOUT
+          value: "7200000"
+        - name: HF_HOME
+          value: "/models"
+        - name: MODEL_NAME
+          value: "nvidia/Kimi-K2.5-NVFP4"
+        - name: VLLM_PLUGINS
+          value: "modelexpress"
+        - name: MX_SERVER_ADDRESS
+          value: "mx-vllm-disagg-sn-modelexpress:8000"
+        - name: MX_CONTIGUOUS_REG
+          value: "0"
+        - name: MX_SKIP_FEATURE_CHECK
+          value: "1"
+        - name: NIXL_LOG_LEVEL
+          value: "INFO"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: UCX_TLS
+          value: "rc_x,rc,dc_x,dc,cuda_copy"
+        # Optional UCX_NET_DEVICES — see decode block.
+        - name: UCX_RNDV_SCHEME
+          value: "get_zcopy"
+        - name: UCX_RNDV_THRESH
+          value: "0"
+      extraPodSpec:
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          - key: dra
+            operator: Exists
+            effect: NoSchedule
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    nvidia.com/dynamo-component: VllmPrefillWorker
+                topologyKey: kubernetes.io/hostname
+        mainContainer:
+          image: <your-registry>/modelexpress-vllm-runtime:latest
+          securityContext:
+            capabilities:
+              add:
+              - IPC_LOCK
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - nvidia/Kimi-K2.5-NVFP4
+            - --load-format
+            - mx
+            - --tensor-parallel-size
+            - "4"
+            - --max-model-len
+            - "32768"
+            - --trust-remote-code
+            - --disaggregation-mode
+            - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /models

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -4,7 +4,7 @@
 # Single-node vLLM DynamoGraphDeployment with disaggregated prefill/decode
 # AND ModelExpress P2P weight transfer.
 #
-# Each worker replica fits on ONE node with TP=8, PP=1. This avoids the known
+# Each worker replica fits on ONE node with TP=4, PP=1. This avoids the known
 # vLLM bug where PP>1 + disaggregated NixlConnector trips a block_lens
 # IndexError in `_validate_remote_agent_handshake` (see
 # https://github.com/vllm-project/vllm/issues/22430).
@@ -128,8 +128,8 @@ spec:
           - key: dra
             operator: Exists
             effect: NoSchedule
-        # Keep decode replicas on distinct nodes so each replica uses a full
-        # 8-GPU node's worth of RDMA bandwidth.
+        # Keep decode replicas on distinct nodes so each replica gets a full
+        # node's GPU/RDMA bandwidth.
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -104,6 +104,8 @@ spec:
           value: "mx-vllm-disagg-sn-modelexpress:8000"
         - name: MX_CONTIGUOUS_REG
           value: "0"
+        # Kimi-K2.5-NVFP4 uses MLA which is blocked by default.
+        # P2P inference verified correct with adopt_hidden_tensors fix.
         - name: MX_SKIP_FEATURE_CHECK
           value: "1"
         - name: NIXL_LOG_LEVEL
@@ -128,8 +130,8 @@ spec:
           - key: dra
             operator: Exists
             effect: NoSchedule
-        # Keep decode replicas on distinct nodes so each replica gets a full
-        # node's GPU/RDMA bandwidth.
+        # Keep decode replicas apart, but allow one decode and one prefill
+        # worker to share an 8-GPU node so all GPUs can be utilized.
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -189,6 +191,8 @@ spec:
           value: "mx-vllm-disagg-sn-modelexpress:8000"
         - name: MX_CONTIGUOUS_REG
           value: "0"
+        # Kimi-K2.5-NVFP4 uses MLA which is blocked by default.
+        # P2P inference verified correct with adopt_hidden_tensors fix.
         - name: MX_SKIP_FEATURE_CHECK
           value: "1"
         - name: NIXL_LOG_LEVEL
@@ -210,6 +214,8 @@ spec:
           - key: dra
             operator: Exists
             effect: NoSchedule
+        # Keep prefill replicas apart, but allow one decode and one prefill
+        # worker to share an 8-GPU node so all GPUs can be utilized.
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary

Adds a single-node disaggregated variant to the Dynamo P2P example so customers have a working disagg reference alongside the existing aggregated one, plus cleanups to the existing files.

## Changes

- **`examples/dynamo_p2p_transfer_k8s/Dockerfile`** — `chown` the copied Python sources to `dynamo:dynamo` and switch to `uv pip install` so the layered build works in the base image's pre-activated venv (the previous `pip install --break-system-packages` failed with `Permission denied` on `egg-info` when the layered image ran as the non-root `dynamo` user).
- **`examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml`** — leave `UCX_NET_DEVICES` commented out by default (it's cluster-specific) and include a short inline example so the knob is discoverable.
- **`examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml`** (new) — TP=4, PP=1, single node per replica, with separate `VllmPrefillWorker` / `VllmDecodeWorker` services wired through NIXL KV transfer. Follows Dynamo's canonical disagg shape (`subComponentType: decode/prefill`, `--disaggregation-mode`, no hardcoded `engine_id`). Pod anti-affinity keeps replicas on distinct nodes for RDMA bandwidth.
- **`examples/dynamo_p2p_transfer_k8s/README.md`** — variants table, both architecture diagrams (agg + disagg), two build recipes (layered vs full Dynamo rebuild), and a short debugging grep cheat-sheet.

## Testing

Exercised end-to-end on B200 (192 GB) nodes with `nvidia/Kimi-K2.5-NVFP4` (≈600 GB NVFP4 weights) using a `vllm-runtime` image rebuilt from the Dynamo repo at `VLLM_REF=v0.19.0` with `ENABLE_MODELEXPRESS_P2P=true`.

### Aggregated (existing manifest)

- Deployed with `replicas=1` → source pod loaded weights from disk, published MX metadata, `adopt_hidden_tensors` ran cleanly.
- Scaled to `replicas=2` → target pod's 4 TP ranks each pulled their shard via NIXL RDMA: 75 GB/rank in 18–29 s (≈21–33 Gbps per rank), then published its own metadata and served inference.
- Inference verified correct on both source and target at `temperature=0` (identical deterministic output).

### Disaggregated single-node (new manifest)

Deployed `vllm-single-node-disaggregated.yaml` at 1p+1d, 2p+1d, and 2p+2d using `--tensor-parallel-size 4`.

- **Source disk-load.** Prefill and decode each loaded from disk in parallel; both registered 2645 tensors with NIXL (149 GB/rank) and ran `adopt_hidden_tensors`.
- **Target P2P via MX.** New decode / prefill replicas each pulled 149 GB/rank at ≈19–32 Gbps from whichever Ready source MX gave them. MX balances across service types correctly — when prefill-1 came up with decode-0, decode-1, and prefill-0 all Ready, its 4 TP ranks ended up distributed across three different source pods.
- **Inference correctness.** Deterministic arithmetic prompts (`19 * 23`, `7 * 8`, etc. at `temperature=0`) returned the same correct output from every request regardless of which decode replica the frontend round-robined to, confirming RDMA-transferred weights match bit-for-bit.
- **Disagg KV transfer.** Decode logs show the expected prefill→decode split under load (prefill throughput ≈230 prompt tok/s with 0 gen tok/s, decode ≈250 prompt tok/s + 270 gen tok/s, external prefix cache hit rate >0).
- **Long-prompt load.** `30 × 2293-token prompts @ concurrency=4` and `60 × 2293-token prompts @ concurrency=8`: 100% HTTP 200, mean latency 1.06 s (p99 ≈ 1.10 s), linear throughput scaling from 1p1d to 2p2d.
- **VRAM.** 170 / 183 GiB per GPU at TP=4 — tight but comfortable on 192 GB class GPUs.

### Known vLLM upstream issue (noted, workaround used)

During investigation we hit [vllm-project/vllm#22430](https://github.com/vllm-project/vllm/issues/22430): the NIXL disagg KV connector's `_validate_remote_agent_handshake` crashes with a `block_lens` `IndexError` under pipeline-parallel > 1, which cascades into a `prometheus counter: non-negative` `ValueError` that tears down the engine. Pipe-parallel disagg is therefore not included in this PR; the ship path is single-node PP=1, which is what the new manifest uses.

## Test plan (reviewer checklist)

- [x] `docker build -f examples/dynamo_p2p_transfer_k8s/Dockerfile ...` succeeds against the base image.
- [x] Apply `vllm/vllm-multi-node-aggregated.yaml` (with your own image tag + namespace), scale to 2 replicas, confirm `Transfer complete` in the target worker's logs.
- [x] Apply `vllm/vllm-single-node-disaggregated.yaml`, confirm decode and prefill each reach Ready, send an HTTP request against the Frontend service, and verify a non-empty response.
