### PR TITLE
fix: apply log_level directive to env filter for tracing subscriber

### DIFF
--- a/modelexpress_server/src/main.rs
+++ b/modelexpress_server/src/main.rs
@@ -48,10 +48,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize tracing with the configured log level
     let log_level = config.log_level();
-
+    let env_filter = EnvFilter::from_default_env().add_directive(log_level.into());
     let subscriber = FmtSubscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_max_level(log_level)
+        .with_env_filter(env_filter)
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
 


### PR DESCRIPTION
The tracing subscriber previously used `EnvFilter::from_default_env()` together with `with_max_level(log_level)`. When `RUST_LOG` was unset, `EnvFilter` defaulted to `ERROR` and overrode the configured `log_level`, making it ineffective.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging configuration setup for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->