### PR TITLE
feat: optimize model downloads by skipping duplicate weight formats

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -427,7 +427,7 @@ Output formats: `--format human` (default), `--format json`, `--format json-pret
 ```rust
 #[async_trait]
 pub trait ModelProviderTrait: Send + Sync {
-    async fn download_model(&self, name: &str, cache_path: Option<PathBuf>, ignore_weights: bool) -> Result<PathBuf>;
+    async fn download_model(&self, name: &str, cache_path: Option<PathBuf>, ignore_weights: bool, weight_format: WeightFormat) -> Result<PathBuf>;
     async fn delete_model(&self, name: &str) -> Result<()>;
     async fn get_model_path(&self, name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
     fn provider_name(&self) -> &'static str;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -496,7 +496,7 @@ Output formats: `--format human` (default), `--format json`, `--format json-pret
 ```rust
 #[async_trait]
 pub trait ModelProviderTrait: Send + Sync {
-    async fn download_model(&self, name: &str, cache_path: Option<PathBuf>, ignore_weights: bool) -> Result<PathBuf>;
+    async fn download_model(&self, name: &str, cache_path: Option<PathBuf>, ignore_weights: bool, weight_format: WeightFormat) -> Result<PathBuf>;
     async fn delete_model(&self, name: &str, cache_dir: PathBuf) -> Result<()>;
     async fn get_model_path(&self, name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
     fn provider_name(&self) -> &'static str;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,6 +45,7 @@ modelexpress-cli [OPTIONS] <COMMAND>
 - `--cache-path <PATH>`: Model storage path override
 - `--no-shared-storage`: Disable shared storage mode (will transfer files from server to client)
 - `--transfer-chunk-size <SIZE>`: Chunk size in bytes for file transfer when shared storage is disabled (default: 32768)
+- `--weight-format <FORMAT>`: Weight file format to download: `auto`, `safetensors`, `pytorch`, `all` (default: auto)
 - `-h, --help`: Print help information
 - `-V, --version`: Print version
 
@@ -53,6 +54,7 @@ modelexpress-cli [OPTIONS] <COMMAND>
 - `MODEL_EXPRESS_CACHE_DIRECTORY`: Set the default model storage path
 - `MODEL_EXPRESS_NO_SHARED_STORAGE`: Disable shared storage mode (set to 'true' to enable file transfers)
 - `MODEL_EXPRESS_TRANSFER_CHUNK_SIZE`: Set the chunk size in bytes for file transfers
+- `MODEL_EXPRESS_WEIGHT_FORMAT`: Set the weight file format preference (auto, safetensors, pytorch, all)
 
 ### Commands
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -130,6 +130,7 @@ The CLI client also uses layered configuration: CLI args > env vars > config fil
 | `MODEL_EXPRESS_MAX_RETRIES` | (none) | Max retry attempts |
 | `MODEL_EXPRESS_NO_SHARED_STORAGE` | `false` | Use gRPC streaming instead of shared storage |
 | `MODEL_EXPRESS_TRANSFER_CHUNK_SIZE` | `32768` | Transfer chunk size (bytes) |
+| `MODEL_EXPRESS_WEIGHT_FORMAT` | `auto` | Weight format preference (`auto`, `safetensors`, `pytorch`, `all`) |
 
 Cache directory resolution for HuggingFace: `MODEL_EXPRESS_CACHE_DIRECTORY` -> `HF_HUB_CACHE` -> `~/.cache/huggingface/hub`.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -164,6 +164,7 @@ The CLI client also uses layered configuration: CLI args > env vars > config fil
 | `MODEL_EXPRESS_MAX_RETRIES` | (none) | Max retry attempts |
 | `MODEL_EXPRESS_NO_SHARED_STORAGE` | `false` | Use gRPC streaming instead of shared storage |
 | `MODEL_EXPRESS_TRANSFER_CHUNK_SIZE` | `32768` | Transfer chunk size (bytes) |
+| `MODEL_EXPRESS_WEIGHT_FORMAT` | `auto` | Weight format preference (`auto`, `safetensors`, `pytorch`, `all`) |
 
 Cache directory resolution for HuggingFace: `MODEL_EXPRESS_CACHE_DIRECTORY` -> `HF_HUB_CACHE` -> `~/.cache/huggingface/hub`.
 

--- a/modelexpress_client/src/bin/fallback_test.rs
+++ b/modelexpress_client/src/bin/fallback_test.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig, ModelProvider};
+use modelexpress_common::models::WeightFormat;
 use tracing::{error, info};
 
 #[tokio::main]
@@ -23,6 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ModelProvider::HuggingFace,
         ClientConfig::default(),
         false,
+        WeightFormat::default(),
     )
     .await
     {

--- a/modelexpress_client/src/bin/fallback_test.rs
+++ b/modelexpress_client/src/bin/fallback_test.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig, ModelProvider};
+use modelexpress_common::models::WeightFormat;
 use tracing::info;
 
 #[tokio::main]
@@ -17,6 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ModelProvider::HuggingFace,
         ClientConfig::for_testing("http://127.0.0.1:54321"),
         false,
+        WeightFormat::default(),
     )
     .await?;
 

--- a/modelexpress_client/src/bin/modules/handlers.rs
+++ b/modelexpress_client/src/bin/modules/handlers.rs
@@ -171,13 +171,15 @@ async fn download_model(
         c
     });
 
+    let weight_format = config.weight_format;
+
     let result = match strategy {
         DownloadStrategy::SmartFallback => {
             debug!("Using smart fallback strategy");
             if let Some(cache_config) = cache_config {
                 let mut client = Client::new_with_cache(config.clone(), cache_config).await?;
                 client
-                    .preload_model_to_cache(&model_name, provider, false)
+                    .preload_model_to_cache(&model_name, provider, false, weight_format)
                     .await
             } else {
                 Client::request_model_with_smart_fallback(
@@ -185,6 +187,7 @@ async fn download_model(
                     provider,
                     config,
                     false,
+                    weight_format,
                 )
                 .await
             }
@@ -197,12 +200,13 @@ async fn download_model(
                 Client::new(config.clone()).await?
             };
             client
-                .request_model_with_provider(&model_name, provider, false)
+                .request_model_with_provider(&model_name, provider, false, weight_format)
                 .await
         }
         DownloadStrategy::Direct => {
             debug!("Using direct download strategy");
-            Client::download_model_directly(model_name.clone(), provider, false).await
+            Client::download_model_directly(model_name.clone(), provider, false, weight_format)
+                .await
         }
     };
 

--- a/modelexpress_client/src/bin/modules/handlers.rs
+++ b/modelexpress_client/src/bin/modules/handlers.rs
@@ -238,6 +238,8 @@ async fn download_model(
         c
     });
 
+    let weight_format = config.weight_format;
+
     let result = match strategy {
         DownloadStrategy::SmartFallback => {
             debug!("Using smart fallback strategy");
@@ -245,9 +247,15 @@ async fn download_model(
             if let Some(cache_config) = cache_config {
                 config.cache = cache_config;
             }
-            Client::request_model_with_smart_fallback(model_name.clone(), provider, config, false)
-                .await
-                .map(|_| ())
+            Client::request_model_with_smart_fallback(
+                model_name.clone(),
+                provider,
+                config,
+                false,
+                weight_format,
+            )
+            .await
+            .map(|_| ())
         }
         DownloadStrategy::ServerOnly => {
             debug!("Using server-only strategy");
@@ -257,7 +265,7 @@ async fn download_model(
                 Client::new(config.clone()).await?
             };
             client
-                .request_model(&model_name, provider, false)
+                .request_model(&model_name, provider, false, weight_format)
                 .await
                 .map(|_| ())
         }
@@ -268,6 +276,7 @@ async fn download_model(
                 provider,
                 cache_config.map(|config| config.local_path),
                 false,
+                weight_format,
             )
             .await
             .map(|_| ())

--- a/modelexpress_client/src/bin/test_client.rs
+++ b/modelexpress_client/src/bin/test_client.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig};
-use modelexpress_common::models::ModelProvider;
+use modelexpress_common::models::{ModelProvider, WeightFormat};
 use std::env;
 use std::time::{Duration, Instant};
 use tracing::{error, info};
@@ -100,7 +100,7 @@ async fn run_concurrent_model_test(model_name: &str) -> Result<(), Box<dyn std::
         info!("Client 1: Requesting model {model_name1}");
         let start = Instant::now();
         client1
-            .request_model(model_name1, false)
+            .request_model(model_name1, false, WeightFormat::default())
             .await
             .expect("Client 1 failed to download model");
         info!("Client 1: Model downloaded in {:?}", start.elapsed());
@@ -116,7 +116,7 @@ async fn run_concurrent_model_test(model_name: &str) -> Result<(), Box<dyn std::
         info!("Client 2: Requesting model {model_name2}");
         let start = Instant::now();
         client2
-            .request_model(model_name2, false)
+            .request_model(model_name2, false, WeightFormat::default())
             .await
             .expect("Client 2 failed to download model");
         info!("Client 2: Model downloaded in {:?}", start.elapsed());
@@ -140,7 +140,10 @@ async fn run_single_model_test(model_name: &str) -> Result<(), Box<dyn std::erro
     info!("Client: Requesting model {model_name}");
     let start = Instant::now();
 
-    match client.request_model(model_name.to_string(), false).await {
+    match client
+        .request_model(model_name.to_string(), false, WeightFormat::default())
+        .await
+    {
         Ok(()) => {
             info!("Client: Model downloaded in {:?}", start.elapsed());
             info!("Client completed in {:?}", start_time.elapsed());
@@ -163,7 +166,12 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
 
     // This should work via server since it's running
     match client
-        .request_model_with_provider_and_fallback(model_name, ModelProvider::HuggingFace, false)
+        .request_model_with_provider_and_fallback(
+            model_name,
+            ModelProvider::HuggingFace,
+            false,
+            WeightFormat::default(),
+        )
         .await
     {
         Ok(()) => {
@@ -181,7 +189,14 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
     info!("Testing direct download (bypassing server)...");
     let start_direct = Instant::now();
 
-    match Client::download_model_directly(model_name, ModelProvider::HuggingFace, false).await {
+    match Client::download_model_directly(
+        model_name,
+        ModelProvider::HuggingFace,
+        false,
+        WeightFormat::default(),
+    )
+    .await
+    {
         Ok(()) => {
             info!("Model downloaded directly in {:?}", start_direct.elapsed());
         }
@@ -199,6 +214,7 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
         ModelProvider::HuggingFace,
         ClientConfig::default(),
         false,
+        WeightFormat::default(),
     )
     .await
     {

--- a/modelexpress_client/src/bin/test_client.rs
+++ b/modelexpress_client/src/bin/test_client.rs
@@ -10,7 +10,7 @@
 
 use modelexpress_client::{Client, ClientConfig};
 use modelexpress_common::download;
-use modelexpress_common::models::ModelProvider;
+use modelexpress_common::models::{ModelProvider, WeightFormat};
 use std::env;
 use std::time::{Duration, Instant};
 use tracing::{error, info};
@@ -101,7 +101,12 @@ async fn run_concurrent_model_test(model_name: &str) -> Result<(), Box<dyn std::
         info!("Client 1: Requesting model {model_name1}");
         let start = Instant::now();
         client1
-            .request_model(model_name1, ModelProvider::default(), false)
+            .request_model(
+                model_name1,
+                ModelProvider::default(),
+                false,
+                WeightFormat::default(),
+            )
             .await
             .expect("Client 1 failed to download model");
         info!("Client 1: Model downloaded in {:?}", start.elapsed());
@@ -117,7 +122,12 @@ async fn run_concurrent_model_test(model_name: &str) -> Result<(), Box<dyn std::
         info!("Client 2: Requesting model {model_name2}");
         let start = Instant::now();
         client2
-            .request_model(model_name2, ModelProvider::default(), false)
+            .request_model(
+                model_name2,
+                ModelProvider::default(),
+                false,
+                WeightFormat::default(),
+            )
             .await
             .expect("Client 2 failed to download model");
         info!("Client 2: Model downloaded in {:?}", start.elapsed());
@@ -142,7 +152,12 @@ async fn run_single_model_test(model_name: &str) -> Result<(), Box<dyn std::erro
     let start = Instant::now();
 
     match client
-        .request_model(model_name.to_string(), ModelProvider::default(), false)
+        .request_model(
+            model_name.to_string(),
+            ModelProvider::default(),
+            false,
+            WeightFormat::default(),
+        )
         .await
     {
         Ok(()) => {
@@ -167,7 +182,12 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
 
     // This should work via server since it's running
     match client
-        .request_model(model_name, ModelProvider::HuggingFace, false)
+        .request_model(
+            model_name,
+            ModelProvider::HuggingFace,
+            false,
+            WeightFormat::default(),
+        )
         .await
     {
         Ok(()) => {
@@ -190,6 +210,7 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
         ModelProvider::HuggingFace,
         Some(ClientConfig::default().cache.local_path.clone()),
         false,
+        WeightFormat::default(),
     )
     .await
     {
@@ -209,6 +230,7 @@ async fn run_fallback_test(model_name: &str) -> Result<(), Box<dyn std::error::E
         ModelProvider::HuggingFace,
         ClientConfig::default(),
         false,
+        WeightFormat::default(),
     )
     .await
     {

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -30,6 +30,9 @@ use uuid::Uuid;
 pub use modelexpress_common::client_config::{ClientArgs, ClientConfig};
 pub use modelexpress_common::models::ModelProvider;
 
+// Re-export WeightFormat for downstream consumers
+pub use modelexpress_common::models::WeightFormat;
+
 /// The main client for interacting with the `modelexpress_server` via gRPC
 pub struct Client {
     health_client: HealthServiceClient<Channel>,
@@ -269,12 +272,13 @@ impl Client {
         model_name: &str,
         provider: ModelProvider,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         info!("Pre-loading model {} to cache", model_name);
 
         // First try to download via server
         match self
-            .request_model_with_provider(model_name, provider, ignore_weights)
+            .request_model_with_provider(model_name, provider, ignore_weights, weight_format)
             .await
         {
             Ok(()) => {
@@ -303,7 +307,8 @@ impl Client {
                     "Server unavailable, pre-loading model {} directly. Error: {}",
                     model_name, e
                 );
-                Self::download_model_directly(model_name, provider, ignore_weights).await
+                Self::download_model_directly(model_name, provider, ignore_weights, weight_format)
+                    .await
             }
         }
     }
@@ -372,12 +377,13 @@ impl Client {
         model_name: impl Into<String>,
         provider: ModelProvider,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         let model_name = model_name.into();
 
         // First try the server-based approach
         match self
-            .request_model_with_provider(&model_name, provider, ignore_weights)
+            .request_model_with_provider(&model_name, provider, ignore_weights, weight_format)
             .await
         {
             Ok(()) => {
@@ -410,7 +416,7 @@ impl Client {
 
                     // Fallback to direct download
                     let cache_dir = CacheConfig::discover().ok().map(|config| config.local_path);
-                    match download::download_model(&model_name, provider, cache_dir, ignore_weights).await {
+                    match download::download_model(&model_name, provider, cache_dir, ignore_weights, weight_format).await {
                         Ok(_) => {
                             info!(
                                 "Model {} downloaded successfully via direct download",
@@ -614,6 +620,7 @@ impl Client {
         model_name: impl Into<String>,
         provider: ModelProvider,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         let model_name = model_name.into();
         info!(
@@ -625,6 +632,8 @@ impl Client {
             model_name: model_name.clone(),
             provider: modelexpress_common::grpc::model::ModelProvider::from(provider) as i32,
             ignore_weights,
+            weight_format: modelexpress_common::grpc::model::WeightFormat::from(weight_format)
+                as i32,
         });
 
         let mut stream = self
@@ -682,11 +691,13 @@ impl Client {
         &mut self,
         model_name: impl Into<String>,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         self.request_model_with_provider_and_fallback(
             model_name,
             ModelProvider::default(),
             ignore_weights,
+            weight_format,
         )
         .await
     }
@@ -697,9 +708,15 @@ impl Client {
         &mut self,
         model_name: impl Into<String>,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
-        self.request_model_with_provider(model_name, ModelProvider::default(), ignore_weights)
-            .await
+        self.request_model_with_provider(
+            model_name,
+            ModelProvider::default(),
+            ignore_weights,
+            weight_format,
+        )
+        .await
     }
 
     /// Request a model with automatic server fallback, creating client connection only if needed
@@ -709,6 +726,7 @@ impl Client {
         provider: ModelProvider,
         config: Config,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         let model_name = model_name.into();
 
@@ -717,13 +735,24 @@ impl Client {
             Ok(mut client) => {
                 info!("Server connection established, downloading via server...");
                 client
-                    .request_model_with_provider_and_fallback(&model_name, provider, ignore_weights)
+                    .request_model_with_provider_and_fallback(
+                        &model_name,
+                        provider,
+                        ignore_weights,
+                        weight_format,
+                    )
                     .await
             }
             Err(e) => {
                 // If we can't even connect to the server, go straight to direct download
                 info!("Cannot connect to server ({}), downloading directly...", e);
-                Client::download_model_directly(&model_name, provider, ignore_weights).await
+                Client::download_model_directly(
+                    &model_name,
+                    provider,
+                    ignore_weights,
+                    weight_format,
+                )
+                .await
             }
         }
     }
@@ -734,6 +763,7 @@ impl Client {
         model_name: impl Into<String>,
         provider: ModelProvider,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         let model_name = model_name.into();
         info!(
@@ -744,11 +774,15 @@ impl Client {
         // Try to get cache configuration, but don't fail if not available
         let cache_dir = CacheConfig::discover().ok().map(|config| config.local_path);
 
-        download::download_model(&model_name, provider, cache_dir, ignore_weights)
-            .await
-            .map_err(|e| {
-                modelexpress_common::Error::Server(format!("Direct download failed: {e}"))
-            })?;
+        download::download_model(
+            &model_name,
+            provider,
+            cache_dir,
+            ignore_weights,
+            weight_format,
+        )
+        .await
+        .map_err(|e| modelexpress_common::Error::Server(format!("Direct download failed: {e}")))?;
 
         info!("Model {} downloaded successfully", model_name);
         Ok(())
@@ -952,6 +986,7 @@ mod tests {
             "definitely-not-a-real-model-name-12345",
             ModelProvider::HuggingFace,
             false,
+            WeightFormat::default(),
         )
         .await;
 
@@ -1155,6 +1190,7 @@ mod tests {
             ModelProvider::HuggingFace,
             config,
             false,
+            WeightFormat::default(),
         )
         .await;
 
@@ -1242,7 +1278,11 @@ mod integration_tests {
             // Use a very small model for testing to avoid long download times
             // Note: This test might still take time and requires network access
             let result = client
-                .request_model_server_only("sentence-transformers/all-MiniLM-L6-v2", false)
+                .request_model_server_only(
+                    "sentence-transformers/all-MiniLM-L6-v2",
+                    false,
+                    WeightFormat::default(),
+                )
                 .await;
 
             // We don't assert success here because it depends on network availability

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -31,6 +31,9 @@ use uuid::Uuid;
 pub use modelexpress_common::client_config::{ClientArgs, ClientConfig};
 pub use modelexpress_common::models::ModelProvider;
 
+// Re-export WeightFormat for downstream consumers
+pub use modelexpress_common::models::WeightFormat;
+
 /// The main client for interacting with the `modelexpress_server` via gRPC
 pub struct Client {
     health_client: HealthServiceClient<Channel>,
@@ -629,6 +632,7 @@ impl Client {
         model_name: impl Into<String>,
         provider: ModelProvider,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         let model_name = model_name.into();
         info!(
@@ -640,6 +644,8 @@ impl Client {
             model_name: model_name.clone(),
             provider: modelexpress_common::grpc::model::ModelProvider::from(provider) as i32,
             ignore_weights,
+            weight_format: modelexpress_common::grpc::model::WeightFormat::from(weight_format)
+                as i32,
         });
 
         let mut stream = self
@@ -699,10 +705,11 @@ impl Client {
         model_name: impl Into<String>,
         provider: ModelProvider,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         let model_name = model_name.into();
 
-        self.request_model_on_server(&model_name, provider, ignore_weights)
+        self.request_model_on_server(&model_name, provider, ignore_weights, weight_format)
             .await?;
 
         info!("Model {} downloaded successfully via server", model_name);
@@ -733,6 +740,7 @@ impl Client {
         provider: ModelProvider,
         config: Config,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> CommonResult<()> {
         let model_name = model_name.into();
 
@@ -740,7 +748,7 @@ impl Client {
             Ok(mut client) => {
                 info!("Server connection established, downloading via server...");
                 client
-                    .request_model(&model_name, provider, ignore_weights)
+                    .request_model(&model_name, provider, ignore_weights, weight_format)
                     .await
             }
             Err(e) => {
@@ -750,6 +758,7 @@ impl Client {
                     provider,
                     Some(config.cache.local_path.clone()),
                     ignore_weights,
+                    weight_format,
                 )
                 .await
                 .map(|_| ())
@@ -1137,6 +1146,7 @@ mod tests {
             ModelProvider::HuggingFace,
             Some(ClientConfig::default().cache.local_path.clone()),
             false,
+            WeightFormat::default(),
         )
         .await;
 
@@ -1494,7 +1504,12 @@ mod tests {
             .expect("Expected test client to connect");
 
         client
-            .request_model(model_name, ModelProvider::Gcs, false)
+            .request_model(
+                model_name,
+                ModelProvider::Gcs,
+                false,
+                WeightFormat::default(),
+            )
             .await
             .expect("Expected streamed model request to succeed");
 
@@ -1526,6 +1541,7 @@ mod tests {
             ModelProvider::HuggingFace,
             config,
             false,
+            WeightFormat::default(),
         )
         .await;
 
@@ -1553,6 +1569,7 @@ mod tests {
             ModelProvider::HuggingFace,
             config,
             false,
+            WeightFormat::default(),
         )
         .await;
 
@@ -1588,6 +1605,7 @@ mod tests {
             ModelProvider::Gcs,
             config,
             false,
+            WeightFormat::default(),
         )
         .await
         .expect("Expected smart fallback request to succeed");
@@ -1679,6 +1697,7 @@ mod integration_tests {
                     "sentence-transformers/all-MiniLM-L6-v2",
                     ModelProvider::default(),
                     false,
+                    WeightFormat::default(),
                 )
                 .await;
 

--- a/modelexpress_common/proto/model.proto
+++ b/modelexpress_common/proto/model.proto
@@ -22,6 +22,7 @@ message ModelDownloadRequest {
   string model_name = 1;
   ModelProvider provider = 2;
   bool ignore_weights = 3;
+  WeightFormat weight_format = 4;
 }
 
 // Streaming status update for model download progress
@@ -44,6 +45,18 @@ enum ModelStatus {
 enum ModelProvider {
   HUGGING_FACE = 0;
   NGC = 1;
+}
+
+// Controls which weight file formats to download
+enum WeightFormat {
+  // Smart defaults: prefer safetensors, deduplicate sharded vs consolidated
+  AUTO = 0;
+  // Only download safetensors files
+  SAFETENSORS = 1;
+  // Only download pytorch bin files
+  PYTORCH = 2;
+  // Download all weight formats (legacy behavior)
+  ALL = 3;
 }
 
 // Request for streaming model files

--- a/modelexpress_common/proto/model.proto
+++ b/modelexpress_common/proto/model.proto
@@ -37,6 +37,7 @@ message ModelDownloadRequest {
   string model_name = 1;
   ModelProvider provider = 2;
   bool ignore_weights = 3;
+  WeightFormat weight_format = 4;
 }
 
 // Streaming status update for model download progress
@@ -60,6 +61,18 @@ enum ModelProvider {
   HUGGING_FACE = 0;
   NGC = 1;
   GCS = 2;
+}
+
+// Controls which weight file formats to download
+enum WeightFormat {
+  // Smart defaults: prefer safetensors, deduplicate sharded vs consolidated
+  AUTO = 0;
+  // Only download safetensors files
+  SAFETENSORS = 1;
+  // Only download pytorch bin files
+  PYTORCH = 2;
+  // Download all weight formats (legacy behavior)
+  ALL = 3;
 }
 
 // Request for streaming model files

--- a/modelexpress_common/src/client_config.rs
+++ b/modelexpress_common/src/client_config.rs
@@ -3,6 +3,7 @@
 
 use crate::cache::CacheConfig;
 use crate::config::{ConnectionConfig, LogFormat, LogLevel, load_layered_config};
+use crate::models::WeightFormat;
 use anyhow::Result;
 use clap::Parser;
 use config::ConfigError;
@@ -77,6 +78,15 @@ pub struct ClientArgs {
     /// Chunk size in bytes for file transfer when shared storage is disabled
     #[arg(long, env = "MODEL_EXPRESS_TRANSFER_CHUNK_SIZE")]
     pub transfer_chunk_size: Option<usize>,
+
+    /// Weight file format to download (auto, safetensors, pytorch, all)
+    #[arg(
+        long,
+        env = "MODEL_EXPRESS_WEIGHT_FORMAT",
+        value_enum,
+        default_value = "auto"
+    )]
+    pub weight_format: WeightFormat,
 }
 
 /// Complete client configuration
@@ -88,6 +98,9 @@ pub struct ClientConfig {
     pub cache: CacheConfig,
     /// Logging configuration
     pub logging: LoggingConfig,
+    /// Weight format preference for downloads
+    #[serde(default)]
+    pub weight_format: WeightFormat,
 }
 
 /// Logging configuration for the client
@@ -169,6 +182,9 @@ impl ClientConfig {
             config.logging.quiet = true;
         }
 
+        // Download settings
+        config.weight_format = args.weight_format;
+
         // ==================== END CLI ARGUMENT OVERRIDES ====================
 
         // Validate configuration
@@ -224,6 +240,7 @@ impl ClientConfig {
             connection: ConnectionConfig::new(endpoint),
             cache: CacheConfig::default(),
             logging: LoggingConfig::default(),
+            weight_format: WeightFormat::default(),
         }
     }
 
@@ -328,6 +345,7 @@ mod tests {
         assert!(!args.quiet);
         assert!(!args.no_shared_storage);
         assert!(args.transfer_chunk_size.is_none());
+        assert_eq!(args.weight_format, WeightFormat::Auto);
     }
 
     #[test]
@@ -389,6 +407,7 @@ mod tests {
             retry_delay: Some(10),
             no_shared_storage: true,
             transfer_chunk_size: Some(2097152),
+            weight_format: WeightFormat::Safetensors,
         };
 
         let config = ClientConfig::load(args).expect("Failed to load config");
@@ -400,5 +419,6 @@ mod tests {
         assert_eq!(config.connection.retry_delay_secs, Some(10));
         assert!(!config.cache.shared_storage);
         assert_eq!(config.cache.transfer_chunk_size, 2097152);
+        assert_eq!(config.weight_format, WeightFormat::Safetensors);
     }
 }

--- a/modelexpress_common/src/client_config.rs
+++ b/modelexpress_common/src/client_config.rs
@@ -5,6 +5,7 @@ use crate::cache::CacheConfig;
 use crate::config::{
     ConnectionConfig, LogFormat, LogLevel, load_layered_config, normalize_grpc_endpoint,
 };
+use crate::models::WeightFormat;
 use anyhow::Result;
 use clap::Parser;
 use config::ConfigError;
@@ -79,6 +80,15 @@ pub struct ClientArgs {
     /// Chunk size in bytes for file transfer when shared storage is disabled
     #[arg(long, env = "MODEL_EXPRESS_TRANSFER_CHUNK_SIZE")]
     pub transfer_chunk_size: Option<usize>,
+
+    /// Weight file format to download (auto, safetensors, pytorch, all)
+    #[arg(
+        long,
+        env = "MODEL_EXPRESS_WEIGHT_FORMAT",
+        value_enum,
+        default_value = "auto"
+    )]
+    pub weight_format: WeightFormat,
 }
 
 /// Complete client configuration
@@ -90,6 +100,9 @@ pub struct ClientConfig {
     pub cache: CacheConfig,
     /// Logging configuration
     pub logging: LoggingConfig,
+    /// Weight format preference for downloads
+    #[serde(default)]
+    pub weight_format: WeightFormat,
 }
 
 /// Logging configuration for the client
@@ -171,6 +184,9 @@ impl ClientConfig {
             config.logging.quiet = true;
         }
 
+        // Download settings
+        config.weight_format = args.weight_format;
+
         // ==================== END CLI ARGUMENT OVERRIDES ====================
 
         config.connection.endpoint =
@@ -231,6 +247,7 @@ impl ClientConfig {
             connection: ConnectionConfig::new(endpoint),
             cache: CacheConfig::default(),
             logging: LoggingConfig::default(),
+            weight_format: WeightFormat::default(),
         }
     }
 
@@ -347,6 +364,7 @@ mod tests {
         assert!(!args.quiet);
         assert!(!args.no_shared_storage);
         assert!(args.transfer_chunk_size.is_none());
+        assert_eq!(args.weight_format, WeightFormat::Auto);
     }
 
     #[test]
@@ -408,6 +426,7 @@ mod tests {
             retry_delay: Some(10),
             no_shared_storage: true,
             transfer_chunk_size: Some(2097152),
+            weight_format: WeightFormat::Safetensors,
         };
 
         let config = ClientConfig::load(args).expect("Failed to load config");
@@ -419,5 +438,6 @@ mod tests {
         assert_eq!(config.connection.retry_delay_secs, Some(10));
         assert!(!config.cache.shared_storage);
         assert_eq!(config.cache.transfer_chunk_size, 2097152);
+        assert_eq!(config.weight_format, WeightFormat::Safetensors);
     }
 }

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::models::ModelProvider;
+use crate::models::{ModelProvider, WeightFormat};
 use crate::providers::{HuggingFaceProvider, ModelProviderTrait, NgcProvider};
 use anyhow::Result;
 use std::path::PathBuf;
@@ -22,12 +22,14 @@ pub async fn download_model(
     provider: ModelProvider,
     cache_dir: Option<PathBuf>,
     ignore_weights: bool,
+    weight_format: WeightFormat,
 ) -> Result<PathBuf> {
     let provider_impl = get_provider(provider);
     info!(
-        "Downloading model '{}' using provider: {}",
+        "Downloading model '{}' using provider: {} (weight_format: {})",
         model_name,
-        provider_impl.provider_name()
+        provider_impl.provider_name(),
+        weight_format,
     );
 
     if ignore_weights {
@@ -35,7 +37,7 @@ pub async fn download_model(
     }
 
     provider_impl
-        .download_model(model_name, cache_dir, ignore_weights)
+        .download_model(model_name, cache_dir, ignore_weights, weight_format)
         .await
 }
 
@@ -59,6 +61,7 @@ mod tests {
             _model_name: &str,
             _cache_dir: Option<PathBuf>,
             _ignore_weights: bool,
+            _weight_format: WeightFormat,
         ) -> Result<PathBuf> {
             if self.should_succeed {
                 Ok(self.return_path.clone())
@@ -111,7 +114,12 @@ mod tests {
         };
 
         let result = mock_provider
-            .download_model("test-model", Some(temp_dir.path().to_path_buf()), false)
+            .download_model(
+                "test-model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                WeightFormat::default(),
+            )
             .await;
         assert!(result.is_ok());
         assert_eq!(result.expect("Expected successful result"), temp_dir.path());
@@ -126,7 +134,12 @@ mod tests {
         };
 
         let result = mock_provider
-            .download_model("test-model", Some(temp_dir.path().to_path_buf()), false)
+            .download_model(
+                "test-model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                WeightFormat::default(),
+            )
             .await;
         assert!(result.is_err());
         assert!(
@@ -159,6 +172,7 @@ mod tests {
                 _model_name: &str,
                 _cache_dir: Option<PathBuf>,
                 _ignore_weights: bool,
+                _weight_format: WeightFormat,
             ) -> Result<PathBuf> {
                 Ok(PathBuf::from("/tmp"))
             }
@@ -189,9 +203,12 @@ mod tests {
 
         // Test default is_ignored behavior - explicit files
         assert!(DefaultProvider::is_ignored("README.md"));
+        assert!(DefaultProvider::is_ignored("LICENSE"));
+        assert!(DefaultProvider::is_ignored("LICENSE.md"));
+        assert!(DefaultProvider::is_ignored("LICENSE.txt"));
+        assert!(DefaultProvider::is_ignored("NOTICE"));
 
         // Test default is_ignored behavior - regular files
-        assert!(!DefaultProvider::is_ignored("LICENSE"));
         assert!(!DefaultProvider::is_ignored("model.bin"));
         assert!(!DefaultProvider::is_ignored("config.json"));
 

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::models::ModelProvider;
+use crate::models::{ModelProvider, WeightFormat};
 use crate::providers::{GcsProvider, HuggingFaceProvider, ModelProviderTrait, NgcProvider};
 use anyhow::Result;
 use std::path::PathBuf;
@@ -28,12 +28,14 @@ pub async fn download_model(
     provider: ModelProvider,
     cache_dir: Option<PathBuf>,
     ignore_weights: bool,
+    weight_format: WeightFormat,
 ) -> Result<PathBuf> {
     let provider_impl = get_provider(provider);
     info!(
-        "Downloading model '{}' using provider: {}",
+        "Downloading model '{}' using provider: {} (weight_format: {})",
         model_name,
-        provider_impl.provider_name()
+        provider_impl.provider_name(),
+        weight_format,
     );
 
     if ignore_weights {
@@ -41,7 +43,7 @@ pub async fn download_model(
     }
 
     provider_impl
-        .download_model(model_name, cache_dir, ignore_weights)
+        .download_model(model_name, cache_dir, ignore_weights, weight_format)
         .await
 }
 
@@ -65,6 +67,7 @@ mod tests {
             _model_name: &str,
             _cache_dir: Option<PathBuf>,
             _ignore_weights: bool,
+            _weight_format: WeightFormat,
         ) -> Result<PathBuf> {
             if self.should_succeed {
                 Ok(self.return_path.clone())
@@ -137,7 +140,12 @@ mod tests {
         };
 
         let result = mock_provider
-            .download_model("test-model", Some(temp_dir.path().to_path_buf()), false)
+            .download_model(
+                "test-model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                WeightFormat::default(),
+            )
             .await;
         assert!(result.is_ok());
         assert_eq!(result.expect("Expected successful result"), temp_dir.path());
@@ -152,7 +160,12 @@ mod tests {
         };
 
         let result = mock_provider
-            .download_model("test-model", Some(temp_dir.path().to_path_buf()), false)
+            .download_model(
+                "test-model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                WeightFormat::default(),
+            )
             .await;
         assert!(result.is_err());
         assert!(
@@ -175,6 +188,7 @@ mod tests {
                 _model_name: &str,
                 _cache_dir: Option<PathBuf>,
                 _ignore_weights: bool,
+                _weight_format: WeightFormat,
             ) -> Result<PathBuf> {
                 Ok(PathBuf::from("/tmp"))
             }
@@ -205,9 +219,12 @@ mod tests {
 
         // Test default is_ignored behavior - explicit files
         assert!(DefaultProvider::is_ignored("README.md"));
+        assert!(DefaultProvider::is_ignored("LICENSE"));
+        assert!(DefaultProvider::is_ignored("LICENSE.md"));
+        assert!(DefaultProvider::is_ignored("LICENSE.txt"));
+        assert!(DefaultProvider::is_ignored("NOTICE"));
 
         // Test default is_ignored behavior - regular files
-        assert!(!DefaultProvider::is_ignored("LICENSE"));
         assert!(!DefaultProvider::is_ignored("model.bin"));
         assert!(!DefaultProvider::is_ignored("config.json"));
 

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -155,6 +155,28 @@ impl From<grpc::model::ModelProvider> for models::ModelProvider {
     }
 }
 
+impl From<models::WeightFormat> for grpc::model::WeightFormat {
+    fn from(format: models::WeightFormat) -> Self {
+        match format {
+            models::WeightFormat::Auto => grpc::model::WeightFormat::Auto,
+            models::WeightFormat::Safetensors => grpc::model::WeightFormat::Safetensors,
+            models::WeightFormat::Pytorch => grpc::model::WeightFormat::Pytorch,
+            models::WeightFormat::All => grpc::model::WeightFormat::All,
+        }
+    }
+}
+
+impl From<grpc::model::WeightFormat> for models::WeightFormat {
+    fn from(format: grpc::model::WeightFormat) -> Self {
+        match format {
+            grpc::model::WeightFormat::Auto => models::WeightFormat::Auto,
+            grpc::model::WeightFormat::Safetensors => models::WeightFormat::Safetensors,
+            grpc::model::WeightFormat::Pytorch => models::WeightFormat::Pytorch,
+            grpc::model::WeightFormat::All => models::WeightFormat::All,
+        }
+    }
+}
+
 impl From<models::ModelStatus> for grpc::model::ModelStatus {
     fn from(status: models::ModelStatus) -> Self {
         match status {
@@ -242,6 +264,22 @@ mod tests {
         let back_to_model: models::ModelProvider = grpc_provider.into();
 
         assert_eq!(model_provider, back_to_model);
+    }
+
+    #[test]
+    fn test_weight_format_conversion_both_ways() {
+        let formats = vec![
+            models::WeightFormat::Auto,
+            models::WeightFormat::Safetensors,
+            models::WeightFormat::Pytorch,
+            models::WeightFormat::All,
+        ];
+
+        for format in formats {
+            let grpc_format: grpc::model::WeightFormat = format.into();
+            let back_to_model: models::WeightFormat = grpc_format.into();
+            assert_eq!(format, back_to_model);
+        }
     }
 
     #[test]

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -188,6 +188,28 @@ impl From<grpc::model::ModelProvider> for models::ModelProvider {
     }
 }
 
+impl From<models::WeightFormat> for grpc::model::WeightFormat {
+    fn from(format: models::WeightFormat) -> Self {
+        match format {
+            models::WeightFormat::Auto => grpc::model::WeightFormat::Auto,
+            models::WeightFormat::Safetensors => grpc::model::WeightFormat::Safetensors,
+            models::WeightFormat::Pytorch => grpc::model::WeightFormat::Pytorch,
+            models::WeightFormat::All => grpc::model::WeightFormat::All,
+        }
+    }
+}
+
+impl From<grpc::model::WeightFormat> for models::WeightFormat {
+    fn from(format: grpc::model::WeightFormat) -> Self {
+        match format {
+            grpc::model::WeightFormat::Auto => models::WeightFormat::Auto,
+            grpc::model::WeightFormat::Safetensors => models::WeightFormat::Safetensors,
+            grpc::model::WeightFormat::Pytorch => models::WeightFormat::Pytorch,
+            grpc::model::WeightFormat::All => models::WeightFormat::All,
+        }
+    }
+}
+
 impl From<models::ModelStatus> for grpc::model::ModelStatus {
     fn from(status: models::ModelStatus) -> Self {
         match status {
@@ -302,6 +324,22 @@ mod tests {
             let grpc_provider: grpc::model::ModelProvider = model_provider.into();
             let back_to_model: models::ModelProvider = grpc_provider.into();
             assert_eq!(model_provider, back_to_model);
+        }
+    }
+
+    #[test]
+    fn test_weight_format_conversion_both_ways() {
+        let formats = vec![
+            models::WeightFormat::Auto,
+            models::WeightFormat::Safetensors,
+            models::WeightFormat::Pytorch,
+            models::WeightFormat::All,
+        ];
+
+        for format in formats {
+            let grpc_format: grpc::model::WeightFormat = format.into();
+            let back_to_model: models::WeightFormat = grpc_format.into();
+            assert_eq!(format, back_to_model);
         }
     }
 

--- a/modelexpress_common/src/models.rs
+++ b/modelexpress_common/src/models.rs
@@ -4,6 +4,7 @@
 use clap::{ValueEnum, builder::PossibleValue};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 /// Status model for server health checks
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,6 +54,69 @@ impl Display for ModelProvider {
 impl ValueEnum for ModelProvider {
     fn value_variants<'a>() -> &'a [Self] {
         &[Self::HuggingFace, Self::Ngc]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.as_str()))
+    }
+}
+
+/// Controls which weight file formats to download.
+///
+/// When set to `Auto` (the default), safetensors files are preferred over other
+/// formats, and sharded vs consolidated duplicates within the same format are
+/// deduplicated. Other variants restrict downloads to a single format, or
+/// disable filtering entirely (`All`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum WeightFormat {
+    /// Smart defaults: prefer safetensors, deduplicate sharded vs consolidated
+    #[default]
+    Auto,
+    /// Only download safetensors files
+    Safetensors,
+    /// Only download pytorch bin files
+    Pytorch,
+    /// Download all weight formats (current/legacy behavior)
+    All,
+}
+
+impl WeightFormat {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Safetensors => "safetensors",
+            Self::Pytorch => "pytorch",
+            Self::All => "all",
+        }
+    }
+}
+
+impl Display for WeightFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for WeightFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "safetensors" => Ok(Self::Safetensors),
+            "pytorch" => Ok(Self::Pytorch),
+            "all" => Ok(Self::All),
+            _ => Err(format!(
+                "invalid weight format '{s}': expected one of auto, safetensors, pytorch, all"
+            )),
+        }
+    }
+}
+
+impl ValueEnum for WeightFormat {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Auto, Self::Safetensors, Self::Pytorch, Self::All]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
@@ -167,5 +231,68 @@ mod tests {
         assert_ne!(ModelStatus::DOWNLOADING, ModelStatus::DOWNLOADED);
         assert_ne!(ModelStatus::DOWNLOADED, ModelStatus::ERROR);
         assert_ne!(ModelStatus::ERROR, ModelStatus::DOWNLOADING);
+    }
+
+    #[test]
+    fn test_weight_format_default() {
+        assert_eq!(WeightFormat::default(), WeightFormat::Auto);
+    }
+
+    #[test]
+    fn test_weight_format_display() {
+        assert_eq!(WeightFormat::Auto.to_string(), "auto");
+        assert_eq!(WeightFormat::Safetensors.to_string(), "safetensors");
+        assert_eq!(WeightFormat::Pytorch.to_string(), "pytorch");
+        assert_eq!(WeightFormat::All.to_string(), "all");
+    }
+
+    #[test]
+    fn test_weight_format_from_str() {
+        assert_eq!(
+            "auto".parse::<WeightFormat>().expect("parse auto"),
+            WeightFormat::Auto
+        );
+        assert_eq!(
+            "safetensors"
+                .parse::<WeightFormat>()
+                .expect("parse safetensors"),
+            WeightFormat::Safetensors
+        );
+        assert_eq!(
+            "pytorch".parse::<WeightFormat>().expect("parse pytorch"),
+            WeightFormat::Pytorch
+        );
+        assert_eq!(
+            "all".parse::<WeightFormat>().expect("parse all"),
+            WeightFormat::All
+        );
+        assert_eq!(
+            "AUTO".parse::<WeightFormat>().expect("parse AUTO"),
+            WeightFormat::Auto
+        );
+        assert!("invalid".parse::<WeightFormat>().is_err());
+    }
+
+    #[test]
+    fn test_weight_format_serialization() {
+        let format = WeightFormat::Safetensors;
+        let serialized = serde_json::to_string(&format).expect("Failed to serialize WeightFormat");
+        let deserialized: WeightFormat =
+            serde_json::from_str(&serialized).expect("Failed to deserialize WeightFormat");
+        assert_eq!(format, deserialized);
+    }
+
+    #[test]
+    fn test_weight_format_value_enum_matches_display() {
+        for format in [
+            WeightFormat::Auto,
+            WeightFormat::Safetensors,
+            WeightFormat::Pytorch,
+            WeightFormat::All,
+        ] {
+            let parsed = <WeightFormat as ValueEnum>::from_str(format.as_str(), false)
+                .expect("Failed to parse WeightFormat from clap value");
+            assert_eq!(parsed, format);
+        }
     }
 }

--- a/modelexpress_common/src/models.rs
+++ b/modelexpress_common/src/models.rs
@@ -4,6 +4,7 @@
 use clap::{ValueEnum, builder::PossibleValue};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 /// Status model for server health checks
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,6 +57,69 @@ impl Display for ModelProvider {
 impl ValueEnum for ModelProvider {
     fn value_variants<'a>() -> &'a [Self] {
         &[Self::HuggingFace, Self::Ngc, Self::Gcs]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.as_str()))
+    }
+}
+
+/// Controls which weight file formats to download.
+///
+/// When set to `Auto` (the default), safetensors files are preferred over other
+/// formats, and sharded vs consolidated duplicates within the same format are
+/// deduplicated. Other variants restrict downloads to a single format, or
+/// disable filtering entirely (`All`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum WeightFormat {
+    /// Smart defaults: prefer safetensors, deduplicate sharded vs consolidated
+    #[default]
+    Auto,
+    /// Only download safetensors files
+    Safetensors,
+    /// Only download pytorch bin files
+    Pytorch,
+    /// Download all weight formats (current/legacy behavior)
+    All,
+}
+
+impl WeightFormat {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Safetensors => "safetensors",
+            Self::Pytorch => "pytorch",
+            Self::All => "all",
+        }
+    }
+}
+
+impl Display for WeightFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for WeightFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "safetensors" => Ok(Self::Safetensors),
+            "pytorch" => Ok(Self::Pytorch),
+            "all" => Ok(Self::All),
+            _ => Err(format!(
+                "invalid weight format '{s}': expected one of auto, safetensors, pytorch, all"
+            )),
+        }
+    }
+}
+
+impl ValueEnum for WeightFormat {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Auto, Self::Safetensors, Self::Pytorch, Self::All]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
@@ -170,5 +234,68 @@ mod tests {
         assert_ne!(ModelStatus::DOWNLOADING, ModelStatus::DOWNLOADED);
         assert_ne!(ModelStatus::DOWNLOADED, ModelStatus::ERROR);
         assert_ne!(ModelStatus::ERROR, ModelStatus::DOWNLOADING);
+    }
+
+    #[test]
+    fn test_weight_format_default() {
+        assert_eq!(WeightFormat::default(), WeightFormat::Auto);
+    }
+
+    #[test]
+    fn test_weight_format_display() {
+        assert_eq!(WeightFormat::Auto.to_string(), "auto");
+        assert_eq!(WeightFormat::Safetensors.to_string(), "safetensors");
+        assert_eq!(WeightFormat::Pytorch.to_string(), "pytorch");
+        assert_eq!(WeightFormat::All.to_string(), "all");
+    }
+
+    #[test]
+    fn test_weight_format_from_str() {
+        assert_eq!(
+            "auto".parse::<WeightFormat>().expect("parse auto"),
+            WeightFormat::Auto
+        );
+        assert_eq!(
+            "safetensors"
+                .parse::<WeightFormat>()
+                .expect("parse safetensors"),
+            WeightFormat::Safetensors
+        );
+        assert_eq!(
+            "pytorch".parse::<WeightFormat>().expect("parse pytorch"),
+            WeightFormat::Pytorch
+        );
+        assert_eq!(
+            "all".parse::<WeightFormat>().expect("parse all"),
+            WeightFormat::All
+        );
+        assert_eq!(
+            "AUTO".parse::<WeightFormat>().expect("parse AUTO"),
+            WeightFormat::Auto
+        );
+        assert!("invalid".parse::<WeightFormat>().is_err());
+    }
+
+    #[test]
+    fn test_weight_format_serialization() {
+        let format = WeightFormat::Safetensors;
+        let serialized = serde_json::to_string(&format).expect("Failed to serialize WeightFormat");
+        let deserialized: WeightFormat =
+            serde_json::from_str(&serialized).expect("Failed to deserialize WeightFormat");
+        assert_eq!(format, deserialized);
+    }
+
+    #[test]
+    fn test_weight_format_value_enum_matches_display() {
+        for format in [
+            WeightFormat::Auto,
+            WeightFormat::Safetensors,
+            WeightFormat::Pytorch,
+            WeightFormat::All,
+        ] {
+            let parsed = <WeightFormat as ValueEnum>::from_str(format.as_str(), false)
+                .expect("Failed to parse WeightFormat from clap value");
+            assert_eq!(parsed, format);
+        }
     }
 }

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::models::WeightFormat;
 use anyhow::Result;
 use std::path::PathBuf;
 
@@ -14,6 +15,7 @@ pub trait ModelProviderTrait: Send + Sync {
         model_name: &str,
         cache_path: Option<PathBuf>,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> Result<PathBuf>;
 
     /// Delete a model from the provider's cache
@@ -34,7 +36,13 @@ pub trait ModelProviderTrait: Send + Sync {
     where
         Self: Sized,
     {
-        const DEFAULT_IGNORED: [&str; 1] = ["README.md"];
+        const DEFAULT_IGNORED: [&str; 5] = [
+            "README.md",
+            "LICENSE",
+            "LICENSE.md",
+            "LICENSE.txt",
+            "NOTICE",
+        ];
         let name = std::path::Path::new(filename)
             .file_name()
             .and_then(|s| s.to_str())
@@ -117,6 +125,11 @@ mod tests {
         // Explicit files
         assert!(HuggingFaceProvider::is_ignored("README.md"));
         assert!(HuggingFaceProvider::is_ignored("subdir/README.md"));
+        assert!(HuggingFaceProvider::is_ignored("LICENSE"));
+        assert!(HuggingFaceProvider::is_ignored("LICENSE.md"));
+        assert!(HuggingFaceProvider::is_ignored("LICENSE.txt"));
+        assert!(HuggingFaceProvider::is_ignored("NOTICE"));
+        assert!(HuggingFaceProvider::is_ignored("subdir/LICENSE"));
 
         // (Not Ignored) Regular files
         assert!(!HuggingFaceProvider::is_ignored("model.bin"));

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::models::WeightFormat;
 use anyhow::Result;
 use std::path::PathBuf;
 
@@ -14,6 +15,7 @@ pub trait ModelProviderTrait: Send + Sync {
         model_name: &str,
         cache_path: Option<PathBuf>,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> Result<PathBuf>;
 
     /// Delete a model from the provider's cache
@@ -39,7 +41,13 @@ pub trait ModelProviderTrait: Send + Sync {
     where
         Self: Sized,
     {
-        const DEFAULT_IGNORED: [&str; 1] = ["README.md"];
+        const DEFAULT_IGNORED: [&str; 5] = [
+            "README.md",
+            "LICENSE",
+            "LICENSE.md",
+            "LICENSE.txt",
+            "NOTICE",
+        ];
         let name = std::path::Path::new(filename)
             .file_name()
             .and_then(|s| s.to_str())
@@ -126,6 +134,11 @@ mod tests {
         // Explicit files
         assert!(HuggingFaceProvider::is_ignored("README.md"));
         assert!(HuggingFaceProvider::is_ignored("subdir/README.md"));
+        assert!(HuggingFaceProvider::is_ignored("LICENSE"));
+        assert!(HuggingFaceProvider::is_ignored("LICENSE.md"));
+        assert!(HuggingFaceProvider::is_ignored("LICENSE.txt"));
+        assert!(HuggingFaceProvider::is_ignored("NOTICE"));
+        assert!(HuggingFaceProvider::is_ignored("subdir/LICENSE"));
 
         // (Not Ignored) Regular files
         assert!(!HuggingFaceProvider::is_ignored("model.bin"));

--- a/modelexpress_common/src/providers/gcs.rs
+++ b/modelexpress_common/src/providers/gcs.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::models::WeightFormat;
 use crate::providers::ModelProviderTrait;
 use anyhow::{Context, Result};
 use google_cloud_storage::client::{Storage, StorageControl};
@@ -130,6 +131,7 @@ impl ModelProviderTrait for GcsProvider {
         model_name: &str,
         cache_dir: Option<PathBuf>,
         ignore_weights: bool,
+        _weight_format: WeightFormat,
     ) -> Result<PathBuf> {
         self.download_with_clients(model_name, cache_dir, ignore_weights, || async {
             ensure_crypto_provider()?;
@@ -484,6 +486,7 @@ mod tests {
                 model_name,
                 cache_dir.as_ref().map(|dir| dir.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             ));
             assert!(
                 result
@@ -532,6 +535,7 @@ mod tests {
                     model_name,
                     Some(temp_dir.path().to_path_buf()),
                     ignore_weights,
+                    WeightFormat::default(),
                 ))
                 .expect("Expected cached model reuse");
 

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -5,7 +5,7 @@ use crate::{
     Utils,
     cache::{ModelInfo, ProviderCache, directory_size},
     constants,
-    models::ModelProvider,
+    models::{ModelProvider, WeightFormat},
     providers::ModelProviderTrait,
 };
 use anyhow::{Context, Result};
@@ -178,6 +178,91 @@ impl HuggingFaceProvider {
     fn is_subdirectory_file(filename: &str) -> bool {
         Path::new(filename).components().count() > 1
     }
+
+    /// Filter a list of filenames according to the requested weight format.
+    ///
+    /// For `WeightFormat::Auto`:
+    ///   1. If any `.safetensors` weight files exist, drop `.bin`, `.h5`, `.msgpack`, `.gguf`.
+    ///   2. Within the chosen format, deduplicate sharded vs. consolidated:
+    ///      - If an index file (e.g. `model.safetensors.index.json`) exists, the sharded set
+    ///        is canonical; skip standalone consolidated files.
+    ///      - Otherwise keep whatever is present.
+    ///
+    /// For `Safetensors` / `Pytorch`: keep only weight files of that format (and all
+    /// non-weight files).
+    ///
+    /// For `All`: no filtering, return all filenames unchanged.
+    fn filter_files_by_weight_format(
+        filenames: &[String],
+        weight_format: WeightFormat,
+    ) -> Vec<String> {
+        match weight_format {
+            WeightFormat::All => filenames.to_vec(),
+            WeightFormat::Safetensors => filenames
+                .iter()
+                .filter(|f| !Self::is_non_preferred_weight(f, true))
+                .cloned()
+                .collect(),
+            WeightFormat::Pytorch => filenames
+                .iter()
+                .filter(|f| !Self::is_non_preferred_weight(f, false))
+                .cloned()
+                .collect(),
+            WeightFormat::Auto => Self::auto_filter_weight_files(filenames),
+        }
+    }
+
+    /// Returns true if this is a weight file that does NOT match the preferred format.
+    /// When `prefer_safetensors` is true, non-safetensors weight files are filtered out.
+    /// When false, safetensors weight files are filtered out (prefer pytorch).
+    fn is_non_preferred_weight(filename: &str, prefer_safetensors: bool) -> bool {
+        if !Self::is_weight_file(filename) {
+            return false;
+        }
+        if prefer_safetensors {
+            !filename.ends_with(".safetensors")
+        } else {
+            !filename.ends_with(".bin")
+        }
+    }
+
+    fn auto_filter_weight_files(filenames: &[String]) -> Vec<String> {
+        let has_safetensors = filenames.iter().any(|f| f.ends_with(".safetensors"));
+        let has_safetensors_index = filenames
+            .iter()
+            .any(|f| f.ends_with(".safetensors.index.json"));
+        let has_pytorch_index = filenames
+            .iter()
+            .any(|f| f == "pytorch_model.bin.index.json");
+
+        filenames
+            .iter()
+            .filter(|f| {
+                // Drop weight files in non-preferred formats
+                if Self::is_weight_file(f) || f.ends_with(".gguf") {
+                    if has_safetensors {
+                        if !f.ends_with(".safetensors") {
+                            return false;
+                        }
+                    } else if f.ends_with(".h5") || f.ends_with(".msgpack") || f.ends_with(".gguf")
+                    {
+                        return false;
+                    }
+                }
+
+                // Deduplicate sharded vs. consolidated within chosen format
+                if has_safetensors_index && *f == "model.safetensors" {
+                    return false;
+                }
+                if has_pytorch_index && *f == "pytorch_model.bin" {
+                    return false;
+                }
+
+                true
+            })
+            .cloned()
+            .collect()
+    }
 }
 
 #[async_trait::async_trait]
@@ -189,6 +274,7 @@ impl ModelProviderTrait for HuggingFaceProvider {
         model_name: &str,
         cache_dir: Option<PathBuf>,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> Result<PathBuf> {
         let cache_dir = get_cache_dir(cache_dir);
         std::fs::create_dir_all(&cache_dir).map_err(|e| {
@@ -228,6 +314,18 @@ impl ModelProviderTrait for HuggingFaceProvider {
             anyhow::bail!("Model '{model_name}' exists but contains no downloadable files.");
         }
 
+        // Collect top-level filenames and apply weight format filtering
+        let all_filenames: Vec<String> = info
+            .siblings
+            .iter()
+            .filter(|s| !HuggingFaceProvider::is_subdirectory_file(&s.rfilename))
+            .map(|s| s.rfilename.clone())
+            .collect();
+        let allowed_files: HashSet<String> =
+            HuggingFaceProvider::filter_files_by_weight_format(&all_filenames, weight_format)
+                .into_iter()
+                .collect();
+
         let mut p = PathBuf::new();
         let mut files_downloaded = false;
 
@@ -243,6 +341,14 @@ impl ModelProviderTrait for HuggingFaceProvider {
             }
 
             if ignore_weights && HuggingFaceProvider::is_weight_file(&sib.rfilename) {
+                continue;
+            }
+
+            if !allowed_files.contains(&sib.rfilename) {
+                debug!(
+                    "Skipping file '{}' due to weight format filter ({})",
+                    sib.rfilename, weight_format
+                );
                 continue;
             }
 
@@ -563,6 +669,7 @@ mod tests {
                 "test/model",
                 Some(explicit_cache.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             )
             .await
             .expect("Failed to seed explicit cache");
@@ -574,7 +681,12 @@ mod tests {
         );
 
         let env_snapshot = provider
-            .download_model("test/model", Some(env_cache.path().to_path_buf()), false)
+            .download_model(
+                "test/model",
+                Some(env_cache.path().to_path_buf()),
+                false,
+                WeightFormat::default(),
+            )
             .await
             .expect("Failed to seed env cache");
         let env_config = env_snapshot.join("config.json");
@@ -699,7 +811,12 @@ mod tests {
         let mock_server = MockHFServer::new(&env_lock).await;
         let provider = HuggingFaceProvider;
         let result = provider
-            .download_model("test/model", Some(mock_server.cache_path.clone()), false)
+            .download_model(
+                "test/model",
+                Some(mock_server.cache_path.clone()),
+                false,
+                WeightFormat::default(),
+            )
             .await
             .expect("Failed to download model");
 
@@ -721,7 +838,12 @@ mod tests {
         let provider = HuggingFaceProvider;
 
         let result = provider
-            .download_model("test/model", Some(mock_server.cache_path.clone()), false)
+            .download_model(
+                "test/model",
+                Some(mock_server.cache_path.clone()),
+                false,
+                WeightFormat::default(),
+            )
             .await
             .expect("Failed to download model");
 
@@ -776,7 +898,12 @@ mod tests {
 
         let provider = HuggingFaceProvider;
         let result = provider
-            .download_model("test/model", Some(temp_dir.path().to_path_buf()), false)
+            .download_model(
+                "test/model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                WeightFormat::default(),
+            )
             .await;
 
         assert!(
@@ -819,7 +946,12 @@ mod tests {
         let _offline_guard = EnvVarGuard::set(&env_lock, HF_HUB_OFFLINE_ENV_VAR, "1");
 
         let result = HuggingFaceProvider
-            .download_model("test/model", Some(temp_dir.path().into()), false)
+            .download_model(
+                "test/model",
+                Some(temp_dir.path().into()),
+                false,
+                WeightFormat::default(),
+            )
             .await;
 
         assert!(result.is_ok());
@@ -835,7 +967,12 @@ mod tests {
         let _offline_guard = EnvVarGuard::set(&env_lock, HF_HUB_OFFLINE_ENV_VAR, "1");
 
         let result = HuggingFaceProvider
-            .download_model("nonexistent/model", Some(temp_dir.path().into()), false)
+            .download_model(
+                "nonexistent/model",
+                Some(temp_dir.path().into()),
+                false,
+                WeightFormat::default(),
+            )
             .await;
 
         assert!(result.is_err());
@@ -845,5 +982,134 @@ mod tests {
                 .to_string()
                 .contains("not found in cache")
         );
+    }
+
+    #[test]
+    fn test_filter_weight_format_auto_prefers_safetensors() {
+        let files = vec![
+            "config.json".to_string(),
+            "model.safetensors".to_string(),
+            "model.safetensors.index.json".to_string(),
+            "model-00001-of-00002.safetensors".to_string(),
+            "model-00002-of-00002.safetensors".to_string(),
+            "pytorch_model.bin".to_string(),
+            "model.h5".to_string(),
+            "tokenizer.json".to_string(),
+        ];
+
+        let filtered =
+            HuggingFaceProvider::filter_files_by_weight_format(&files, WeightFormat::Auto);
+
+        assert!(filtered.contains(&"config.json".to_string()));
+        assert!(filtered.contains(&"tokenizer.json".to_string()));
+        assert!(filtered.contains(&"model.safetensors.index.json".to_string()));
+        assert!(filtered.contains(&"model-00001-of-00002.safetensors".to_string()));
+        assert!(filtered.contains(&"model-00002-of-00002.safetensors".to_string()));
+        // Consolidated file should be skipped when index exists
+        assert!(!filtered.contains(&"model.safetensors".to_string()));
+        // Non-safetensors weight formats should be skipped
+        assert!(!filtered.contains(&"pytorch_model.bin".to_string()));
+        assert!(!filtered.contains(&"model.h5".to_string()));
+    }
+
+    #[test]
+    fn test_filter_weight_format_auto_consolidated_only() {
+        let files = vec![
+            "config.json".to_string(),
+            "model.safetensors".to_string(),
+            "tokenizer.json".to_string(),
+        ];
+
+        let filtered =
+            HuggingFaceProvider::filter_files_by_weight_format(&files, WeightFormat::Auto);
+
+        assert!(filtered.contains(&"config.json".to_string()));
+        assert!(filtered.contains(&"model.safetensors".to_string()));
+        assert!(filtered.contains(&"tokenizer.json".to_string()));
+    }
+
+    #[test]
+    fn test_filter_weight_format_auto_falls_back_to_pytorch() {
+        let files = vec![
+            "config.json".to_string(),
+            "pytorch_model.bin".to_string(),
+            "pytorch_model.bin.index.json".to_string(),
+            "pytorch_model-00001-of-00002.bin".to_string(),
+        ];
+
+        let filtered =
+            HuggingFaceProvider::filter_files_by_weight_format(&files, WeightFormat::Auto);
+
+        assert!(filtered.contains(&"config.json".to_string()));
+        assert!(filtered.contains(&"pytorch_model.bin.index.json".to_string()));
+        assert!(filtered.contains(&"pytorch_model-00001-of-00002.bin".to_string()));
+        // Consolidated should be skipped when index exists
+        assert!(!filtered.contains(&"pytorch_model.bin".to_string()));
+    }
+
+    #[test]
+    fn test_filter_weight_format_safetensors_only() {
+        let files = vec![
+            "config.json".to_string(),
+            "model.safetensors".to_string(),
+            "pytorch_model.bin".to_string(),
+            "tokenizer.json".to_string(),
+        ];
+
+        let filtered =
+            HuggingFaceProvider::filter_files_by_weight_format(&files, WeightFormat::Safetensors);
+
+        assert!(filtered.contains(&"config.json".to_string()));
+        assert!(filtered.contains(&"model.safetensors".to_string()));
+        assert!(filtered.contains(&"tokenizer.json".to_string()));
+        assert!(!filtered.contains(&"pytorch_model.bin".to_string()));
+    }
+
+    #[test]
+    fn test_filter_weight_format_pytorch_only() {
+        let files = vec![
+            "config.json".to_string(),
+            "model.safetensors".to_string(),
+            "pytorch_model.bin".to_string(),
+            "tokenizer.json".to_string(),
+        ];
+
+        let filtered =
+            HuggingFaceProvider::filter_files_by_weight_format(&files, WeightFormat::Pytorch);
+
+        assert!(filtered.contains(&"config.json".to_string()));
+        assert!(filtered.contains(&"pytorch_model.bin".to_string()));
+        assert!(filtered.contains(&"tokenizer.json".to_string()));
+        assert!(!filtered.contains(&"model.safetensors".to_string()));
+    }
+
+    #[test]
+    fn test_filter_weight_format_all() {
+        let files = vec![
+            "config.json".to_string(),
+            "model.safetensors".to_string(),
+            "pytorch_model.bin".to_string(),
+            "model.h5".to_string(),
+        ];
+
+        let filtered =
+            HuggingFaceProvider::filter_files_by_weight_format(&files, WeightFormat::All);
+
+        assert_eq!(filtered.len(), files.len());
+    }
+
+    #[test]
+    fn test_filter_weight_format_auto_skips_gguf() {
+        let files = vec![
+            "config.json".to_string(),
+            "model.safetensors".to_string(),
+            "model-Q4_K_M.gguf".to_string(),
+        ];
+
+        let filtered =
+            HuggingFaceProvider::filter_files_by_weight_format(&files, WeightFormat::Auto);
+
+        assert!(filtered.contains(&"model.safetensors".to_string()));
+        assert!(!filtered.contains(&"model-Q4_K_M.gguf".to_string()));
     }
 }

--- a/modelexpress_common/src/providers/ngc.rs
+++ b/modelexpress_common/src/providers/ngc.rs
@@ -4,7 +4,7 @@
 use crate::{
     Utils,
     cache::{ModelInfo, ProviderCache, directory_size},
-    models::ModelProvider,
+    models::{ModelProvider, WeightFormat},
     providers::ModelProviderTrait,
 };
 use anyhow::{Context, Result};
@@ -890,6 +890,7 @@ impl ModelProviderTrait for NgcProvider {
         model_name: &str,
         cache_dir: Option<PathBuf>,
         ignore_weights: bool,
+        _weight_format: WeightFormat,
     ) -> Result<PathBuf> {
         let cache_root = get_cache_dir(cache_dir);
         let id = parse_model_name(model_name)?;
@@ -1643,6 +1644,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(mock.cache_path.clone()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 
@@ -1702,6 +1704,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(temp_dir.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 
@@ -1767,6 +1770,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(temp_dir.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 
@@ -1813,6 +1817,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(temp_dir.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 

--- a/modelexpress_common/src/providers/ngc.rs
+++ b/modelexpress_common/src/providers/ngc.rs
@@ -4,7 +4,7 @@
 use crate::{
     Utils,
     cache::{ModelInfo, ProviderCache, directory_size},
-    models::ModelProvider,
+    models::{ModelProvider, WeightFormat},
     providers::ModelProviderTrait,
 };
 use anyhow::{Context, Result};
@@ -802,6 +802,7 @@ impl ModelProviderTrait for NgcProvider {
         model_name: &str,
         cache_dir: Option<PathBuf>,
         ignore_weights: bool,
+        _weight_format: WeightFormat,
     ) -> Result<PathBuf> {
         let cache_root = get_cache_dir(cache_dir);
         let id = parse_model_name(model_name)?;
@@ -1499,6 +1500,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(mock.cache_path.clone()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 
@@ -1555,6 +1557,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(temp_dir.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 
@@ -1618,6 +1621,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(temp_dir.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 
@@ -1661,6 +1665,7 @@ mod tests {
                 "nim/nvidia/test-model/v1",
                 Some(temp_dir.path().to_path_buf()),
                 false,
+                WeightFormat::default(),
             )
             .await;
 

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -13,7 +13,7 @@ use modelexpress_common::{
             ModelStatusUpdate, model_service_server::ModelService,
         },
     },
-    models::{ModelProvider, ModelStatus},
+    models::{ModelProvider, ModelStatus, WeightFormat},
 };
 use std::{
     collections::HashMap,
@@ -189,6 +189,10 @@ impl ModelService for ModelServiceImpl {
                 .unwrap_or(modelexpress_common::grpc::model::ModelProvider::HuggingFace)
                 .into();
         let ignore_weights = model_request.ignore_weights;
+        let weight_format: WeightFormat =
+            modelexpress_common::grpc::model::WeightFormat::try_from(model_request.weight_format)
+                .unwrap_or(modelexpress_common::grpc::model::WeightFormat::Auto)
+                .into();
 
         // Spawn a task to handle the streaming download updates
         tokio::spawn(async move {
@@ -220,7 +224,7 @@ impl ModelService for ModelServiceImpl {
 
             // Start or monitor the download process
             let final_status = MODEL_TRACKER
-                .ensure_model_downloaded(&model_name, provider, &tx, ignore_weights)
+                .ensure_model_downloaded(&model_name, provider, &tx, ignore_weights, weight_format)
                 .await;
 
             // Send final status update
@@ -566,6 +570,7 @@ impl ModelDownloadTracker {
         provider: ModelProvider,
         tx: &tokio::sync::mpsc::Sender<Result<ModelStatusUpdate, Status>>,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> ModelStatus {
         // Atomically try to claim this model for download using compare-and-swap
         let status = match self.database.try_claim_for_download(model_name, provider) {
@@ -633,6 +638,7 @@ impl ModelDownloadTracker {
                         provider,
                         cache_dir,
                         ignore_weights,
+                        weight_format,
                     )
                     .await
                     {
@@ -695,6 +701,7 @@ impl ModelDownloadTracker {
                     provider,
                     cache_dir,
                     ignore_weights,
+                    weight_format,
                 )
                 .await
                 {
@@ -892,6 +899,7 @@ mod tests {
             model_name: model_name.clone(),
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
             ignore_weights: false,
+            weight_format: modelexpress_common::grpc::model::WeightFormat::Auto as i32,
         });
 
         let response = service.ensure_model_downloaded(request).await;
@@ -990,6 +998,7 @@ mod tests {
             model_name: model_name.to_string(),
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
             ignore_weights: false,
+            weight_format: modelexpress_common::grpc::model::WeightFormat::Auto as i32,
         });
 
         let response = service.ensure_model_downloaded(request).await;

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -16,7 +16,7 @@ use modelexpress_common::{
             model_service_server::ModelService,
         },
     },
-    models::{ModelProvider, ModelStatus},
+    models::{ModelProvider, ModelStatus, WeightFormat},
 };
 use std::{
     collections::HashMap,
@@ -228,6 +228,10 @@ impl ModelService for ModelServiceImpl {
         let model_name = download::canonical_model_name(&model_request.model_name, provider)
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
         let ignore_weights = model_request.ignore_weights;
+        let weight_format: WeightFormat =
+            modelexpress_common::grpc::model::WeightFormat::try_from(model_request.weight_format)
+                .unwrap_or(modelexpress_common::grpc::model::WeightFormat::Auto)
+                .into();
 
         // Spawn a task to handle the streaming download updates
         tokio::spawn(async move {
@@ -246,7 +250,7 @@ impl ModelService for ModelServiceImpl {
             // about to retry and trip the client-lib's terminal-error bailout before
             // the retry completion broadcast arrives.
             let final_status = tracker
-                .ensure_model_downloaded(&model_name, provider, &tx, ignore_weights)
+                .ensure_model_downloaded(&model_name, provider, &tx, ignore_weights, weight_format)
                 .await;
 
             // Send final status update
@@ -675,12 +679,21 @@ impl ModelDownloadTracker {
         model_name: String,
         provider: ModelProvider,
         ignore_weights: bool,
+        weight_format: WeightFormat,
         retry: bool,
     ) {
         let tracker = self.clone();
         tokio::spawn(async move {
             let cache_dir = get_server_cache_dir();
-            match download::download_model(&model_name, provider, cache_dir, ignore_weights).await {
+            match download::download_model(
+                &model_name,
+                provider,
+                cache_dir,
+                ignore_weights,
+                weight_format,
+            )
+            .await
+            {
                 Ok(_path) => {
                     tracker
                         .set_status_and_notify(
@@ -717,6 +730,7 @@ impl ModelDownloadTracker {
         provider: ModelProvider,
         tx: &tokio::sync::mpsc::Sender<Result<ModelStatusUpdate, Status>>,
         ignore_weights: bool,
+        weight_format: WeightFormat,
     ) -> ModelStatus {
         // Atomically try to claim this model for download. The `ClaimOutcome` tells us
         // whether THIS replica won the claim or is observing someone else's claim —
@@ -822,7 +836,13 @@ impl ModelDownloadTracker {
             // download) or won the ERROR-retry CAS. Everyone else waits.
             if is_owner || is_retry_owner {
                 let retry = status == ModelStatus::ERROR;
-                self.spawn_download_task(model_name.to_string(), provider, ignore_weights, retry);
+                self.spawn_download_task(
+                    model_name.to_string(),
+                    provider,
+                    ignore_weights,
+                    weight_format,
+                    retry,
+                );
             }
 
             // Wait for completion by polling the registry.
@@ -1444,6 +1464,7 @@ mod tests {
             model_name: "test/model".to_string(),
             provider: 99,
             ignore_weights: false,
+            weight_format: modelexpress_common::grpc::model::WeightFormat::Auto as i32,
         });
 
         let result = service.ensure_model_downloaded(request).await;

--- a/workspace-tests/tests/integration_tests.rs
+++ b/workspace-tests/tests/integration_tests.rs
@@ -4,7 +4,10 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig};
-use modelexpress_common::{constants, models::ModelProvider};
+use modelexpress_common::{
+    constants,
+    models::{ModelProvider, WeightFormat},
+};
 use std::sync::Mutex;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -67,6 +70,7 @@ async fn test_integration_model_download_fallback() {
         ModelProvider::HuggingFace,
         config,
         false,
+        WeightFormat::default(),
     )
     .await;
 
@@ -83,6 +87,7 @@ async fn test_integration_direct_download_invalid_model() {
         "definitely-not-a-real-model-name-12345",
         ModelProvider::HuggingFace,
         false,
+        WeightFormat::default(),
     )
     .await;
 
@@ -102,6 +107,7 @@ async fn test_integration_small_model_download() {
         "prajjwal1/bert-tiny", // A very small BERT model for testing
         ModelProvider::HuggingFace,
         false,
+        WeightFormat::default(),
     )
     .await;
 
@@ -153,6 +159,7 @@ async fn test_integration_offline_mode_without_cache() {
         "nonexistent-model-for-offline-test",
         ModelProvider::HuggingFace,
         false,
+        WeightFormat::default(),
     )
     .await;
 
@@ -202,6 +209,7 @@ async fn test_integration_offline_mode_with_cached_model() {
         ModelProvider::HuggingFace,
         Some(cache_path),
         false,
+        WeightFormat::default(),
     )
     .await;
 

--- a/workspace-tests/tests/integration_tests.rs
+++ b/workspace-tests/tests/integration_tests.rs
@@ -4,7 +4,10 @@
 #![allow(clippy::expect_used)]
 
 use modelexpress_client::{Client, ClientConfig};
-use modelexpress_common::{constants, download, models::ModelProvider};
+use modelexpress_common::{
+    constants, download,
+    models::{ModelProvider, WeightFormat},
+};
 use std::sync::Mutex;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -18,6 +21,7 @@ async fn download_model_directly(
     model_name: &str,
     provider: ModelProvider,
     ignore_weights: bool,
+    weight_format: WeightFormat,
 ) -> Result<(), modelexpress_common::Error> {
     let cache_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
 
@@ -26,6 +30,7 @@ async fn download_model_directly(
         provider,
         Some(cache_dir.path().to_path_buf()),
         ignore_weights,
+        weight_format,
     )
     .await
     .map(|_| ())
@@ -85,6 +90,7 @@ async fn test_integration_model_download_fallback() {
         ModelProvider::HuggingFace,
         config,
         false,
+        WeightFormat::default(),
     )
     .await;
 
@@ -101,6 +107,7 @@ async fn test_integration_direct_download_invalid_model() {
         "definitely-not-a-real-model-name-12345",
         ModelProvider::HuggingFace,
         false,
+        WeightFormat::default(),
     )
     .await;
 
@@ -116,8 +123,13 @@ async fn test_integration_small_model_download() {
     // Test with a very small, real model (only run this in CI or when explicitly requested)
     // Note: This test requires internet access and may take some time
 
-    let result =
-        download_model_directly("prajjwal1/bert-tiny", ModelProvider::HuggingFace, false).await;
+    let result = download_model_directly(
+        "prajjwal1/bert-tiny",
+        ModelProvider::HuggingFace,
+        false,
+        WeightFormat::default(),
+    )
+    .await;
 
     match result {
         Ok(()) => info!("Small model download successful"),
@@ -167,6 +179,7 @@ async fn test_integration_offline_mode_without_cache() {
         "nonexistent-model-for-offline-test",
         ModelProvider::HuggingFace,
         false,
+        WeightFormat::default(),
     )
     .await;
 
@@ -216,6 +229,7 @@ async fn test_integration_offline_mode_with_cached_model() {
         ModelProvider::HuggingFace,
         Some(cache_path),
         false,
+        WeightFormat::default(),
     )
     .await;
 


### PR DESCRIPTION
## Summary

- Add `--weight-format` CLI flag (`auto`/`safetensors`/`pytorch`/`all`) and `MODEL_EXPRESS_WEIGHT_FORMAT` env var to control which weight file formats are downloaded
- In `auto` mode (default), prefer safetensors over pytorch/h5/msgpack, deduplicate sharded vs consolidated weights using index file presence, and exclude GGUF files
- Add `LICENSE`, `LICENSE.md`, `LICENSE.txt`, and `NOTICE` to the default ignored files list since they are never used by model runtimes

Closes #173

## Test plan

- [x] All 292 existing tests pass
- [x] 13 new unit tests for `WeightFormat` enum and `filter_files_by_weight_format()` logic
- [x] `cargo clippy` passes with no warnings
- [ ] Manual test: download a dual-format model (e.g. `openai/gpt-oss-20b`) with `--weight-format auto` and verify only safetensors files are fetched
- [ ] Manual test: `--weight-format pytorch` downloads only `.bin` files
- [ ] Manual test: `--weight-format all` preserves current behavior
- [ ] Manual test: `MODEL_EXPRESS_WEIGHT_FORMAT=safetensors` env var works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--weight-format` global option to specify model weight file format preferences: `auto`, `safetensors`, `pytorch`, or `all` (defaults to `auto`)
  * Added `MODEL_EXPRESS_WEIGHT_FORMAT` environment variable for weight format configuration

* **Documentation**
  * Updated CLI documentation with new weight-format option
  * Updated deployment documentation with environment variable details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->