### PR TITLE
refactor(output): simplify redundant quiet mode writer condition

### DIFF
--- a/modelexpress_client/src/bin/modules/output.rs
+++ b/modelexpress_client/src/bin/modules/output.rs
@@ -22,12 +22,7 @@ pub fn setup_logging(verbose: u8, quiet: bool) {
     tracing_subscriber::fmt()
         .with_max_level(level)
         .with_target(false)
-        .with_writer(if quiet {
-            // In quiet mode, redirect tracing to stderr to keep stdout clean
-            std::io::stderr
-        } else {
-            std::io::stderr
-        })
+        .with_writer(std::io::stderr)
         .init();
 }
 


### PR DESCRIPTION
Remove redundant conditional that returned std::io::stderr in both branches. Logging now consistently writes to stderr regardless of quiet mode, keeping stdout clean for actual command output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging output consistency by ensuring logs are always directed to stderr instead of variable behavior based on quiet mode settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->