### PR TITLE
Fix runtime config, standalone backend handling, and client TLS

### DIFF
--- a/modelexpress_client/python/modelexpress/client.py
+++ b/modelexpress_client/python/modelexpress/client.py
@@ -23,16 +23,16 @@ from . import p2p_pb2_grpc
 logger = logging.getLogger("modelexpress.client")
 
 
-def _parse_server_address(address: str) -> str:
-    """Strip http:// or https:// prefix from server address for gRPC."""
+def _parse_server_address(address: str) -> tuple[str, bool]:
+    """Return normalized server address and whether TLS is required."""
     if address.startswith("http://"):
-        return address[7:]
+        return address[7:], False
     elif address.startswith("https://"):
-        return address[8:]
-    return address
+        return address[8:], True
+    return address, False
 
 
-def _get_server_url(explicit_url: str | None = None) -> str:
+def _get_server_url(explicit_url: str | None = None) -> tuple[str, bool]:
     """
     Resolve the ModelExpress server URL.
 
@@ -75,7 +75,7 @@ class MxClient:
         server_url: str | None = None,
         max_message_size: int = 100 * 1024 * 1024,  # 100 MB
     ):
-        self.server_url = _get_server_url(server_url)
+        self.server_url, self._use_tls = _get_server_url(server_url)
         self._max_message_size = max_message_size
         self._channel: grpc.Channel | None = None
         self._stub: p2p_pb2_grpc.P2pServiceStub | None = None
@@ -90,7 +90,15 @@ class MxClient:
                 ("grpc.max_send_message_length", self._max_message_size),
                 ("grpc.max_receive_message_length", self._max_message_size),
             ]
-            self._channel = grpc.insecure_channel(self.server_url, options=options)
+            if self._use_tls:
+                credentials = grpc.ssl_channel_credentials()
+                self._channel = grpc.secure_channel(
+                    self.server_url,
+                    credentials,
+                    options=options,
+                )
+            else:
+                self._channel = grpc.insecure_channel(self.server_url, options=options)
             self._stub = p2p_pb2_grpc.P2pServiceStub(self._channel)
             logger.debug("MxClient connected to %s", self.server_url)
         return self._stub

--- a/modelexpress_client/python/tests/test_client.py
+++ b/modelexpress_client/python/tests/test_client.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+from modelexpress.client import MxClient, _get_server_url
+
+
+def test_get_server_url_defaults_to_insecure_localhost():
+    address, use_tls = _get_server_url()
+    assert address == "localhost:8001"
+    assert use_tls is False
+
+
+def test_get_server_url_parses_https_as_tls():
+    address, use_tls = _get_server_url("https://mx.example.com:8443")
+    assert address == "mx.example.com:8443"
+    assert use_tls is True
+
+
+def test_mx_client_uses_secure_channel_for_https():
+    client = MxClient(server_url="https://mx.example.com:8443")
+
+    with patch("modelexpress.client.grpc.ssl_channel_credentials", return_value="creds") as creds, \
+         patch("modelexpress.client.grpc.secure_channel", return_value="secure-channel") as secure, \
+         patch("modelexpress.client.p2p_pb2_grpc.P2pServiceStub", return_value="stub") as stub:
+        assert client.stub == "stub"
+        creds.assert_called_once_with()
+        secure.assert_called_once_with(
+            "mx.example.com:8443",
+            "creds",
+            options=[
+                ("grpc.max_send_message_length", 100 * 1024 * 1024),
+                ("grpc.max_receive_message_length", 100 * 1024 * 1024),
+            ],
+        )
+        stub.assert_called_once_with("secure-channel")
+
+
+def test_mx_client_uses_insecure_channel_for_plaintext():
+    client = MxClient(server_url="http://mx.example.com:8001")
+
+    with patch("modelexpress.client.grpc.insecure_channel", return_value="insecure-channel") as insecure, \
+         patch("modelexpress.client.p2p_pb2_grpc.P2pServiceStub", return_value="stub") as stub:
+        assert client.stub == "stub"
+        insecure.assert_called_once_with(
+            "mx.example.com:8001",
+            options=[
+                ("grpc.max_send_message_length", 100 * 1024 * 1024),
+                ("grpc.max_receive_message_length", 100 * 1024 * 1024),
+            ],
+        )
+        stub.assert_called_once_with("insecure-channel")

--- a/modelexpress_server/src/main.rs
+++ b/modelexpress_server/src/main.rs
@@ -99,7 +99,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create service implementations
     let health_service = HealthServiceImpl;
     let api_service = ApiServiceImpl;
-    let model_service = ModelServiceImpl;
+    let model_service =
+        ModelServiceImpl::new(config.cache.directory.clone(), config.database.path.clone());
 
     // Create standard gRPC health service (grpc.health.v1.Health)
     let (health_reporter, health_service_v1) = tonic_health::server::health_reporter();

--- a/modelexpress_server/src/metadata_backend.rs
+++ b/modelexpress_server/src/metadata_backend.rs
@@ -3,17 +3,19 @@
 
 //! Metadata backend abstraction for P2P model metadata.
 //!
-//! Supports two persistent backends:
+//! Supports multiple backends:
+//! - **Memory**: Volatile in-process storage for standalone/dev use
 //! - **Redis**: Persistent storage via Redis keys + atomic Lua merge
 //! - **Kubernetes**: CRDs and ConfigMaps for native K8s integration
 //!
-//! Select the backend via `MX_METADATA_BACKEND=redis` or `MX_METADATA_BACKEND=kubernetes`.
+//! Select the backend via `MX_METADATA_BACKEND=memory|redis|kubernetes`.
 
 use async_trait::async_trait;
 use modelexpress_common::grpc::p2p::{SourceIdentity, SourceStatus, WorkerMetadata};
 use std::sync::Arc;
 
 pub mod kubernetes;
+pub mod memory;
 pub mod redis;
 
 /// Result type for metadata operations
@@ -263,6 +265,8 @@ pub trait MetadataBackend: Send + Sync {
 /// Configuration for metadata backends
 #[derive(Debug, Clone)]
 pub enum BackendConfig {
+    /// In-memory backend — volatile, process-local, zero external dependencies
+    Memory,
     /// Redis backend — persistent, horizontally scalable
     Redis { url: String },
     /// Kubernetes CRD backend — native K8s integration
@@ -272,6 +276,7 @@ pub enum BackendConfig {
 impl std::fmt::Display for BackendConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Memory => write!(f, "memory"),
             Self::Redis { .. } => write!(f, "redis"),
             Self::Kubernetes { .. } => write!(f, "kubernetes"),
         }
@@ -281,11 +286,13 @@ impl std::fmt::Display for BackendConfig {
 impl BackendConfig {
     /// Create backend config from environment variables.
     ///
-    /// `MX_METADATA_BACKEND` is required. Valid values:
+    /// `MX_METADATA_BACKEND` defaults to `memory`. Valid values:
+    /// - `memory`: in-process volatile storage
     /// - `redis`: Redis
     /// - `kubernetes` | `k8s` | `crd`: Kubernetes CRD
     pub fn from_env() -> Result<Self, String> {
-        let backend_type = std::env::var("MX_METADATA_BACKEND").unwrap_or_default();
+        let backend_type =
+            std::env::var("MX_METADATA_BACKEND").unwrap_or_else(|_| "memory".to_string());
         let redis_url = Self::redis_url_from_env();
         let k8s_namespace = Self::k8s_namespace_from_env();
         Self::from_type_str(&backend_type, &redis_url, &k8s_namespace)
@@ -298,6 +305,7 @@ impl BackendConfig {
         k8s_namespace: &str,
     ) -> Result<Self, String> {
         match backend_type.to_lowercase().as_str() {
+            "" | "memory" => Ok(Self::Memory),
             "redis" => Ok(Self::Redis {
                 url: redis_url.to_string(),
             }),
@@ -305,7 +313,7 @@ impl BackendConfig {
                 namespace: k8s_namespace.to_string(),
             }),
             other => Err(format!(
-                "MX_METADATA_BACKEND='{}' is not valid. Use 'redis' or 'kubernetes'.",
+                "MX_METADATA_BACKEND='{}' is not valid. Use 'memory', 'redis', or 'kubernetes'.",
                 other
             )),
         }
@@ -334,6 +342,11 @@ impl BackendConfig {
 /// Create a backend from configuration.
 pub async fn create_backend(config: BackendConfig) -> MetadataResult<Arc<dyn MetadataBackend>> {
     match config {
+        BackendConfig::Memory => {
+            let backend = memory::MemoryBackend::new();
+            backend.connect().await?;
+            Ok(Arc::new(backend) as Arc<dyn MetadataBackend>)
+        }
         BackendConfig::Redis { url } => {
             let backend = redis::RedisBackend::new(&url);
             backend.connect().await?;

--- a/modelexpress_server/src/metadata_backend/memory.rs
+++ b/modelexpress_server/src/metadata_backend/memory.rs
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory metadata backend for standalone and development deployments.
+
+use crate::metadata_backend::{
+    MetadataBackend, MetadataResult, ModelMetadataRecord, SourceInstanceInfo, WorkerRecord,
+};
+use crate::source_identity::compute_mx_source_id;
+use async_trait::async_trait;
+use modelexpress_common::grpc::p2p::{SourceIdentity, SourceStatus, WorkerMetadata};
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+use tracing::info;
+
+#[derive(Debug, Clone)]
+struct SourceEntry {
+    model_name: String,
+    published_at: i64,
+    workers: HashMap<String, WorkerRecord>,
+}
+
+#[derive(Default)]
+pub struct MemoryBackend {
+    entries: RwLock<HashMap<String, SourceEntry>>,
+}
+
+impl MemoryBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl MetadataBackend for MemoryBackend {
+    async fn connect(&self) -> MetadataResult<()> {
+        info!("Memory metadata backend initialized");
+        Ok(())
+    }
+
+    async fn publish_metadata(
+        &self,
+        identity: &SourceIdentity,
+        worker_id: &str,
+        worker: WorkerMetadata,
+    ) -> MetadataResult<()> {
+        let source_id = compute_mx_source_id(identity);
+        let mut entries = self.entries.write().await;
+        let published_at = chrono::Utc::now().timestamp_millis();
+        let entry = entries.entry(source_id).or_insert_with(|| SourceEntry {
+            model_name: identity.model_name.clone(),
+            published_at,
+            workers: HashMap::new(),
+        });
+        entry.model_name = identity.model_name.clone();
+        entry.published_at = published_at;
+        entry
+            .workers
+            .insert(worker_id.to_string(), WorkerRecord::from(worker));
+        Ok(())
+    }
+
+    async fn get_metadata(
+        &self,
+        source_id: &str,
+        worker_id: &str,
+    ) -> MetadataResult<Option<ModelMetadataRecord>> {
+        let entries = self.entries.read().await;
+        let Some(entry) = entries.get(source_id) else {
+            return Ok(None);
+        };
+        let Some(worker) = entry.workers.get(worker_id) else {
+            return Ok(None);
+        };
+        Ok(Some(ModelMetadataRecord {
+            source_id: source_id.to_string(),
+            worker_id: worker_id.to_string(),
+            model_name: entry.model_name.clone(),
+            workers: vec![worker.clone()],
+            published_at: entry.published_at,
+        }))
+    }
+
+    async fn list_workers(
+        &self,
+        source_id: Option<String>,
+        status_filter: Option<SourceStatus>,
+    ) -> MetadataResult<Vec<SourceInstanceInfo>> {
+        let entries = self.entries.read().await;
+        let mut results = Vec::new();
+
+        for (entry_source_id, entry) in entries.iter() {
+            if source_id
+                .as_ref()
+                .is_some_and(|wanted| wanted != entry_source_id)
+            {
+                continue;
+            }
+
+            for (worker_id, worker) in &entry.workers {
+                if status_filter.is_some_and(|status| worker.status != status as i32) {
+                    continue;
+                }
+
+                results.push(SourceInstanceInfo {
+                    source_id: entry_source_id.clone(),
+                    worker_id: worker_id.clone(),
+                    model_name: entry.model_name.clone(),
+                    worker_rank: worker.worker_rank,
+                    status: worker.status,
+                    updated_at: worker.updated_at,
+                });
+            }
+        }
+
+        Ok(results)
+    }
+
+    async fn remove_metadata(&self, source_id: &str) -> MetadataResult<()> {
+        self.entries.write().await.remove(source_id);
+        Ok(())
+    }
+
+    async fn remove_worker(&self, source_id: &str, worker_id: &str) -> MetadataResult<()> {
+        let mut entries = self.entries.write().await;
+        let should_remove_source = if let Some(entry) = entries.get_mut(source_id) {
+            entry.workers.remove(worker_id);
+            entry.workers.is_empty()
+        } else {
+            false
+        };
+
+        if should_remove_source {
+            entries.remove(source_id);
+        }
+
+        Ok(())
+    }
+
+    async fn list_sources(&self) -> MetadataResult<Vec<(String, String)>> {
+        let entries = self.entries.read().await;
+        Ok(entries
+            .iter()
+            .map(|(source_id, entry)| (source_id.clone(), entry.model_name.clone()))
+            .collect())
+    }
+
+    async fn update_status(
+        &self,
+        source_id: &str,
+        worker_id: &str,
+        worker_rank: u32,
+        status: SourceStatus,
+        updated_at: i64,
+    ) -> MetadataResult<()> {
+        let mut entries = self.entries.write().await;
+        if let Some(entry) = entries.get_mut(source_id)
+            && let Some(worker) = entry.workers.get_mut(worker_id)
+            && worker.worker_rank == worker_rank
+        {
+            worker.status = status as i32;
+            worker.updated_at = updated_at;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use modelexpress_common::grpc::p2p::{
+        BackendFramework, MxSourceType, TensorDescriptor, worker_metadata::BackendMetadata,
+    };
+
+    fn identity() -> SourceIdentity {
+        SourceIdentity {
+            mx_version: "0.3.0".to_string(),
+            mx_source_type: MxSourceType::Weights as i32,
+            model_name: "test/model".to_string(),
+            backend_framework: BackendFramework::Vllm as i32,
+            tensor_parallel_size: 1,
+            pipeline_parallel_size: 1,
+            expert_parallel_size: 0,
+            dtype: "bfloat16".to_string(),
+            quantization: String::new(),
+            extra_parameters: Default::default(),
+        }
+    }
+
+    fn worker(rank: u32) -> WorkerMetadata {
+        WorkerMetadata {
+            worker_rank: rank,
+            backend_metadata: Some(BackendMetadata::NixlMetadata(vec![1, 2, 3])),
+            tensors: vec![TensorDescriptor {
+                name: "weight".to_string(),
+                addr: 123,
+                size: 456,
+                device_id: rank,
+                dtype: "bfloat16".to_string(),
+            }],
+            status: SourceStatus::Ready as i32,
+            updated_at: 1000,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_publish_and_get_metadata() {
+        let backend = MemoryBackend::new();
+        let identity = identity();
+        let source_id = compute_mx_source_id(&identity);
+
+        backend
+            .publish_metadata(&identity, "worker-a", worker(0))
+            .await
+            .expect("publish should succeed");
+
+        let record = backend
+            .get_metadata(&source_id, "worker-a")
+            .await
+            .expect("lookup should succeed")
+            .expect("record should exist");
+
+        assert_eq!(record.model_name, "test/model");
+        assert_eq!(record.workers.len(), 1);
+        assert_eq!(record.workers[0].worker_rank, 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_and_remove_workers() {
+        let backend = MemoryBackend::new();
+        let identity = identity();
+        let source_id = compute_mx_source_id(&identity);
+
+        backend
+            .publish_metadata(&identity, "worker-a", worker(0))
+            .await
+            .expect("publish rank 0");
+        backend
+            .publish_metadata(&identity, "worker-b", worker(1))
+            .await
+            .expect("publish rank 1");
+
+        let workers = backend
+            .list_workers(Some(source_id.clone()), Some(SourceStatus::Ready))
+            .await
+            .expect("list should succeed");
+        assert_eq!(workers.len(), 2);
+
+        backend
+            .remove_worker(&source_id, "worker-a")
+            .await
+            .expect("remove worker");
+        let workers = backend
+            .list_workers(Some(source_id.clone()), None)
+            .await
+            .expect("list after removal");
+        assert_eq!(workers.len(), 1);
+
+        backend
+            .remove_metadata(&source_id)
+            .await
+            .expect("remove source");
+        let sources = backend.list_sources().await.expect("list sources");
+        assert!(sources.is_empty());
+    }
+}

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -29,17 +29,17 @@ use tracing::{debug, error, info};
 
 static START_TIME: std::sync::OnceLock<SystemTime> = std::sync::OnceLock::new();
 
-/// Get the configured cache directory for model downloads
-fn get_server_cache_dir() -> Option<std::path::PathBuf> {
-    // Try to get cache configuration
-    if let Ok(config) = CacheConfig::discover() {
-        Some(config.local_path)
-    } else {
-        // Fall back to environment variable
-        std::env::var("HF_HUB_CACHE")
-            .ok()
-            .map(std::path::PathBuf::from)
-    }
+fn default_server_cache_dir() -> PathBuf {
+    CacheConfig::discover()
+        .map(|config| config.local_path)
+        .or_else(|_| std::env::var("HF_HUB_CACHE").map(PathBuf::from))
+        .unwrap_or_else(|_| CacheConfig::default().local_path)
+}
+
+fn default_server_database_path() -> PathBuf {
+    std::env::var("MODEL_EXPRESS_DATABASE_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("./models.db"))
 }
 
 /// Health service implementation
@@ -105,8 +105,27 @@ impl ApiService for ApiServiceImpl {
 }
 
 /// Model service implementation
-#[derive(Debug, Default)]
-pub struct ModelServiceImpl;
+#[derive(Debug, Clone)]
+pub struct ModelServiceImpl {
+    cache_dir: PathBuf,
+    tracker: ModelDownloadTracker,
+}
+
+impl Default for ModelServiceImpl {
+    fn default() -> Self {
+        Self::new(default_server_cache_dir(), default_server_database_path())
+    }
+}
+
+impl ModelServiceImpl {
+    #[must_use]
+    pub fn new(cache_dir: PathBuf, database_path: PathBuf) -> Self {
+        Self {
+            cache_dir,
+            tracker: ModelDownloadTracker::with_database_path(database_path),
+        }
+    }
+}
 
 /// Helper function to collect all files in a model directory recursively
 fn collect_model_files(base_path: &Path, current_path: &Path) -> Vec<(PathBuf, u64)> {
@@ -115,36 +134,40 @@ fn collect_model_files(base_path: &Path, current_path: &Path) -> Vec<(PathBuf, u
     if let Ok(entries) = std::fs::read_dir(current_path) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_file() {
-                if let Ok(metadata) = std::fs::metadata(&path) {
-                    // Get relative path from base_path
-                    if let Ok(relative) = path.strip_prefix(base_path) {
-                        // Validate that the relative path does not contain any '..' components or is absolute
-                        let mut is_safe = true;
-                        for comp in relative.components() {
-                            use std::path::Component;
-                            match comp {
-                                Component::ParentDir
-                                | Component::RootDir
-                                | Component::Prefix(_) => {
-                                    is_safe = false;
-                                    break;
-                                }
-                                _ => {}
+            let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() {
+                tracing::warn!("Skipping symlink in model directory: {:?}", path);
+                continue;
+            }
+            if file_type.is_file() {
+                // Get relative path from base_path
+                if let Ok(relative) = path.strip_prefix(base_path) {
+                    // Validate that the relative path does not contain any '..' components or is absolute
+                    let mut is_safe = true;
+                    for comp in relative.components() {
+                        use std::path::Component;
+                        match comp {
+                            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                                is_safe = false;
+                                break;
                             }
-                        }
-                        if is_safe {
-                            files.push((relative.to_path_buf(), metadata.len()));
-                        } else {
-                            tracing::warn!(
-                                "Skipping potentially unsafe file path: {:?} (relative: {:?})",
-                                path,
-                                relative
-                            );
+                            _ => {}
                         }
                     }
+                    if is_safe {
+                        files.push((relative.to_path_buf(), metadata.len()));
+                    } else {
+                        tracing::warn!(
+                            "Skipping potentially unsafe file path: {:?} (relative: {:?})",
+                            path,
+                            relative
+                        );
+                    }
                 }
-            } else if path.is_dir() {
+            } else if file_type.is_dir() {
                 files.extend(collect_model_files(base_path, &path));
             }
         }
@@ -177,11 +200,13 @@ impl ModelService for ModelServiceImpl {
         let model_name = download::canonical_model_name(&model_request.model_name, provider)
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
         let ignore_weights = model_request.ignore_weights;
+        let tracker = self.tracker.clone();
+        let cache_dir = self.cache_dir.clone();
 
         // Spawn a task to handle the streaming download updates
         tokio::spawn(async move {
             // Check if the model is already downloaded
-            if let Some(status) = MODEL_TRACKER.get_status(&model_name) {
+            if let Some(status) = tracker.get_status(&model_name) {
                 let update = ModelStatusUpdate {
                     model_name: model_name.clone(),
                     status: modelexpress_common::grpc::model::ModelStatus::from(status) as i32,
@@ -206,8 +231,8 @@ impl ModelService for ModelServiceImpl {
             }
 
             // Start or monitor the download process
-            let final_status = MODEL_TRACKER
-                .ensure_model_downloaded(&model_name, provider, &tx, ignore_weights)
+            let final_status = tracker
+                .ensure_model_downloaded(&model_name, provider, &tx, cache_dir, ignore_weights)
                 .await;
 
             // Send final status update
@@ -259,8 +284,7 @@ impl ModelService for ModelServiceImpl {
         );
 
         // Get the cache directory
-        let cache_dir = get_server_cache_dir()
-            .ok_or_else(|| Status::internal("Server cache directory not configured"))?;
+        let cache_dir = self.cache_dir.clone();
 
         // Get the model path using the provider from the request
         let model_path = provider_impl
@@ -435,8 +459,7 @@ impl ModelService for ModelServiceImpl {
         info!("Listing files for model: {}", model_name);
 
         // Get the cache directory
-        let cache_dir = get_server_cache_dir()
-            .ok_or_else(|| Status::internal("Server cache directory not configured"))?;
+        let cache_dir = self.cache_dir.clone();
 
         // Get the model path using the provider from the request
         let model_path = provider_impl
@@ -487,12 +510,22 @@ impl Default for ModelDownloadTracker {
 impl ModelDownloadTracker {
     #[must_use]
     pub fn new() -> Self {
-        // Initialize database in the current directory
-        let database = match ModelDatabase::new("./models.db") {
+        Self::with_database_path(default_server_database_path())
+    }
+
+    #[must_use]
+    pub fn with_database_path(database_path: PathBuf) -> Self {
+        let database = match ModelDatabase::new(&database_path.to_string_lossy()) {
             Ok(db) => db,
             Err(e) => {
-                error!("Critical error: Could not initialize model database at ./models.db: {e}");
-                panic!("Critical error: Could not initialize model database at ./models.db");
+                error!(
+                    "Critical error: Could not initialize model database at {}: {e}",
+                    database_path.display()
+                );
+                panic!(
+                    "Critical error: Could not initialize model database at {}",
+                    database_path.display()
+                );
             }
         };
 
@@ -607,6 +640,7 @@ impl ModelDownloadTracker {
         model_name: &str,
         provider: ModelProvider,
         tx: &tokio::sync::mpsc::Sender<Result<ModelStatusUpdate, Status>>,
+        cache_dir: PathBuf,
         ignore_weights: bool,
     ) -> ModelStatus {
         // Atomically try to claim this model for download using compare-and-swap
@@ -665,14 +699,14 @@ impl ModelDownloadTracker {
                 // We claimed the model, so we're responsible for downloading it
                 let tracker = self.clone();
                 let model_name_owned = model_name.to_string();
+                let cache_dir = cache_dir.clone();
 
                 // Perform the download in the background
                 tokio::spawn(async move {
-                    let cache_dir = get_server_cache_dir();
                     match download::download_model(
                         &model_name_owned,
                         provider,
-                        cache_dir,
+                        Some(cache_dir),
                         ignore_weights,
                     )
                     .await
@@ -728,13 +762,13 @@ impl ModelDownloadTracker {
             // Start the download
             let tracker = self.clone();
             let model_name_owned = model_name.to_string();
+            let cache_dir = cache_dir.clone();
 
             tokio::spawn(async move {
-                let cache_dir = get_server_cache_dir();
                 match download::download_model(
                     &model_name_owned,
                     provider,
-                    cache_dir,
+                    Some(cache_dir),
                     ignore_weights,
                 )
                 .await
@@ -776,10 +810,6 @@ impl ModelDownloadTracker {
     }
 }
 
-/// Global model download tracker
-pub static MODEL_TRACKER: std::sync::LazyLock<ModelDownloadTracker> =
-    std::sync::LazyLock::new(ModelDownloadTracker::new);
-
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
@@ -791,6 +821,14 @@ mod tests {
     use tempfile::TempDir;
     use tokio_stream::StreamExt;
     use tonic::Request;
+
+    fn build_test_service() -> (ModelServiceImpl, TempDir) {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let cache_dir = temp_dir.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).expect("Failed to create cache dir");
+        let db_path = temp_dir.path().join("models.db");
+        (ModelServiceImpl::new(cache_dir, db_path), temp_dir)
+    }
 
     #[tokio::test]
     async fn test_health_service() {
@@ -915,7 +953,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_model_service_already_downloaded() {
-        let service = ModelServiceImpl;
+        let (service, _temp_dir) = build_test_service();
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("Time went backwards")
@@ -923,7 +961,7 @@ mod tests {
         let model_name = format!("test-already-downloaded-model-{timestamp}");
 
         // Pre-populate the model as downloaded
-        MODEL_TRACKER.set_status(
+        service.tracker.set_status(
             model_name.clone(),
             ModelStatus::DOWNLOADED,
             ModelProvider::HuggingFace,
@@ -955,7 +993,7 @@ mod tests {
         );
 
         // Cleanup
-        MODEL_TRACKER.delete_status(&model_name);
+        service.tracker.delete_status(&model_name);
     }
 
     #[test]
@@ -1024,7 +1062,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_model_service_stream_closes_properly() {
-        let service = ModelServiceImpl;
+        let (service, _temp_dir) = build_test_service();
         let model_name = "test-stream-model";
 
         let request = Request::new(ModelDownloadRequest {
@@ -1053,7 +1091,7 @@ mod tests {
         assert!(update_count > 0);
 
         // Cleanup
-        MODEL_TRACKER.delete_status(model_name);
+        service.tracker.delete_status(model_name);
     }
 
     #[tokio::test]
@@ -1151,9 +1189,26 @@ mod tests {
         assert!(paths.iter().any(|p| p.contains("nested_file")));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_collect_model_files_skips_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let outside = temp_dir.path().join("outside.txt");
+        std::fs::write(&outside, "outside").expect("Failed to write outside file");
+
+        let model_dir = temp_dir.path().join("model");
+        std::fs::create_dir(&model_dir).expect("Failed to create model dir");
+        symlink(&outside, model_dir.join("linked.bin")).expect("Failed to create symlink");
+
+        let files = collect_model_files(&model_dir, &model_dir);
+        assert!(files.is_empty(), "symlinked files must not be streamed");
+    }
+
     #[tokio::test]
     async fn test_list_model_files_not_found() {
-        let service = ModelServiceImpl;
+        let (service, _temp_dir) = build_test_service();
 
         let request = Request::new(ModelFilesRequest {
             model_name: "non-existent-model-12345".to_string(),
@@ -1169,7 +1224,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_stream_model_files_not_found() {
-        let service = ModelServiceImpl;
+        let (service, _temp_dir) = build_test_service();
 
         let request = Request::new(ModelFilesRequest {
             model_name: "non-existent-model-12345".to_string(),
@@ -1185,7 +1240,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ensure_model_downloaded_rejects_invalid_provider() {
-        let service = ModelServiceImpl;
+        let (service, _temp_dir) = build_test_service();
 
         let request = Request::new(ModelDownloadRequest {
             model_name: "test/model".to_string(),
@@ -1202,7 +1257,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_model_files_rejects_invalid_provider() {
-        let service = ModelServiceImpl;
+        let (service, _temp_dir) = build_test_service();
 
         let request = Request::new(ModelFilesRequest {
             model_name: "test/model".to_string(),
@@ -1219,7 +1274,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_stream_model_files_rejects_invalid_provider() {
-        let service = ModelServiceImpl;
+        let (service, _temp_dir) = build_test_service();
 
         let request = Request::new(ModelFilesRequest {
             model_name: "test/model".to_string(),
@@ -1239,11 +1294,6 @@ mod tests {
     async fn test_stream_model_files_hf_first_chunk_includes_commit_hash() {
         let env_lock = acquire_env_mutex();
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let _cache_dir_guard = EnvVarGuard::set(
-            &env_lock,
-            "MODEL_EXPRESS_CACHE_DIRECTORY",
-            temp_dir.path().to_str().expect("Expected temp dir path"),
-        );
         let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
 
         let model_dir = temp_dir.path().join("models--test--model/snapshots/abc123");
@@ -1251,7 +1301,10 @@ mod tests {
         std::fs::write(model_dir.join("config.json"), br#"{"model":"test"}"#)
             .expect("Failed to write model file");
 
-        let service = ModelServiceImpl;
+        let service = ModelServiceImpl::new(
+            temp_dir.path().to_path_buf(),
+            temp_dir.path().join("models.db"),
+        );
         let request = Request::new(ModelFilesRequest {
             model_name: "test/model".to_string(),
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
@@ -1280,18 +1333,16 @@ mod tests {
     async fn test_stream_model_files_hf_emits_chunk_for_zero_byte_file() {
         let env_lock = acquire_env_mutex();
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let _cache_dir_guard = EnvVarGuard::set(
-            &env_lock,
-            "MODEL_EXPRESS_CACHE_DIRECTORY",
-            temp_dir.path().to_str().expect("Expected temp dir path"),
-        );
         let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
 
         let model_dir = temp_dir.path().join("models--test--model/snapshots/abc123");
         std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
         std::fs::write(model_dir.join("empty.bin"), []).expect("Failed to write empty file");
 
-        let service = ModelServiceImpl;
+        let service = ModelServiceImpl::new(
+            temp_dir.path().to_path_buf(),
+            temp_dir.path().join("models.db"),
+        );
         let request = Request::new(ModelFilesRequest {
             model_name: "test/model".to_string(),
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,

--- a/modelexpress_server/src/state.rs
+++ b/modelexpress_server/src/state.rs
@@ -3,7 +3,7 @@
 
 //! State management for P2P model metadata.
 //!
-//! `P2pStateManager` wraps a metadata backend (Redis or Kubernetes CRD).
+//! `P2pStateManager` wraps a metadata backend (memory, Redis, or Kubernetes CRD).
 //! All state — model metadata and source status — is persisted to the backend,
 //! making the server stateless and horizontally scalable.
 
@@ -37,8 +37,8 @@ impl Default for P2pStateManager {
 impl P2pStateManager {
     /// Create a new state manager, resolving backend config from the environment.
     ///
-    /// Configure via `MX_METADATA_BACKEND` (required) and `REDIS_URL` /
-    /// `MX_REDIS_HOST` / `MX_REDIS_PORT` (for Redis).
+    /// Configure via `MX_METADATA_BACKEND` (defaults to `memory`) and
+    /// `REDIS_URL` / `MX_REDIS_HOST` / `MX_REDIS_PORT` (for Redis).
     pub fn new() -> Self {
         Self {
             backend: Arc::new(RwLock::new(None)),
@@ -66,7 +66,7 @@ impl P2pStateManager {
     /// Initialize the backend connection. Returns the backend type name on success.
     pub async fn connect(&self) -> MetadataResult<String> {
         let config = self.config.clone().ok_or(
-            "MX_METADATA_BACKEND is not set or invalid. Set it to 'redis' or 'kubernetes'.",
+            "MX_METADATA_BACKEND is invalid. Set it to 'memory', 'redis', or 'kubernetes'.",
         )?;
 
         let backend_name = config.to_string();
@@ -93,7 +93,7 @@ impl P2pStateManager {
         }
 
         let config = self.config.clone().ok_or(
-            "MX_METADATA_BACKEND is not set or invalid. Set it to 'redis' or 'kubernetes'.",
+            "MX_METADATA_BACKEND is invalid. Set it to 'memory', 'redis', or 'kubernetes'.",
         )?;
 
         let backend = create_backend(config.clone()).await?;
@@ -387,6 +387,12 @@ mod tests {
         let default_redis = "redis://localhost:6379";
         let default_ns = "default";
 
+        // Memory backend is the default and is also accepted explicitly
+        let config = BackendConfig::from_type_str("memory", default_redis, default_ns).expect("ok");
+        assert!(matches!(config, BackendConfig::Memory));
+        let config = BackendConfig::from_type_str("", default_redis, default_ns).expect("ok");
+        assert!(matches!(config, BackendConfig::Memory));
+
         // Redis
         let config =
             BackendConfig::from_type_str("redis", "redis://myhost:6379", default_ns).expect("ok");
@@ -402,8 +408,6 @@ mod tests {
 
         // Unknown returns Err
         assert!(BackendConfig::from_type_str("bogus", default_redis, default_ns).is_err());
-        assert!(BackendConfig::from_type_str("memory", default_redis, default_ns).is_err());
-        assert!(BackendConfig::from_type_str("", default_redis, default_ns).is_err());
 
         // Case insensitive
         let config = BackendConfig::from_type_str("REDIS", default_redis, default_ns).expect("ok");


### PR DESCRIPTION
## Summary
- add an in-memory metadata backend and make it the default so standalone/server-only deployments start cleanly
- bind the model service to the configured cache and database paths instead of falling back to process defaults
- prevent model file streaming from following symlinks outside the cache and add Python TLS channel handling for https endpoints

## Testing
- cargo test -q
- python3 -m pytest modelexpress_client/python/tests/test_client.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python client automatically detects and enables secure TLS connections when server address uses HTTPS protocol
  * Server metadata backend now includes memory option as default for standalone and development deployments

* **Improvements**
  * Enhanced model service initialization with configurable cache directories and database paths
  * Improved model file collection with proper symlink handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->