### PR TITLE
feat: Add option to select LIBFABRIC backend in NIXL

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -302,6 +302,7 @@ ModelExpress supports GPU-to-GPU model weight transfers between vLLM instances u
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
 | `MX_REGISTER_LOADERS` | `1` | Auto-register the mx loader with vLLM |
 | `MX_CONTIGUOUS_REG` | `0` | Contiguous region registration (experimental) |
+| `MX_NIXL_BACKEND` | `UCX` | NIXL backend for GPU-to-GPU RDMA. `UCX` (default) for InfiniBand / RoCE. `LIBFABRIC` for AWS EFA — see [NIXL Backend Selection](#nixl-backend-selection). |
 | `MX_RDMA_NIC_PIN` | (unset) | Per-rank IB NIC pinning. `auto` runs a topology probe; comma-separated NIC list is an explicit override. Workaround for openucx/ucx#11259. |
 | `MX_RDMA_NIC_PIN_MIN_RATE_GBPS` | (auto, max-rate filter) | Override the auto-detect rate filter with an explicit lower bound (Gb/s). |
 | `MODEL_EXPRESS_LOG_LEVEL` | (inherits vLLM) | Override log level for `modelexpress.*` loggers. `DEBUG` enables per-tensor checksums and adopted tensor details |
@@ -317,6 +318,21 @@ ModelExpress supports GPU-to-GPU model weight transfers between vLLM instances u
 | `VLLM_PLUGINS` | - | Set to `modelexpress` to register the mx loader |
 
 Each GPU worker publishes independently using its global rank (`torch.distributed.get_rank()`). No inter-worker coordination or barriers required.
+
+### NIXL Backend Selection
+
+`MX_NIXL_BACKEND` selects the NIXL plugin used for GPU-to-GPU RDMA.
+The default `UCX` covers InfiniBand and RoCE clusters. Set
+`MX_NIXL_BACKEND=LIBFABRIC` on AWS EFA, where the UCX backend can
+silently fall back to TCP depending on the libibverbs / EFA installer
+combination on the host.
+
+Both source and target workers must use the same backend — backends
+do not interoperate. Confirm via worker logs:
+
+```
+NIXL agent 'mx-auto-worker0-...' created on device 0 (backend=LIBFABRIC)
+```
 
 ### NIC Pinning (UCX Workaround)
 

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -35,9 +35,29 @@ except ImportError:
     pass
 
 
+SUPPORTED_NIXL_BACKENDS = ("UCX", "LIBFABRIC")
+DEFAULT_NIXL_BACKEND = "UCX"
+
+
 def is_nixl_available() -> bool:
     """Check if NIXL is available."""
     return NIXL_AVAILABLE
+
+
+def _resolve_nixl_backend() -> str:
+    """Resolve the NIXL backend from MX_NIXL_BACKEND.
+
+    Defaults to UCX. Set MX_NIXL_BACKEND=LIBFABRIC on AWS EFA.
+    """
+    import os
+
+    raw = os.environ.get("MX_NIXL_BACKEND", DEFAULT_NIXL_BACKEND).strip().upper()
+    if raw not in SUPPORTED_NIXL_BACKENDS:
+        raise ValueError(
+            f"MX_NIXL_BACKEND={raw!r} is not supported. "
+            f"Expected one of {SUPPORTED_NIXL_BACKENDS}."
+        )
+    return raw
 
 
 class NixlTransferManager:
@@ -58,6 +78,9 @@ class NixlTransferManager:
         self._agent_name = agent_name
         self._device_id = device_id
         self._listen_port = listen_port
+
+        self._backend = _resolve_nixl_backend()
+        self._backends = [self._backend]
 
         self._agent: Any = None
         self._metadata: bytes = b""
@@ -123,7 +146,7 @@ class NixlTransferManager:
         try:
             if self._listen_port is not None and nixl_agent_config:
                 config = nixl_agent_config(
-                    backends=["UCX"],
+                    backends=self._backends,
                     enable_listen_thread=True,
                     listen_port=self._listen_port,
                 )
@@ -131,11 +154,14 @@ class NixlTransferManager:
                     f"NIXL listen thread enabled on port {self._listen_port}"
                 )
             elif nixl_agent_config:
-                config = nixl_agent_config(backends=["UCX"])
+                config = nixl_agent_config(backends=self._backends)
             else:
                 config = None
             self._agent = NixlAgent(self._agent_name, config)
-            logger.info(f"NIXL agent '{self._agent_name}' created on device {self._device_id}")
+            logger.info(
+                f"NIXL agent '{self._agent_name}' created on device "
+                f"{self._device_id} (backend={self._backend})"
+            )
         finally:
             if saved_ucx_tls is not None:
                 os.environ["UCX_TLS"] = saved_ucx_tls
@@ -200,7 +226,7 @@ class NixlTransferManager:
             # Register regions using raw address tuples
             # Format: (addr, size, device_id, mem_type) - 4-tuple required by NIXL API
             region_tuples = [(r[0], r[1], self._device_id, "cuda") for r in regions]
-            self._agent.register_memory(region_tuples, mem_type="cuda", backends=["UCX"])
+            self._agent.register_memory(region_tuples, mem_type="cuda", backends=self._backends)
             self._registered_regions = regions
             logger.info(f"Registered {len(regions)} contiguous regions with NIXL")
             # Debug: Log first few registered region addresses
@@ -209,7 +235,7 @@ class NixlTransferManager:
         else:
             # Traditional: register individual tensors
             tensor_list = list(tensors.values())
-            self._agent.register_memory(tensor_list, backends=["UCX"])
+            self._agent.register_memory(tensor_list, backends=self._backends)
             self._registered_regions = None
             logger.info(f"Registered {len(tensor_list)} individual tensors with NIXL")
 
@@ -462,7 +488,7 @@ class NixlTransferManager:
             agent_name=remote_agent_name,
             xfer_list=remote_descs,
             mem_type="cuda",
-            backends=["UCX"],
+            backends=self._backends,
         )
 
         if use_raw_descriptors:
@@ -471,7 +497,7 @@ class NixlTransferManager:
                 agent_name="",
                 xfer_list=local_descs,
                 mem_type="cuda",
-                backends=["UCX"],
+                backends=self._backends,
             )
         else:
             # Use tensor objects
@@ -479,7 +505,7 @@ class NixlTransferManager:
                 agent_name="",
                 xfer_list=local_descs,
                 mem_type="cuda",
-                backends=["UCX"],
+                backends=self._backends,
             )
 
         indices = list(range(len(remote_descs)))
@@ -491,7 +517,7 @@ class NixlTransferManager:
             local_indices=indices,
             remote_xfer_side=src_prepped,
             remote_indices=indices,
-            backends=["UCX"],
+            backends=self._backends,
         )
         self._agent.transfer(handle)
 

--- a/modelexpress_client/python/tests/test_nixl_backend.py
+++ b/modelexpress_client/python/tests/test_nixl_backend.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MX_NIXL_BACKEND resolution in NixlTransferManager."""
+
+import pytest
+
+from modelexpress.nixl_transfer import (
+    DEFAULT_NIXL_BACKEND,
+    NixlTransferManager,
+    SUPPORTED_NIXL_BACKENDS,
+    _resolve_nixl_backend,
+)
+
+
+class TestResolveNixlBackend:
+    def test_default_is_ucx(self, monkeypatch):
+        monkeypatch.delenv("MX_NIXL_BACKEND", raising=False)
+        assert _resolve_nixl_backend() == "UCX"
+        assert DEFAULT_NIXL_BACKEND == "UCX"
+
+    def test_libfabric_explicit(self, monkeypatch):
+        monkeypatch.setenv("MX_NIXL_BACKEND", "LIBFABRIC")
+        assert _resolve_nixl_backend() == "LIBFABRIC"
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("MX_NIXL_BACKEND", "libfabric")
+        assert _resolve_nixl_backend() == "LIBFABRIC"
+
+    def test_whitespace_stripped(self, monkeypatch):
+        monkeypatch.setenv("MX_NIXL_BACKEND", "  ucx  ")
+        assert _resolve_nixl_backend() == "UCX"
+
+    def test_unknown_backend_raises(self, monkeypatch):
+        monkeypatch.setenv("MX_NIXL_BACKEND", "GDS_MT")
+        with pytest.raises(ValueError, match="MX_NIXL_BACKEND="):
+            _resolve_nixl_backend()
+
+    def test_supported_backends_contains_both(self):
+        assert "UCX" in SUPPORTED_NIXL_BACKENDS
+        assert "LIBFABRIC" in SUPPORTED_NIXL_BACKENDS
+
+
+class TestNixlTransferManagerBackend:
+    """Verify the manager picks up the env var at construction time."""
+
+    def test_default_backend_on_manager(self, monkeypatch):
+        monkeypatch.delenv("MX_NIXL_BACKEND", raising=False)
+        mgr = NixlTransferManager(agent_name="test", device_id=0)
+        assert mgr._backend == "UCX"
+        assert mgr._backends == ["UCX"]
+
+    def test_libfabric_backend_on_manager(self, monkeypatch):
+        monkeypatch.setenv("MX_NIXL_BACKEND", "LIBFABRIC")
+        mgr = NixlTransferManager(agent_name="test", device_id=0)
+        assert mgr._backend == "LIBFABRIC"
+        assert mgr._backends == ["LIBFABRIC"]
+
+    def test_invalid_value_fails_construction(self, monkeypatch):
+        monkeypatch.setenv("MX_NIXL_BACKEND", "bogus")
+        with pytest.raises(ValueError, match="MX_NIXL_BACKEND="):
+            NixlTransferManager(agent_name="test", device_id=0)


### PR DESCRIPTION
## Description

Adds `MX_NIXL_BACKEND` env var to select the NIXL transport plugin (`UCX` default, `LIBFABRIC` for AWS EFA). Replaces the 8 hardcoded `backends=["UCX"]` literals in `nixl_transfer.py` with a single value resolved once per `NixlTransferManager`. The default behavior is unchanged (UCX). 

**Issue it's solving:**
On AWS EFA, the UCX backend can fall back to TCP depending on the libibverbs / EFA installer combo on the host (in my case I have `libefa-rdmav59.so` installed, while `libibverbs` used by UCX is looking for `libefa-rdmav34.so`. When this happens, UCX silently falls back to TCP). `MX_NIXL_BACKEND=LIBFABRIC` routes through libfabric directly and matches what NCCL uses on the same hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MX_NIXL_BACKEND` environment variable support for configurable NIXL backend selection, supporting UCX (default) and LIBFABRIC options.
  * Enforced validation requirement that source and target workers use the same backend.

* **Documentation**
  * Added comprehensive NIXL backend configuration guidance and backend selection documentation.

* **Tests**
  * Added test suite validating backend selection functionality and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->