### PR TITLE
feat(model-streamer): distributed streaming and S3 URI support for --load-format mx

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -398,6 +398,7 @@ All storage backends (S3, GCS, Azure) are included as core dependencies — no e
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MX_MODEL_URI` | (none) | Model location. Must be set to enable ModelStreamer. Accepts: remote URI (`s3://bucket/model`, `gs://...`, `az://...`), absolute local path (`/models/deepseek-ai/DeepSeek-V3`), or HuggingFace model ID (`deepseek-ai/DeepSeek-V3` — resolved via `HF_HUB_CACHE`). |
+| `MX_MS_DISTRIBUTED` | `0` | Enable distributed streaming (streams directly to each worker's GPU). Requires tensor parallelism > 1 and a CUDA-capable platform. Set to `1` to activate. |
 | `RUNAI_STREAMER_CONCURRENCY` | `8` | Number of concurrent read threads |
 | `RUNAI_STREAMER_MEMORY_LIMIT` | (none) | CPU staging buffer size in bytes. `0` reuses a single-tensor buffer (most memory efficient). See [runai-model-streamer docs](https://github.com/run-ai/model-streamer). |
 

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-streamer-local.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-streamer-local.yaml
@@ -4,7 +4,8 @@
 # Single-node vLLM deployment with ModelExpress ModelStreamer (local disk).
 # Streams weights from PVC via runai-model-streamer with concurrent I/O.
 #
-# MX_MODEL_URI accepts:
+# MX_MODEL_URI activates the streamer; its value is passed to vllm via --model.
+# Accepts:
 #   - HF model ID: "deepseek-ai/DeepSeek-V3" (resolved via HF_HUB_CACHE)
 #   - Absolute path: "/models/my-model"
 #   - Remote URI: "s3://bucket/model" (see vllm-single-node-streamer-s3.yaml)
@@ -56,8 +57,6 @@ spec:
           env:
             - name: VLLM_RPC_TIMEOUT
               value: "7200000"
-            - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
             - name: HF_HUB_CACHE
               value: "/models"
             # HF model ID — resolved to snapshot path via HF_HUB_CACHE
@@ -70,7 +69,7 @@ spec:
             #   value: "modelexpress-server:8001"
           args:
             - --model
-            - $(MODEL_NAME)
+            - $(MX_MODEL_URI)
             - --load-format
             - mx
             - --tensor-parallel-size

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-streamer-s3.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-streamer-s3.yaml
@@ -57,8 +57,6 @@ spec:
           env:
             - name: VLLM_RPC_TIMEOUT
               value: "7200000"
-            - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-V3"
             # Update to your S3 bucket and region
             - name: MX_MODEL_URI
               value: "s3://my-bucket/deepseek-ai/DeepSeek-V3"
@@ -78,7 +76,7 @@ spec:
                 name: aws-creds
           args:
             - --model
-            - $(MODEL_NAME)
+            - $(MX_MODEL_URI)
             - --load-format
             - mx
             - --tensor-parallel-size

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -31,6 +31,7 @@ import torch.nn as nn
 
 from ... import configure_vllm_logging
 from ...load_strategy import LoadContext, LoadStrategyChain
+from ...load_strategy.model_streamer_strategy import _patch_vllm_s3_format_check
 from ...nixl_transfer import NixlTransferManager
 from .adapter import build_vllm_load_context
 
@@ -48,6 +49,11 @@ logger = logging.getLogger("modelexpress.engines.vllm.loader")
 # Global storage for tensor metadata, keyed by device_id (local CUDA ordinal).
 _tensor_registry: dict[int, dict[str, torch.Tensor]] = {}
 _nixl_managers: dict[int, NixlTransferManager] = {}
+
+
+# Install eagerly: vllm calls try_verify_and_update_config during engine init,
+# before LoadStrategyChain.run() would lazily import the strategy module.
+_patch_vllm_s3_format_check()
 
 
 @register_model_loader("mx")

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -27,46 +27,57 @@ logger = logging.getLogger("modelexpress.strategy_model_streamer")
 _LOG_INTERVAL_SECS = 30
 
 
-_REMOTE_SCHEMES = ("s3://", "gs://", "az://")
+def _patch_vllm_s3_format_check() -> None:
+    """Allow 'mx' as a valid load format when the model path is an object storage URI.
 
+    vllm's `try_verify_and_update_config` rejects any `load_format` other than
+    'runai_streamer'/'runai_streamer_sharded' when `model_config.model_weights`
+    is an object-storage URI. The guard is the only place inside that method
+    that consults `model_weights`, so we temporarily detach the attribute for
+    the duration of the call and restore it afterwards. This keeps
+    `load_format == 'mx'` truthful throughout verification.
 
-def _resolve_model_uri(uri: str) -> str:
-    """Resolve MX_MODEL_URI to a path that runai-model-streamer can read.
+    Co-located with ModelStreamerStrategy because that strategy is the only
+    consumer of object-storage URIs in the mx pathway. Installed eagerly from
+    `vllm_loader` at module-import time, before vllm runs verification.
 
-    - s3://, gs://, az:// -> pass through (remote storage)
-    - /absolute/path -> pass through (local filesystem)
-    - org/model-name -> resolve via HuggingFace Hub cache
-      (HF_HUB_CACHE, HF_HOME/hub, or ~/.cache/huggingface/hub)
+    No-ops gracefully if the vllm version does not have this check.
     """
-    if any(uri.startswith(s) for s in _REMOTE_SCHEMES) or os.path.isabs(uri):
-        return uri
-
     try:
-        from huggingface_hub import scan_cache_dir
-        cache_dir = os.environ.get("HF_HUB_CACHE")
-        if not cache_dir:
-            hf_home = os.environ.get("HF_HOME")
-            if hf_home:
-                cache_dir = os.path.join(hf_home, "hub")
-        cache_info = scan_cache_dir(cache_dir) if cache_dir else scan_cache_dir()
-        for repo in cache_info.repos:
-            if repo.repo_id == uri:
-                rev = max(repo.revisions, key=lambda r: r.last_modified)
-                logger.info(f"Resolved HF model '{uri}' -> {rev.snapshot_path}")
-                return str(rev.snapshot_path)
-    except Exception as e:
-        logger.warning(f"Failed to resolve HF cache for '{uri}': {e}")
+        from vllm.config import VllmConfig
+        from vllm.transformers_utils.runai_utils import is_runai_obj_uri
+    except ImportError:
+        return
 
-    return uri
+    original = VllmConfig.try_verify_and_update_config
+
+    def patched(self: VllmConfig) -> None:
+        if (
+            self.load_config.load_format == "mx"
+            and hasattr(self.model_config, "model_weights")
+            and is_runai_obj_uri(self.model_config.model_weights)
+        ):
+            saved = self.model_config.model_weights
+            del self.model_config.model_weights
+            try:
+                original(self)
+            finally:
+                self.model_config.model_weights = saved
+        else:
+            original(self)
+
+    VllmConfig.try_verify_and_update_config = patched
+    logger.debug("Patched VllmConfig.try_verify_and_update_config to allow 'mx' for object storage URIs")
 
 
 class ModelStreamerStrategy(LoadStrategy):
     """Load weights by streaming safetensors via runai-model-streamer.
 
-    Activated by setting MX_MODEL_URI. Supported formats:
-      - Remote: s3://bucket/model, gs://bucket/model, az://container/model
-      - Local absolute path: /models/deepseek-ai/DeepSeek-V3
-      - HF model ID: deepseek-ai/DeepSeek-V3 (resolved via HF_HUB_CACHE)
+    Activated by setting MX_MODEL_URI (gate only). The actual URI used to
+    stream weights is taken from `model_config.model_weights` if set
+    (object-storage URIs: s3://, gs://, az://) and falls back to
+    `model_config.model` otherwise (local paths, HF-resolved snapshots).
+    This mirrors vllm's runai_streamer_loader.
     """
 
     name = "model_streamer"
@@ -91,7 +102,7 @@ class ModelStreamerStrategy(LoadStrategy):
 
     def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
         result = _as_load_result(result)
-        model_uri = _resolve_model_uri(os.environ["MX_MODEL_URI"])
+        model_uri = getattr(ctx.model_config, "model_weights", None) or ctx.model_config.model
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting model streamer loading from {model_uri}")
         try:
@@ -129,9 +140,22 @@ class ModelStreamerStrategy(LoadStrategy):
             f"from {model_uri}"
         )
 
+        from vllm.platforms import current_platform
+
+        tp_size = getattr(ctx.vllm_config.parallel_config, "tensor_parallel_size", 1)
+        distributed = (
+            tp_size > 1
+            and current_platform.is_cuda_alike()
+            and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
+        )
+        stream_kwargs: dict = {}
+        if distributed:
+            stream_kwargs["device"] = f"cuda:{ctx.device_id}"
+            stream_kwargs["is_distributed"] = True
+
         start = time.perf_counter()
         with SafetensorsStreamer() as streamer:
-            streamer.stream_files(file_uris)
+            streamer.stream_files(file_uris, **stream_kwargs)
             total_tensors = sum(
                 len(meta) for meta in streamer.files_to_tensors_metadata.values()
             )

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -123,58 +123,63 @@ class TestModelStreamerLoad:
         from modelexpress.load_strategy.model_streamer_strategy import ModelStreamerStrategy
         return ModelStreamerStrategy()
 
+    def _make_ctx_with_uri(self, *, model_weights=None, model="ignored"):
+        model_config = MagicMock()
+        model_config.model_weights = model_weights
+        model_config.model = model
+        return _make_load_context(model_config=model_config)
+
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
     def test_success_path_s3(self, mock_register):
         model = MagicMock()
-        ctx = _make_load_context()
+        ctx = self._make_ctx_with_uri(model_weights="s3://bucket/model")
         strategy = self._make_strategy()
 
-        with patch.dict("os.environ", {"MX_MODEL_URI": "s3://bucket/model"}):
-            with patch(
-                "modelexpress.load_strategy.model_streamer_strategy."
-                "ModelStreamerStrategy._stream_weights"
-            ) as mock_stream:
-                mock_stream.return_value = iter([
-                    ("layer.0.weight", torch.randn(4, 4)),
-                    ("layer.1.weight", torch.randn(4, 4)),
-                ])
-                result = strategy.load(model, ctx)
+        with patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy._stream_weights"
+        ) as mock_stream:
+            mock_stream.return_value = iter([
+                ("layer.0.weight", torch.randn(4, 4)),
+                ("layer.1.weight", torch.randn(4, 4)),
+            ])
+            result = strategy.load(model, ctx)
 
         assert isinstance(result, LoadResult)
         assert result.model is model
+        mock_stream.assert_called_once_with("s3://bucket/model", ctx)
         model.load_weights.assert_called_once()
         mock_register.assert_called_once_with(result, ctx)
 
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
-    def test_success_path_local(self, mock_register):
-        """load() works with a local path in MX_MODEL_URI."""
+    def test_success_path_local_falls_back_to_model(self, mock_register):
+        """When model_weights is unset, the URI comes from model_config.model."""
         model = MagicMock()
-        ctx = _make_load_context()
+        ctx = self._make_ctx_with_uri(model_weights=None, model="/models/llama")
         strategy = self._make_strategy()
 
-        with patch.dict("os.environ", {"MX_MODEL_URI": "/models/llama"}):
-            with patch(
-                "modelexpress.load_strategy.model_streamer_strategy."
-                "ModelStreamerStrategy._stream_weights"
-            ) as mock_stream:
-                mock_stream.return_value = iter([
-                    ("layer.0.weight", torch.randn(4, 4)),
-                ])
-                result = strategy.load(model, ctx)
+        with patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy._stream_weights"
+        ) as mock_stream:
+            mock_stream.return_value = iter([
+                ("layer.0.weight", torch.randn(4, 4)),
+            ])
+            result = strategy.load(model, ctx)
 
         assert isinstance(result, LoadResult)
         mock_stream.assert_called_once_with("/models/llama", ctx)
 
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
-    def test_env_overrides_model_config(self, mock_register):
-        """MX_MODEL_URI takes priority over model_config.model."""
+    def test_uri_from_model_weights_not_from_env(self, mock_register):
+        """The streaming URI comes from model_config, not from MX_MODEL_URI."""
         model = MagicMock()
-        model_config = MagicMock()
-        model_config.model = "/models/local-llama"
-        ctx = _make_load_context(model_config=model_config)
+        ctx = self._make_ctx_with_uri(
+            model_weights="s3://bucket/from-config", model="/ignored"
+        )
         strategy = self._make_strategy()
 
-        with patch.dict("os.environ", {"MX_MODEL_URI": "s3://bucket/model"}):
+        with patch.dict("os.environ", {"MX_MODEL_URI": "s3://other/path-in-env"}):
             with patch(
                 "modelexpress.load_strategy.model_streamer_strategy."
                 "ModelStreamerStrategy._stream_weights"
@@ -183,22 +188,21 @@ class TestModelStreamerLoad:
                 with pytest.raises(StrategyFailed, match="expected"):
                     strategy.load(model, ctx)
 
-        mock_stream.assert_called_once_with("s3://bucket/model", ctx)
+        mock_stream.assert_called_once_with("s3://bucket/from-config", ctx)
 
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
     def test_raises_strategy_failed_on_error(self, mock_register):
         model = MagicMock()
-        ctx = _make_load_context()
+        ctx = self._make_ctx_with_uri(model_weights="s3://bucket/model")
         strategy = self._make_strategy()
 
-        with patch.dict("os.environ", {"MX_MODEL_URI": "s3://bucket/model"}):
-            with patch(
-                "modelexpress.load_strategy.model_streamer_strategy."
-                "ModelStreamerStrategy._stream_weights",
-                side_effect=RuntimeError("S3 connection failed"),
-            ):
-                with pytest.raises(StrategyFailed, match="S3 connection failed") as exc:
-                    strategy.load(model, ctx)
+        with patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy._stream_weights",
+            side_effect=RuntimeError("S3 connection failed"),
+        ):
+            with pytest.raises(StrategyFailed, match="S3 connection failed") as exc:
+                strategy.load(model, ctx)
 
         assert exc.value.mutated is False
         mock_register.assert_not_called()
@@ -249,88 +253,25 @@ class TestModelStreamerLoad:
 # ---------------------------------------------------------------------------
 
 
-class TestResolveModelUri:
-    def _resolve(self, uri, **env_overrides):
-        from modelexpress.load_strategy.model_streamer_strategy import _resolve_model_uri
-        with patch.dict("os.environ", env_overrides, clear=True):
-            return _resolve_model_uri(uri)
-
-    def test_s3_passthrough(self):
-        assert self._resolve("s3://bucket/model") == "s3://bucket/model"
-
-    def test_gs_passthrough(self):
-        assert self._resolve("gs://bucket/model") == "gs://bucket/model"
-
-    def test_az_passthrough(self):
-        assert self._resolve("az://container/model") == "az://container/model"
-
-    def test_absolute_path_passthrough(self):
-        assert self._resolve("/models/deepseek-ai/DeepSeek-V3") == "/models/deepseek-ai/DeepSeek-V3"
-
-    def _mock_hf_cache(self, repos):
-        mock_cache = MagicMock()
-        mock_cache.repos = repos
-        mock_scan = MagicMock(return_value=mock_cache)
-        mock_hf_hub = MagicMock()
-        mock_hf_hub.scan_cache_dir = mock_scan
-        return mock_hf_hub, mock_scan
-
-    def test_hf_model_id_resolved_via_cache(self):
-        mock_rev = MagicMock()
-        mock_rev.snapshot_path = "/cache/models--org--name/snapshots/abc123"
-        mock_rev.last_modified = 1000
-        mock_repo = MagicMock()
-        mock_repo.repo_id = "org/name"
-        mock_repo.revisions = [mock_rev]
-
-        mock_hf_hub, mock_scan = self._mock_hf_cache([mock_repo])
-        with patch.dict("sys.modules", {"huggingface_hub": mock_hf_hub}):
-            result = self._resolve("org/name", HF_HUB_CACHE="/cache")
-
-        assert result == "/cache/models--org--name/snapshots/abc123"
-        mock_scan.assert_called_once_with("/cache")
-
-    def test_hf_home_fallback_appends_hub(self):
-        mock_hf_hub, mock_scan = self._mock_hf_cache([])
-        with patch.dict("sys.modules", {"huggingface_hub": mock_hf_hub}):
-            self._resolve("org/name", HF_HOME="/home/user/.cache/huggingface")
-
-        mock_scan.assert_called_once_with("/home/user/.cache/huggingface/hub")
-
-    def test_unresolved_hf_id_returned_as_is(self):
-        mock_hf_hub, _ = self._mock_hf_cache([])
-        with patch.dict("sys.modules", {"huggingface_hub": mock_hf_hub}):
-            assert self._resolve("org/unknown-model", HF_HUB_CACHE="/cache") == "org/unknown-model"
-
-    def test_no_cache_env_scans_default_cache(self):
-        """When no cache env is set, scan_cache_dir() is called with no args (uses ~/.cache/huggingface/hub)."""
-        mock_hf_hub, mock_scan = self._mock_hf_cache([])
-        with patch.dict("sys.modules", {"huggingface_hub": mock_hf_hub}):
-            assert self._resolve("org/unknown") == "org/unknown"
-
-        mock_scan.assert_called_once_with()
-
-    def test_no_cache_env_resolves_via_default_cache(self):
-        """Model IDs can be resolved via the default HF cache even when no env vars are set."""
-        mock_rev = MagicMock()
-        mock_rev.snapshot_path = "/home/user/.cache/huggingface/hub/models--org--name/snapshots/abc123"
-        mock_rev.last_modified = 1000
-        mock_repo = MagicMock()
-        mock_repo.repo_id = "org/name"
-        mock_repo.revisions = [mock_rev]
-
-        mock_hf_hub, mock_scan = self._mock_hf_cache([mock_repo])
-        with patch.dict("sys.modules", {"huggingface_hub": mock_hf_hub}):
-            result = self._resolve("org/name")
-
-        assert result == "/home/user/.cache/huggingface/hub/models--org--name/snapshots/abc123"
-        mock_scan.assert_called_once_with()
-
-
 class TestStreamWeights:
     def _make_strategy(self):
         from modelexpress.load_strategy.model_streamer_strategy import ModelStreamerStrategy
         return ModelStreamerStrategy()
+
+    def _make_streamer_module(self, file_uris, tensors):
+        mock_streamer_instance = MagicMock()
+        mock_streamer_instance.__enter__ = MagicMock(return_value=mock_streamer_instance)
+        mock_streamer_instance.__exit__ = MagicMock(return_value=False)
+        mock_streamer_instance.files_to_tensors_metadata = {f: [MagicMock()] for f in file_uris}
+        mock_streamer_instance.get_tensors.return_value = iter(tensors)
+        mock_streamer_cls = MagicMock(return_value=mock_streamer_instance)
+        return (
+            MagicMock(
+                list_safetensors=MagicMock(return_value=file_uris),
+                SafetensorsStreamer=mock_streamer_cls,
+            ),
+            mock_streamer_instance,
+        )
 
     def test_raises_when_no_files(self):
         strategy = self._make_strategy()
@@ -347,6 +288,94 @@ class TestStreamWeights:
         }):
             with pytest.raises(FileNotFoundError, match="No safetensors files found"):
                 list(strategy._stream_weights("s3://empty-bucket/model", ctx))
+
+    def _make_ctx_with_tp(self, tp_size: int, device_id: int = 2):
+        ctx = _make_load_context(device_id=device_id)
+        parallel_config = MagicMock()
+        parallel_config.tensor_parallel_size = tp_size
+        ctx.vllm_config.parallel_config = parallel_config
+        return ctx
+
+    def _patch_cuda_alike(self, is_cuda: bool):
+        mock_platform = MagicMock()
+        mock_platform.is_cuda_alike.return_value = is_cuda
+        mock_platforms_mod = MagicMock()
+        mock_platforms_mod.current_platform = mock_platform
+        return patch.dict("sys.modules", {"vllm.platforms": mock_platforms_mod})
+
+    def test_distributed_disabled_by_default(self):
+        strategy = self._make_strategy()
+        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2)
+        file_uris = ["s3://bucket/model.safetensors"]
+        tensors = [("w", torch.randn(2, 2))]
+
+        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
+        with patch.dict("sys.modules", {"runai_model_streamer": module}):
+            with self._patch_cuda_alike(True):
+                with patch.dict("os.environ", {}, clear=True):
+                    list(strategy._stream_weights("s3://bucket/model", ctx))
+
+        streamer_instance.stream_files.assert_called_once_with(file_uris)
+
+    def test_distributed_enabled_by_mx_ms_distributed_1(self):
+        strategy = self._make_strategy()
+        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2)
+        file_uris = ["s3://bucket/model.safetensors"]
+        tensors = [("w", torch.randn(2, 2))]
+
+        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
+        with patch.dict("sys.modules", {"runai_model_streamer": module}):
+            with self._patch_cuda_alike(True):
+                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                    list(strategy._stream_weights("s3://bucket/model", ctx))
+
+        streamer_instance.stream_files.assert_called_once_with(
+            file_uris, device="cuda:2", is_distributed=True
+        )
+
+    def test_distributed_disabled_when_tp_is_1(self):
+        strategy = self._make_strategy()
+        ctx = self._make_ctx_with_tp(tp_size=1, device_id=0)
+        file_uris = ["s3://bucket/model.safetensors"]
+        tensors = [("w", torch.randn(2, 2))]
+
+        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
+        with patch.dict("sys.modules", {"runai_model_streamer": module}):
+            with self._patch_cuda_alike(True):
+                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                    list(strategy._stream_weights("s3://bucket/model", ctx))
+
+        streamer_instance.stream_files.assert_called_once_with(file_uris)
+
+    def test_distributed_disabled_on_non_cuda_platform(self):
+        strategy = self._make_strategy()
+        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2)
+        file_uris = ["s3://bucket/model.safetensors"]
+        tensors = [("w", torch.randn(2, 2))]
+
+        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
+        with patch.dict("sys.modules", {"runai_model_streamer": module}):
+            with self._patch_cuda_alike(False):
+                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                    list(strategy._stream_weights("s3://bucket/model", ctx))
+
+        streamer_instance.stream_files.assert_called_once_with(file_uris)
+
+    def test_distributed_device_id_used_in_cuda_device(self):
+        strategy = self._make_strategy()
+        ctx = self._make_ctx_with_tp(tp_size=8, device_id=5)
+        file_uris = ["s3://bucket/model.safetensors"]
+        tensors = [("w", torch.randn(2, 2))]
+
+        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
+        with patch.dict("sys.modules", {"runai_model_streamer": module}):
+            with self._patch_cuda_alike(True):
+                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                    list(strategy._stream_weights("s3://bucket/model", ctx))
+
+        streamer_instance.stream_files.assert_called_once_with(
+            file_uris, device="cuda:5", is_distributed=True
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# feat(model-streamer): distributed streaming and S3 URI support for `--load-format mx`

## Summary

- **`MX_MS_DISTRIBUTED`**: New environment variable that enables distributed safetensors
  streaming via the model streamer load strategy when using tensor parallelism. When set
  to `1`, each worker streams and broadcasts a unique part of the model to the other processes via GPU-to-GPU communication, rather than each worker downloading the full checkpoint. Requires `tensor_parallel_size > 1`
  and a CUDA-capable platform; defaults to `0` (disabled) similar to the upstream `distributed` flag.

- **S3/GCS URI support with `--load-format mx`**: vLLM rejects `--load-format mx` when
  the `--model` argument is an object storage URI (`s3://`, `gs://`), because it only
  permits `runai_streamer` or `runai_streamer_sharded` in that path. A lightweight
  monkey-patch on `VllmConfig.try_verify_and_update_config` temporarily swaps the format
  to `runai_streamer` during validation, then restores `mx` so `MxModelLoader` handles
  the actual loading. Note: `MX_MODEL_URI` must still be set to trigger the model
  streamer load strategy in the current design.

## Tests

Unit tests added in `test_model_streamer_strategy.py` covering all branches of the
distributed streaming logic: default-off behavior, activation via `MX_MS_DISTRIBUTED=1`,
no-op when `tensor_parallel_size=1`, no-op on non-CUDA platforms, and correct
`cuda:{device_id}` assignment per worker.


## Testing

Validated end-to-end on an AWS g5.12xlarge (4× A10G) with `vllm==0.20.1`:

```bash
# Distributed streaming with TP=2 from S3
MX_MODEL_URI=s3://core-llm/Llama-3-8b/ MX_MS_DISTRIBUTED=1 \
  vllm serve s3://core-llm/Llama-3-8b/ \
  --tensor-parallel-size 2 --enforce-eager --load-format mx
```

Log confirms 2-way distributed streaming:
```
[Worker 0] Streaming: 291/291 tensors (100%) in 8s   # 7.5 GiB / worker
[Worker 0] MxModelLoader.load_model() COMPLETE in 8.90s
[Worker 1] MxModelLoader.load_model() COMPLETE in 8.90s
Application startup complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MX_MS_DISTRIBUTED` configuration option to enable distributed weight streaming directly to each worker's GPU on multi-GPU systems.

* **Documentation**
  * Documented `MX_MS_DISTRIBUTED` option requirements: tensor parallelism > 1 and CUDA-capable platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->