### PR TITLE
refactor: organize engine and metadata loading paths

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,23 +123,35 @@ ModelExpress/
 │   └── modelexpress/
 │       ├── __init__.py                 # Package init, vLLM loader auto-registration
 │       ├── client.py                   # MxClient gRPC client
-│       ├── heartbeat.py                # Client-side heartbeat for source liveness
 │       ├── nixl_transfer.py            # NixlTransferManager
 │       ├── gds_transfer.py             # GPUDirect Storage transfer support
 │       ├── gds_loader.py               # GDS model loader
-│       ├── vllm_loader.py              # MxModelLoader (thin orchestration)
+│       ├── adapter.py                  # EngineAdapter contract and strategy errors
+│       ├── vllm_loader.py              # Compatibility shim for engines.vllm.loader
+│       ├── metadata/                   # Metadata clients, publishing, heartbeat, worker manifest service
+│       │   ├── __init__.py
+│       │   ├── publish.py              # Source identity + metadata publication
+│       │   ├── heartbeat.py            # Client-side heartbeat for source liveness
+│       │   ├── worker_server.py        # WorkerGrpcServer (P2P tensor manifest)
+│       │   ├── source_id.py            # Python mx_source_id computation
+│       │   ├── client_factory.py       # Selects central vs k8s-service metadata client
+│       │   └── k8s_service_client.py   # Decentralized k8s-service metadata client
 │       ├── load_strategy/              # Loading strategy chain
 │       │   ├── __init__.py             # LoadStrategyChain.run()
-│       │   ├── base.py                 # LoadStrategy ABC, LoadContext, shared helpers
+│       │   ├── context.py              # LoadContext and LoadResult
+│       │   ├── base.py                 # LoadStrategy ABC and shared helpers
 │       │   ├── rdma_strategy.py        # RdmaStrategy (P2P GPU transfer via NIXL)
 │       │   ├── model_streamer_strategy.py # ModelStreamerStrategy (S3/GCS/Azure/local)
 │       │   ├── gds_strategy.py         # GdsStrategy (GPUDirect Storage)
-│       │   └── default_strategy.py     # DefaultStrategy (vLLM DefaultModelLoader)
+│       │   └── default_strategy.py     # DefaultStrategy (engine-native fallback)
+│       ├── engines/
+│       │   └── vllm/                   # vLLM integration
+│       │       ├── __init__.py         # vLLM loader registration
+│       │       ├── adapter.py          # VllmAdapter and context builder
+│       │       └── loader.py           # MxModelLoader implementation
 │       ├── tensor_utils.py             # Tensor collection, checksums, storage views
 │       ├── transfer_safety.py          # MLA feature gate, TransferFingerprint
-│       ├── metadata.py                 # Metadata building and publishing
 │       ├── rank_utils.py               # Rank detection utilities
-│       ├── worker_server.py            # WorkerGrpcServer (P2P tensor manifest)
 │       ├── vllm_worker.py              # ModelExpressWorker (custom vLLM worker)
 │       ├── types.py                    # TensorDescriptor, WorkerMetadata dataclasses
 │       ├── p2p_pb2.py                  # Generated protobuf stubs
@@ -491,16 +503,16 @@ Loading precedence: CLI args > environment variables > config file > defaults.
 |--------|---------|
 | `__init__.py` | Package init, exports `register_modelexpress_loaders()` for callers to register the `mx` loader with vLLM |
 | `client.py` | `MxClient` - gRPC client wrapping `PublishMetadata`, `ListSources`, `GetMetadata`, and `UpdateStatus` RPCs |
-| `heartbeat.py` | `HeartbeatThread` - background thread sending periodic `UpdateStatus(READY)` and `STALE` on shutdown |
 | `nixl_transfer.py` | `NixlTransferManager` - NIXL agent lifecycle, tensor registration, RDMA transfers |
 | `gds_transfer.py` | GPUDirect Storage availability check and transfer utilities |
 | `gds_loader.py` | `MxGdsLoader` - GDS-based model loader (direct file-to-GPU) |
-| `vllm_loader.py` | `MxModelLoader` - thin orchestration, delegates to `LoadStrategyChain` |
-| `load_strategy/` | Loading strategy chain: `RdmaStrategy`, `ModelStreamerStrategy` (S3/GCS/Azure/local), `GdsStrategy`, `DefaultStrategy` |
+| `adapter.py` | `EngineAdapter` lifecycle hooks and strategy retry errors |
+| `vllm_loader.py` | Compatibility shim for `modelexpress.engines.vllm.loader` |
+| `metadata/` | Metadata publishing, source identity, heartbeat, worker manifest serving, metadata client selection |
+| `load_strategy/` | Engine-neutral loading strategy chain: `RdmaStrategy`, `ModelStreamerStrategy` (S3/GCS/Azure/local), `GdsStrategy`, `DefaultStrategy` |
+| `engines/vllm/` | `VllmAdapter` and `MxModelLoader` - maps strategy hooks to vLLM loader APIs and post-load lifecycle |
 | `tensor_utils.py` | Tensor collection, checksums, storage views, `capture_tensor_attrs` |
-| `metadata.py` | `build_source_identity`, `publish_metadata_and_ready`, retry logic |
 | `rank_utils.py` | `get_global_rank`, `get_worker_rank` |
-| `worker_server.py` | `WorkerGrpcServer` - per-worker gRPC server for P2P tensor manifest exchange |
 | `vllm_worker.py` | `ModelExpressWorker` - custom vLLM worker class (use `--worker-cls=modelexpress.vllm_worker.ModelExpressWorker`) |
 | `types.py` | `TensorDescriptor`, `WorkerMetadata`, `GetMetadataResponse` dataclasses |
 | `p2p_pb2.py` / `p2p_pb2_grpc.py` | Generated protobuf/gRPC stubs |
@@ -540,16 +552,16 @@ Thin orchestration layer that delegates to `LoadStrategyChain.run()`. Builds a `
 
 **LoadStrategyChain** (`load_strategy/`):
 
-Auto-detects the best loading strategy with a prioritized chain. Each strategy is a subclass of `LoadStrategy` (ABC) with `is_available(ctx)` and `load(model, ctx)` methods. The chain filters to eligible strategies and runs them in order until one succeeds:
+Auto-detects the best loading strategy with a prioritized chain. Each strategy is a subclass of `LoadStrategy` (ABC) with `is_available(ctx)` and `load(result, ctx)` methods. Engine-specific work is delegated to `ctx.adapter`; `LoadResult` carries the value returned to the engine plus the model used for tensor discovery and publication. The chain filters to eligible strategies and runs them in order until one succeeds:
 
 | Priority | Strategy | `is_available()` | Behavior |
 |---|---|---|---|
 | p0 | `RdmaStrategy` | NIXL available | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). On `SourceTransferError` or `ManifestMismatchError`, try next. |
 | p1 | `ModelStreamerStrategy` | `MX_MODEL_URI` set + `runai_model_streamer` installed | Stream safetensors to GPU via CPU staging buffer. `MX_MODEL_URI` accepts remote URIs (`s3://`, `gs://`, `az://`), absolute local paths, or HF model IDs (resolved via `HF_HUB_CACHE`). All storage backends (S3, GCS, Azure) included by default. |
 | p2 | `GdsStrategy` | GDS hardware available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. |
-| p3 | `DefaultStrategy` | Always | vLLM `DefaultModelLoader` (CPU-staged, auto-downloads from HF Hub). |
+| p3 | `DefaultStrategy` | Engine native fallback loader available | Native loader fallback (for vLLM, `DefaultModelLoader`, CPU-staged, auto-downloads from HF Hub). |
 
-Each strategy is fully self-contained: it handles weight loading, post-processing (`process_weights_after_loading`), NIXL tensor registration, and metadata publishing. New strategies can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
+Strategies handle the loading path and NIXL tensor registration. Adapter hooks handle engine lifecycle such as vLLM `process_weights_after_loading`, and the chain performs best-effort metadata publication after a successful strategy. New strategies can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
 
 ### Transfer Safety
 

--- a/examples/dynamo_p2p_transfer_k8s/vllm/rbac-modelmetadata.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/rbac-modelmetadata.yaml
@@ -56,6 +56,27 @@ rules:
       - update
       - patch
       - delete
+  # ModelCacheEntry CRD for the registry backend (same MX_METADATA_BACKEND value).
+  - apiGroups:
+      - modelexpress.nvidia.com
+    resources:
+      - modelcacheentries
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  # ModelCacheEntry status subresource
+  - apiGroups:
+      - modelexpress.nvidia.com
+    resources:
+      - modelcacheentries/status
+    verbs:
+      - get
+      - update
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -68,9 +89,11 @@ roleRef:
   kind: Role
   name: modelexpress-metadata
 subjects:
+  # subjects[].namespace omitted on purpose: for a namespaced RoleBinding,
+  # a ServiceAccount subject without an explicit namespace resolves to the
+  # RoleBinding's own namespace (whatever `kubectl apply -n <ns>` lands in).
   - kind: ServiceAccount
     name: modelexpress
-    namespace: default  # Change to your target namespace
 ---
 # ClusterRole for CRD management (cluster-admin typically handles this)
 # Only needed if server creates/manages the CRD itself

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -119,13 +119,6 @@ spec:
         - name: UCX_RNDV_THRESH
           value: "0"
       extraPodSpec:
-        tolerations:
-          - key: nvidia.com/gpu
-            operator: Exists
-            effect: NoSchedule
-          - key: dra
-            operator: Exists
-            effect: NoSchedule
         # Keep decode replicas apart, but allow one decode and one prefill
         # worker to share an 8-GPU node so all GPUs can be utilized.
         affinity:
@@ -157,6 +150,8 @@ spec:
             - --trust-remote-code
             - --disaggregation-mode
             - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
       volumeMounts:
         - name: shared-model-cache
           mountPoint: /models
@@ -199,13 +194,6 @@ spec:
         - name: UCX_RNDV_THRESH
           value: "0"
       extraPodSpec:
-        tolerations:
-          - key: nvidia.com/gpu
-            operator: Exists
-            effect: NoSchedule
-          - key: dra
-            operator: Exists
-            effect: NoSchedule
         # Keep prefill replicas apart, but allow one decode and one prefill
         # worker to share an 8-GPU node so all GPUs can be utilized.
         affinity:

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -150,8 +150,6 @@ spec:
             - --trust-remote-code
             - --disaggregation-mode
             - decode
-            - --kv-transfer-config
-            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
       volumeMounts:
         - name: shared-model-cache
           mountPoint: /models

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -102,7 +102,9 @@ register_modelexpress_loaders()
 | Module | Description |
 |--------|-------------|
 | `modelexpress.client` | `MxClient` -- gRPC client for the ModelExpress server |
-| `modelexpress.vllm_loader` | `MxModelLoader` -- vLLM integration |
+| `modelexpress.metadata` | Metadata clients, source identity, heartbeat, and worker manifest serving |
+| `modelexpress.engines.vllm.loader` | `MxModelLoader` -- vLLM integration |
+| `modelexpress.vllm_loader` | Compatibility shim for the vLLM loader |
 | `modelexpress.nixl_transfer` | `NixlTransferManager` -- NIXL agent lifecycle and RDMA transfers |
 | `modelexpress.types` | `TensorDescriptor`, `WorkerMetadata` -- core data types |
 | `modelexpress.vllm_worker` | vLLM worker extensions |

--- a/modelexpress_client/python/modelexpress/__init__.py
+++ b/modelexpress_client/python/modelexpress/__init__.py
@@ -60,8 +60,9 @@ def register_modelexpress_loaders():
     if _loaders_registered:
         return
 
-    # Import triggers @register_model_loader decorators on the classes
-    from . import vllm_loader  # noqa: F401
+    from .engines.vllm import register_modelexpress_loaders as register_vllm_loaders
+
+    register_vllm_loaders()
 
     _loaders_registered = True
     _logger.debug("ModelExpress loader registered: mx")
@@ -70,7 +71,7 @@ def register_modelexpress_loaders():
 from .client import MxClient  # noqa: F401
 from .gds_loader import MxGdsLoader  # noqa: F401
 from .gds_transfer import GdsTransferManager  # noqa: F401
-from .heartbeat import HeartbeatThread  # noqa: F401
+from .metadata.heartbeat import HeartbeatThread  # noqa: F401
 
 __all__ = [
     "GdsTransferManager",

--- a/modelexpress_client/python/modelexpress/adapter.py
+++ b/modelexpress_client/python/modelexpress/adapter.py
@@ -52,26 +52,54 @@ def gated_capability(method):
 
 
 class EngineAdapter:
-    """Optional-method integration contract implemented by each engine."""
+    """Engine-specific boundary used by shared loading strategies.
+
+    Load strategies own ModelExpress policy: fallback order, metadata
+    publishing, RDMA transfer, and retry decisions. Engine adapters own the
+    operations that depend on a framework's model object, device mapping, and
+    post-load processing rules.
+
+    Methods decorated with @gated_capability are optional capabilities. A
+    strategy lists the exact adapter methods it needs in its `requires` tuple;
+    the strategy is eligible only when the concrete engine overrides those
+    methods. Plain lifecycle hooks below are no-op by default because they are
+    safe extension points around an already-selected strategy.
+    """
 
     @gated_capability
     def build_identity(self) -> p2p_pb2.SourceIdentity:
+        """Return the stable identity used to match compatible source workers."""
         ...
 
     @gated_capability
     def get_worker_rank(self) -> int:
+        """Return the model-shard key used to pair source and target workers.
+
+        Data-parallel replicas should normally return the same key because
+        their weights are interchangeable. Tensor, pipeline, and expert
+        parallel shards should return distinct keys when they own distinct
+        model weights.
+        """
         ...
 
     @gated_capability
     def get_global_rank(self) -> int:
+        """Return the engine's global distributed rank for logging and metadata."""
         ...
 
     @gated_capability
     def get_device_id(self) -> int:
+        """Return the local CUDA device id owned by this adapter instance."""
         ...
 
     @gated_capability
     def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
+        """Return publishable tensors from the loaded engine model.
+
+        Strategies call this after weights are ready. Implementations may run
+        engine-specific tensor adoption or normalization before collecting the
+        tensors, but should not change model weights.
+        """
         ...
 
     @gated_capability
@@ -80,41 +108,50 @@ class EngineAdapter:
         result: LoadResult,
         weights_iter: Iterator[tuple[str, torch.Tensor]],
     ) -> LoadResult:
+        """Apply a stream of named tensors to the engine model.
+
+        This hook may mutate model weights. If a strategy catches an exception
+        from this method, it should raise StrategyFailed(mutated=True) so the
+        chain reinitializes the model before trying another strategy.
+        """
         ...
 
     @gated_capability
     def load_via_native(self, result: LoadResult) -> LoadResult:
+        """Load the model using the engine's native disk/checkpoint loader."""
         ...
 
     @gated_capability
     def reinit_for_retry(self, result: LoadResult) -> LoadResult:
+        """Replace a possibly-mutated model with a fresh engine model instance."""
         ...
 
     def get_unique_id(self) -> str:
+        """Return a best-effort unique id for engines without custom identity."""
         if torch.distributed.is_available() and torch.distributed.is_initialized():
             return f"rank-{torch.distributed.get_rank()}"
         return f"pid-{os.getpid()}"
 
     def get_target_device(self) -> torch.device:
+        """Return the torch device where target model state should live."""
         return torch.device(f"cuda:{self.get_device_id()}")
 
     def prepare_rdma_target(self, result: LoadResult) -> LoadResult:
+        """Prepare target-side model storage before receiving RDMA weights."""
         return result
 
     def before_rdma_receive(self, result: LoadResult) -> LoadResult:
+        """Run engine post-processing needed before RDMA writes into tensors."""
         return result
 
     def after_rdma_receive(self, result: LoadResult) -> LoadResult:
+        """Run engine post-processing after RDMA weights have been received."""
         return result
 
     def after_weight_iter_load(self, result: LoadResult) -> LoadResult:
+        """Run engine post-processing after apply_weight_iter() succeeds."""
         return result
 
     def after_native_load(self, result: LoadResult) -> LoadResult:
+        """Run engine post-processing after load_via_native() succeeds."""
         return result
-
-    def unpublish(self, result: LoadResult) -> None:
-        return None
-
-    def cleanup(self, result: LoadResult) -> None:
-        return None

--- a/modelexpress_client/python/modelexpress/adapter.py
+++ b/modelexpress_client/python/modelexpress/adapter.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Engine adapter contract for ModelExpress loading strategies."""
+
+from __future__ import annotations
+
+import functools
+import os
+from typing import TYPE_CHECKING, Iterator
+
+import torch
+
+from . import p2p_pb2
+
+if TYPE_CHECKING:
+    from .load_strategy.context import LoadResult
+
+
+class UnsupportedCapability(NotImplementedError):
+    """Raised by default bodies for adapter capabilities."""
+
+
+class StrategyFailed(RuntimeError):
+    """A strategy failed but the chain may try the next strategy."""
+
+    def __init__(self, message: str, *, mutated: bool = False):
+        super().__init__(message)
+        self.mutated = mutated
+
+
+def gated_capability(method):
+    """Create an optional adapter method that engines must override to support it.
+
+    Strategies compare their required EngineAdapter methods by object identity.
+    If an engine inherits this default method, the strategy is not eligible; if
+    the engine overrides it, the strategy may call the engine implementation.
+    Calling the inherited default still raises UnsupportedCapability.
+    """
+
+    @functools.wraps(method)
+    def default(self, *args, **kwargs):
+        raise UnsupportedCapability(method.__name__)
+
+    default.__gated_capability__ = True
+    return default
+
+
+class EngineAdapter:
+    """Optional-method integration contract implemented by each engine."""
+
+    @gated_capability
+    def build_identity(self) -> p2p_pb2.SourceIdentity:
+        ...
+
+    @gated_capability
+    def get_worker_rank(self) -> int:
+        ...
+
+    @gated_capability
+    def get_device_id(self) -> int:
+        ...
+
+    @gated_capability
+    def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
+        ...
+
+    @gated_capability
+    def apply_weight_iter(
+        self,
+        result: LoadResult,
+        weights_iter: Iterator[tuple[str, torch.Tensor]],
+    ) -> LoadResult:
+        ...
+
+    @gated_capability
+    def load_via_native(self, result: LoadResult) -> LoadResult:
+        ...
+
+    @gated_capability
+    def reinit_for_retry(self, result: LoadResult) -> LoadResult:
+        ...
+
+    def get_unique_id(self) -> str:
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            return f"rank-{torch.distributed.get_rank()}"
+        return f"pid-{os.getpid()}"
+
+    def get_target_device(self) -> torch.device:
+        return torch.device(f"cuda:{self.get_device_id()}")
+
+    def prepare_rdma_target(self, result: LoadResult) -> LoadResult:
+        return result
+
+    def before_rdma_receive(self, result: LoadResult) -> LoadResult:
+        return result
+
+    def after_rdma_receive(self, result: LoadResult) -> LoadResult:
+        return result
+
+    def after_weight_iter_load(self, result: LoadResult) -> LoadResult:
+        return result
+
+    def after_native_load(self, result: LoadResult) -> LoadResult:
+        return result
+
+    def unpublish(self, result: LoadResult) -> None:
+        return None
+
+    def cleanup(self, result: LoadResult) -> None:
+        return None

--- a/modelexpress_client/python/modelexpress/adapter.py
+++ b/modelexpress_client/python/modelexpress/adapter.py
@@ -22,7 +22,12 @@ class UnsupportedCapability(NotImplementedError):
 
 
 class StrategyFailed(RuntimeError):
-    """A strategy failed but the chain may try the next strategy."""
+    """Expected strategy miss that lets the chain try the next strategy.
+
+    Set mutated=True when the current strategy may have changed model weights
+    or model structure before failing. The chain will run rollback() for
+    strategy-owned cleanup, then ask the adapter to re-initialize the model.
+    """
 
     def __init__(self, message: str, *, mutated: bool = False):
         super().__init__(message)
@@ -55,6 +60,10 @@ class EngineAdapter:
 
     @gated_capability
     def get_worker_rank(self) -> int:
+        ...
+
+    @gated_capability
+    def get_global_rank(self) -> int:
         ...
 
     @gated_capability

--- a/modelexpress_client/python/modelexpress/engines/__init__.py
+++ b/modelexpress_client/python/modelexpress/engines/__init__.py
@@ -1,8 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compatibility import path for the vLLM ModelExpress loader."""
-
-from .engines.vllm.loader import MxModelLoader
-
-__all__ = ["MxModelLoader"]
+"""Compatibility adapters for supported inference engines."""

--- a/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM compatibility integration for ModelExpress."""
+
+from .adapter import VllmAdapter, build_vllm_load_context
+
+_loaders_registered = False
+
+
+def register_modelexpress_loaders() -> None:
+    """Register ModelExpress's vLLM loader."""
+    global _loaders_registered
+    if _loaders_registered:
+        return
+    from . import loader  # noqa: F401
+
+    _loaders_registered = True
+
+
+__all__ = [
+    "VllmAdapter",
+    "build_vllm_load_context",
+    "register_modelexpress_loaders",
+]

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -145,6 +145,13 @@ class VllmAdapter(EngineAdapter):
 
     def _reset_compilation_state(self) -> None:
         compilation_config = self.vllm_config.compilation_config
+        # vLLM registers each attention / MLA / Mamba / FusedMoE layer into
+        # fields on vllm_config.compilation_config during initialize_model().
+        # Those fields live on the config object, not the model, so they survive
+        # del model and trip duplicate registration on the next initialize_model().
+        # Clear them so re-init starts from a clean slate. Audited against vLLM
+        # 0.17.1; other versions may add init=False fields that need similar
+        # treatment.
         compilation_config.static_forward_context.clear()
         compilation_config.static_all_moe_layers.clear()
         compilation_config.enabled_custom_ops.clear()

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM implementation of the ModelExpress engine adapter contract."""
+
+from __future__ import annotations
+
+import copy
+import logging
+import uuid
+from typing import Iterator
+
+import torch
+
+from ...adapter import EngineAdapter
+from ...load_strategy.context import LoadContext, LoadResult
+from ...metadata.client_factory import create_metadata_client
+from ...metadata.publish import build_source_identity
+from ...rank_utils import get_global_rank, get_worker_rank
+from ...tensor_utils import adopt_hidden_tensors, capture_tensor_attrs, collect_module_tensors
+
+logger = logging.getLogger("modelexpress.engines.vllm.adapter")
+
+
+class VllmAdapter(EngineAdapter):
+    """Adapter that maps strategy hooks onto vLLM's native loader APIs."""
+
+    def __init__(self, vllm_config, model_config):
+        self.vllm_config = vllm_config
+        self.model_config = model_config
+        self.load_config = vllm_config.load_config
+        self.target_device = self._resolve_target_device()
+
+    def build_identity(self):
+        return build_source_identity(self.vllm_config, self.model_config)
+
+    def get_worker_rank(self) -> int:
+        return get_worker_rank(self.target_device)
+
+    def get_global_rank(self) -> int:
+        return get_global_rank(self.target_device)
+
+    def get_device_id(self) -> int:
+        return get_worker_rank(self.target_device)
+
+    def get_target_device(self) -> torch.device:
+        return self.target_device
+
+    def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
+        if result.model is None:
+            raise RuntimeError("vLLM tensor discovery requires result.model")
+        adopt_hidden_tensors(result.model)
+        return collect_module_tensors(result.model)
+
+    def prepare_rdma_target(self, result: LoadResult) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("vLLM RDMA target preparation requires result.model")
+
+        from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
+
+        dummy_config = copy.copy(self.load_config)
+        try:
+            dummy_config.load_format = "dummy"
+        except AttributeError:
+            object.__setattr__(dummy_config, "load_format", "dummy")
+        DummyModelLoader(dummy_config).load_weights(result.model, self.model_config)
+        return result
+
+    def before_rdma_receive(self, result: LoadResult) -> LoadResult:
+        return self._process_weights_after_loading(result)
+
+    def apply_weight_iter(
+        self,
+        result: LoadResult,
+        weights_iter: Iterator[tuple[str, torch.Tensor]],
+    ) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("vLLM weight iterator loading requires result.model")
+        result.model.load_weights(weights_iter)
+        return result
+
+    def load_via_native(self, result: LoadResult) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("vLLM native loading requires result.model")
+
+        from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+
+        disk_config = copy.copy(self.load_config)
+        try:
+            disk_config.load_format = "auto"
+        except AttributeError:
+            object.__setattr__(disk_config, "load_format", "auto")
+
+        DefaultModelLoader(disk_config).load_weights(result.model, self.model_config)
+        return result
+
+    def after_weight_iter_load(self, result: LoadResult) -> LoadResult:
+        return self._process_weights_after_loading(result)
+
+    def after_native_load(self, result: LoadResult) -> LoadResult:
+        return self._process_weights_after_loading(result)
+
+    def reinit_for_retry(self, result: LoadResult) -> LoadResult:
+        from vllm.model_executor.model_loader.utils import initialize_model
+
+        old_value = result.value
+        result.value = None
+        result.model = None
+        del old_value
+        torch.cuda.empty_cache()
+        self._reset_compilation_state()
+        logger.info(
+            "[Worker %s] Re-initializing vLLM model after failed strategy",
+            self.get_global_rank(),
+        )
+        with self.target_device:
+            model = initialize_model(
+                vllm_config=self.vllm_config,
+                model_config=self.model_config,
+            )
+        return LoadResult(value=model, model=model, publishable=result.publishable)
+
+    def _process_weights_after_loading(self, result: LoadResult) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("vLLM post-load processing requires result.model")
+
+        from vllm.model_executor.model_loader.utils import process_weights_after_loading
+
+        with capture_tensor_attrs():
+            process_weights_after_loading(
+                result.model, self.model_config, self.target_device,
+            )
+        return result
+
+    def _resolve_target_device(self) -> torch.device:
+        load_device = (
+            self.vllm_config.device_config.device
+            if self.load_config.device is None
+            else self.load_config.device
+        )
+        return torch.device(load_device)
+
+    def _reset_compilation_state(self) -> None:
+        compilation_config = self.vllm_config.compilation_config
+        compilation_config.static_forward_context.clear()
+        compilation_config.static_all_moe_layers.clear()
+        compilation_config.enabled_custom_ops.clear()
+        compilation_config.disabled_custom_ops.clear()
+        compilation_config.traced_files.clear()
+        compilation_config.compilation_time = 0.0
+
+
+def build_vllm_load_context(vllm_config, model_config) -> LoadContext:
+    """Build a LoadContext from vLLM config objects."""
+
+    adapter = VllmAdapter(vllm_config, model_config)
+    global_rank = adapter.get_global_rank()
+    worker_rank = adapter.get_worker_rank()
+    return LoadContext(
+        vllm_config=vllm_config,
+        model_config=model_config,
+        load_config=vllm_config.load_config,
+        target_device=adapter.get_target_device(),
+        global_rank=global_rank,
+        worker_rank=worker_rank,
+        device_id=adapter.get_device_id(),
+        identity=adapter.build_identity(),
+        mx_client=create_metadata_client(worker_rank=worker_rank),
+        worker_id=uuid.uuid4().hex[:8],
+        adapter=adapter,
+    )

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import copy
 import logging
 import uuid
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 import torch
 
@@ -16,10 +16,13 @@ from ...adapter import EngineAdapter
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 from ...metadata.publish import build_source_identity
-from ...rank_utils import get_global_rank, get_worker_rank
+from ...rank_utils import get_device_id, get_global_rank
 from ...tensor_utils import adopt_hidden_tensors, capture_tensor_attrs, collect_module_tensors
 
 logger = logging.getLogger("modelexpress.engines.vllm.adapter")
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
 
 
 class VllmAdapter(EngineAdapter):
@@ -35,13 +38,13 @@ class VllmAdapter(EngineAdapter):
         return build_source_identity(self.vllm_config, self.model_config)
 
     def get_worker_rank(self) -> int:
-        return get_worker_rank(self.target_device)
+        return _get_vllm_worker_rank(self.vllm_config)
 
     def get_global_rank(self) -> int:
         return get_global_rank(self.target_device)
 
     def get_device_id(self) -> int:
-        return get_worker_rank(self.target_device)
+        return get_device_id(self.target_device)
 
     def get_target_device(self) -> torch.device:
         return self.target_device
@@ -148,6 +151,27 @@ class VllmAdapter(EngineAdapter):
         compilation_config.disabled_custom_ops.clear()
         compilation_config.traced_files.clear()
         compilation_config.compilation_time = 0.0
+
+
+def _get_vllm_worker_rank(vllm_config: VllmConfig) -> int:
+    """Return the vLLM model-shard key used for source/target matching.
+
+    vLLM's parallel_config.rank is flattened in model-parallel order. Modulo the
+    model-parallel size keeps the TP/PP shard identity and ignores DP replicas,
+    whose weights are interchangeable.
+    """
+    parallel_config = vllm_config.parallel_config
+    rank = parallel_config.rank
+    tp_size = int(parallel_config.tensor_parallel_size)
+    pp_size = int(parallel_config.pipeline_parallel_size)
+    model_parallel_size = max(1, tp_size * pp_size)
+    worker_rank = int(rank) % model_parallel_size
+    logger.debug(
+        "Got vLLM worker rank from parallel_config: "
+        "rank=%d worker_rank=%d model_parallel_size=%d",
+        rank, worker_rank, model_parallel_size,
+    )
+    return worker_rank
 
 
 def build_vllm_load_context(vllm_config, model_config) -> LoadContext:

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ModelExpress Custom Model Loader for vLLM.
+
+This loader hooks into vLLM's weight loading pipeline to perform RDMA transfers
+of fully-processed model tensors. Registration happens AFTER
+process_weights_after_loading() so that all final tensors are captured.
+Tensor discovery uses named_parameters() and named_buffers(); bare tensor
+attributes created during post-processing (e.g. FP8 scales, MLA projections)
+are auto-promoted to non-persistent buffers via capture_tensor_attrs().
+
+Uses LoadStrategyChain to auto-detect the best loading strategy:
+    1. RDMA (P2P GPU transfer via NIXL) - if a source is already serving
+    2. ModelStreamer (S3/GCS/Azure/local via runai-model-streamer) - set MX_MODEL_URI
+    3. GDS (GPUDirect Storage) - direct file-to-GPU, bypassing CPU
+    4. Default (vLLM DefaultModelLoader) - standard CPU-staged loading
+
+Usage:
+    --load-format mx  (auto-detect: RDMA -> ModelStreamer -> GDS -> default)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import torch
+import torch.nn as nn
+
+from ... import configure_vllm_logging
+from ...load_strategy import build_load_context, LoadContext, LoadStrategyChain
+from ...nixl_transfer import NixlTransferManager
+
+from vllm.config import ModelConfig, VllmConfig
+from vllm.config.load import LoadConfig
+from vllm.model_executor.model_loader import register_model_loader
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+from vllm.model_executor.model_loader.utils import initialize_model
+from vllm.utils.torch_utils import set_default_torch_dtype
+
+logger = logging.getLogger("modelexpress.engines.vllm.loader")
+
+
+# Global storage for tensor metadata, keyed by device_id (local CUDA ordinal).
+_tensor_registry: dict[int, dict[str, torch.Tensor]] = {}
+_nixl_managers: dict[int, NixlTransferManager] = {}
+
+
+@register_model_loader("mx")
+class MxModelLoader(BaseModelLoader):
+    """
+    Auto-detecting model loader for ModelExpress.
+
+    Uses LoadStrategyChain to find the best available loading strategy
+    (RDMA P2P, GDS, or default disk loading), then registers tensors
+    with NIXL and publishes metadata so future nodes can discover this
+    one as a source.
+    """
+
+    def __init__(self, load_config: LoadConfig):
+        super().__init__(load_config)
+        configure_vllm_logging()
+        self._ctx: LoadContext | None = None
+
+    def load_model(
+        self, vllm_config: VllmConfig, model_config: ModelConfig
+    ) -> nn.Module:
+        """Load model, auto-detecting the best loading strategy."""
+        load_start = time.perf_counter()
+
+        ctx = build_load_context(vllm_config, model_config)
+        self._ctx = ctx
+
+        logger.info(f"[Worker {ctx.global_rank}] MxModelLoader starting (model={ctx.identity.model_name})")
+
+        with set_default_torch_dtype(model_config.dtype):
+            with ctx.target_device:
+                model = initialize_model(
+                    vllm_config=vllm_config, model_config=model_config
+                )
+
+            model = LoadStrategyChain.run(model, ctx)
+
+            # Update global registries
+            _tensor_registry[ctx.device_id] = ctx.tensors
+            if ctx.nixl_manager is not None:
+                _nixl_managers[ctx.device_id] = ctx.nixl_manager
+
+        total_time = time.perf_counter() - load_start
+        logger.info(
+            f"[Worker {ctx.global_rank}] MxModelLoader.load_model() COMPLETE "
+            f"in {total_time:.2f}s"
+        )
+        return model.eval()
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        """Download the model so it can be loaded immediately."""
+        import copy
+        disk_config = copy.copy(self.load_config)
+        try:
+            disk_config.load_format = "auto"
+        except AttributeError:
+            object.__setattr__(disk_config, "load_format", "auto")
+        DefaultModelLoader(disk_config).download_model(model_config)
+
+    def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        """Load weights into an already-initialized model (standalone API)."""
+        import copy
+        disk_config = copy.copy(self.load_config)
+        try:
+            disk_config.load_format = "auto"
+        except AttributeError:
+            object.__setattr__(disk_config, "load_format", "auto")
+        DefaultModelLoader(disk_config).load_weights(model, model_config)
+
+    @property
+    def nixl_manager(self) -> NixlTransferManager | None:
+        """Access the NIXL manager for external use."""
+        if self._ctx is not None:
+            return self._ctx.nixl_manager
+        return None
+
+    @property
+    def tensors(self) -> dict[str, torch.Tensor]:
+        """Access the registered tensor dict."""
+        if self._ctx is not None:
+            return self._ctx.tensors
+        return {}

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -30,8 +30,9 @@ import torch
 import torch.nn as nn
 
 from ... import configure_vllm_logging
-from ...load_strategy import build_load_context, LoadContext, LoadStrategyChain
+from ...load_strategy import LoadContext, LoadStrategyChain
 from ...nixl_transfer import NixlTransferManager
+from .adapter import build_vllm_load_context
 
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
@@ -71,7 +72,7 @@ class MxModelLoader(BaseModelLoader):
         """Load model, auto-detecting the best loading strategy."""
         load_start = time.perf_counter()
 
-        ctx = build_load_context(vllm_config, model_config)
+        ctx = build_vllm_load_context(vllm_config, model_config)
         self._ctx = ctx
 
         logger.info(f"[Worker {ctx.global_rank}] MxModelLoader starting (model={ctx.identity.model_name})")
@@ -88,6 +89,8 @@ class MxModelLoader(BaseModelLoader):
             _tensor_registry[ctx.device_id] = ctx.tensors
             if ctx.nixl_manager is not None:
                 _nixl_managers[ctx.device_id] = ctx.nixl_manager
+            else:
+                _nixl_managers.pop(ctx.device_id, None)
 
         total_time = time.perf_counter() - load_start
         logger.info(

--- a/modelexpress_client/python/modelexpress/load_strategy/__init__.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/__init__.py
@@ -20,7 +20,6 @@ from .base import (
     LoadResult,
     LoadStrategy,
     SourceTransferError,
-    build_load_context,
     publish_source_if_supported,
     register_tensors,
     publish_metadata,
@@ -33,7 +32,6 @@ __all__ = [
     "LoadStrategy",
     "LoadStrategyChain",
     "SourceTransferError",
-    "build_load_context",
     "register_tensors",
     "publish_metadata",
     "unpublish_metadata",
@@ -53,6 +51,11 @@ class LoadStrategyChain:
     def run(model: nn.Module, ctx: LoadContext) -> nn.Module:
         """Build the chain and execute strategies until one succeeds.
 
+        Strategies return LoadResult on success. Expected misses raise
+        StrategyFailed; mutated failures trigger adapter re-initialization
+        before the next strategy runs. Unexpected exceptions are rolled back
+        and treated as fallback to preserve the existing chain behavior.
+
         Returns the (possibly re-initialized) model on success.
         Raises RuntimeError if no strategy succeeds.
         """
@@ -71,18 +74,10 @@ class LoadStrategyChain:
         logger.info(f"Eligible loaders: {[s.name for s in eligible]}")
 
         result = LoadResult(value=model, model=model)
-        del model
         for strategy in eligible:
             logger.info(f"[Worker {ctx.global_rank}] Trying strategy: {strategy.name}")
             try:
-                loaded = strategy.load(result, ctx)
-                if loaded is False:
-                    if strategy.rollback(ctx):
-                        result = LoadStrategyChain._reinit_for_retry(result, ctx, strategy)
-                    continue
-                if loaded is True:
-                    loaded = result
-                result = loaded
+                result = strategy.load(result, ctx)
                 publish_source_if_supported(result, ctx)
                 return result.value
             except StrategyFailed as e:
@@ -90,17 +85,19 @@ class LoadStrategyChain:
                     f"[Worker {ctx.global_rank}] Strategy {strategy.name} failed, "
                     f"trying next: {e}"
                 )
+                strategy.rollback(ctx)
                 if e.mutated:
                     result = LoadStrategyChain._reinit_for_retry(result, ctx, strategy)
                 continue
             except Exception as e:
+                # Unexpected strategy errors should be rare. Keep the engine
+                # alive by falling through to the next strategy; expected
+                # fallback paths should use StrategyFailed instead.
                 logger.warning(
                     f"[Worker {ctx.global_rank}] Strategy {strategy.name} "
                     f"raised unexpected error, trying next: {e}"
                 )
-
-            if strategy.rollback(ctx):
-                result = LoadStrategyChain._reinit_for_retry(result, ctx, strategy)
+                strategy.rollback(ctx)
 
         raise RuntimeError(
             f"[Worker {ctx.global_rank}] No loading strategy succeeded "

--- a/modelexpress_client/python/modelexpress/load_strategy/__init__.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/__init__.py
@@ -12,14 +12,16 @@ from __future__ import annotations
 
 import logging
 
-import torch
 import torch.nn as nn
 
+from ..adapter import StrategyFailed, UnsupportedCapability
 from .base import (
     LoadContext,
+    LoadResult,
     LoadStrategy,
     SourceTransferError,
     build_load_context,
+    publish_source_if_supported,
     register_tensors,
     publish_metadata,
     unpublish_metadata,
@@ -27,6 +29,7 @@ from .base import (
 
 __all__ = [
     "LoadContext",
+    "LoadResult",
     "LoadStrategy",
     "LoadStrategyChain",
     "SourceTransferError",
@@ -37,30 +40,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger("modelexpress.load_strategy")
-
-
-def _reset_vllm_compilation_state(compilation_config) -> None:
-    """Reset per-model mutable state on vLLM's CompilationConfig.
-
-    vLLM registers attention / MLA / Mamba / FusedMoE layers and accumulates
-    compile stats into dicts / sets / counters on ``compilation_config``
-    during ``initialize_model()``. These live on the config object, not the
-    model, so they survive ``del model`` and either crash the next
-    ``initialize_model()`` (``static_forward_context`` has an explicit
-    duplicate-name guard) or silently corrupt subsequent state (MoE layer
-    list, custom op counters, traced files, compilation time).
-
-    Called from the chain's re-init path so the next strategy sees a clean
-    config. Audited against vLLM 0.17.1; newer vLLM versions may add
-    additional ``init=False`` fields on ``CompilationConfig`` that need
-    similar treatment.
-    """
-    compilation_config.static_forward_context.clear()
-    compilation_config.static_all_moe_layers.clear()
-    compilation_config.enabled_custom_ops.clear()
-    compilation_config.disabled_custom_ops.clear()
-    compilation_config.traced_files.clear()
-    compilation_config.compilation_time = 0.0
 
 
 class LoadStrategyChain:
@@ -77,7 +56,6 @@ class LoadStrategyChain:
         Returns the (possibly re-initialized) model on success.
         Raises RuntimeError if no strategy succeeds.
         """
-        from vllm.model_executor.model_loader.utils import initialize_model
         from .rdma_strategy import RdmaStrategy
         from .model_streamer_strategy import ModelStreamerStrategy
         from .gds_strategy import GdsStrategy
@@ -92,11 +70,29 @@ class LoadStrategyChain:
         eligible = [s for s in all_strategies if s.is_available(ctx)]
         logger.info(f"Eligible loaders: {[s.name for s in eligible]}")
 
+        result = LoadResult(value=model, model=model)
+        del model
         for strategy in eligible:
             logger.info(f"[Worker {ctx.global_rank}] Trying strategy: {strategy.name}")
             try:
-                if strategy.load(model, ctx):
-                    return model
+                loaded = strategy.load(result, ctx)
+                if loaded is False:
+                    if strategy.rollback(ctx):
+                        result = LoadStrategyChain._reinit_for_retry(result, ctx, strategy)
+                    continue
+                if loaded is True:
+                    loaded = result
+                result = loaded
+                publish_source_if_supported(result, ctx)
+                return result.value
+            except StrategyFailed as e:
+                logger.warning(
+                    f"[Worker {ctx.global_rank}] Strategy {strategy.name} failed, "
+                    f"trying next: {e}"
+                )
+                if e.mutated:
+                    result = LoadStrategyChain._reinit_for_retry(result, ctx, strategy)
+                continue
             except Exception as e:
                 logger.warning(
                     f"[Worker {ctx.global_rank}] Strategy {strategy.name} "
@@ -104,20 +100,28 @@ class LoadStrategyChain:
                 )
 
             if strategy.rollback(ctx):
-                del model
-                torch.cuda.empty_cache()
-                _reset_vllm_compilation_state(ctx.vllm_config.compilation_config)
-                logger.info(
-                    f"[Worker {ctx.global_rank}] Re-initializing model after "
-                    f"failed strategy '{strategy.name}'"
-                )
-                with ctx.target_device:
-                    model = initialize_model(
-                        vllm_config=ctx.vllm_config,
-                        model_config=ctx.model_config,
-                    )
+                result = LoadStrategyChain._reinit_for_retry(result, ctx, strategy)
 
         raise RuntimeError(
             f"[Worker {ctx.global_rank}] No loading strategy succeeded "
             f"for model '{ctx.identity.model_name}'"
         )
+
+    @staticmethod
+    def _reinit_for_retry(
+        result: LoadResult,
+        ctx: LoadContext,
+        strategy: LoadStrategy,
+    ) -> LoadResult:
+        if ctx.adapter is None:
+            raise RuntimeError(
+                f"[Worker {ctx.global_rank}] Strategy '{strategy.name}' mutated "
+                "the model but no adapter can reinitialize it"
+            )
+        try:
+            return ctx.adapter.reinit_for_retry(result)
+        except UnsupportedCapability as exc:
+            raise RuntimeError(
+                f"[Worker {ctx.global_rank}] Strategy '{strategy.name}' mutated "
+                "the model but adapter does not support retry reinitialization"
+            ) from exc

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn as nn
 
 from ..nixl_transfer import is_nixl_available
-from ..tensor_utils import adopt_hidden_tensors, collect_module_tensors, log_tensor_summary
+from ..tensor_utils import log_tensor_summary
 from ..metadata.publish import publish_metadata_and_ready
 from .context import LoadContext, LoadResult
 
@@ -114,6 +114,8 @@ def register_tensors(result_or_model: LoadResult | nn.Module, ctx: LoadContext) 
     if not is_nixl_available():
         logger.warning(f"[Worker {ctx.global_rank}] NIXL not available, skipping registration")
         return
+    if ctx.adapter is None:
+        raise RuntimeError("NIXL registration requires an engine adapter")
 
     try:
         result = _as_load_result(result_or_model)
@@ -123,12 +125,7 @@ def register_tensors(result_or_model: LoadResult | nn.Module, ctx: LoadContext) 
             )
             return
 
-        if ctx.adapter is not None:
-            ctx.tensors = ctx.adapter.discover_tensors(result)
-        else:
-            # Compatibility path for tests and legacy callers.
-            adopt_hidden_tensors(result.model)
-            ctx.tensors = collect_module_tensors(result.model)
+        ctx.tensors = ctx.adapter.discover_tensors(result)
         log_tensor_summary(ctx.tensors, ctx.global_rank, "Registering tensors")
 
         if ctx.nixl_manager is None:
@@ -197,7 +194,7 @@ def unpublish_metadata(ctx: LoadContext) -> None:
     """
     from ..metadata.publish import _heartbeat_threads, _worker_servers
 
-    hb = _heartbeat_threads.pop(ctx.global_rank, None)
+    hb = _heartbeat_threads.pop(ctx.worker_rank, None)
     if hb is not None:
         try:
             hb.stop()  # also marks STALE on MX server

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -9,23 +9,18 @@ import logging
 import os
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 import torch.nn as nn
 
-from ..client import MxClientBase
-from ..client_factory import create_metadata_client
 from ..nixl_transfer import is_nixl_available
 from ..tensor_utils import adopt_hidden_tensors, collect_module_tensors, log_tensor_summary
-from ..metadata import build_source_identity, publish_metadata_and_ready
-from .. import p2p_pb2
+from ..metadata.publish import publish_metadata_and_ready
+from .context import LoadContext, LoadResult
 
 if TYPE_CHECKING:
     from ..nixl_transfer import NixlTransferManager
-    from vllm.config import ModelConfig, VllmConfig
-    from vllm.config.load import LoadConfig
 
 logger = logging.getLogger("modelexpress.load_strategy")
 
@@ -39,95 +34,46 @@ class SourceTransferError(Exception):
     """
 
 
-@dataclass
-class LoadContext:
-    """Shared state passed to all loading strategies.
-
-    Rank semantics:
-        global_rank: unique rank across all TP/PP groups (torch.distributed.get_rank()).
-            Used for WorkerMetadata.worker_rank and source/target matching in RDMA.
-        device_id: local CUDA device ordinal / TP rank (get_tensor_model_parallel_rank()).
-            Used for CUDA device selection, port offsets (metadata_port + device_id).
-    """
-
-    vllm_config: VllmConfig
-    model_config: ModelConfig
-    load_config: LoadConfig
-    target_device: torch.device
-    global_rank: int
-    device_id: int
-    identity: p2p_pb2.SourceIdentity
-    mx_client: MxClientBase
-    worker_id: str
-    nixl_manager: NixlTransferManager | None = None
-    tensors: dict[str, torch.Tensor] = field(default_factory=dict)
-
-
 def build_load_context(
-    vllm_config: VllmConfig,
-    model_config: ModelConfig,
+    vllm_config,
+    model_config,
 ) -> LoadContext:
-    """Build a LoadContext from vLLM config objects.
+    """Compatibility wrapper for the vLLM context builder."""
+    from ..engines.vllm.adapter import build_vllm_load_context
 
-    Resolves device, ranks, builds source identity, and creates MX client
-    and worker ID. Used by both MxModelLoader and GMS loader to avoid
-    duplicating context construction logic.
-
-    Args:
-        vllm_config: vLLM engine configuration.
-        model_config: Model configuration (name, dtype, quantization).
-    """
-    from ..rank_utils import get_global_rank, get_worker_rank
-
-    load_config = vllm_config.load_config
-    load_device = (
-        vllm_config.device_config.device
-        if load_config.device is None
-        else load_config.device
-    )
-    target_device = torch.device(load_device)
-    device_id = get_worker_rank(target_device)
-    global_rank = get_global_rank(target_device)
-
-    return LoadContext(
-        vllm_config=vllm_config,
-        model_config=model_config,
-        load_config=load_config,
-        target_device=target_device,
-        global_rank=global_rank,
-        device_id=device_id,
-        identity=build_source_identity(vllm_config, model_config),
-        mx_client=create_metadata_client(worker_rank=global_rank),
-        worker_id=uuid.uuid4().hex[:8],
-    )
+    return build_vllm_load_context(vllm_config, model_config)
 
 
 class LoadStrategy(ABC):
     """Base class for weight-loading strategies.
 
-    Each strategy is fully self-contained: load() handles weight loading,
-    post-processing, NIXL registration, and metadata publishing.
-    Publish failures should not fail the worker.
+    Each strategy is fully self-contained for one loading path. Source
+    publication is handled by the chain after a strategy succeeds.
     """
 
     name: str
+    requires: ClassVar[tuple] = ()
 
-    @abstractmethod
     def is_available(self, ctx: LoadContext) -> bool:
         """Check environment: is this strategy usable right now?"""
+        if not self.requires:
+            return True
+        if ctx.adapter is None:
+            return False
+        cls = type(ctx.adapter)
+        return all(getattr(cls, m.__name__) is not m for m in self.requires)
 
     @abstractmethod
-    def load(self, model: nn.Module, ctx: LoadContext) -> bool:
-        """Attempt to load weights. Return True on success, False to try next."""
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
+        """Attempt to load weights and return the updated result."""
 
     def rollback(self, ctx: LoadContext) -> bool:
         """Clean up after a failed load attempt.
 
         Called by the chain when load() returns False or raises. Strategies
-        that mutate the model before their failure point (e.g. RDMA runs
-        process_weights_after_loading before the transfer) should override
-        this to clean up their state and return True so the chain can
-        re-initialize the model for the next strategy.
+        that mutate the model before their failure point should override this
+        to clean up their state and return True so the chain can re-initialize
+        the model for the next strategy.
 
         Returns True if the model was mutated and needs re-initialization.
         """
@@ -157,7 +103,13 @@ def _init_nixl_manager(
     return manager
 
 
-def register_tensors(model: nn.Module, ctx: LoadContext) -> None:
+def _as_load_result(result_or_model: LoadResult | nn.Module) -> LoadResult:
+    if isinstance(result_or_model, LoadResult):
+        return result_or_model
+    return LoadResult(value=result_or_model, model=result_or_model)
+
+
+def register_tensors(result_or_model: LoadResult | nn.Module, ctx: LoadContext) -> None:
     """Collect model tensors and register them with NIXL.
 
     Failures are logged but do not raise — the worker continues without
@@ -168,10 +120,19 @@ def register_tensors(model: nn.Module, ctx: LoadContext) -> None:
         return
 
     try:
-        # Order matters: adopt first so hidden tensors appear in named_buffers()
-        # before collect_module_tensors iterates them.
-        adopt_hidden_tensors(model)
-        ctx.tensors = collect_module_tensors(model)
+        result = _as_load_result(result_or_model)
+        if result.model is None:
+            logger.info(
+                f"[Worker {ctx.global_rank}] No model available, skipping NIXL registration"
+            )
+            return
+
+        if ctx.adapter is not None:
+            ctx.tensors = ctx.adapter.discover_tensors(result)
+        else:
+            # Compatibility path for tests and legacy callers.
+            adopt_hidden_tensors(result.model)
+            ctx.tensors = collect_module_tensors(result.model)
         log_tensor_summary(ctx.tensors, ctx.global_rank, "Registering tensors")
 
         if ctx.nixl_manager is None:
@@ -214,13 +175,20 @@ def publish_metadata(ctx: LoadContext) -> None:
     try:
         publish_metadata_and_ready(
             ctx.mx_client, ctx.nixl_manager, ctx.tensors,
-            ctx.global_rank, ctx.device_id, ctx.identity, ctx.worker_id,
+            ctx.worker_rank, ctx.device_id, ctx.identity, ctx.worker_id,
         )
     except Exception as e:
         logger.warning(
             f"[Worker {ctx.global_rank}] Failed to publish metadata, "
             f"worker will continue without P2P serving: {e}"
         )
+
+
+def publish_source_if_supported(result: LoadResult, ctx: LoadContext) -> None:
+    """Best-effort source publication after a successful load."""
+    if result.model_for_publish is None:
+        return
+    publish_metadata(ctx)
 
 
 def unpublish_metadata(ctx: LoadContext) -> None:
@@ -231,7 +199,7 @@ def unpublish_metadata(ctx: LoadContext) -> None:
     Call publish_metadata() again after memory is valid to re-enter the
     P2P network.
     """
-    from ..metadata import _heartbeat_threads, _worker_servers
+    from ..metadata.publish import _heartbeat_threads, _worker_servers
 
     hb = _heartbeat_threads.pop(ctx.global_rank, None)
     if hb is not None:

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -34,21 +34,17 @@ class SourceTransferError(Exception):
     """
 
 
-def build_load_context(
-    vllm_config,
-    model_config,
-) -> LoadContext:
-    """Compatibility wrapper for the vLLM context builder."""
-    from ..engines.vllm.adapter import build_vllm_load_context
-
-    return build_vllm_load_context(vllm_config, model_config)
-
-
 class LoadStrategy(ABC):
     """Base class for weight-loading strategies.
 
     Each strategy is fully self-contained for one loading path. Source
     publication is handled by the chain after a strategy succeeds.
+
+    Contract:
+      - return LoadResult only after successful loading
+      - raise StrategyFailed(mutated=False) for expected fallback paths
+      - raise StrategyFailed(mutated=True) after mutating the model
+      - reserve unexpected errors for rare defensive fallback in the chain
     """
 
     name: str
@@ -64,20 +60,20 @@ class LoadStrategy(ABC):
         return all(getattr(cls, m.__name__) is not m for m in self.requires)
 
     @abstractmethod
-    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
-        """Attempt to load weights and return the updated result."""
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
+        """Attempt to load weights and return the updated result.
 
-    def rollback(self, ctx: LoadContext) -> bool:
-        """Clean up after a failed load attempt.
-
-        Called by the chain when load() returns False or raises. Strategies
-        that mutate the model before their failure point should override this
-        to clean up their state and return True so the chain can re-initialize
-        the model for the next strategy.
-
-        Returns True if the model was mutated and needs re-initialization.
+        Do not return booleans for fallback. Use StrategyFailed so the chain
+        can distinguish clean misses from failures that require re-init.
         """
-        return False
+
+    def rollback(self, ctx: LoadContext) -> None:
+        """Clean up strategy-owned state after a failed load attempt.
+
+        This hook must not decide whether the model is dirty. Strategies report
+        that through StrategyFailed(mutated=True).
+        """
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/modelexpress_client/python/modelexpress/load_strategy/context.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/context.py
@@ -47,15 +47,11 @@ class LoadContext:
     load_config: LoadConfig
     target_device: torch.device
     global_rank: int
+    worker_rank: int
     device_id: int
     identity: p2p_pb2.SourceIdentity
     mx_client: MxClientBase
     worker_id: str
     adapter: EngineAdapter | None = None
-    worker_rank: int | None = None
     nixl_manager: NixlTransferManager | None = None
     tensors: dict[str, torch.Tensor] = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        if self.worker_rank is None:
-            self.worker_rank = self.global_rank

--- a/modelexpress_client/python/modelexpress/load_strategy/context.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/context.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared context objects for ModelExpress load strategies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+import torch
+import torch.nn as nn
+
+from .. import p2p_pb2
+from ..client import MxClientBase
+
+if TYPE_CHECKING:
+    from ..adapter import EngineAdapter
+    from ..nixl_transfer import NixlTransferManager
+    from vllm.config import ModelConfig, VllmConfig
+    from vllm.config.load import LoadConfig
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class LoadResult(Generic[T]):
+    """Stable envelope passed through strategies and adapter hooks."""
+
+    value: T
+    model: nn.Module | None = None
+    publishable: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def model_for_publish(self) -> nn.Module | None:
+        return self.model if self.publishable else None
+
+
+@dataclass
+class LoadContext:
+    """Shared state passed to all loading strategies."""
+
+    vllm_config: VllmConfig
+    model_config: ModelConfig
+    load_config: LoadConfig
+    target_device: torch.device
+    global_rank: int
+    device_id: int
+    identity: p2p_pb2.SourceIdentity
+    mx_client: MxClientBase
+    worker_id: str
+    adapter: EngineAdapter | None = None
+    worker_rank: int | None = None
+    nixl_manager: NixlTransferManager | None = None
+    tensors: dict[str, torch.Tensor] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.worker_rank is None:
+            self.worker_rank = self.global_rank

--- a/modelexpress_client/python/modelexpress/load_strategy/default_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/default_strategy.py
@@ -1,47 +1,34 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Default loading strategy: vLLM DefaultModelLoader (CPU-staged, HF Hub download)."""
+"""Default loading strategy: engine-native disk or hub loading."""
 
 from __future__ import annotations
 
-import copy
 import logging
 
-import torch.nn as nn
-
-from .base import LoadContext, LoadStrategy, register_tensors, publish_metadata
-from ..tensor_utils import capture_tensor_attrs
+from ..adapter import EngineAdapter
+from .base import LoadContext, LoadStrategy, _as_load_result, register_tensors
+from .context import LoadResult
 
 logger = logging.getLogger("modelexpress.strategy_default")
 
 
 class DefaultStrategy(LoadStrategy):
-    """Load weights via vLLM DefaultModelLoader (CPU-staged, HF Hub download)."""
+    """Load weights via the engine's native fallback loader."""
 
     name = "default"
+    requires = (EngineAdapter.load_via_native,)
 
     def is_available(self, ctx: LoadContext) -> bool:
-        return True
+        return super().is_available(ctx)
 
-    def load(self, model: nn.Module, ctx: LoadContext) -> bool:
-        from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
-        from vllm.model_executor.model_loader.utils import process_weights_after_loading
-
-        disk_config = copy.copy(ctx.load_config)
-        try:
-            disk_config.load_format = "auto"
-        except AttributeError:
-            object.__setattr__(disk_config, "load_format", "auto")
-
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
+        result = _as_load_result(result)
         logger.info(f"[Worker {ctx.global_rank}] Loading weights from disk...")
-        default_loader = DefaultModelLoader(disk_config)
-        default_loader.load_weights(model, ctx.model_config)
+        result = ctx.adapter.load_via_native(result)
         logger.info(f"[Worker {ctx.global_rank}] Weights loaded from disk")
 
-        with capture_tensor_attrs():
-            process_weights_after_loading(model, ctx.model_config, ctx.target_device)
-
-        register_tensors(model, ctx)
-        publish_metadata(ctx)
-        return True
+        result = ctx.adapter.after_native_load(result)
+        register_tensors(result, ctx)
+        return result

--- a/modelexpress_client/python/modelexpress/load_strategy/default_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/default_strategy.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-from ..adapter import EngineAdapter
+from ..adapter import EngineAdapter, StrategyFailed
 from .base import LoadContext, LoadStrategy, _as_load_result, register_tensors
 from .context import LoadResult
 
@@ -26,9 +26,13 @@ class DefaultStrategy(LoadStrategy):
     def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
         result = _as_load_result(result)
         logger.info(f"[Worker {ctx.global_rank}] Loading weights from disk...")
-        result = ctx.adapter.load_via_native(result)
-        logger.info(f"[Worker {ctx.global_rank}] Weights loaded from disk")
+        try:
+            result = ctx.adapter.load_via_native(result)
+            logger.info(f"[Worker {ctx.global_rank}] Weights loaded from disk")
 
-        result = ctx.adapter.after_native_load(result)
+            result = ctx.adapter.after_native_load(result)
+        except Exception as e:
+            raise StrategyFailed(str(e), mutated=True) from e
+
         register_tensors(result, ctx)
         return result

--- a/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
@@ -51,6 +51,7 @@ class GdsStrategy(LoadStrategy):
             try:
                 result = ctx.adapter.apply_weight_iter(result, weights_iter)
                 logger.info(f"[Worker {ctx.global_rank}] GDS weight loading complete")
+                result = ctx.adapter.after_weight_iter_load(result)
             except Exception as e:
                 logger.warning(
                     f"[Worker {ctx.global_rank}] GDS loading failed, falling through: {e}"
@@ -59,6 +60,5 @@ class GdsStrategy(LoadStrategy):
         finally:
             gds_loader.shutdown()
 
-        result = ctx.adapter.after_weight_iter_load(result)
         register_tensors(result, ctx)
         return result

--- a/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-from ..adapter import EngineAdapter
+from ..adapter import EngineAdapter, StrategyFailed
 from .base import LoadContext, LoadStrategy, _as_load_result, register_tensors
 from .context import LoadResult
 
@@ -29,25 +29,33 @@ class GdsStrategy(LoadStrategy):
             logger.info(f"[Worker {ctx.global_rank}] GDS not available, skipping")
         return available
 
-    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
         result = _as_load_result(result)
         from ..gds_loader import MxGdsLoader
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting GDS loading...")
         gds_loader = MxGdsLoader()
         try:
-            use_tqdm = getattr(ctx.load_config, "use_tqdm_on_load", True)
-            revision = getattr(ctx.model_config, "revision", None)
-            weights_iter = gds_loader.load_iter(
-                ctx.model_config.model, use_tqdm=use_tqdm, revision=revision
-            )
-            result = ctx.adapter.apply_weight_iter(result, weights_iter)
-            logger.info(f"[Worker {ctx.global_rank}] GDS weight loading complete")
-        except Exception as e:
-            logger.warning(
-                f"[Worker {ctx.global_rank}] GDS loading failed, falling through: {e}"
-            )
-            return False
+            try:
+                use_tqdm = getattr(ctx.load_config, "use_tqdm_on_load", True)
+                revision = getattr(ctx.model_config, "revision", None)
+                weights_iter = gds_loader.load_iter(
+                    ctx.model_config.model, use_tqdm=use_tqdm, revision=revision
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[Worker {ctx.global_rank}] GDS loading failed, falling through: {e}"
+                )
+                raise StrategyFailed(str(e), mutated=False) from e
+
+            try:
+                result = ctx.adapter.apply_weight_iter(result, weights_iter)
+                logger.info(f"[Worker {ctx.global_rank}] GDS weight loading complete")
+            except Exception as e:
+                logger.warning(
+                    f"[Worker {ctx.global_rank}] GDS loading failed, falling through: {e}"
+                )
+                raise StrategyFailed(str(e), mutated=True) from e
         finally:
             gds_loader.shutdown()
 

--- a/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 import logging
 
-import torch.nn as nn
-
-from .base import LoadContext, LoadStrategy, register_tensors, publish_metadata
-from ..tensor_utils import capture_tensor_attrs
+from ..adapter import EngineAdapter
+from .base import LoadContext, LoadStrategy, _as_load_result, register_tensors
+from .context import LoadResult
 
 logger = logging.getLogger("modelexpress.strategy_gds")
 
@@ -19,17 +18,20 @@ class GdsStrategy(LoadStrategy):
     """Load weights via GPUDirect Storage (direct file-to-GPU)."""
 
     name = "gds"
+    requires = (EngineAdapter.apply_weight_iter,)
 
     def is_available(self, ctx: LoadContext) -> bool:
+        if not super().is_available(ctx):
+            return False
         from ..gds_transfer import is_gds_available
         available = is_gds_available()
         if not available:
             logger.info(f"[Worker {ctx.global_rank}] GDS not available, skipping")
         return available
 
-    def load(self, model: nn.Module, ctx: LoadContext) -> bool:
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
+        result = _as_load_result(result)
         from ..gds_loader import MxGdsLoader
-        from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting GDS loading...")
         gds_loader = MxGdsLoader()
@@ -39,7 +41,7 @@ class GdsStrategy(LoadStrategy):
             weights_iter = gds_loader.load_iter(
                 ctx.model_config.model, use_tqdm=use_tqdm, revision=revision
             )
-            model.load_weights(weights_iter)
+            result = ctx.adapter.apply_weight_iter(result, weights_iter)
             logger.info(f"[Worker {ctx.global_rank}] GDS weight loading complete")
         except Exception as e:
             logger.warning(
@@ -49,9 +51,6 @@ class GdsStrategy(LoadStrategy):
         finally:
             gds_loader.shutdown()
 
-        with capture_tensor_attrs():
-            process_weights_after_loading(model, ctx.model_config, ctx.target_device)
-
-        register_tensors(model, ctx)
-        publish_metadata(ctx)
-        return True
+        result = ctx.adapter.after_weight_iter_load(result)
+        register_tensors(result, ctx)
+        return result

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -18,7 +18,7 @@ from typing import Iterator
 
 import torch
 
-from ..adapter import EngineAdapter
+from ..adapter import EngineAdapter, StrategyFailed
 from .base import LoadContext, LoadStrategy, _as_load_result, register_tensors
 from .context import LoadResult
 
@@ -89,20 +89,27 @@ class ModelStreamerStrategy(LoadStrategy):
             return False
         return True
 
-    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
         result = _as_load_result(result)
         model_uri = _resolve_model_uri(os.environ["MX_MODEL_URI"])
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting model streamer loading from {model_uri}")
         try:
             weights_iter = self._stream_weights(model_uri, ctx)
+        except Exception as e:
+            logger.warning(
+                f"[Worker {ctx.global_rank}] Model streamer loading failed, falling through: {e}"
+            )
+            raise StrategyFailed(str(e), mutated=False) from e
+
+        try:
             result = ctx.adapter.apply_weight_iter(result, weights_iter)
             logger.info(f"[Worker {ctx.global_rank}] Model streamer weight loading complete")
         except Exception as e:
             logger.warning(
                 f"[Worker {ctx.global_rank}] Model streamer loading failed, falling through: {e}"
             )
-            return False
+            raise StrategyFailed(str(e), mutated=True) from e
 
         result = ctx.adapter.after_weight_iter_load(result)
         register_tensors(result, ctx)

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -17,10 +17,10 @@ import time
 from typing import Iterator
 
 import torch
-import torch.nn as nn
 
-from .base import LoadContext, LoadStrategy, register_tensors, publish_metadata
-from ..tensor_utils import capture_tensor_attrs
+from ..adapter import EngineAdapter
+from .base import LoadContext, LoadStrategy, _as_load_result, register_tensors
+from .context import LoadResult
 
 logger = logging.getLogger("modelexpress.strategy_model_streamer")
 
@@ -70,8 +70,11 @@ class ModelStreamerStrategy(LoadStrategy):
     """
 
     name = "model_streamer"
+    requires = (EngineAdapter.apply_weight_iter,)
 
     def is_available(self, ctx: LoadContext) -> bool:
+        if not super().is_available(ctx):
+            return False
         if importlib.util.find_spec("runai_model_streamer") is None:
             logger.info(
                 f"[Worker {ctx.global_rank}] runai_model_streamer not installed, skipping"
@@ -86,13 +89,14 @@ class ModelStreamerStrategy(LoadStrategy):
             return False
         return True
 
-    def load(self, model: nn.Module, ctx: LoadContext) -> bool:
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
+        result = _as_load_result(result)
         model_uri = _resolve_model_uri(os.environ["MX_MODEL_URI"])
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting model streamer loading from {model_uri}")
         try:
             weights_iter = self._stream_weights(model_uri, ctx)
-            model.load_weights(weights_iter)
+            result = ctx.adapter.apply_weight_iter(result, weights_iter)
             logger.info(f"[Worker {ctx.global_rank}] Model streamer weight loading complete")
         except Exception as e:
             logger.warning(
@@ -100,13 +104,9 @@ class ModelStreamerStrategy(LoadStrategy):
             )
             return False
 
-        from vllm.model_executor.model_loader.utils import process_weights_after_loading
-        with capture_tensor_attrs():
-            process_weights_after_loading(model, ctx.model_config, ctx.target_device)
-
-        register_tensors(model, ctx)
-        publish_metadata(ctx)
-        return True
+        result = ctx.adapter.after_weight_iter_load(result)
+        register_tensors(result, ctx)
+        return result
 
     def _stream_weights(
         self, model_uri: str, ctx: LoadContext

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -105,13 +105,13 @@ class ModelStreamerStrategy(LoadStrategy):
         try:
             result = ctx.adapter.apply_weight_iter(result, weights_iter)
             logger.info(f"[Worker {ctx.global_rank}] Model streamer weight loading complete")
+            result = ctx.adapter.after_weight_iter_load(result)
         except Exception as e:
             logger.warning(
                 f"[Worker {ctx.global_rank}] Model streamer loading failed, falling through: {e}"
             )
             raise StrategyFailed(str(e), mutated=True) from e
 
-        result = ctx.adapter.after_weight_iter_load(result)
         register_tensors(result, ctx)
         return result
 

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -12,7 +12,7 @@ import time
 
 import torch
 
-from ..adapter import EngineAdapter
+from ..adapter import EngineAdapter, StrategyFailed
 from .base import (
     LoadContext,
     LoadStrategy,
@@ -23,7 +23,7 @@ from .base import (
 from .context import LoadResult
 from ..nixl_transfer import is_nixl_available
 from ..transfer_safety import check_transfer_allowed
-from ..types import ManifestMismatchError, TensorDescriptor
+from ..types import TensorDescriptor
 from .. import p2p_pb2
 
 logger = logging.getLogger("modelexpress.strategy_rdma")
@@ -41,17 +41,17 @@ class RdmaStrategy(LoadStrategy):
     name = "rdma"
     requires = (EngineAdapter.discover_tensors,)
 
-    def rollback(self, ctx: LoadContext) -> bool:
-        """Clean up NIXL state from a failed RDMA target attempt.
-
-        Returns True if the target path registered tensors or initialized a
-        NIXL manager during the attempt.
-        """
-        if ctx.tensors or ctx.nixl_manager is not None:
-            ctx.tensors = {}
-            ctx.nixl_manager = None
-            return True
-        return False
+    def rollback(self, ctx: LoadContext) -> None:
+        """Clean up NIXL state from a failed RDMA target attempt."""
+        if ctx.nixl_manager is not None:
+            try:
+                ctx.nixl_manager.shutdown()
+            except Exception as e:
+                logger.warning(
+                    f"[Worker {ctx.global_rank}] Failed to shut down NIXL manager: {e}"
+                )
+        ctx.tensors = {}
+        ctx.nixl_manager = None
 
     def is_available(self, ctx: LoadContext) -> bool:
         if not super().is_available(ctx):
@@ -78,12 +78,20 @@ class RdmaStrategy(LoadStrategy):
 
         return True
 
-    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
+        """Load from a READY source or raise StrategyFailed for fallback.
+
+        Source discovery and metadata misses do not mutate the target model and
+        therefore raise clean StrategyFailed errors. Once _load_as_target()
+        prepares target storage, failures are treated as mutated because the
+        engine may have initialized or transformed model tensors, and those
+        failures are raised immediately instead of trying another source.
+        """
         result = _as_load_result(result)
         candidates = self._find_source_instances(ctx)
         if not candidates:
             logger.info(f"[Worker {ctx.global_rank}] No RDMA source available, skipping")
-            return False
+            raise StrategyFailed("No RDMA source available", mutated=False)
 
         for instance in candidates[:MAX_SOURCE_RETRIES]:
             mx_source_id = instance.mx_source_id
@@ -108,28 +116,22 @@ class RdmaStrategy(LoadStrategy):
                 f"({len(source_worker.tensors)} tensors)"
             )
 
-            try:
-                result = self._load_as_target(
-                    result, ctx, source_worker, mx_source_id, worker_id,
-                )
-                return result
-            except SourceTransferError as e:
-                logger.warning(
-                    f"[Worker {ctx.global_rank}] Source transfer failed for worker {worker_id}: {e}. "
-                    f"Trying next candidate."
-                )
-            except ManifestMismatchError as e:
-                logger.warning(
-                    f"[Worker {ctx.global_rank}] Manifest mismatch with worker {worker_id}: {e}. "
-                    f"Trying next candidate."
-                )
+            # Do not try another source after target preparation starts. The
+            # adapter may have initialized or transformed model tensors, and a
+            # failed receive may have partially written weights. The chain will
+            # re-initialize the model before trying the next loading strategy.
+            return self._load_as_target(
+                result, ctx, source_worker, mx_source_id, worker_id,
+            )
 
         tried = min(len(candidates), MAX_SOURCE_RETRIES)
         logger.warning(
             f"[Worker {ctx.global_rank}] Tried {tried} of {len(candidates)} source workers "
             f"(max retries={MAX_SOURCE_RETRIES}), falling through"
         )
-        return False
+        # Only pre-target metadata/discovery misses reach here. Failures after
+        # target preparation are raised from _load_as_target() as mutated=True.
+        raise StrategyFailed("No RDMA source succeeded", mutated=False)
 
     def _find_source_instances(
         self, ctx: LoadContext,
@@ -202,10 +204,15 @@ class RdmaStrategy(LoadStrategy):
         source_worker_id: str,
     ) -> LoadResult:
         """Receive fully-processed weights via RDMA from an existing source."""
-        result = ctx.adapter.prepare_rdma_target(result)
-        result = ctx.adapter.before_rdma_receive(result)
-        self._receive_from_peer(result, ctx, source_worker, mx_source_id)
-        return ctx.adapter.after_rdma_receive(result)
+        try:
+            result = ctx.adapter.prepare_rdma_target(result)
+            result = ctx.adapter.before_rdma_receive(result)
+            self._receive_from_peer(result, ctx, source_worker, mx_source_id)
+            return ctx.adapter.after_rdma_receive(result)
+        except StrategyFailed:
+            raise
+        except Exception as e:
+            raise StrategyFailed(str(e), mutated=True) from e
 
     def _receive_from_peer(
         self,

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -5,18 +5,23 @@
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 import random
 import time
 
 import torch
-import torch.nn as nn
 
-from .base import LoadContext, LoadStrategy, SourceTransferError, register_tensors, publish_metadata
+from ..adapter import EngineAdapter
+from .base import (
+    LoadContext,
+    LoadStrategy,
+    SourceTransferError,
+    _as_load_result,
+    register_tensors,
+)
+from .context import LoadResult
 from ..nixl_transfer import is_nixl_available
-from ..tensor_utils import capture_tensor_attrs
 from ..transfer_safety import check_transfer_allowed
 from ..types import ManifestMismatchError, TensorDescriptor
 from .. import p2p_pb2
@@ -30,18 +35,17 @@ class RdmaStrategy(LoadStrategy):
     """Load weights via RDMA P2P transfer from an existing source.
 
     Overrides load() entirely since RDMA has a fundamentally different flow:
-    dummy weights -> process -> RDMA receive -> register + publish.
+    prepare target storage -> RDMA receive -> register + publish.
     """
 
     name = "rdma"
+    requires = (EngineAdapter.discover_tensors,)
 
     def rollback(self, ctx: LoadContext) -> bool:
         """Clean up NIXL state from a failed RDMA target attempt.
 
-        Returns True if _load_as_target() ran (and thus
-        process_weights_after_loading mutated the model).  Detected by
-        checking whether register_tensors() populated ctx during the
-        attempt.
+        Returns True if the target path registered tensors or initialized a
+        NIXL manager during the attempt.
         """
         if ctx.tensors or ctx.nixl_manager is not None:
             ctx.tensors = {}
@@ -50,6 +54,8 @@ class RdmaStrategy(LoadStrategy):
         return False
 
     def is_available(self, ctx: LoadContext) -> bool:
+        if not super().is_available(ctx):
+            return False
         if not is_nixl_available():
             return False
 
@@ -72,7 +78,8 @@ class RdmaStrategy(LoadStrategy):
 
         return True
 
-    def load(self, model: nn.Module, ctx: LoadContext) -> bool:
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult | bool:
+        result = _as_load_result(result)
         candidates = self._find_source_instances(ctx)
         if not candidates:
             logger.info(f"[Worker {ctx.global_rank}] No RDMA source available, skipping")
@@ -102,8 +109,10 @@ class RdmaStrategy(LoadStrategy):
             )
 
             try:
-                self._load_as_target(model, ctx, source_worker, mx_source_id, worker_id)
-                return True
+                result = self._load_as_target(
+                    result, ctx, source_worker, mx_source_id, worker_id,
+                )
+                return result
             except SourceTransferError as e:
                 logger.warning(
                     f"[Worker {ctx.global_rank}] Source transfer failed for worker {worker_id}: {e}. "
@@ -137,7 +146,7 @@ class RdmaStrategy(LoadStrategy):
 
             candidates = [
                 inst for inst in list_resp.instances
-                if inst.worker_rank == ctx.global_rank
+                if inst.worker_rank == ctx.worker_rank
             ]
             random.shuffle(candidates)
             logger.info(
@@ -186,47 +195,34 @@ class RdmaStrategy(LoadStrategy):
 
     def _load_as_target(
         self,
-        model: nn.Module,
+        result: LoadResult,
         ctx: LoadContext,
         source_worker,
         mx_source_id: str,
         source_worker_id: str,
-    ) -> None:
+    ) -> LoadResult:
         """Receive fully-processed weights via RDMA from an existing source."""
-        from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
-        from vllm.model_executor.model_loader.utils import process_weights_after_loading
-
-        dummy_config = copy.copy(ctx.load_config)
-        try:
-            dummy_config.load_format = "dummy"
-        except AttributeError:
-            object.__setattr__(dummy_config, "load_format", "dummy")
-        dummy_loader = DummyModelLoader(dummy_config)
-        dummy_loader.load_weights(model, ctx.model_config)
-
-        with capture_tensor_attrs():
-            process_weights_after_loading(model, ctx.model_config, ctx.target_device)
-
-        self._receive_from_peer(model, ctx, source_worker, mx_source_id)
-
-        publish_metadata(ctx)
+        result = ctx.adapter.prepare_rdma_target(result)
+        result = ctx.adapter.before_rdma_receive(result)
+        self._receive_from_peer(result, ctx, source_worker, mx_source_id)
+        return ctx.adapter.after_rdma_receive(result)
 
     def _receive_from_peer(
         self,
-        model: nn.Module,
+        result: LoadResult,
         ctx: LoadContext,
         source_worker,
         mx_source_id: str,
     ) -> None:
         """Receive fully-processed tensors via RDMA from the detected source."""
         receive_start = time.perf_counter()
-        register_tensors(model, ctx)
+        register_tensors(result, ctx)
 
         is_p2p = bool(source_worker.worker_grpc_endpoint)
         remote_agent_name_override = None
 
         if is_p2p:
-            from ..worker_server import fetch_tensor_manifest
+            from ..metadata.worker_server import fetch_tensor_manifest
 
             manifest_start = time.perf_counter()
             logger.info(

--- a/modelexpress_client/python/modelexpress/metadata/__init__.py
+++ b/modelexpress_client/python/modelexpress/metadata/__init__.py
@@ -1,8 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compatibility import path for the vLLM ModelExpress loader."""
-
-from .engines.vllm.loader import MxModelLoader
-
-__all__ = ["MxModelLoader"]
+"""Metadata coordination helpers for ModelExpress."""

--- a/modelexpress_client/python/modelexpress/metadata/client_factory.py
+++ b/modelexpress_client/python/modelexpress/metadata/client_factory.py
@@ -23,10 +23,10 @@ from __future__ import annotations
 import logging
 import os
 
-from .client import MxClient, MxClientBase
+from ..client import MxClient, MxClientBase
 from .k8s_service_client import MxK8sServiceClient
 
-logger = logging.getLogger("modelexpress.client_factory")
+logger = logging.getLogger("modelexpress.metadata.client_factory")
 
 _CENTRAL_BACKEND_ALIASES = frozenset({
     "", "server", "redis", "kubernetes", "k8s", "crd",

--- a/modelexpress_client/python/modelexpress/metadata/heartbeat.py
+++ b/modelexpress_client/python/modelexpress/metadata/heartbeat.py
@@ -18,10 +18,10 @@ import threading
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .client import MxClient
-    from .nixl_transfer import NixlTransferManager
+    from ..client import MxClient
+    from ..nixl_transfer import NixlTransferManager
 
-logger = logging.getLogger("modelexpress.heartbeat")
+logger = logging.getLogger("modelexpress.metadata.heartbeat")
 
 
 class HeartbeatThread:
@@ -97,7 +97,7 @@ class HeartbeatThread:
         if not self._started:
             return
         try:
-            from . import p2p_pb2
+            from .. import p2p_pb2
             self._update_status(p2p_pb2.SOURCE_STATUS_STALE)
             logger.info(f"[Worker {self._worker_rank}] Marked STALE on shutdown")
             self._started = False
@@ -119,7 +119,7 @@ class HeartbeatThread:
 
     def _tick(self) -> None:
         """Single heartbeat tick: check health and send READY if healthy."""
-        from . import p2p_pb2
+        from .. import p2p_pb2
 
         if not self._nixl_manager.is_healthy():
             return

--- a/modelexpress_client/python/modelexpress/metadata/k8s_service_client.py
+++ b/modelexpress_client/python/modelexpress/metadata/k8s_service_client.py
@@ -46,12 +46,12 @@ import time
 
 import grpc
 
-from . import p2p_pb2
-from . import p2p_pb2_grpc
-from .client import MxClientBase
+from .. import p2p_pb2
+from .. import p2p_pb2_grpc
+from ..client import MxClientBase
 from .source_id import compute_mx_source_id
 
-logger = logging.getLogger("modelexpress.k8s_service_client")
+logger = logging.getLogger("modelexpress.metadata.k8s_service_client")
 
 _DEFAULT_SERVICE_PATTERN = "mx-sources"
 _DEFAULT_WORKER_GRPC_PORT = 6555
@@ -108,7 +108,7 @@ class MxK8sServiceClient(MxClientBase):
     ) -> str:
         """Compute mx_source_id locally - there is no central store to hit.
 
-        Caller (metadata.py) is responsible for starting the local
+        Caller (metadata.publish) is responsible for starting the local
         WorkerGrpcServer; this method only produces the ID so caller
         has something to key against. Also records ``worker_rank`` so
         the DNS pattern can be resolved without a separate call.

--- a/modelexpress_client/python/modelexpress/metadata/publish.py
+++ b/modelexpress_client/python/modelexpress/metadata/publish.py
@@ -131,18 +131,18 @@ def publish_metadata_and_ready(
     mx_client: MxClient,
     nixl_manager: "NixlTransferManager",
     tensors: dict[str, torch.Tensor],
-    global_rank: int,
+    worker_rank: int,
     device_id: int,
     identity: "p2p_pb2.SourceIdentity",
     worker_id: str,
 ) -> None:
     """Publish tensor metadata and ready flag to the ModelExpress server."""
     logger.info(
-        f"[Worker {global_rank}] Publishing {len(tensors)} tensors for model '{identity.model_name}'"
+        f"[Worker {worker_rank}] Publishing {len(tensors)} tensors for model '{identity.model_name}'"
     )
 
     tensor_protos = build_tensor_protos(
-        nixl_manager, tensors, device_id, global_rank,
+        nixl_manager, tensors, device_id, worker_rank,
     )
 
     if _is_p2p_metadata_enabled(mx_client):
@@ -154,7 +154,7 @@ def publish_metadata_and_ready(
         worker_grpc_port = grpc_base + device_id
 
         worker = p2p_pb2.WorkerMetadata(
-            worker_rank=global_rank,
+            worker_rank=worker_rank,
             metadata_endpoint=f"{host}:{nixl_manager._listen_port}",
             agent_name=nixl_manager.agent_name,
             worker_grpc_endpoint="",
@@ -164,7 +164,7 @@ def publish_metadata_and_ready(
             identity=identity,
             worker=worker,
             worker_id=worker_id,
-            global_rank=global_rank,
+            worker_rank=worker_rank,
         )
 
         grpc_server = WorkerGrpcServer(
@@ -173,13 +173,13 @@ def publish_metadata_and_ready(
             port=worker_grpc_port,
             metadata_endpoint=f"{host}:{nixl_manager._listen_port}",
             agent_name=nixl_manager.agent_name,
-            worker_rank=global_rank,
+            worker_rank=worker_rank,
         )
         actual_port = grpc_server.start()
         _worker_servers[device_id] = grpc_server
 
         worker = p2p_pb2.WorkerMetadata(
-            worker_rank=global_rank,
+            worker_rank=worker_rank,
             metadata_endpoint=f"{host}:{nixl_manager._listen_port}",
             agent_name=nixl_manager.agent_name,
             worker_grpc_endpoint=f"{host}:{actual_port}",
@@ -189,15 +189,15 @@ def publish_metadata_and_ready(
             identity=identity,
             worker=worker,
             worker_id=worker_id,
-            global_rank=global_rank,
+            worker_rank=worker_rank,
         )
         logger.info(
-            f"[Worker {global_rank}] Published P2P metadata to MX server "
+            f"[Worker {worker_rank}] Published P2P metadata to MX server "
             f"(mx_source_id={mx_source_id}, worker_grpc={host}:{actual_port})"
         )
     else:
         worker = p2p_pb2.WorkerMetadata(
-            worker_rank=global_rank,
+            worker_rank=worker_rank,
             nixl_metadata=nixl_manager.nixl_metadata,
             tensors=tensor_protos,
         )
@@ -206,10 +206,10 @@ def publish_metadata_and_ready(
             identity=identity,
             worker=worker,
             worker_id=worker_id,
-            global_rank=global_rank,
+            worker_rank=worker_rank,
         )
         logger.info(
-            f"[Worker {global_rank}] Published metadata to MX server "
+            f"[Worker {worker_rank}] Published metadata to MX server "
             f"(mx_source_id={mx_source_id}, worker_id={worker_id})"
         )
 
@@ -217,11 +217,11 @@ def publish_metadata_and_ready(
         mx_client=mx_client,
         mx_source_id=mx_source_id,
         worker_id=worker_id,
-        worker_rank=global_rank,
+        worker_rank=worker_rank,
         nixl_manager=nixl_manager,
     )
     heartbeat.start()
-    _heartbeat_threads[global_rank] = heartbeat
+    _heartbeat_threads[worker_rank] = heartbeat
 
 
 def _publish_metadata_to_server(
@@ -229,7 +229,7 @@ def _publish_metadata_to_server(
     identity: "p2p_pb2.SourceIdentity",
     worker: "p2p_pb2.WorkerMetadata",
     worker_id: str,
-    global_rank: int,
+    worker_rank: int,
 ) -> str:
     """Publish metadata with bounded retries and exponential backoff."""
     last_error: grpc.RpcError | None = None
@@ -247,14 +247,14 @@ def _publish_metadata_to_server(
 
             backoff_seconds = PUBLISH_METADATA_INITIAL_BACKOFF_SECONDS * (2 ** (attempt - 1))
             logger.warning(
-                f"[Worker {global_rank}] Publish metadata attempt {attempt}/"
+                f"[Worker {worker_rank}] Publish metadata attempt {attempt}/"
                 f"{PUBLISH_METADATA_MAX_ATTEMPTS} failed with retryable gRPC status "
                 f"{exc.code().name}: {exc}. Retrying in {backoff_seconds:.1f}s"
             )
             time.sleep(backoff_seconds)
 
     message = (
-        f"[Worker {global_rank}] Failed to publish metadata after "
+        f"[Worker {worker_rank}] Failed to publish metadata after "
         f"{PUBLISH_METADATA_MAX_ATTEMPTS} attempts"
     )
     logger.error("%s: %s", message, last_error)

--- a/modelexpress_client/python/modelexpress/metadata/publish.py
+++ b/modelexpress_client/python/modelexpress/metadata/publish.py
@@ -13,15 +13,15 @@ from typing import TYPE_CHECKING
 import grpc
 import torch
 
-from .client import MxClient
 from .heartbeat import HeartbeatThread
-from . import p2p_pb2
+from ..client import MxClient
+from .. import p2p_pb2
 
 if TYPE_CHECKING:
-    from .nixl_transfer import NixlTransferManager
+    from ..nixl_transfer import NixlTransferManager
     from .worker_server import WorkerGrpcServer
 
-logger = logging.getLogger("modelexpress.metadata")
+logger = logging.getLogger("modelexpress.metadata.publish")
 
 PUBLISH_METADATA_MAX_ATTEMPTS = 3
 PUBLISH_METADATA_INITIAL_BACKOFF_SECONDS = 1.0

--- a/modelexpress_client/python/modelexpress/metadata/source_id.py
+++ b/modelexpress_client/python/modelexpress/metadata/source_id.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 
-from . import p2p_pb2
+from .. import p2p_pb2
 
 
 def compute_mx_source_id(identity: p2p_pb2.SourceIdentity) -> str:

--- a/modelexpress_client/python/modelexpress/metadata/worker_server.py
+++ b/modelexpress_client/python/modelexpress/metadata/worker_server.py
@@ -17,10 +17,10 @@ from concurrent import futures
 
 import grpc
 
-from . import p2p_pb2
-from . import p2p_pb2_grpc
+from .. import p2p_pb2
+from .. import p2p_pb2_grpc
 
-logger = logging.getLogger("modelexpress.worker_server")
+logger = logging.getLogger("modelexpress.metadata.worker_server")
 
 
 class WorkerServiceServicer(p2p_pb2_grpc.WorkerServiceServicer):

--- a/modelexpress_client/python/modelexpress/rank_utils.py
+++ b/modelexpress_client/python/modelexpress/rank_utils.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("modelexpress.rank_utils")
 
 
 def get_global_rank(device: torch.device) -> int:
-    """Get the global rank of this worker across all TP and PP groups."""
+    """Get the global distributed rank for this worker."""
     try:
         import torch.distributed as dist
         if dist.is_initialized():
@@ -24,24 +24,14 @@ def get_global_rank(device: torch.device) -> int:
         logger.debug(f"Could not get global rank from torch.distributed: {e}")
 
     if hasattr(device, "index") and device.index is not None:
-        logger.debug(f"Using device.index as rank: {device.index}")
+        logger.debug(f"Using device.index as global rank fallback: {device.index}")
         return device.index
 
     return 0
 
 
-def get_worker_rank(device: torch.device) -> int:
-    """Get the local CUDA device ordinal (TP rank) of this worker."""
-    try:
-        from vllm.distributed import get_tensor_model_parallel_rank
-        rank = get_tensor_model_parallel_rank()
-        logger.debug(f"Got TP rank from vllm.distributed: {rank}")
-        return rank
-    except (ImportError, RuntimeError) as e:
-        logger.debug(f"Could not get TP rank from vllm.distributed: {e}")
-
+def get_device_id(device: torch.device) -> int:
+    """Get the local CUDA device ordinal used for CUDA and NIXL operations."""
     if hasattr(device, "index") and device.index is not None:
-        logger.debug(f"Using device.index as rank: {device.index}")
         return device.index
-
     return 0

--- a/modelexpress_client/python/modelexpress/vllm_worker.py
+++ b/modelexpress_client/python/modelexpress/vllm_worker.py
@@ -19,8 +19,7 @@ class ModelExpressWorker(Worker):
 
     def __init__(self, *args, **kwargs):
         # Register loaders before parent initialization.
-        # This imports modelexpress.vllm_loader which has @register_model_loader
-        # decorators on the MxModelLoader class.
+        # This imports the vLLM engine package, which registers MxModelLoader.
         from modelexpress import register_modelexpress_loaders
 
         register_modelexpress_loaders()

--- a/modelexpress_client/python/tests/test_adapter.py
+++ b/modelexpress_client/python/tests/test_adapter.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the engine adapter capability contract."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from modelexpress.adapter import EngineAdapter, UnsupportedCapability
+from modelexpress.load_strategy.base import LoadStrategy
+from modelexpress.load_strategy.context import LoadResult
+
+
+class _DiscoverTensorsStrategy(LoadStrategy):
+    name = "discover_tensors"
+    requires = (EngineAdapter.discover_tensors,)
+
+    def load(self, result, ctx):
+        return result
+
+
+class _BaseAdapter(EngineAdapter):
+    pass
+
+
+class _DiscoverTensorsAdapter(EngineAdapter):
+    def discover_tensors(self, result: LoadResult):
+        return {}
+
+
+def test_inherited_gated_capability_raises_unsupported_capability():
+    adapter = EngineAdapter()
+
+    with pytest.raises(UnsupportedCapability, match="discover_tensors"):
+        adapter.discover_tensors(LoadResult(value=None))
+
+
+def test_strategy_unavailable_when_required_capability_is_inherited_default():
+    strategy = _DiscoverTensorsStrategy()
+    ctx = SimpleNamespace(adapter=_BaseAdapter())
+
+    assert strategy.is_available(ctx) is False
+
+
+def test_strategy_available_when_required_capability_is_overridden():
+    strategy = _DiscoverTensorsStrategy()
+    ctx = SimpleNamespace(adapter=_DiscoverTensorsAdapter())
+
+    assert strategy.is_available(ctx) is True

--- a/modelexpress_client/python/tests/test_adapter.py
+++ b/modelexpress_client/python/tests/test_adapter.py
@@ -35,6 +35,9 @@ def test_inherited_gated_capability_raises_unsupported_capability():
     with pytest.raises(UnsupportedCapability, match="discover_tensors"):
         adapter.discover_tensors(LoadResult(value=None))
 
+    with pytest.raises(UnsupportedCapability, match="get_global_rank"):
+        adapter.get_global_rank()
+
 
 def test_strategy_unavailable_when_required_capability_is_inherited_default():
     strategy = _DiscoverTensorsStrategy()

--- a/modelexpress_client/python/tests/test_gds_loader.py
+++ b/modelexpress_client/python/tests/test_gds_loader.py
@@ -209,6 +209,9 @@ class TestGdsStrategyIntegration:
         def discover_tensors(self, result: LoadResult):
             return {}
 
+        def after_weight_iter_load(self, result: LoadResult):
+            return result
+
         def apply_weight_iter(self, result: LoadResult, weights_iter):
             if result.model is not None:
                 result.model.load_weights(weights_iter)
@@ -222,6 +225,7 @@ class TestGdsStrategyIntegration:
             load_config=MagicMock(),
             target_device=torch.device("cpu"),
             global_rank=0,
+            worker_rank=0,
             device_id=0,
             identity=MagicMock(),
             mx_client=MagicMock(),
@@ -287,6 +291,26 @@ class TestGdsStrategyIntegration:
 
         strategy = GdsStrategy()
         with pytest.raises(StrategyFailed, match="partial load") as exc:
+            strategy.load(MagicMock(), ctx)
+
+        assert exc.value.mutated is True
+        mock_gds.shutdown.assert_called_once()
+
+    @patch("modelexpress.gds_transfer.is_gds_available", return_value=True)
+    @patch("modelexpress.gds_loader.MxGdsLoader")
+    def test_gds_after_weight_iter_failure_is_mutated(self, mock_gds_cls, _mock_avail):
+        from modelexpress.load_strategy.gds_strategy import GdsStrategy
+
+        mock_gds = MagicMock()
+        mock_gds.load_iter.return_value = iter([("w", torch.zeros(1))])
+        mock_gds_cls.return_value = mock_gds
+
+        ctx = self._make_context()
+        ctx.adapter.after_weight_iter_load = MagicMock(side_effect=RuntimeError("post load"))
+        ctx.model_config.model = "test-model"
+
+        strategy = GdsStrategy()
+        with pytest.raises(StrategyFailed, match="post load") as exc:
             strategy.load(MagicMock(), ctx)
 
         assert exc.value.mutated is True

--- a/modelexpress_client/python/tests/test_gds_loader.py
+++ b/modelexpress_client/python/tests/test_gds_loader.py
@@ -10,6 +10,9 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 import torch
 
+from modelexpress.adapter import EngineAdapter
+from modelexpress.load_strategy.context import LoadResult
+
 
 # ---------------------------------------------------------------------------
 # GDS availability detection
@@ -202,6 +205,15 @@ class TestResolveSafetensorsFiles:
 class TestGdsStrategyIntegration:
     """Tests for GdsStrategy loading behavior."""
 
+    class _FakeAdapter(EngineAdapter):
+        def discover_tensors(self, result: LoadResult):
+            return {}
+
+        def apply_weight_iter(self, result: LoadResult, weights_iter):
+            if result.model is not None:
+                result.model.load_weights(weights_iter)
+            return result
+
     def _make_context(self):
         from modelexpress.load_strategy import LoadContext
         return LoadContext(
@@ -214,6 +226,7 @@ class TestGdsStrategyIntegration:
             identity=MagicMock(),
             mx_client=MagicMock(),
             worker_id="test-worker",
+            adapter=self._FakeAdapter(),
         )
 
     @patch("modelexpress.gds_transfer.is_gds_available", return_value=True)
@@ -234,7 +247,8 @@ class TestGdsStrategyIntegration:
         model = MagicMock()
         result = strategy.load(model, ctx)
 
-        assert result is True
+        assert isinstance(result, LoadResult)
+        assert result.model is model
         mock_gds.load_iter.assert_called_once()
         model.load_weights.assert_called_once()
         mock_gds.shutdown.assert_called_once()

--- a/modelexpress_client/python/tests/test_gds_loader.py
+++ b/modelexpress_client/python/tests/test_gds_loader.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 import torch
 
-from modelexpress.adapter import EngineAdapter
+from modelexpress.adapter import EngineAdapter, StrategyFailed
 from modelexpress.load_strategy.context import LoadResult
 
 
@@ -255,7 +255,7 @@ class TestGdsStrategyIntegration:
 
     @patch("modelexpress.gds_transfer.is_gds_available", return_value=True)
     @patch("modelexpress.gds_loader.MxGdsLoader")
-    def test_gds_failure_returns_false(self, mock_gds_cls, _mock_avail):
+    def test_gds_failure_raises_strategy_failed(self, mock_gds_cls, _mock_avail):
         from modelexpress.load_strategy.gds_strategy import GdsStrategy
 
         mock_gds = MagicMock()
@@ -266,9 +266,30 @@ class TestGdsStrategyIntegration:
         ctx.model_config.model = "test-model"
 
         strategy = GdsStrategy()
-        result = strategy.load(MagicMock(), ctx)
+        with pytest.raises(StrategyFailed, match="GDS error") as exc:
+            strategy.load(MagicMock(), ctx)
 
-        assert result is False
+        assert exc.value.mutated is False
+        mock_gds.shutdown.assert_called_once()
+
+    @patch("modelexpress.gds_transfer.is_gds_available", return_value=True)
+    @patch("modelexpress.gds_loader.MxGdsLoader")
+    def test_gds_apply_weight_iter_failure_is_mutated(self, mock_gds_cls, _mock_avail):
+        from modelexpress.load_strategy.gds_strategy import GdsStrategy
+
+        mock_gds = MagicMock()
+        mock_gds.load_iter.return_value = iter([("w", torch.zeros(1))])
+        mock_gds_cls.return_value = mock_gds
+
+        ctx = self._make_context()
+        ctx.adapter.apply_weight_iter = MagicMock(side_effect=RuntimeError("partial load"))
+        ctx.model_config.model = "test-model"
+
+        strategy = GdsStrategy()
+        with pytest.raises(StrategyFailed, match="partial load") as exc:
+            strategy.load(MagicMock(), ctx)
+
+        assert exc.value.mutated is True
         mock_gds.shutdown.assert_called_once()
 
     @patch("modelexpress.gds_transfer.is_gds_available", return_value=False)

--- a/modelexpress_client/python/tests/test_heartbeat.py
+++ b/modelexpress_client/python/tests/test_heartbeat.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from modelexpress.heartbeat import HeartbeatThread
+from modelexpress.metadata.heartbeat import HeartbeatThread
 
 
 @pytest.fixture

--- a/modelexpress_client/python/tests/test_k8s_service_client.py
+++ b/modelexpress_client/python/tests/test_k8s_service_client.py
@@ -14,10 +14,10 @@ import pytest
 from modelexpress import p2p_pb2
 from modelexpress import p2p_pb2_grpc
 from modelexpress.client import MxClient
-from modelexpress.client_factory import create_metadata_client
-from modelexpress.k8s_service_client import MxK8sServiceClient
-from modelexpress.source_id import compute_mx_source_id
-from modelexpress.metadata import _is_p2p_metadata_enabled
+from modelexpress.metadata.client_factory import create_metadata_client
+from modelexpress.metadata.k8s_service_client import MxK8sServiceClient
+from modelexpress.metadata.publish import _is_p2p_metadata_enabled
+from modelexpress.metadata.source_id import compute_mx_source_id
 
 
 def _base_identity() -> p2p_pb2.SourceIdentity:

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -23,6 +23,9 @@ class _FakeAdapter(EngineAdapter):
     def discover_tensors(self, result: LoadResult):
         return {}
 
+    def after_weight_iter_load(self, result: LoadResult):
+        return result
+
     def apply_weight_iter(self, result: LoadResult, weights_iter):
         if result.model is not None:
             result.model.load_weights(weights_iter)
@@ -39,6 +42,7 @@ def _make_load_context(**overrides):
         load_config=MagicMock(),
         target_device=torch.device("cpu"),
         global_rank=0,
+        worker_rank=0,
         device_id=0,
         identity=p2p_pb2.SourceIdentity(model_name="test-model"),
         mx_client=MagicMock(),
@@ -214,6 +218,26 @@ class TestModelStreamerLoad:
                 return_value=iter([("layer.0.weight", torch.randn(4, 4))]),
             ):
                 with pytest.raises(StrategyFailed, match="partial load") as exc:
+                    strategy.load(model, ctx)
+
+        assert exc.value.mutated is True
+        mock_register.assert_not_called()
+
+    @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
+    def test_after_weight_iter_failure_is_mutated(self, mock_register):
+        model = MagicMock()
+        adapter = _FakeAdapter()
+        adapter.after_weight_iter_load = MagicMock(side_effect=RuntimeError("post load"))
+        ctx = _make_load_context(adapter=adapter)
+        strategy = self._make_strategy()
+
+        with patch.dict("os.environ", {"MX_MODEL_URI": "s3://bucket/model"}):
+            with patch(
+                "modelexpress.load_strategy.model_streamer_strategy."
+                "ModelStreamerStrategy._stream_weights",
+                return_value=iter([("layer.0.weight", torch.randn(4, 4))]),
+            ):
+                with pytest.raises(StrategyFailed, match="post load") as exc:
                     strategy.load(model, ctx)
 
         assert exc.value.mutated is True

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -10,6 +10,7 @@ import torch
 
 from modelexpress import p2p_pb2
 from modelexpress.adapter import EngineAdapter
+from modelexpress.adapter import StrategyFailed
 from modelexpress.load_strategy.context import LoadResult
 
 
@@ -175,12 +176,13 @@ class TestModelStreamerLoad:
                 "ModelStreamerStrategy._stream_weights"
             ) as mock_stream:
                 mock_stream.side_effect = RuntimeError("expected")
-                strategy.load(model, ctx)
+                with pytest.raises(StrategyFailed, match="expected"):
+                    strategy.load(model, ctx)
 
         mock_stream.assert_called_once_with("s3://bucket/model", ctx)
 
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
-    def test_returns_false_on_error(self, mock_register):
+    def test_raises_strategy_failed_on_error(self, mock_register):
         model = MagicMock()
         ctx = _make_load_context()
         strategy = self._make_strategy()
@@ -191,9 +193,30 @@ class TestModelStreamerLoad:
                 "ModelStreamerStrategy._stream_weights",
                 side_effect=RuntimeError("S3 connection failed"),
             ):
-                result = strategy.load(model, ctx)
+                with pytest.raises(StrategyFailed, match="S3 connection failed") as exc:
+                    strategy.load(model, ctx)
 
-        assert result is False
+        assert exc.value.mutated is False
+        mock_register.assert_not_called()
+
+    @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
+    def test_apply_weight_iter_failure_is_mutated(self, mock_register):
+        model = MagicMock()
+        adapter = _FakeAdapter()
+        adapter.apply_weight_iter = MagicMock(side_effect=RuntimeError("partial load"))
+        ctx = _make_load_context(adapter=adapter)
+        strategy = self._make_strategy()
+
+        with patch.dict("os.environ", {"MX_MODEL_URI": "s3://bucket/model"}):
+            with patch(
+                "modelexpress.load_strategy.model_streamer_strategy."
+                "ModelStreamerStrategy._stream_weights",
+                return_value=iter([("layer.0.weight", torch.randn(4, 4))]),
+            ):
+                with pytest.raises(StrategyFailed, match="partial load") as exc:
+                    strategy.load(model, ctx)
+
+        assert exc.value.mutated is True
         mock_register.assert_not_called()
 
 
@@ -333,7 +356,9 @@ class TestChainOrder:
         def track_load(strategy_name):
             def _load(self_or_model, *args, **kwargs):
                 call_order.append(strategy_name)
-                return strategy_name == "default"
+                if strategy_name != "default":
+                    raise StrategyFailed(f"{strategy_name} miss")
+                return args[0]
             return _load
 
         model = MagicMock()
@@ -382,7 +407,9 @@ class TestChainOrder:
         def track_load(strategy_name):
             def _load(self_or_model, *args, **kwargs):
                 call_order.append(strategy_name)
-                return strategy_name == "default"
+                if strategy_name != "default":
+                    raise StrategyFailed(f"{strategy_name} miss")
+                return args[0]
             return _load
 
         model = MagicMock()

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -9,11 +9,23 @@ import pytest
 import torch
 
 from modelexpress import p2p_pb2
+from modelexpress.adapter import EngineAdapter
+from modelexpress.load_strategy.context import LoadResult
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+class _FakeAdapter(EngineAdapter):
+    def discover_tensors(self, result: LoadResult):
+        return {}
+
+    def apply_weight_iter(self, result: LoadResult, weights_iter):
+        if result.model is not None:
+            result.model.load_weights(weights_iter)
+        return result
 
 
 def _make_load_context(**overrides):
@@ -30,6 +42,7 @@ def _make_load_context(**overrides):
         identity=p2p_pb2.SourceIdentity(model_name="test-model"),
         mx_client=MagicMock(),
         worker_id="test-worker",
+        adapter=_FakeAdapter(),
     )
     defaults.update(overrides)
     return LoadContext(**defaults)
@@ -105,13 +118,8 @@ class TestModelStreamerLoad:
         from modelexpress.load_strategy.model_streamer_strategy import ModelStreamerStrategy
         return ModelStreamerStrategy()
 
-    @patch("modelexpress.load_strategy.model_streamer_strategy.publish_metadata")
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
-    @patch("modelexpress.load_strategy.model_streamer_strategy.capture_tensor_attrs")
-    def test_success_path_s3(self, mock_capture, mock_register, mock_publish):
-        mock_capture.return_value.__enter__ = MagicMock()
-        mock_capture.return_value.__exit__ = MagicMock(return_value=False)
-
+    def test_success_path_s3(self, mock_register):
         model = MagicMock()
         ctx = _make_load_context()
         strategy = self._make_strategy()
@@ -125,24 +133,16 @@ class TestModelStreamerLoad:
                     ("layer.0.weight", torch.randn(4, 4)),
                     ("layer.1.weight", torch.randn(4, 4)),
                 ])
-                with patch(
-                    "vllm.model_executor.model_loader.utils.process_weights_after_loading"
-                ):
-                    result = strategy.load(model, ctx)
+                result = strategy.load(model, ctx)
 
-        assert result is True
+        assert isinstance(result, LoadResult)
+        assert result.model is model
         model.load_weights.assert_called_once()
-        mock_register.assert_called_once_with(model, ctx)
-        mock_publish.assert_called_once_with(ctx)
+        mock_register.assert_called_once_with(result, ctx)
 
-    @patch("modelexpress.load_strategy.model_streamer_strategy.publish_metadata")
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
-    @patch("modelexpress.load_strategy.model_streamer_strategy.capture_tensor_attrs")
-    def test_success_path_local(self, mock_capture, mock_register, mock_publish):
+    def test_success_path_local(self, mock_register):
         """load() works with a local path in MX_MODEL_URI."""
-        mock_capture.return_value.__enter__ = MagicMock()
-        mock_capture.return_value.__exit__ = MagicMock(return_value=False)
-
         model = MagicMock()
         ctx = _make_load_context()
         strategy = self._make_strategy()
@@ -155,17 +155,13 @@ class TestModelStreamerLoad:
                 mock_stream.return_value = iter([
                     ("layer.0.weight", torch.randn(4, 4)),
                 ])
-                with patch(
-                    "vllm.model_executor.model_loader.utils.process_weights_after_loading"
-                ):
-                    result = strategy.load(model, ctx)
+                result = strategy.load(model, ctx)
 
-        assert result is True
+        assert isinstance(result, LoadResult)
         mock_stream.assert_called_once_with("/models/llama", ctx)
 
-    @patch("modelexpress.load_strategy.model_streamer_strategy.publish_metadata")
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
-    def test_env_overrides_model_config(self, mock_register, mock_publish):
+    def test_env_overrides_model_config(self, mock_register):
         """MX_MODEL_URI takes priority over model_config.model."""
         model = MagicMock()
         model_config = MagicMock()
@@ -183,9 +179,8 @@ class TestModelStreamerLoad:
 
         mock_stream.assert_called_once_with("s3://bucket/model", ctx)
 
-    @patch("modelexpress.load_strategy.model_streamer_strategy.publish_metadata")
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
-    def test_returns_false_on_error(self, mock_register, mock_publish):
+    def test_returns_false_on_error(self, mock_register):
         model = MagicMock()
         ctx = _make_load_context()
         strategy = self._make_strategy()
@@ -200,7 +195,6 @@ class TestModelStreamerLoad:
 
         assert result is False
         mock_register.assert_not_called()
-        mock_publish.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/modelexpress_client/python/tests/test_source_id.py
+++ b/modelexpress_client/python/tests/test_source_id.py
@@ -12,7 +12,7 @@ sides' tests will fail together and catch it.
 from __future__ import annotations
 
 from modelexpress import p2p_pb2
-from modelexpress.source_id import compute_mx_source_id
+from modelexpress.metadata.source_id import compute_mx_source_id
 
 
 def _base_identity() -> p2p_pb2.SourceIdentity:

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the vLLM engine adapter."""
+
+from types import SimpleNamespace
+
+import torch
+
+from modelexpress.engines.vllm.adapter import _get_vllm_worker_rank
+from modelexpress.rank_utils import get_device_id
+
+
+def _vllm_config(*, rank: int, tp_size: int, pp_size: int):
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            rank=rank,
+            tensor_parallel_size=tp_size,
+            pipeline_parallel_size=pp_size,
+        )
+    )
+
+
+def test_worker_rank_uses_vllm_model_parallel_rank():
+    # vLLM rank layout is DP x PP x TP. Modulo TP*PP keeps PP/TP shard
+    # identity and drops the DP component.
+    config = _vllm_config(rank=6, tp_size=4, pp_size=2)
+
+    assert _get_vllm_worker_rank(config) == 6
+
+
+def test_worker_rank_ignores_dp_component():
+    dp0 = _vllm_config(rank=5, tp_size=4, pp_size=2)
+    dp1 = _vllm_config(rank=13, tp_size=4, pp_size=2)
+
+    assert _get_vllm_worker_rank(dp0) == 5
+    assert _get_vllm_worker_rank(dp1) == 5
+
+
+def test_device_id_uses_local_cuda_ordinal():
+    assert get_device_id(torch.device("cuda:3")) == 3

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn as nn
 
 from modelexpress import p2p_pb2
-from modelexpress.adapter import EngineAdapter
+from modelexpress.adapter import EngineAdapter, StrategyFailed
 from modelexpress.load_strategy.context import LoadResult
 from modelexpress.nixl_transfer import NixlTransferManager
 
@@ -238,6 +238,37 @@ class TestAbstractMethodCompleteness:
             loader.load_weights(model, cfg)
             mock_cls.return_value.load_weights.assert_called_once_with(model, cfg)
 
+    def test_load_model_clears_stale_nixl_manager_when_none_registered(self):
+        from modelexpress.engines.vllm import loader as loader_mod
+
+        loader = _make_loader()
+        stale_manager = MagicMock()
+        model = MagicMock()
+        ctx = _make_load_context(device_id=3)
+        ctx.tensors = {"w": MagicMock()}
+        ctx.nixl_manager = None
+        loader_mod._nixl_managers[3] = stale_manager
+
+        try:
+            with patch(
+                "modelexpress.engines.vllm.loader.build_vllm_load_context",
+                return_value=ctx,
+            ), patch(
+                "modelexpress.engines.vllm.loader.initialize_model",
+                return_value=model,
+            ), patch(
+                "modelexpress.engines.vllm.loader.LoadStrategyChain.run",
+                return_value=model,
+            ):
+                loaded = loader.load_model(MagicMock(), MagicMock(dtype=torch.float32))
+
+            assert loaded is model.eval.return_value
+            assert loader_mod._tensor_registry[3] == ctx.tensors
+            assert 3 not in loader_mod._nixl_managers
+        finally:
+            loader_mod._nixl_managers.pop(3, None)
+            loader_mod._tensor_registry.pop(3, None)
+
 
 # ---------------------------------------------------------------------------
 # register_tensors (load_strategy.base)
@@ -322,7 +353,7 @@ class TestPublishMetadataErrorHandling:
 class TestLoadStrategyChainRunErrorHandling:
     """Verify LoadStrategyChain.run catches exceptions from strategy.load()."""
 
-    def test_strategy_exception_falls_through_to_next(self):
+    def test_unexpected_strategy_exception_rolls_back_before_next(self):
         from modelexpress.load_strategy import LoadStrategyChain
 
         call_order = []
@@ -331,9 +362,12 @@ class TestLoadStrategyChainRunErrorHandling:
             call_order.append("exploding")
             raise RuntimeError("unexpected crash")
 
+        def rollback(self_or_ctx, *args, **kwargs):
+            call_order.append("rollback")
+
         def fallback_load(self_or_model, *args, **kwargs):
             call_order.append("fallback")
-            return True
+            return args[0]
 
         ctx = _make_load_context()
         model = MagicMock()
@@ -350,6 +384,10 @@ class TestLoadStrategyChainRunErrorHandling:
             "ModelStreamerStrategy.load",
             exploding_load,
         ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.rollback",
+            rollback,
+        ), patch(
             "modelexpress.load_strategy.gds_strategy.GdsStrategy.is_available",
             return_value=False,
         ), patch(
@@ -361,24 +399,23 @@ class TestLoadStrategyChainRunErrorHandling:
         ):
             LoadStrategyChain.run(model, ctx)
 
-        assert call_order == ["exploding", "fallback"]
+        assert call_order == ["exploding", "rollback", "fallback"]
 
-    def test_strategy_false_runs_rollback_before_next(self):
+    def test_strategy_failed_runs_rollback_before_next(self):
         from modelexpress.load_strategy import LoadStrategyChain
 
         call_order = []
 
-        def false_load(self_or_model, *args, **kwargs):
-            call_order.append("false")
-            return False
+        def failed_load(self_or_model, *args, **kwargs):
+            call_order.append("failed")
+            raise StrategyFailed("expected miss")
 
         def rollback(self_or_ctx, *args, **kwargs):
             call_order.append("rollback")
-            return True
 
         def fallback_load(self_or_model, *args, **kwargs):
             call_order.append("fallback")
-            return True
+            return args[0]
 
         ctx = _make_load_context()
         ctx.adapter.reinit_for_retry = MagicMock(side_effect=lambda result: result)
@@ -394,7 +431,7 @@ class TestLoadStrategyChainRunErrorHandling:
         ), patch(
             "modelexpress.load_strategy.model_streamer_strategy."
             "ModelStreamerStrategy.load",
-            false_load,
+            failed_load,
         ), patch(
             "modelexpress.load_strategy.model_streamer_strategy."
             "ModelStreamerStrategy.rollback",
@@ -411,8 +448,111 @@ class TestLoadStrategyChainRunErrorHandling:
         ):
             LoadStrategyChain.run(model, ctx)
 
-        assert call_order == ["false", "rollback", "fallback"]
-        ctx.adapter.reinit_for_retry.assert_called_once()
+        assert call_order == ["failed", "rollback", "fallback"]
+        ctx.adapter.reinit_for_retry.assert_not_called()
+
+    def test_strategy_failed_runs_rollback_and_reinit_when_mutated(self):
+        from modelexpress.load_strategy import LoadStrategyChain
+
+        call_order = []
+
+        def failed_load(self_or_model, *args, **kwargs):
+            call_order.append("failed")
+            raise StrategyFailed("mutated failure", mutated=True)
+
+        def rollback(self_or_ctx, *args, **kwargs):
+            call_order.append("rollback")
+
+        def reinit(result):
+            call_order.append("reinit")
+            return result
+
+        def fallback_load(self_or_model, *args, **kwargs):
+            call_order.append("fallback")
+            return args[0]
+
+        ctx = _make_load_context()
+        ctx.adapter.reinit_for_retry = MagicMock(side_effect=reinit)
+        model = MagicMock()
+
+        with patch(
+            "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.load",
+            failed_load,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.rollback",
+            rollback,
+        ), patch(
+            "modelexpress.load_strategy.gds_strategy.GdsStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.load",
+            fallback_load,
+        ):
+            LoadStrategyChain.run(model, ctx)
+
+        assert call_order == ["failed", "rollback", "reinit", "fallback"]
+
+    def test_strategy_failed_runs_rollback_without_reinit_when_clean(self):
+        from modelexpress.load_strategy import LoadStrategyChain
+
+        call_order = []
+
+        def failed_load(self_or_model, *args, **kwargs):
+            call_order.append("failed")
+            raise StrategyFailed("clean failure", mutated=False)
+
+        def rollback(self_or_ctx, *args, **kwargs):
+            call_order.append("rollback")
+
+        def fallback_load(self_or_model, *args, **kwargs):
+            call_order.append("fallback")
+            return args[0]
+
+        ctx = _make_load_context()
+        ctx.adapter.reinit_for_retry = MagicMock(side_effect=lambda result: result)
+        model = MagicMock()
+
+        with patch(
+            "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.load",
+            failed_load,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.rollback",
+            rollback,
+        ), patch(
+            "modelexpress.load_strategy.gds_strategy.GdsStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.load",
+            fallback_load,
+        ):
+            LoadStrategyChain.run(model, ctx)
+
+        assert call_order == ["failed", "rollback", "fallback"]
+        ctx.adapter.reinit_for_retry.assert_not_called()
 
 
 class TestRdmaStrategyAvailability:
@@ -573,7 +713,6 @@ class TestFetchWorkerMetadata:
 class TestRdmaStrategyLoad:
     def _setup(self, ctx, candidates, metadata_side_effects, load_raises_for=None):
         from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
-        from modelexpress.load_strategy import SourceTransferError
 
         strategy = RdmaStrategy()
         ctx.mx_client.list_sources.return_value = p2p_pb2.ListSourcesResponse(
@@ -582,18 +721,16 @@ class TestRdmaStrategyLoad:
         ctx.mx_client.get_metadata.side_effect = metadata_side_effects
         attempts = []
 
-        original_load_as_target = strategy._load_as_target
-
         def fake_load_as_target(_result, _ctx, _worker, _mx_id, worker_id):
             attempts.append(worker_id)
             if load_raises_for and worker_id in load_raises_for:
-                raise SourceTransferError(f"transfer failed: {worker_id}")
+                raise StrategyFailed(f"transfer failed: {worker_id}", mutated=True)
             return _result
 
         strategy._load_as_target = fake_load_as_target
         return strategy, attempts
 
-    def test_returns_true_on_first_success(self):
+    def test_returns_result_on_first_success(self):
         ctx = _make_load_context()
         candidates = [_make_instance_ref(worker_id="w-1")]
         strategy, attempts = self._setup(ctx, candidates, [_make_metadata_resp(rank=0, worker_id="w-1")])
@@ -605,7 +742,7 @@ class TestRdmaStrategyLoad:
         assert isinstance(result, LoadResult)
         assert attempts == ["w-1"]
 
-    def test_tries_next_on_source_transfer_error(self):
+    def test_propagates_strategy_failed_after_target_mutation(self):
         ctx = _make_load_context()
         candidates = [
             _make_instance_ref(worker_id="w-1"),
@@ -620,35 +757,72 @@ class TestRdmaStrategyLoad:
 
         with patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True), \
              patch("modelexpress.load_strategy.rdma_strategy.random.shuffle"):
-            result = strategy.load(MagicMock(), ctx)
+            with pytest.raises(StrategyFailed, match="transfer failed: w-1") as exc:
+                strategy.load(MagicMock(), ctx)
 
-        assert isinstance(result, LoadResult)
-        assert attempts == ["w-1", "w-2"]
+        assert exc.value.mutated is True
+        assert attempts == ["w-1"]
 
-    def test_returns_false_when_no_candidates(self):
+    def test_raises_strategy_failed_when_no_candidates(self):
         ctx = _make_load_context()
         ctx.mx_client.list_sources.return_value = p2p_pb2.ListSourcesResponse(instances=[])
         from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
         strategy = RdmaStrategy()
 
         with patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True):
-            result = strategy.load(MagicMock(), ctx)
-        assert result is False
+            with pytest.raises(StrategyFailed, match="No RDMA source available") as exc:
+                strategy.load(MagicMock(), ctx)
+        assert exc.value.mutated is False
 
-    def test_returns_false_when_all_fail(self):
+    def test_raises_strategy_failed_when_all_sources_fail(self):
         ctx = _make_load_context()
         candidates = [_make_instance_ref(worker_id=f"w-{i}") for i in range(3)]
         strategy, _ = self._setup(
             ctx, candidates,
-            [_make_metadata_resp(rank=0, worker_id=f"w-{i}") for i in range(3)],
-            load_raises_for={"w-0", "w-1", "w-2"},
+            [
+                p2p_pb2.GetMetadataResponse(found=False)
+                for _ in range(3)
+            ],
         )
 
         with patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True), \
              patch("modelexpress.load_strategy.rdma_strategy.random.shuffle"):
-            result = strategy.load(MagicMock(), ctx)
+            with pytest.raises(StrategyFailed, match="No RDMA source succeeded") as exc:
+                strategy.load(MagicMock(), ctx)
 
-        assert result is False
+        assert exc.value.mutated is False
+
+    def test_load_as_target_marks_post_prepare_failure_as_mutated(self):
+        from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
+
+        ctx = _make_load_context()
+        result = LoadResult(value=MagicMock(), model=MagicMock())
+        strategy = RdmaStrategy()
+        source_worker = _make_worker()
+
+        ctx.adapter.prepare_rdma_target = MagicMock(side_effect=lambda result: result)
+        ctx.adapter.before_rdma_receive = MagicMock(
+            side_effect=RuntimeError("post-prepare failure")
+        )
+
+        with pytest.raises(StrategyFailed, match="post-prepare failure") as exc:
+            strategy._load_as_target(result, ctx, source_worker, "src", "worker")
+
+        assert exc.value.mutated is True
+
+    def test_rollback_shuts_down_nixl_manager(self):
+        from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
+
+        ctx = _make_load_context()
+        ctx.tensors = {"w": MagicMock()}
+        manager = MagicMock()
+        ctx.nixl_manager = manager
+
+        RdmaStrategy().rollback(ctx)
+
+        manager.shutdown.assert_called_once()
+        assert ctx.nixl_manager is None
+        assert ctx.tensors == {}
 
 
 # ---------------------------------------------------------------------------

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -14,6 +14,8 @@ import torch
 import torch.nn as nn
 
 from modelexpress import p2p_pb2
+from modelexpress.adapter import EngineAdapter
+from modelexpress.load_strategy.context import LoadResult
 from modelexpress.nixl_transfer import NixlTransferManager
 
 
@@ -24,11 +26,11 @@ from modelexpress.nixl_transfer import NixlTransferManager
 
 def _make_loader():
     """Return an MxModelLoader with a fresh mock MxClient."""
-    with patch("modelexpress.vllm_loader.DefaultModelLoader"):
+    with patch("modelexpress.engines.vllm.loader.DefaultModelLoader"):
         load_config = MagicMock()
         load_config.load_format = "mx"
         load_config.device = None
-        from modelexpress.vllm_loader import MxModelLoader
+        from modelexpress.engines.vllm.loader import MxModelLoader
         loader = MxModelLoader(load_config)
     loader._mx_client = MagicMock()
     return loader
@@ -55,6 +57,33 @@ def _make_instance_ref(mx_source_id="abc123def456abcd", worker_id="inst-1", mode
     )
 
 
+class _FakeAdapter(EngineAdapter):
+    def build_identity(self):
+        return _make_identity()
+
+    def get_worker_rank(self) -> int:
+        return 0
+
+    def get_device_id(self) -> int:
+        return 0
+
+    def discover_tensors(self, result: LoadResult):
+        return {}
+
+    def apply_weight_iter(self, result: LoadResult, weights_iter):
+        if result.model is not None:
+            result.model.load_weights(weights_iter)
+        return result
+
+    def load_via_native(self, result: LoadResult):
+        if result.model is not None:
+            result.model.load_weights([])
+        return result
+
+    def reinit_for_retry(self, result: LoadResult):
+        return result
+
+
 def _make_metadata_resp(found=True, rank=0, mx_source_id="abc123def456abcd", worker_id="inst-1"):
     worker = _make_worker(rank=rank) if found else None
     return p2p_pb2.GetMetadataResponse(
@@ -78,6 +107,7 @@ def _make_load_context(**overrides):
         identity=_make_identity(),
         mx_client=MagicMock(),
         worker_id="test-worker",
+        adapter=_FakeAdapter(),
     )
     defaults.update(overrides)
     return LoadContext(**defaults)
@@ -190,21 +220,21 @@ class TestAbstractMethodCompleteness:
         assert _make_loader() is not None
 
     def test_no_remaining_abstract_methods(self):
-        from modelexpress.vllm_loader import MxModelLoader
+        from modelexpress.engines.vllm.loader import MxModelLoader
         remaining = getattr(MxModelLoader, "__abstractmethods__", frozenset())
         assert remaining == frozenset()
 
     def test_download_model_delegates(self):
         loader = _make_loader()
         cfg = MagicMock()
-        with patch("modelexpress.vllm_loader.DefaultModelLoader") as mock_cls:
+        with patch("modelexpress.engines.vllm.loader.DefaultModelLoader") as mock_cls:
             loader.download_model(cfg)
             mock_cls.return_value.download_model.assert_called_once_with(cfg)
 
     def test_load_weights_delegates(self):
         loader = _make_loader()
         model, cfg = MagicMock(), MagicMock()
-        with patch("modelexpress.vllm_loader.DefaultModelLoader") as mock_cls:
+        with patch("modelexpress.engines.vllm.loader.DefaultModelLoader") as mock_cls:
             loader.load_weights(model, cfg)
             mock_cls.return_value.load_weights.assert_called_once_with(model, cfg)
 
@@ -332,6 +362,57 @@ class TestLoadStrategyChainRunErrorHandling:
             LoadStrategyChain.run(model, ctx)
 
         assert call_order == ["exploding", "fallback"]
+
+    def test_strategy_false_runs_rollback_before_next(self):
+        from modelexpress.load_strategy import LoadStrategyChain
+
+        call_order = []
+
+        def false_load(self_or_model, *args, **kwargs):
+            call_order.append("false")
+            return False
+
+        def rollback(self_or_ctx, *args, **kwargs):
+            call_order.append("rollback")
+            return True
+
+        def fallback_load(self_or_model, *args, **kwargs):
+            call_order.append("fallback")
+            return True
+
+        ctx = _make_load_context()
+        ctx.adapter.reinit_for_retry = MagicMock(side_effect=lambda result: result)
+        model = MagicMock()
+
+        with patch(
+            "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.load",
+            false_load,
+        ), patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy.rollback",
+            rollback,
+        ), patch(
+            "modelexpress.load_strategy.gds_strategy.GdsStrategy.is_available",
+            return_value=False,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.is_available",
+            return_value=True,
+        ), patch(
+            "modelexpress.load_strategy.default_strategy.DefaultStrategy.load",
+            fallback_load,
+        ):
+            LoadStrategyChain.run(model, ctx)
+
+        assert call_order == ["false", "rollback", "fallback"]
+        ctx.adapter.reinit_for_retry.assert_called_once()
 
 
 class TestRdmaStrategyAvailability:
@@ -503,10 +584,11 @@ class TestRdmaStrategyLoad:
 
         original_load_as_target = strategy._load_as_target
 
-        def fake_load_as_target(_m, _ctx, _worker, _mx_id, worker_id):
+        def fake_load_as_target(_result, _ctx, _worker, _mx_id, worker_id):
             attempts.append(worker_id)
             if load_raises_for and worker_id in load_raises_for:
                 raise SourceTransferError(f"transfer failed: {worker_id}")
+            return _result
 
         strategy._load_as_target = fake_load_as_target
         return strategy, attempts
@@ -520,7 +602,7 @@ class TestRdmaStrategyLoad:
              patch("modelexpress.load_strategy.rdma_strategy.random.shuffle"):
             result = strategy.load(MagicMock(), ctx)
 
-        assert result is True
+        assert isinstance(result, LoadResult)
         assert attempts == ["w-1"]
 
     def test_tries_next_on_source_transfer_error(self):
@@ -540,7 +622,7 @@ class TestRdmaStrategyLoad:
              patch("modelexpress.load_strategy.rdma_strategy.random.shuffle"):
             result = strategy.load(MagicMock(), ctx)
 
-        assert result is True
+        assert isinstance(result, LoadResult)
         assert attempts == ["w-1", "w-2"]
 
     def test_returns_false_when_no_candidates(self):
@@ -576,7 +658,7 @@ class TestRdmaStrategyLoad:
 
 class TestPublishMetadataAndReady:
     def test_calls_publish_and_starts_heartbeat(self):
-        from modelexpress.metadata import publish_metadata_and_ready
+        from modelexpress.metadata.publish import publish_metadata_and_ready
 
         mx_client = MagicMock()
         mx_client.publish_metadata.return_value = "abc123def456abcd"
@@ -596,7 +678,7 @@ class TestPublishMetadataAndReady:
         identity = _make_identity("my-model")
         mock_hb = MagicMock()
         with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
+             patch("modelexpress.metadata.publish.HeartbeatThread", return_value=mock_hb) as hb_cls:
             publish_metadata_and_ready(mx_client, nixl_manager, tensors, global_rank=2, device_id=0, identity=identity, worker_id="inst-uuid")
 
         mx_client.publish_metadata.assert_called_once()
@@ -614,7 +696,7 @@ class TestPublishMetadataAndReady:
         mock_hb.start.assert_called_once()
 
     def test_retries_publish_before_starting_heartbeat(self):
-        from modelexpress.metadata import publish_metadata_and_ready
+        from modelexpress.metadata.publish import publish_metadata_and_ready
 
         mx_client = MagicMock()
         mx_client.publish_metadata.side_effect = [
@@ -629,8 +711,8 @@ class TestPublishMetadataAndReady:
         identity = _make_identity()
         mock_hb = MagicMock()
         with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.time.sleep") as sleep_mock, \
-             patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
+             patch("modelexpress.metadata.publish.time.sleep") as sleep_mock, \
+             patch("modelexpress.metadata.publish.HeartbeatThread", return_value=mock_hb) as hb_cls:
             publish_metadata_and_ready(
                 mx_client,
                 nixl_manager,
@@ -654,7 +736,7 @@ class TestPublishMetadataAndReady:
 
     def test_publish_failure_after_retries_raises_runtime_error(self):
         """If publish_metadata keeps failing, heartbeat should not be started."""
-        from modelexpress.metadata import publish_metadata_and_ready
+        from modelexpress.metadata.publish import publish_metadata_and_ready
 
         mx_client = MagicMock()
         mx_client.publish_metadata.side_effect = [
@@ -669,8 +751,8 @@ class TestPublishMetadataAndReady:
         identity = _make_identity()
         mock_hb = MagicMock()
         with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.time.sleep") as sleep_mock, \
-             patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
+             patch("modelexpress.metadata.publish.time.sleep") as sleep_mock, \
+             patch("modelexpress.metadata.publish.HeartbeatThread", return_value=mock_hb) as hb_cls:
             with pytest.raises(RuntimeError, match="Failed to publish metadata after 3 attempts"):
                 publish_metadata_and_ready(
                     mx_client,
@@ -687,7 +769,7 @@ class TestPublishMetadataAndReady:
         hb_cls.assert_not_called()
 
     def test_non_retryable_grpc_failure_fails_immediately(self):
-        from modelexpress.metadata import publish_metadata_and_ready
+        from modelexpress.metadata.publish import publish_metadata_and_ready
 
         mx_client = MagicMock()
         mx_client.publish_metadata.side_effect = _FakeRpcError(
@@ -701,8 +783,8 @@ class TestPublishMetadataAndReady:
         identity = _make_identity()
         mock_hb = MagicMock()
         with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.time.sleep") as sleep_mock, \
-             patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
+             patch("modelexpress.metadata.publish.time.sleep") as sleep_mock, \
+             patch("modelexpress.metadata.publish.HeartbeatThread", return_value=mock_hb) as hb_cls:
             with pytest.raises(_FakeRpcError, match="permission denied"):
                 publish_metadata_and_ready(
                     mx_client,
@@ -907,12 +989,12 @@ class TestConfigureVllmLogging:
             self._reset_mx_logger()
             configure_vllm_logging()
 
-            child = logging.getLogger("modelexpress.heartbeat")
+            child = logging.getLogger("modelexpress.metadata.heartbeat")
             child.info("Heartbeat started")
 
             assert len(buf.buffer) == 1
             assert "Heartbeat started" in buf.buffer[0].getMessage()
-            assert buf.buffer[0].name == "modelexpress.heartbeat"
+            assert buf.buffer[0].name == "modelexpress.metadata.heartbeat"
         finally:
             vllm_logger.removeHandler(buf)
             self._cleanup(vllm_logger)

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -70,6 +70,12 @@ class _FakeAdapter(EngineAdapter):
     def discover_tensors(self, result: LoadResult):
         return {}
 
+    def after_weight_iter_load(self, result: LoadResult):
+        return result
+
+    def after_native_load(self, result: LoadResult):
+        return result
+
     def apply_weight_iter(self, result: LoadResult, weights_iter):
         if result.model is not None:
             result.model.load_weights(weights_iter)
@@ -103,6 +109,7 @@ def _make_load_context(**overrides):
         load_config=MagicMock(),
         target_device=torch.device("cpu"),
         global_rank=0,
+        worker_rank=0,
         device_id=0,
         identity=_make_identity(),
         mx_client=MagicMock(),
@@ -307,12 +314,18 @@ class TestRegisterTensorsErrorHandling:
         assert ctx.nixl_manager is None
 
     @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
-    @patch("modelexpress.load_strategy.base.collect_module_tensors", return_value={})
+    def test_requires_adapter_when_nixl_available(self, _mock):
+        from modelexpress.load_strategy.base import register_tensors
+        ctx = _make_load_context(adapter=None)
+        with pytest.raises(RuntimeError, match="engine adapter"):
+            register_tensors(MagicMock(), ctx)
+
+    @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
     @patch(
         "modelexpress.load_strategy.base._init_nixl_manager",
         side_effect=RuntimeError("NIXL_ERR_BACKEND"),
     )
-    def test_nixl_init_failure_does_not_raise(self, _init, _collect, _avail):
+    def test_nixl_init_failure_does_not_raise(self, _init, _avail):
         from modelexpress.load_strategy.base import register_tensors
         ctx = _make_load_context()
         model = MagicMock()
@@ -320,15 +333,15 @@ class TestRegisterTensorsErrorHandling:
         assert ctx.nixl_manager is None
 
     @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
-    @patch("modelexpress.load_strategy.base.collect_module_tensors", return_value={"t": MagicMock()})
     @patch("modelexpress.load_strategy.base._init_nixl_manager")
-    def test_tensor_registration_failure_does_not_raise(self, mock_init, _collect, _avail):
+    def test_tensor_registration_failure_does_not_raise(self, mock_init, _avail):
         from modelexpress.load_strategy.base import register_tensors
         mock_mgr = MagicMock()
         mock_mgr.tensor_descriptors = []
         mock_mgr.register_tensors.side_effect = RuntimeError("memory registration failed")
         mock_init.return_value = mock_mgr
         ctx = _make_load_context()
+        ctx.adapter.discover_tensors = MagicMock(return_value={"t": MagicMock()})
         model = MagicMock()
         register_tensors(model, ctx)
 
@@ -348,6 +361,21 @@ class TestPublishMetadataErrorHandling:
         ctx = _make_load_context()
         ctx.nixl_manager = MagicMock()
         publish_metadata(ctx)
+
+    def test_unpublish_uses_worker_rank_for_heartbeat_lifecycle(self):
+        from modelexpress.load_strategy.base import unpublish_metadata
+        from modelexpress.metadata.publish import _heartbeat_threads, _worker_servers
+
+        ctx = _make_load_context(global_rank=4, worker_rank=0)
+        heartbeat = MagicMock()
+        _heartbeat_threads[ctx.worker_rank] = heartbeat
+        try:
+            unpublish_metadata(ctx)
+        finally:
+            _heartbeat_threads.pop(ctx.worker_rank, None)
+            _worker_servers.pop(ctx.device_id, None)
+
+        heartbeat.stop.assert_called_once()
 
 
 class TestLoadStrategyChainRunErrorHandling:
@@ -553,6 +581,21 @@ class TestLoadStrategyChainRunErrorHandling:
 
         assert call_order == ["failed", "rollback", "fallback"]
         ctx.adapter.reinit_for_retry.assert_not_called()
+
+
+class TestDefaultStrategy:
+    @patch("modelexpress.load_strategy.default_strategy.register_tensors")
+    def test_after_native_load_failure_is_mutated(self, mock_register):
+        from modelexpress.load_strategy.default_strategy import DefaultStrategy
+
+        ctx = _make_load_context()
+        ctx.adapter.after_native_load = MagicMock(side_effect=RuntimeError("post load"))
+
+        with pytest.raises(StrategyFailed, match="post load") as exc:
+            DefaultStrategy().load(MagicMock(), ctx)
+
+        assert exc.value.mutated is True
+        mock_register.assert_not_called()
 
 
 class TestRdmaStrategyAvailability:
@@ -853,7 +896,7 @@ class TestPublishMetadataAndReady:
         mock_hb = MagicMock()
         with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
              patch("modelexpress.metadata.publish.HeartbeatThread", return_value=mock_hb) as hb_cls:
-            publish_metadata_and_ready(mx_client, nixl_manager, tensors, global_rank=2, device_id=0, identity=identity, worker_id="inst-uuid")
+            publish_metadata_and_ready(mx_client, nixl_manager, tensors, worker_rank=2, device_id=0, identity=identity, worker_id="inst-uuid")
 
         mx_client.publish_metadata.assert_called_once()
         call_args = mx_client.publish_metadata.call_args
@@ -891,7 +934,7 @@ class TestPublishMetadataAndReady:
                 mx_client,
                 nixl_manager,
                 {},
-                global_rank=0,
+                worker_rank=0,
                 device_id=0,
                 identity=identity,
                 worker_id="w-1",
@@ -932,7 +975,7 @@ class TestPublishMetadataAndReady:
                     mx_client,
                     nixl_manager,
                     {},
-                    global_rank=0,
+                    worker_rank=0,
                     device_id=0,
                     identity=identity,
                     worker_id="w-1",
@@ -964,7 +1007,7 @@ class TestPublishMetadataAndReady:
                     mx_client,
                     nixl_manager,
                     {},
-                    global_rank=0,
+                    worker_rank=0,
                     device_id=0,
                     identity=identity,
                     worker_id="w-1",


### PR DESCRIPTION
Refactors the Python client loading path so engine-specific code sits behind a small adapter boundary, while preserving the existing vLLM entry point used by current manifests.

Design doc: https://docs.google.com/document/d/1MlvAx_evyI75a1TkOIlKR3UV7-ESjw2R1WJNBYrWum8/edit?tab=t.5fveasr8cwdc#heading=h.7rw11mbt6qjl

## Why

ModelExpress now has more than one loading path and more than one engine integration target:

- RDMA P2P from another live worker
- ModelStreamer from object storage / local disk
- GDS / native fallback
- vLLM today, with SGLang and TRT-LLM integration work following the same pattern

Before this PR, vLLM-specific logic, metadata publication, rank/device identity, and strategy selection were coupled together. That made it hard to reason about which behavior was engine-neutral and which behavior belonged to vLLM.

This PR separates those concerns without changing the public vLLM loader import path.

Configurable chain, @register_strategy + entry-points, MxConfig are new features and they are for follow up PRs. 

## Before / after

| Aspect | Before | After |
|---|---|---|
| Strategy result contract | Strategies returned engine-specific objects or booleans directly | Strategies pass a `LoadResult` through the chain |
| Engine coupling | Strategies called vLLM-shaped behavior directly | Strategies call `EngineAdapter` hooks |
| vLLM integration code | Mixed into top-level `modelexpress` modules | Implemented under `modelexpress.engines.vllm` |
| Existing vLLM entry point | `modelexpress.vllm_loader` | Still available as the compatibility entry point |
| Metadata helpers | Top-level modules mixed with loading code | Moved under `modelexpress.metadata` |
| File renames | Broad package rename was considered | `load_strategy/` is intentionally kept as-is |
| P2P rank identity | Some paths used global rank where worker rank is required | Adapter exposes engine-specific worker/global rank mapping |

## What changed

**Engine adapter boundary:** added `modelexpress.adapter.EngineAdapter`, `LoadResult`, and adapter hooks for weight iterators, native load, tensor discovery, rank/device identity, lifecycle hooks, and retry reinitialization.

**vLLM adapter:** moved vLLM-specific implementation under `modelexpress.engines.vllm`, including the adapter and loader implementation. The existing `modelexpress.vllm_loader` module remains as the compatibility import path.

**Load strategy chain:** updated RDMA, ModelStreamer, GDS, and default strategies to operate through `LoadResult` and adapter hooks instead of directly assuming vLLM internals.

**Metadata package:** moved metadata publication, heartbeat, client factory, K8s service client, worker server, and source identity code into `modelexpress.metadata` without keeping top-level shim modules.

**Docs and examples:** updated architecture/deployment docs and examples to reflect the current package boundaries and required RBAC/example layout.

## Compatibility notes

- Existing vLLM users should continue using `--load-format mx` and the existing `modelexpress.vllm_loader` entry point.
- `load_strategy/` is not renamed in this PR.
- Top-level metadata helper modules were moved; internal imports now use `modelexpress.metadata.*`.

## Testing

### Unit tests

Focused Python tests were run for the strategy chain and ModelStreamer behavior:

```bash
UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest \
  tests/test_model_streamer_strategy.py \
  tests/test_vllm_loader.py::TestLoadStrategyChainRunErrorHandling
```

Result: **26 passed**.

### nscale Dynamo DGD end-to-end

Built branch images and deployed the Dynamo aggregated vLLM example with TP=4 / PP=1. Scaled `VllmWorker` from 1 to 2 replicas.

| Check | Result |
|---|---|
| First replica startup | Ready |
| Second replica startup | Ready |
| Second replica weight path | RDMA P2P |
| Transfer size | 149.59 GB per rank |
| Transfer time | ~5.6s |
| Throughput | ~211-212 Gbps |
| Frontend inference | HTTP 200 responses; traffic observed on both replicas |

### AWS ModelStreamer S3 validation

Built and pushed the linux/arm64 client image for AWS GB200:

```bash
nvcr.io/nvidian/dynamo-dev/model-express-dev-containers:vllm-streamer-29ae4a6
```

Deployed `examples/p2p_transfer_k8s/client/vllm/vllm-single-node-streamer-s3.yaml` as a temporary manifest with:

```bash
MX_MODEL_URI=s3://model-express-models/deepseek-ai/DeepSeek-V3/
AWS_DEFAULT_REGION=us-east-1
```

Result: ModelStreamer successfully streamed all 163 safetensors files.

| Check | Result |
|---|---|
| S3 object discovery | 163 safetensors files |
| Streamed bytes | ~641.3 GiB per rank |
| Stream time | ~356-376s |
| ModelStreamer completion | `Model streamer weight loading complete` on all ranks |

The AWS test also found a deployment pitfall now documented in the local test skill: the `model-express-models` bucket is in `us-east-1`. With `AWS_DEFAULT_REGION=us-west-2`, boto3 `HeadObject` and range reads can still work, but RunAI libstreamer fails with `File access error`.

The same AWS TP=4 smoke test then hit a vLLM serving configuration limit after successful weight load: DeepSeek-V3 default max length `163840` required more KV cache than available (`10.72 GiB` needed vs `4.26 GiB` available). For TP=4 smoke inference, use a lower `--max-model-len`, for example `32768`.

## Follow-ups

- Add engine adapters for SGLang and TRT-LLM on top of this boundary.
- Add automatic UCX device selection instead of requiring manual per-rank device selection.
- Add a dedicated ModelStreamer S3 smoke recipe for AWS that sets the bucket region and TP=4 serving parameters explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced engine adapter system enabling flexible, engine-specific loading strategies with improved retry and rollback capabilities.
  * KV transfer connector configuration for vLLM decode workers in Kubernetes deployments.

* **Documentation**
  * Updated architecture documentation reflecting reorganized module structure.

* **Chores**
  * Expanded Kubernetes RBAC permissions for model cache entry management.
  * Restructured internal modules for better API organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->