### PR TITLE
docs: add SGLang usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ModelExpress orchestrates the full flow—from download to GPU memory. It ensure
 | vLLM | `--load-format mx` for P2P weight transfer |
 | NVIDIA Dynamo (vLLM) | `get_model_path` API; [aggregated K8s example](examples/aggregated_k8s/README.md) |
 | TensorRT-LLM | `LoadFormat.PRESHARDED` with `MxLiveCheckpointLoader` for P2P weight transfer (beta) — [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) |
-| SGLang | Coming soon |
+| SGLang | `--modelexpress-config` with `transport=nixl` — see [`docs/SGLANG.md`](docs/SGLANG.md) |
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -574,6 +574,13 @@ kubectl -n $NAMESPACE delete -f examples/k8s_service_sources/sources-tp2-single-
 
 See [`../examples/k8s_service_sources/README.md`](../examples/k8s_service_sources/README.md) for the annotated manifests and [`K8S_SERVICE_BACKEND.md`](K8S_SERVICE_BACKEND.md) for the design rationale.
 
+#### SGLang Clients
+
+ModelExpress also works as the remote-instance weight loader for SGLang via
+upstream [sgl-project/sglang#23105](https://github.com/sgl-project/sglang/pull/23105),
+supporting both Mooncake TransferEngine and NIXL transports. See
+[`SGLANG.md`](SGLANG.md) for the user-facing guide.
+
 ## Debugging
 
 ```bash

--- a/docs/SGLANG.md
+++ b/docs/SGLANG.md
@@ -1,0 +1,68 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Using ModelExpress with SGLang
+
+ModelExpress can serve as the remote-instance weight loader for SGLang,
+streaming weights GPU-to-GPU over RDMA between SGLang processes instead
+of loading from disk on every replica. The integration is contributed by
+upstream [sgl-project/sglang#23105](https://github.com/sgl-project/sglang/pull/23105),
+which adds the `--modelexpress-config` flag and supports two transports:
+
+- **Mooncake TransferEngine** — SGLang's existing remote-instance path.
+- **NIXL** — selected with `transport: "nixl"`.
+
+## 1. Install SGLang
+
+Install SGLang either way:
+
+- **Pull the official image** — use a recent `lmsysorg/sglang` tag from
+  Docker Hub. PR #23105 was merged on `main`, so any image built from
+  `main` after the merge contains it.
+- **Build from `main`** — follow SGLang's official install guide at
+  [docs.sglang.ai/start/install](https://docs.sglang.ai/start/install.html).
+
+Either way, confirm the flag is present before running:
+
+## 2. Install the ModelExpress Python client
+
+```bash
+pip install "modelexpress @ git+https://github.com/ai-dynamo/modelexpress.git#subdirectory=modelexpress_client/python"
+```
+
+## 3. Start a ModelExpress server
+
+ModelExpress server should be reachable at
+`modelexpress-server:8001`. See [`DEPLOYMENT.md`](DEPLOYMENT.md) for how
+to start one (Docker, Helm, or Kubernetes).
+
+## 4. Launch SGLang
+
+### NIXL transport
+
+**Seed:**
+
+```bash
+python -m sglang.launch_server \
+  --model-path deepseek-ai/DeepSeek-V3 --tp 8 --port 30000 \
+  --load-format auto \
+  --modelexpress-config '{"url": "modelexpress-server:8001", "source": true, "transport": "nixl"}'
+```
+
+**Client:**
+
+```bash
+python -m sglang.launch_server \
+  --model-path deepseek-ai/DeepSeek-V3 --tp 8 --port 30001 \
+  --load-format remote_instance \
+  --remote-instance-weight-loader-backend modelexpress \
+  --modelexpress-config '{"url": "modelexpress-server:8001", "transport": "nixl"}'
+```
+
+
+## See also
+
+- Upstream PR: [sgl-project/sglang#23105](https://github.com/sgl-project/sglang/pull/23105).
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) — running the ModelExpress server, NIXL/UCX tuning, performance reference.


### PR DESCRIPTION
## Summary

Adds a single user-facing doc, `docs/SGLANG.md`, that walks QA / users through running SGLang with the ModelExpress P2P weight loader, covering both transports added by upstream [sgl-project/sglang#23105](https://github.com/sgl-project/sglang/pull/23105):

- **NIXL** (new in PR #23105) via `transport: "nixl"`.

The doc points users to either pull a recent `lmsysorg/sglang` image or build from `main` per [docs.sglang.ai](https://docs.sglang.ai/start/install.html), and reproduces the launch commands verbatim from the PR description.

Also updates the README integration table (replaces "SGLang | Coming soon") and adds a one-line SGLang subsection in `DEPLOYMENT.md` linking back to the new doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * SGLang integration is now fully documented with end-to-end setup and configuration instructions
  * Added comprehensive guide for using ModelExpress with SGLang, including NIXL transport configuration
  * Updated integration status from "Coming soon" to complete with detailed configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->