### PR TITLE
feat: enable P2P transfer for MLA models by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ cargo bench
 
 ## Known Issues
 
-- **MLA models blocked from P2P transfer** — Models using Multi-head Latent Attention (DeepSeek-V2/V3, Kimi K2/K2.5) are automatically blocked from GPU-to-GPU transfer and fall back to disk loading. Bytes transfer correctly but inference produces corrupted output. Set `MX_SKIP_FEATURE_CHECK=1` to bypass for debugging. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 - **NIXL_ERR_REMOTE_DISCONNECT** — Source restarts invalidate rkeys. Flush Redis, redeploy.
 - **Long source warmup** — DeepSeek-V3 (DeepGemm, CUDA graphs) can take significant time; targets wait via coordination.
 - **Large model gRPC stream** — May not close automatically; use client timeout.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -544,7 +544,7 @@ Auto-detects the best loading strategy with a prioritized chain. Each strategy i
 
 | Priority | Strategy | `is_available()` | Behavior |
 |---|---|---|---|
-| p0 | `RdmaStrategy` | NIXL available + MLA check passes | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). On `SourceTransferError` or `ManifestMismatchError`, try next. |
+| p0 | `RdmaStrategy` | NIXL available | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). On `SourceTransferError` or `ManifestMismatchError`, try next. |
 | p1 | `ModelStreamerStrategy` | `MX_MODEL_URI` set + `runai_model_streamer` installed | Stream safetensors to GPU via CPU staging buffer. `MX_MODEL_URI` accepts remote URIs (`s3://`, `gs://`, `az://`), absolute local paths, or HF model IDs (resolved via `HF_HUB_CACHE`). All storage backends (S3, GCS, Azure) included by default. |
 | p2 | `GdsStrategy` | GDS hardware available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. |
 | p3 | `DefaultStrategy` | Always | vLLM `DefaultModelLoader` (CPU-staged, auto-downloads from HF Hub). |
@@ -553,9 +553,9 @@ Each strategy is fully self-contained: it handles weight loading, post-processin
 
 ### Transfer Safety
 
-`RdmaStrategy.is_available()` checks `transfer_safety.check_transfer_allowed()` before attempting P2P transfer. Currently the only blocked feature is MLA (Multi-head Latent Attention), detected via `kv_lora_rank` in the HF model config. MLA models (DeepSeek-V2/V3, Kimi K2/K2.5, GLM-5.1, and any future model using MLA) fall back to GDS or disk loading automatically.
+`RdmaStrategy.is_available()` calls `transfer_safety.check_transfer_allowed()` before attempting P2P transfer. The function logs the model's detected features (attention type, quantization, MoE) and currently allows all combinations — no feature is blocked. The function is kept as a hook for future safety gates.
 
-NVFP4 MoE models (known case: Kimi-K2.5-NVFP4) previously produced corrupted inference after RDMA transfer despite all registered tensor bytes matching. This is a specific instance of a broader class of bugs: post-processing stashes computed state on non-Module objects (e.g. `FusedMoEQuantConfig.a1_gscale = 1/activation_scale` on the quant method), which is invisible to `named_parameters()`/`named_buffers()`. On the target those values are computed from dummy weights before RDMA, and RDMA only overwrites the registered tensors, so the stashed values stay wrong. Note DeepSeek-V3 (MLA + FP8) is not affected — FP8 scale state lives on Modules and is already captured. The fix (`adopt_hidden_tensors()`) recursively scans module attributes for orphaned CUDA tensors and registers them as non-persistent buffers so they are included in the RDMA manifest. Verified correct on vLLM v0.17.1 and v0.19.0 with Kimi-K2.5-NVFP4. Set `MX_SKIP_FEATURE_CHECK=1` to bypass the MLA feature gate for models in this class.
+NVFP4 MoE models (known case: Kimi-K2.5-NVFP4) previously produced corrupted inference after RDMA transfer despite all registered tensor bytes matching. This is a specific instance of a broader class of bugs: post-processing stashes computed state on non-Module objects (e.g. `FusedMoEQuantConfig.a1_gscale = 1/activation_scale` on the quant method), which is invisible to `named_parameters()`/`named_buffers()`. On the target those values are computed from dummy weights before RDMA, and RDMA only overwrites the registered tensors, so the stashed values stay wrong. The fix (`adopt_hidden_tensors()`) recursively scans module attributes for orphaned CUDA tensors and registers them as non-persistent buffers so they are included in the RDMA manifest. Verified correct on vLLM v0.17.1 and v0.19.0 with Kimi-K2.5-NVFP4 and on DeepSeek-V3 (MLA + FP8).
 
 During transfer, `ManifestMismatchError` is raised if source and target tensor names or sizes don't match. This triggers trying the next source candidate rather than marking the source as stale, which is important during rolling updates where pods may run different image versions.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -323,7 +323,6 @@ See [`K8S_SERVICE_BACKEND.md`](K8S_SERVICE_BACKEND.md) for the design rationale,
 | `MX_RDMA_NIC_PIN` | (unset) | Per-rank IB NIC pinning. `auto` runs a topology probe; comma-separated NIC list is an explicit override. Workaround for openucx/ucx#11259. |
 | `MX_RDMA_NIC_PIN_MIN_RATE_GBPS` | (auto, max-rate filter) | Override the auto-detect rate filter with an explicit lower bound (Gb/s). |
 | `MODEL_EXPRESS_LOG_LEVEL` | (inherits vLLM) | Override log level for `modelexpress.*` loggers. `DEBUG` enables per-tensor checksums and adopted tensor details |
-| `MX_SKIP_FEATURE_CHECK` | `0` | Bypass the MLA feature gate for P2P transfer (testing only) |
 | `MX_P2P_METADATA` | `0` | Enable P2P metadata exchange (source workers only). Opt-in on central-coordinator backends. Auto-enabled (and this env var ignored) on backends that declare themselves decentralized, currently `k8s-service`. |
 | `MX_METADATA_PORT` | `5555` | Base NIXL listen port; effective port is `MX_METADATA_PORT + device_id` |
 | `MX_WORKER_GRPC_PORT` | `0` | Worker gRPC port for P2P tensor manifest serving |

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -113,10 +113,6 @@ spec:
           value: "mx-vllm-modelexpress:8000"
         - name: MX_CONTIGUOUS_REG
           value: "0"
-        # Kimi-K2.5-NVFP4 uses MLA which is blocked by default.
-        # P2P inference verified correct with adopt_hidden_tensors fix.
-        - name: MX_SKIP_FEATURE_CHECK
-          value: "1"
         # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
         - name: MX_RDMA_NIC_PIN
           value: "auto"

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -104,10 +104,6 @@ spec:
           value: "mx-vllm-disagg-sn-modelexpress:8000"
         - name: MX_CONTIGUOUS_REG
           value: "0"
-        # Kimi-K2.5-NVFP4 uses MLA which is blocked by default.
-        # P2P inference verified correct with adopt_hidden_tensors fix.
-        - name: MX_SKIP_FEATURE_CHECK
-          value: "1"
         - name: NIXL_LOG_LEVEL
           value: "INFO"
         - name: UCX_LOG_LEVEL
@@ -191,10 +187,6 @@ spec:
           value: "mx-vllm-disagg-sn-modelexpress:8000"
         - name: MX_CONTIGUOUS_REG
           value: "0"
-        # Kimi-K2.5-NVFP4 uses MLA which is blocked by default.
-        # P2P inference verified correct with adopt_hidden_tensors fix.
-        - name: MX_SKIP_FEATURE_CHECK
-          value: "1"
         - name: NIXL_LOG_LEVEL
           value: "INFO"
         - name: UCX_LOG_LEVEL

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -102,11 +102,6 @@ spec:
               value: "modelexpress-server:8001"
             - name: MX_CONTIGUOUS_REG
               value: "0"
-            # Kimi-K2.5-NVFP4 uses MLA which is blocked by default.
-            # P2P inference verified correct with adopt_hidden_tensors fix.
-            # Do not enable globally without verifying model correctness.
-            - name: MX_SKIP_FEATURE_CHECK
-              value: "1"
             # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
             - name: MX_RDMA_NIC_PIN
               value: "auto"

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -6,12 +6,9 @@ Transfer safety checks for ModelExpress GPU-to-GPU weight transfer.
 
 Two independent safety mechanisms:
 
-1. Feature allow-list: checks model config before attempting P2P transfer.
-   Models with unsupported features are rejected early and fall back to
-   disk loading. MLA attention models (DeepSeek, Kimi) are blocked from
-   P2P transfers due to unresolved weight corruption after RDMA receive.
-   The bytes transfer correctly but inference diverges - root cause is
-   under investigation.
+1. Feature detection: surfaces model features (attention, quantization, MoE)
+   in the loader log so unexpected combinations are visible during QA.
+   Currently no feature combination blocks P2P transfer.
 
 2. Transfer fingerprint: captures the runtime environment and tensor
    manifest structure. Source publishes its fingerprint; target computes
@@ -23,7 +20,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 
 import torch
@@ -31,15 +27,8 @@ import torch
 logger = logging.getLogger("modelexpress.transfer_safety")
 
 # ---------------------------------------------------------------------------
-# Feature detection and blocking
+# Feature detection
 # ---------------------------------------------------------------------------
-
-# MLA (Multi-head Latent Attention) is the only feature currently blocked.
-# Bytes transfer correctly via RDMA but inference diverges on all tested
-# vLLM versions (0.12.0 through 0.17.1). Root cause under investigation.
-# Detection is config-based: kv_lora_rank presence in the HF config.
-# Bypass with MX_SKIP_FEATURE_CHECK=1 to test MLA transfers anyway.
-
 
 
 def detect_model_features(model_config) -> dict[str, str]:
@@ -73,29 +62,13 @@ def detect_model_features(model_config) -> dict[str, str]:
 def check_transfer_allowed(model_config) -> tuple[bool, str]:
     """Check if P2P weight transfer is allowed for this model.
 
-    Currently blocks only MLA attention models (detected via kv_lora_rank
-    in the HF config). All other models are allowed.
+    No feature combination is currently blocked; the function logs detected
+    features and always returns allowed. Kept as a hook so future safety
+    gates can be added in one place.
 
-    Returns (allowed, reason). If not allowed, reason explains why.
+    Returns (allowed, reason).
     """
-    if os.environ.get("MX_SKIP_FEATURE_CHECK", "0") == "1":
-        logger.warning("MX_SKIP_FEATURE_CHECK=1: bypassing feature checks")
-        return True, "bypassed"
-
     features = detect_model_features(model_config)
-
-    if features["attention"] == "mla":
-        reason = (
-            "MLA attention models are blocked from P2P transfer due to "
-            "unresolved weight corruption after RDMA receive"
-        )
-        logger.warning(
-            f"[Transfer Safety] P2P transfer denied: {reason}. "
-            f"Features: {features}. "
-            f"Set MX_SKIP_FEATURE_CHECK=1 to bypass."
-        )
-        return False, reason
-
     logger.info(f"[Transfer Safety] P2P transfer allowed. Features: {features}")
     return True, "allowed"
 

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -4,8 +4,6 @@
 """Tests for transfer safety checks."""
 
 import json
-import os
-import unittest.mock
 
 import pytest
 import torch
@@ -120,52 +118,28 @@ class TestCheckTransferAllowed:
         allowed, reason = check_transfer_allowed(config)
         assert allowed
 
-    def test_deepseek_mla_denied(self):
+    def test_deepseek_mla_allowed(self):
         config = FakeConfig(
             model_type="deepseek_v2",
             kv_lora_rank=512,
         )
-        allowed, reason = check_transfer_allowed(config)
-        assert not allowed
-        assert "mla" in reason.lower()
+        allowed, _ = check_transfer_allowed(config)
+        assert allowed
 
-    def test_kimi_mla_denied(self):
+    def test_kimi_mla_allowed(self):
         config = FakeConfig(
             model_type="kimi_k25",
             kv_lora_rank=512,
         )
-        allowed, reason = check_transfer_allowed(config)
-        assert not allowed
-        assert "mla" in reason.lower()
-
-    def test_mla_detected_by_kv_lora_rank(self):
-        config = FakeConfig(
-            model_type="some_future_mla_model",
-            kv_lora_rank=256,
-        )
-        allowed, reason = check_transfer_allowed(config)
-        assert not allowed
-        assert "mla" in reason.lower()
+        allowed, _ = check_transfer_allowed(config)
+        assert allowed
 
     def test_no_kv_lora_rank_allowed(self):
         config = FakeConfig(
             model_type="deepseek_v2",
         )
-        allowed, reason = check_transfer_allowed(config)
+        allowed, _ = check_transfer_allowed(config)
         assert allowed
-
-    def test_bypass_env_var(self):
-        config = FakeConfig(
-            model_type="deepseek_v2",
-            kv_lora_rank=512,
-        )
-        os.environ["MX_SKIP_FEATURE_CHECK"] = "1"
-        try:
-            allowed, reason = check_transfer_allowed(config)
-            assert allowed
-            assert reason == "bypassed"
-        finally:
-            del os.environ["MX_SKIP_FEATURE_CHECK"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The MLA gate in `transfer_safety.check_transfer_allowed()` blocks DeepSeek-V2/V3, Kimi K2/K2.5, GLM-5.1, and any other MLA model from RDMA P2P transfer, forcing every example manifest that runs them to set `MX_SKIP_FEATURE_CHECK=1` to opt out. The gate is now stale: the corruption it was guarding against has been fixed twice in tree.

- **PR #200** (`capture_tensor_attrs` + `storage_view`) handled FP8 scale state on `nn.Module` attributes and the shared-storage views MLA uses (e.g. `W_UV` / `W_UK_T` over a dequantized intermediate).
- **PR #241** (`adopt_hidden_tensors`) handled orphan CUDA tensors on non-`Module` objects (e.g. `FusedMoEQuantConfig.a1_gscale` on NVFP4 MoE). Its own test plan **explicitly verified DeepSeek-V3 (MLA + FP8) exact source-vs-target match on vLLM 0.17.1 with a 1635-tensor manifest, on `main` without `adopt_hidden_tensors`**.

This PR removes the gate and the now-dead `MX_SKIP_FEATURE_CHECK` env var. `check_transfer_allowed()` is preserved as a hook (logs detected features, always returns allowed) so future feature gates can land in one place.

## Changes

- `modelexpress_client/python/modelexpress/transfer_safety.py` — drop the MLA-block branch and the `MX_SKIP_FEATURE_CHECK` bypass; rewrite the module docstring.
- `modelexpress_client/python/tests/test_transfer_safety.py` — flip MLA cases from denied to allowed, drop the bypass-env-var test. Detection of `attention=mla` from `kv_lora_rank` is still covered by `TestDetectModelFeatures.test_deepseek_v2_mla`.
- `README.md` / `docs/DEPLOYMENT.md` / `docs/ARCHITECTURE.md` — drop the stale "MLA blocked" notes and the `MX_SKIP_FEATURE_CHECK` env-var row; rewrite the Transfer Safety paragraph to reflect that no feature is currently blocked.
- `examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml`, `examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml`, `examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml` — drop `MX_SKIP_FEATURE_CHECK=1` and its commentary.

## Backward compatibility

`MX_SKIP_FEATURE_CHECK` was a workaround to *disable* the gate. With the gate gone, deployments that still set the variable continue to work — the variable is just unread. No deployment that was succeeding before this PR will start failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MLA-compatible models now fully supported for P2P transfers.

* **Documentation**
  * Updated architecture and deployment documentation reflecting changes to P2P transfer handling and safety checks.
  * Removed obsolete feature-check environment variable references.

* **Configuration**
  * Updated Kubernetes deployment manifests with new required environment variables for P2P transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->