### PR TITLE
feat: allocation-based NIXL pool registration via MX_POOL_REG

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,7 +86,6 @@ Feature branches use `<username>/feature-name` format, forked from `main`.
 - Always read files to understand context before making changes.
 - Do not implement changes eagerly. When discussing a problem or new feature, investigate thoroughly first, report findings, propose changes, and ask if they are acceptable before writing code.
 - Flush Redis on redeploy: stale metadata causes P2P transfer failures.
-- Use baseline mode (`MX_CONTIGUOUS_REG=0`) until contiguous region transfers are fixed.
 - Long startup times are normal: DeepSeek-V3 takes ~40 min to warm up.
 - Set `UCX_LOG_LEVEL=DEBUG` for NIXL/RDMA diagnostics.
 - NIXL agents must match ranks: source rank 0 -> target rank 0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,6 @@ Feature branches use `<username>/feature-name` format, forked from `main`.
 - Always read files to understand context before making changes.
 - Do not implement changes eagerly. When discussing a problem or new feature, investigate thoroughly first, report findings, propose changes, and ask if they are acceptable before writing code.
 - Flush Redis on redeploy: stale metadata causes P2P transfer failures.
-- Use baseline mode (`MX_CONTIGUOUS_REG=0`) until contiguous region transfers are fixed.
 - Long startup times are normal: DeepSeek-V3 takes ~40 min to warm up.
 - Set `UCX_LOG_LEVEL=DEBUG` for NIXL/RDMA diagnostics.
 - NIXL agents must match ranks: source rank 0 -> target rank 0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Cache directory resolution order: `MODEL_EXPRESS_CACHE_DIRECTORY` -> `HF_HUB_CAC
 |----------|---------|-------------|
 | `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server address |
 | `MX_REGISTER_LOADERS` | `1` | Auto-register the mx vLLM loader |
-| `MX_CONTIGUOUS_REG` | `0` | Enable contiguous region registration (experimental) |
+| `MX_POOL_REG` | `0` | Allocation-level NIXL registration (registers cudaMalloc blocks instead of individual tensors) |
 | `MX_EXPECTED_WORKERS` | `8` | Number of GPU workers to wait for |
 | `MX_SYNC_PUBLISH` | `1` | Source: wait for all workers before publishing |
 | `MX_SYNC_START` | `1` | Target: wait for all workers before transferring |

--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ cargo bench
 - **NIXL_ERR_REMOTE_DISCONNECT** — Source restarts invalidate rkeys. Flush Redis, redeploy.
 - **Long source warmup** — DeepSeek-V3 (DeepGemm, CUDA graphs) can take significant time; targets wait via coordination.
 - **Large model gRPC stream** — May not close automatically; use client timeout.
-- **MX_CONTIGUOUS_REG=1** — Blocked; use `0`.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -524,8 +524,7 @@ Manages a NIXL agent and RDMA transfers for a single GPU worker:
 | Method | Purpose |
 |--------|---------|
 | `__init__(agent_name, device_id, listen_port)` | Create NIXL agent with UCX backend; `listen_port` enables P2P listen thread |
-| `register_tensors(tensors)` | Register GPU tensors for RDMA, return serialized metadata |
-| `get_registered_descriptors()` | Return region descriptors (`MX_CONTIGUOUS_REG=1`) or tensor descriptors |
+| `register_tensors(tensors)` | Register GPU tensors for RDMA, return serialized metadata. With `MX_POOL_REG=1`, registers each unique cudaMalloc allocation backing the tensors instead of registering each tensor individually |
 | `fetch_remote_and_wait(agent_name, ip, port)` | P2P: fetch remote NIXL metadata via listen thread (polls until loaded) |
 | `receive_from_source(source_metadata, source_tensors, ..., remote_agent_name)` | Execute RDMA read transfer; `remote_agent_name` skips `add_remote_agent` (P2P) |
 | `shutdown()` | Clean up NIXL agent and resources |
@@ -671,7 +670,7 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 | `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server address |
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
 | `MX_METADATA_BACKEND` | (required on server; `""` on client) | Server: `redis` or `kubernetes`. Client: `""` / `server` / `redis` / `kubernetes` (central server) or `k8s-service` (decentralized via K8s Service routing) |
-| `MX_CONTIGUOUS_REG` | `0` | Enable contiguous region registration (experimental) |
+| `MX_POOL_REG` | `0` | Discover cudaMalloc allocations via `cuMemGetAddressRange` and register each as a single NIXL block instead of registering tensors individually. Reduces NIXL registration count by 80-99% on typical vLLM models, cutting `ibv_reg_mr` time and metadata blob size; transfer semantics unchanged |
 | `MX_P2P_METADATA` | `0` | Enable P2P metadata exchange on source workers. Opt-in on central-coordinator backends; auto-enabled (env var ignored) on decentralized backends |
 | `MX_MODEL_REVISION` | (from vLLM config) | Override for `SourceIdentity.revision`. Pin to the exact checkpoint identifier so `mx_source_id` is content-addressed |
 | `MX_K8S_SERVICE_PATTERN` | `mx-sources` | DNS template for the `k8s-service` backend; `{rank}` is substituted with the worker's own rank. Client auto-appends `:{MX_WORKER_GRPC_PORT + rank}` if the resolved pattern has no explicit port |
@@ -701,10 +700,6 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 ### NIXL_ERR_REMOTE_DISCONNECT
 
 Target fails with `Remote access error on mlx5_X:1/IB`. Common causes: source crashed/restarted (stale rkeys), UCX transport misconfiguration, premature target connection. Fix: use robust ready coordination, check for restarts, enable `UCX_LOG_LEVEL=DEBUG`.
-
-### Contiguous Region Failures
-
-When `MX_CONTIGUOUS_REG=1`, transfers fail even when source is stable. Current workaround: use baseline mode (`MX_CONTIGUOUS_REG=0`).
 
 ### Long Source Warmup
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -318,7 +318,7 @@ See [`K8S_SERVICE_BACKEND.md`](K8S_SERVICE_BACKEND.md) for the design rationale,
 | `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server address (ignored when client uses `k8s-service` backend) |
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
 | `MX_REGISTER_LOADERS` | `1` | Auto-register the mx loader with vLLM |
-| `MX_CONTIGUOUS_REG` | `0` | Contiguous region registration (experimental) |
+| `MX_POOL_REG` | `0` | Allocation-level NIXL registration via `cuMemGetAddressRange`. Registers each unique cudaMalloc block instead of each tensor (typically 80-99% fewer registrations) without changing transfer semantics. |
 | `MX_NIXL_BACKEND` | `UCX` | NIXL backend for GPU-to-GPU RDMA. `UCX` (default) for InfiniBand / RoCE. `LIBFABRIC` for AWS EFA — see [NIXL Backend Selection](#nixl-backend-selection). |
 | `MX_RDMA_NIC_PIN` | (unset) | Per-rank IB NIC pinning. `auto` runs a topology probe; comma-separated NIC list is an explicit override. Workaround for openucx/ucx#11259. |
 | `MX_RDMA_NIC_PIN_MIN_RATE_GBPS` | (auto, max-rate filter) | Override the auto-detect rate filter with an explicit lower bound (Gb/s). |

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -389,7 +389,7 @@ The `backend_type` discriminator is persisted in storage for unambiguous deseria
 | `MX_HEARTBEAT_TIMEOUT_SECS` | `90` | Server reaper staleness threshold |
 | `MX_REAPER_SCAN_INTERVAL_SECS` | `30` | Server reaper scan frequency |
 | `MX_GC_TIMEOUT_SECS` | `3600` | Time before stale entries are deleted |
-| `MX_CONTIGUOUS_REG` | `0` | Use contiguous region registration (experimental) |
+| `MX_POOL_REG` | `0` | Register each unique cudaMalloc allocation instead of each tensor (allocation-level NIXL registration) |
 
 ## Debugging
 

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -111,8 +111,6 @@ spec:
           value: "modelexpress"
         - name: MX_SERVER_ADDRESS
           value: "mx-vllm-modelexpress:8000"
-        - name: MX_CONTIGUOUS_REG
-          value: "0"
         # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
         - name: MX_RDMA_NIC_PIN
           value: "auto"

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -102,8 +102,6 @@ spec:
           value: "modelexpress"
         - name: MX_SERVER_ADDRESS
           value: "mx-vllm-disagg-sn-modelexpress:8000"
-        - name: MX_CONTIGUOUS_REG
-          value: "0"
         - name: NIXL_LOG_LEVEL
           value: "INFO"
         - name: UCX_LOG_LEVEL
@@ -185,8 +183,6 @@ spec:
           value: "modelexpress"
         - name: MX_SERVER_ADDRESS
           value: "mx-vllm-disagg-sn-modelexpress:8000"
-        - name: MX_CONTIGUOUS_REG
-          value: "0"
         - name: NIXL_LOG_LEVEL
           value: "INFO"
         - name: UCX_LOG_LEVEL

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -100,8 +100,6 @@ spec:
               value: "modelexpress"
             - name: MX_SERVER_ADDRESS
               value: "modelexpress-server:8001"
-            - name: MX_CONTIGUOUS_REG
-              value: "0"
             # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
             - name: MX_RDMA_NIC_PIN
               value: "auto"

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -66,8 +66,6 @@ spec:
               value: "modelexpress"
             - name: MX_SERVER_ADDRESS
               value: "modelexpress-server:8001"
-            - name: MX_CONTIGUOUS_REG
-              value: "0"
             # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
             - name: MX_RDMA_NIC_PIN
               value: "auto"

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -70,10 +70,6 @@ spec:
             # Server address for metadata publishing
             - name: MX_SERVER_ADDRESS
               value: "modelexpress-server:8001"
-            # Baseline: individual tensor registration (stable and tested)
-            # Set to "1" for contiguous regions (experimental - see docs/CONTIGUOUS_CONTEXT.md)
-            - name: MX_CONTIGUOUS_REG
-              value: "0"
             # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
             - name: MX_RDMA_NIC_PIN
               value: "auto"

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -86,7 +86,7 @@ register_modelexpress_loaders()
 | `MX_EXPECTED_WORKERS` | Auto-detected from TP size | Number of GPU workers to coordinate |
 | `MX_SYNC_PUBLISH` | `0` | Source: wait for all workers before publishing metadata |
 | `MX_SYNC_START` | `1` | Target: wait for all source workers before transferring |
-| `MX_CONTIGUOUS_REG` | `0` | Enable contiguous region registration (experimental) |
+| `MX_POOL_REG` | `0` | Allocation-level NIXL registration (registers cudaMalloc blocks instead of individual tensors) |
 
 ### UCX/NIXL Tuning
 

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -278,15 +278,12 @@ class RdmaStrategy(LoadStrategy):
             f"{' (P2P)' if is_p2p else ''}"
         )
 
-        coalesce = os.environ.get("MX_CONTIGUOUS_REG", "0") == "1"
-
         transfer_start = time.perf_counter()
         try:
             bytes_transferred, tensor_count, _ = ctx.nixl_manager.receive_from_source(
                 source_metadata=source_worker.nixl_metadata,
                 source_tensors=source_tensors,
                 timeout_seconds=300.0,
-                coalesce_transfers=coalesce,
                 remote_agent_name=remote_agent_name_override,
             )
         except Exception as e:

--- a/modelexpress_client/python/modelexpress/metadata.py
+++ b/modelexpress_client/python/modelexpress/metadata.py
@@ -89,42 +89,22 @@ def _resolve_model_revision(model_config) -> str:
 
 
 def build_tensor_protos(
-    nixl_manager: "NixlTransferManager",
     tensors: dict[str, torch.Tensor],
     device_id: int,
     global_rank: int,
 ) -> list["p2p_pb2.TensorDescriptor"]:
-    """Build tensor descriptor protos from registered tensors."""
-    use_contiguous = os.environ.get("MX_CONTIGUOUS_REG", "0") == "1"
-
-    if use_contiguous:
-        region_descriptors = nixl_manager.get_registered_descriptors()
-        protos = [
-            p2p_pb2.TensorDescriptor(
-                name=desc.name,
-                addr=desc.addr,
-                size=desc.size,
-                device_id=desc.device_id,
-                dtype=desc.dtype,
-            )
-            for desc in region_descriptors
-        ]
-        logger.info(
-            f"[Worker {global_rank}] Built {len(protos)} REGION descriptors "
-            f"(MX_CONTIGUOUS_REG=1)"
+    """Build per-tensor descriptor protos from registered tensors."""
+    del global_rank  # unused, kept for caller-symmetry with publish_metadata_and_ready
+    return [
+        p2p_pb2.TensorDescriptor(
+            name=name,
+            addr=t.data_ptr(),
+            size=t.numel() * t.element_size(),
+            device_id=device_id,
+            dtype=str(t.dtype),
         )
-    else:
-        protos = [
-            p2p_pb2.TensorDescriptor(
-                name=name,
-                addr=t.data_ptr(),
-                size=t.numel() * t.element_size(),
-                device_id=device_id,
-                dtype=str(t.dtype),
-            )
-            for name, t in tensors.items()
-        ]
-    return protos
+        for name, t in tensors.items()
+    ]
 
 
 def publish_metadata_and_ready(
@@ -141,9 +121,7 @@ def publish_metadata_and_ready(
         f"[Worker {global_rank}] Publishing {len(tensors)} tensors for model '{identity.model_name}'"
     )
 
-    tensor_protos = build_tensor_protos(
-        nixl_manager, tensors, device_id, global_rank,
-    )
+    tensor_protos = build_tensor_protos(tensors, device_id, global_rank)
 
     if _is_p2p_metadata_enabled(mx_client):
         from .worker_server import WorkerGrpcServer

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -274,12 +274,12 @@ class NixlTransferManager:
         """
         Find unique CUDA allocations backing the tensor descriptors.
 
-        Uses cuMemGetAddressRange_v2 to query each tensor's containing
-        cudaMalloc block. Adjacent allocations in virtual address space
-        are NOT merged: UCX's rcache produces broken rkeys when a single
-        registered region spans multiple cudaMalloc blocks, even when
-        they happen to be adjacent. Each unique allocation is registered
-        independently.
+        Uses cuMemGetAddressRange (cuda-python binding for the v2 driver
+        ABI) to query each tensor's containing cudaMalloc block. Adjacent
+        allocations in virtual address space are NOT merged: UCX's rcache
+        produces broken rkeys when a single registered region spans
+        multiple cudaMalloc blocks, even when they happen to be adjacent.
+        Each unique allocation is registered independently.
 
         Args:
             descriptors: List of tensor descriptors
@@ -291,25 +291,20 @@ class NixlTransferManager:
         if not descriptors:
             return []
 
-        import ctypes
+        from cuda.bindings import driver as cuda_driver
 
-        cuda = ctypes.CDLL("libcuda.so")
         seen: dict[int, int] = {}  # alloc_base -> alloc_size
 
         for desc in descriptors:
-            base = ctypes.c_uint64()
-            alloc_size = ctypes.c_size_t()
-            ret = cuda.cuMemGetAddressRange_v2(
-                ctypes.byref(base), ctypes.byref(alloc_size), ctypes.c_uint64(desc.addr)
-            )
-            if ret != 0:
+            err, alloc_base, alloc_size = cuda_driver.cuMemGetAddressRange(desc.addr)
+            if err != cuda_driver.CUresult.CUDA_SUCCESS:
                 raise RuntimeError(
-                    f"cuMemGetAddressRange_v2 failed (error {ret}) for tensor "
+                    f"cuMemGetAddressRange failed ({err.name}) for tensor "
                     f"'{desc.name}' at 0x{desc.addr:x}. Is the tensor on a CUDA device?"
                 )
-            alloc_base = base.value
-            if alloc_base not in seen:
-                seen[alloc_base] = alloc_size.value
+            base_int = int(alloc_base)
+            if base_int not in seen:
+                seen[base_int] = int(alloc_size)
 
         return sorted(seen.items())
 

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -21,7 +21,7 @@ from typing import Any
 import torch
 
 from . import ucx_utils
-from .types import TensorDescriptor
+from .types import ManifestMismatchError, TensorDescriptor
 
 logger = logging.getLogger("modelexpress.nixl_transfer")
 
@@ -400,13 +400,25 @@ class NixlTransferManager:
             local_tensor = self._tensors.get(src_tensor.name)
             if local_tensor is None:
                 continue
+            local_size = local_tensor.numel() * local_tensor.element_size()
+            if local_size != src_tensor.size:
+                raise ManifestMismatchError(
+                    f"Tensor '{src_tensor.name}' size mismatch: "
+                    f"source={src_tensor.size} bytes, local={local_size} bytes"
+                )
+            local_dtype = str(local_tensor.dtype)
+            if local_dtype != src_tensor.dtype:
+                raise ManifestMismatchError(
+                    f"Tensor '{src_tensor.name}' dtype mismatch: "
+                    f"source={src_tensor.dtype!r}, local={local_dtype!r}"
+                )
             remote_descs.append(
                 (src_tensor.addr, src_tensor.size, src_tensor.device_id)
             )
             local_descs.append(
                 (
                     local_tensor.data_ptr(),
-                    local_tensor.numel() * local_tensor.element_size(),
+                    local_size,
                     self._device_id,
                 )
             )

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -14,6 +14,7 @@ a single NIXL agent for that worker's GPU.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import Any
 
@@ -49,8 +50,6 @@ def _resolve_nixl_backend() -> str:
 
     Defaults to UCX. Set MX_NIXL_BACKEND=LIBFABRIC on AWS EFA.
     """
-    import os
-
     raw = os.environ.get("MX_NIXL_BACKEND", DEFAULT_NIXL_BACKEND).strip().upper()
     if raw not in SUPPORTED_NIXL_BACKENDS:
         raise ValueError(
@@ -58,6 +57,15 @@ def _resolve_nixl_backend() -> str:
             f"Expected one of {SUPPORTED_NIXL_BACKENDS}."
         )
     return raw
+
+
+def _pool_reg_enabled() -> bool:
+    """Whether allocation-level pool registration is enabled.
+
+    MX_POOL_REG=1 enables it; default is per-tensor registration. Read at
+    call time so tests can toggle the env var without re-importing.
+    """
+    return os.environ.get("MX_POOL_REG", "0") == "1"
 
 
 class NixlTransferManager:
@@ -86,7 +94,6 @@ class NixlTransferManager:
         self._metadata: bytes = b""
         self._tensor_descriptors: list[TensorDescriptor] = []
         self._tensors: dict[str, torch.Tensor] = {}
-        self._registered_regions: list[tuple[int, int]] | None = None
 
     @property
     def agent_name(self) -> str:
@@ -115,8 +122,6 @@ class NixlTransferManager:
         ucx_utils.apply_nic_pin_for_device. Default (env var unset) is a
         no-op. See ucx_utils for the topology probe and env var modes.
         """
-        import os
-
         if not NIXL_AVAILABLE:
             raise RuntimeError("NIXL is not available")
 
@@ -172,11 +177,21 @@ class NixlTransferManager:
         """
         Register tensors with NIXL for RDMA access.
 
-        CRITICAL: We must ensure self._tensors contains the SAME tensor objects
-        that are registered with NIXL, so receive_from_source uses correct memory.
+        With MX_POOL_REG=1, discovers the unique cudaMalloc allocations
+        backing the tensors via cuMemGetAddressRange and registers each
+        allocation as a single NIXL block. This dramatically reduces the
+        number of memory registrations (kernel ibv_reg_mr calls, rkeys,
+        and bytes in the agent metadata blob) without changing transfer
+        semantics: receive_from_source still matches by tensor name and
+        builds per-tensor RDMA descriptors that target addresses inside
+        the registered allocations.
 
-        If MX_CONTIGUOUS_REG=1, detects and registers contiguous memory regions
-        as single blocks, reducing descriptor overhead significantly.
+        With MX_POOL_REG unset (default), falls back to per-tensor
+        registration.
+
+        CRITICAL: self._tensors must hold the SAME tensor objects as
+        param.data in vLLM. Do NOT call .contiguous() here - that would
+        create copies and RDMA writes would land in the wrong memory.
 
         Args:
             tensors: Dictionary of tensor name -> tensor
@@ -184,14 +199,9 @@ class NixlTransferManager:
         Returns:
             NIXL metadata bytes for this agent
         """
-        import os
-
         if self._agent is None:
             raise RuntimeError("NIXL agent not initialized")
 
-        # CRITICAL: Do NOT call .contiguous() here!
-        # The tensors must be the exact same objects as param.data in vLLM,
-        # otherwise RDMA writes to copies and vLLM uses originals = garbage.
         self._tensors = tensors
         tensor_descriptors = []
 
@@ -211,102 +221,97 @@ class NixlTransferManager:
 
         self._tensor_descriptors = tensor_descriptors
 
-        # Check if contiguous region registration is enabled
-        use_contiguous = os.environ.get("MX_CONTIGUOUS_REG", "0") == "1"
-
-        if use_contiguous:
-            # Register contiguous memory regions as single blocks
-            regions = self._find_contiguous_regions(tensor_descriptors)
-            logger.info(
-                f"[Contiguous Registration] Found {len(regions)} contiguous regions "
-                f"from {len(tensor_descriptors)} tensors "
-                f"({(1 - len(regions)/len(tensor_descriptors))*100:.1f}% reduction)"
-            )
-
-            # Register regions using raw address tuples
-            # Format: (addr, size, device_id, mem_type) - 4-tuple required by NIXL API
-            region_tuples = [(r[0], r[1], self._device_id, "cuda") for r in regions]
-            self._agent.register_memory(region_tuples, mem_type="cuda", backends=self._backends)
-            self._registered_regions = regions
-            logger.info(f"Registered {len(regions)} contiguous regions with NIXL")
-            # Debug: Log first few registered region addresses
-            if len(regions) > 0:
-                logger.info(f"[Contiguous Registration] DEBUG - First 3 regions: {[(hex(r[0]), r[1]) for r in regions[:3]]}")
+        # Phase 1: Discover CUDA allocation boundaries (if pool reg enabled)
+        alloc_discovery_start = time.perf_counter()
+        if _pool_reg_enabled():
+            allocations = self._find_cuda_allocations(tensor_descriptors)
         else:
-            # Traditional: register individual tensors
+            allocations = None
+            logger.info("Pool registration disabled (MX_POOL_REG != '1'), using per-tensor registration")
+        alloc_discovery_time = time.perf_counter() - alloc_discovery_start
+
+        # Phase 2: Register memory with NIXL (ibv_reg_mr kernel calls)
+        nixl_reg_start = time.perf_counter()
+        if allocations:
+            alloc_tuples = [
+                (base, size, self._device_id, "")
+                for base, size in allocations
+            ]
+            self._agent.register_memory(alloc_tuples, mem_type="cuda", backends=self._backends)
+            reg_count = len(allocations)
+        else:
             tensor_list = list(tensors.values())
             self._agent.register_memory(tensor_list, backends=self._backends)
-            self._registered_regions = None
-            logger.info(f"Registered {len(tensor_list)} individual tensors with NIXL")
+            reg_count = len(tensor_list)
+        nixl_reg_time = time.perf_counter() - nixl_reg_start
 
+        # Phase 3: Get agent metadata blob
+        metadata_start = time.perf_counter()
         self._metadata = self._agent.get_agent_metadata()
+        metadata_time = time.perf_counter() - metadata_start
+
+        total_time = alloc_discovery_time + nixl_reg_time + metadata_time
+        reduction = (1 - reg_count / len(tensor_descriptors)) * 100 if tensor_descriptors else 0
+        total_bytes = sum(d.size for d in tensor_descriptors)
+
+        logger.info(
+            f"[TIMING] register_tensors: {total_time:.3f}s total "
+            f"(alloc_discovery={alloc_discovery_time:.3f}s, "
+            f"nixl_register={nixl_reg_time:.3f}s [{reg_count} regions], "
+            f"get_metadata={metadata_time:.3f}s [{len(self._metadata)} bytes])"
+        )
+        logger.info(
+            f"Registered {reg_count} regions from {len(tensor_descriptors)} tensors "
+            f"({reduction:.1f}% reduction), {total_bytes / 1e9:.2f} GB total"
+        )
+
         return self._metadata
 
-    def get_registered_descriptors(self) -> list[TensorDescriptor]:
-        """
-        Get the descriptors that were actually registered with NIXL.
-
-        When MX_CONTIGUOUS_REG=1, returns contiguous region descriptors.
-        Otherwise, returns individual tensor descriptors.
-
-        This is important for publishing to the server - we must publish
-        what was actually registered, not the original tensors.
-        """
-        if self._registered_regions is not None:
-            # Return region descriptors with synthetic names
-            return [
-                TensorDescriptor(
-                    name=f"__region_{i}__",
-                    addr=addr,
-                    size=size,
-                    device_id=self._device_id,
-                    dtype="contiguous_region",
-                )
-                for i, (addr, size) in enumerate(self._registered_regions)
-            ]
-        else:
-            # Return original tensor descriptors
-            return self._tensor_descriptors
-
-    def _find_contiguous_regions(
-        self, descriptors: list[TensorDescriptor]
+    @staticmethod
+    def _find_cuda_allocations(
+        descriptors: list[TensorDescriptor],
     ) -> list[tuple[int, int]]:
         """
-        Find contiguous memory regions from tensor descriptors.
+        Find unique CUDA allocations backing the tensor descriptors.
 
-        Sorts tensors by address and merges adjacent ones into larger regions.
-        This reduces the number of NIXL registrations significantly.
+        Uses cuMemGetAddressRange_v2 to query each tensor's containing
+        cudaMalloc block. Adjacent allocations in virtual address space
+        are NOT merged: UCX's rcache produces broken rkeys when a single
+        registered region spans multiple cudaMalloc blocks, even when
+        they happen to be adjacent. Each unique allocation is registered
+        independently.
 
         Args:
             descriptors: List of tensor descriptors
 
         Returns:
-            List of (start_addr, total_size) tuples for contiguous regions
+            Sorted list of (alloc_base, alloc_size) tuples for unique
+            CUDA allocations.
         """
         if not descriptors:
             return []
 
-        # Sort by address
-        sorted_descs = sorted(descriptors, key=lambda d: d.addr)
+        import ctypes
 
-        regions = []
-        current_start = sorted_descs[0].addr
-        current_end = current_start + sorted_descs[0].size
+        cuda = ctypes.CDLL("libcuda.so")
+        seen: dict[int, int] = {}  # alloc_base -> alloc_size
 
-        for desc in sorted_descs[1:]:
-            if desc.addr == current_end:
-                # Contiguous - extend region
-                current_end = desc.addr + desc.size
-            else:
-                # Gap - save current region and start new one
-                regions.append((current_start, current_end - current_start))
-                current_start = desc.addr
-                current_end = desc.addr + desc.size
+        for desc in descriptors:
+            base = ctypes.c_uint64()
+            alloc_size = ctypes.c_size_t()
+            ret = cuda.cuMemGetAddressRange_v2(
+                ctypes.byref(base), ctypes.byref(alloc_size), ctypes.c_uint64(desc.addr)
+            )
+            if ret != 0:
+                raise RuntimeError(
+                    f"cuMemGetAddressRange_v2 failed (error {ret}) for tensor "
+                    f"'{desc.name}' at 0x{desc.addr:x}. Is the tensor on a CUDA device?"
+                )
+            alloc_base = base.value
+            if alloc_base not in seen:
+                seen[alloc_base] = alloc_size.value
 
-        # Don't forget the last region
-        regions.append((current_start, current_end - current_start))
-
-        return regions
+        return sorted(seen.items())
 
     def fetch_remote_and_wait(
         self,
@@ -348,19 +353,26 @@ class NixlTransferManager:
         source_metadata: bytes,
         source_tensors: list[TensorDescriptor],
         timeout_seconds: float | None = None,
-        coalesce_transfers: bool = False,
         remote_agent_name: str | None = None,
     ) -> tuple[int, int, float]:
         """
         Receive weights from a remote source via NIXL RDMA.
 
+        Matches source tensors to local tensors by name and issues per-tensor
+        RDMA READs. Both sides may have registered either pools (MX_POOL_REG=1)
+        or individual tensors; the addresses inside source_tensors and the
+        local tensor data_ptrs are what NIXL prep_xfer_dlist resolves against
+        the registered memory metadata.
+
         Args:
-            source_metadata: NIXL metadata from the source agent (unused if remote_agent_name set)
+            source_metadata: NIXL metadata from the source agent (unused if
+                remote_agent_name is set)
             source_tensors: Tensor descriptors from the source
-            timeout_seconds: Maximum time to wait for transfer (None for no timeout)
-            coalesce_transfers: If True, coalesce contiguous memory regions (optimization)
-            remote_agent_name: If set, use this pre-loaded agent (P2P mode) instead of
-                calling add_remote_agent with source_metadata (centralized mode)
+            timeout_seconds: Maximum time to wait for transfer (None for no
+                timeout)
+            remote_agent_name: If set, use this pre-loaded agent (P2P mode)
+                instead of calling add_remote_agent with source_metadata
+                (centralized mode)
 
         Returns:
             Tuple of (total_bytes, total_tensors, duration)
@@ -382,131 +394,57 @@ class NixlTransferManager:
         else:
             logger.info(f"Using pre-loaded remote agent {remote_agent_name}")
 
-        # Check if source is sending region descriptors (MX_CONTIGUOUS_REG=1 on source)
-        is_region_transfer = (
-            len(source_tensors) > 0 and
-            source_tensors[0].name.startswith("__region_")
+        # Match source tensors to local tensors by name and build raw
+        # (addr, size, device_id) descriptor lists for both sides.
+        match_start = time.perf_counter()
+        remote_descs: list[tuple[int, int, int]] = []
+        local_descs: list[tuple[int, int, int]] = []
+        total_bytes = 0
+
+        for src_tensor in source_tensors:
+            local_tensor = self._tensors.get(src_tensor.name)
+            if local_tensor is None:
+                continue
+            remote_descs.append(
+                (src_tensor.addr, src_tensor.size, src_tensor.device_id)
+            )
+            local_descs.append(
+                (
+                    local_tensor.data_ptr(),
+                    local_tensor.numel() * local_tensor.element_size(),
+                    self._device_id,
+                )
+            )
+            total_bytes += src_tensor.size
+
+        matched_tensors = len(remote_descs)
+        match_time = time.perf_counter() - match_start
+
+        if not remote_descs:
+            logger.warning("No matching tensors found for transfer")
+            return 0, 0, 0.0
+
+        logger.info(
+            f"[TIMING] match_tensors: {match_time:.3f}s "
+            f"({matched_tensors} tensors, {total_bytes / 1e9:.2f} GB)"
         )
 
-        if is_region_transfer:
-            # REGION-BASED TRANSFER: Source registered contiguous regions
-            # We must also have registered regions and match by index
-            if self._registered_regions is None:
-                logger.error("Source sent region descriptors but we didn't register regions!")
-                logger.error("Set MX_CONTIGUOUS_REG=1 on target to enable region transfer")
-                raise RuntimeError("Region transfer mismatch: target must also use MX_CONTIGUOUS_REG=1")
-
-            logger.info(f"Region-based transfer: {len(source_tensors)} source regions -> {len(self._registered_regions)} local regions")
-
-            # Validate region counts match
-            if len(source_tensors) != len(self._registered_regions):
-                logger.warning(
-                    f"Region count mismatch: source has {len(source_tensors)}, "
-                    f"local has {len(self._registered_regions)}. Proceeding with min."
-                )
-
-            # Build transfer lists by region index
-            remote_descs = []
-            local_descs = []  # Will be (addr, size, device_id) tuples
-            total_bytes = 0
-            matched_count = min(len(source_tensors), len(self._registered_regions))
-
-            for i in range(matched_count):
-                src_region = source_tensors[i]
-                local_addr, local_size = self._registered_regions[i]
-
-                # Verify sizes match (regions should be same size)
-                if src_region.size != local_size:
-                    logger.warning(f"Region {i} size mismatch: source={src_region.size}, local={local_size}")
-
-                remote_descs.append((src_region.addr, src_region.size, src_region.device_id))
-                local_descs.append((local_addr, local_size, self._device_id))
-                total_bytes += src_region.size
-
-            matched_tensors = matched_count
-            use_raw_descriptors = True
-            coalesced_count = matched_count
-
-            logger.info(f"[Region Transfer] Matched {matched_count} regions, {total_bytes / 1e9:.2f} GB")
-
-            # Debug: Log first few region addresses for comparison
-            if matched_count > 0:
-                logger.info(f"[Region Transfer] DEBUG - First 3 source regions: {[(hex(r[0]), r[1]) for r in remote_descs[:3]]}")
-                logger.info(f"[Region Transfer] DEBUG - First 3 local regions: {[(hex(r[0]), r[1]) for r in local_descs[:3]]}")
-
-        else:
-            # TENSOR-BASED TRANSFER: Match by tensor name (baseline)
-            remote_descs = []
-            local_tensor_list = []
-            total_bytes = 0
-            matched_tensors = 0
-
-            for src_tensor in source_tensors:
-                if src_tensor.name not in self._tensors:
-                    continue
-                local_tensor = self._tensors[src_tensor.name]
-                remote_descs.append((src_tensor.addr, src_tensor.size, src_tensor.device_id))
-                local_tensor_list.append(local_tensor)
-                total_bytes += src_tensor.size
-                matched_tensors += 1
-
-            if not remote_descs:
-                logger.warning("No matching tensors found for transfer")
-                return 0, 0, 0.0
-
-            # For tensor-based, we might still coalesce if enabled
-            local_descs = local_tensor_list
-            use_raw_descriptors = False
-            coalesced_count = matched_tensors
-
-        # OPTIMIZATION: Coalesce contiguous memory regions to reduce descriptor overhead
-        # Skip if we're doing region-based transfer (already optimized at registration time)
-        if is_region_transfer:
-            # Region transfer already has optimal descriptors, skip coalescing
-            logger.info(f"[Region Transfer] Skipping coalesce - already optimized with {coalesced_count} regions")
-        elif coalesce_transfers:
-            logger.info(f"[Coalesce] Starting coalescing of {len(remote_descs)} descriptors...")
-            remote_descs, local_descs, coalesced_count = self._coalesce_transfers(
-                remote_descs, local_tensor_list
-            )
-            reduction_pct = (1 - coalesced_count / matched_tensors) * 100 if matched_tensors > 0 else 0
-            logger.info(
-                f"[Coalesce] Reduced {matched_tensors} descriptors -> {coalesced_count} regions "
-                f"({reduction_pct:.1f}% reduction)"
-            )
-            # local_descs are now (addr, size, device_id) tuples, not tensors
-            use_raw_descriptors = True
-        else:
-            logger.info(f"[Coalesce] DISABLED - transferring {matched_tensors} individual tensors")
-            # Fall back to tensor list
-            local_descs = local_tensor_list
-            use_raw_descriptors = False
-            coalesced_count = matched_tensors
-
-        # Prepare transfer
+        # Prepare transfer descriptors on both sides.
+        prep_start = time.perf_counter()
         src_prepped = self._agent.prep_xfer_dlist(
             agent_name=remote_agent_name,
             xfer_list=remote_descs,
             mem_type="cuda",
             backends=self._backends,
         )
-
-        if use_raw_descriptors:
-            # Use raw address descriptors for coalesced regions
-            dst_prepped = self._agent.prep_xfer_dlist(
-                agent_name="",
-                xfer_list=local_descs,
-                mem_type="cuda",
-                backends=self._backends,
-            )
-        else:
-            # Use tensor objects
-            dst_prepped = self._agent.prep_xfer_dlist(
-                agent_name="",
-                xfer_list=local_descs,
-                mem_type="cuda",
-                backends=self._backends,
-            )
+        dst_prepped = self._agent.prep_xfer_dlist(
+            agent_name="",
+            xfer_list=local_descs,
+            mem_type="cuda",
+            backends=self._backends,
+        )
+        prep_time = time.perf_counter() - prep_start
+        logger.info(f"[TIMING] prep_xfer_dlist: {prep_time:.3f}s")
 
         indices = list(range(len(remote_descs)))
 
@@ -537,128 +475,20 @@ class NixlTransferManager:
                 raise RuntimeError(f"Transfer failed with status {status}")
             time.sleep(0.001)
 
-        # CRITICAL: Synchronize CUDA to ensure RDMA writes are visible
-        # GPUDirect RDMA writes bypass CUDA streams, so we must sync
+        # CRITICAL: Synchronize CUDA to ensure RDMA writes are visible.
+        # GPUDirect RDMA writes bypass CUDA streams, so we must sync.
         torch.cuda.synchronize(self._device_id)
 
         duration = time.perf_counter() - start_time
         bandwidth_gbps = (total_bytes * 8) / (duration * 1e9) if duration > 0 else 0.0
 
-        if coalesce_transfers and coalesced_count < matched_tensors:
-            logger.info(
-                f"Transfer complete: {matched_tensors} tensors ({coalesced_count} regions), "
-                f"{total_bytes / 1e9:.2f} GB in {duration:.2f}s "
-                f"({bandwidth_gbps:.1f} Gbps)"
-            )
-        else:
-            logger.info(
-                f"Transfer complete: {matched_tensors} tensors, "
-                f"{total_bytes / 1e9:.2f} GB in {duration:.2f}s "
-                f"({bandwidth_gbps:.1f} Gbps)"
-            )
+        logger.info(
+            f"Transfer complete: {matched_tensors} tensors, "
+            f"{total_bytes / 1e9:.2f} GB in {duration:.2f}s "
+            f"({bandwidth_gbps:.1f} Gbps)"
+        )
 
         return total_bytes, matched_tensors, duration
-
-    def _coalesce_transfers(
-        self,
-        remote_descs: list[tuple[int, int, int]],
-        local_tensors: list[torch.Tensor],
-    ) -> tuple[list[tuple[int, int, int]], list[tuple[int, int, int]], int]:
-        """
-        Coalesce contiguous memory regions into larger transfer blocks.
-
-        Model weights are often allocated contiguously in memory. By detecting
-        adjacent regions and merging them, we reduce RDMA descriptor overhead
-        from 1327 descriptors to potentially dozens.
-
-        NIXL's prep_xfer_dlist accepts both tensor objects AND raw (addr, size, device_id)
-        tuples. We use raw tuples for both sides to enable true coalescing.
-
-        Args:
-            remote_descs: List of (addr, size, device_id) tuples
-            local_tensors: List of local tensors
-
-        Returns:
-            Tuple of (coalesced_remote_descs, coalesced_local_descs, count)
-            Note: local_descs are now tuples, not tensors!
-        """
-        if len(remote_descs) <= 1:
-            # Convert single tensor to descriptor
-            if local_tensors:
-                t = local_tensors[0]
-                local_descs = [(t.data_ptr(), t.numel() * t.element_size(), self._device_id)]
-            else:
-                local_descs = []
-            return remote_descs, local_descs, len(remote_descs)
-
-        # Build indexed list with local tensor info
-        # (remote_desc, local_addr, local_size)
-        indexed = []
-        for remote, local in zip(remote_descs, local_tensors, strict=True):
-            local_addr = local.data_ptr()
-            local_size = local.numel() * local.element_size()
-            indexed.append((remote, local_addr, local_size))
-
-        # Sort by remote address to find contiguous regions
-        indexed.sort(key=lambda x: x[0][0])
-
-        # Coalesce contiguous regions
-        coalesced_remote = []
-        coalesced_local = []
-
-        i = 0
-        while i < len(indexed):
-            # Start a new region
-            start_remote_addr = indexed[i][0][0]
-            start_local_addr = indexed[i][1]
-            current_remote_end = start_remote_addr + indexed[i][0][1]
-            current_local_end = start_local_addr + indexed[i][2]
-            device_id = indexed[i][0][2]
-
-            # Try to extend by checking next tensors
-            j = i + 1
-            while j < len(indexed):
-                next_remote_addr = indexed[j][0][0]
-                next_remote_size = indexed[j][0][1]
-                next_local_addr = indexed[j][1]
-                next_local_size = indexed[j][2]
-                next_device = indexed[j][0][2]
-
-                # Check if both remote AND local are contiguous
-                # Strict check: no gaps allowed for RDMA correctness
-                remote_contiguous = (next_remote_addr == current_remote_end)
-                local_contiguous = (next_local_addr == current_local_end)
-                same_device = (next_device == device_id)
-
-                if remote_contiguous and local_contiguous and same_device:
-                    # Extend region
-                    current_remote_end = next_remote_addr + next_remote_size
-                    current_local_end = next_local_addr + next_local_size
-                    j += 1
-                else:
-                    break
-
-            # Calculate total region sizes
-            total_remote_size = current_remote_end - start_remote_addr
-            total_local_size = current_local_end - start_local_addr
-
-            # Add coalesced region descriptors
-            coalesced_remote.append((start_remote_addr, total_remote_size, device_id))
-            coalesced_local.append((start_local_addr, total_local_size, self._device_id))
-
-            i = j
-
-        # Log coalescing results
-        original_count = len(remote_descs)
-        coalesced_count = len(coalesced_remote)
-        if coalesced_count < original_count:
-            reduction_pct = 100 * (1 - coalesced_count / original_count)
-            logger.info(
-                f"Coalesced {original_count} tensors into {coalesced_count} regions "
-                f"({reduction_pct:.1f}% reduction in descriptors)"
-            )
-
-        return coalesced_remote, coalesced_local, coalesced_count
 
     def is_healthy(self) -> bool:
         """Check if the NIXL agent is initialized and has registered metadata."""

--- a/modelexpress_client/python/modelexpress/trtllm_live_transfer.py
+++ b/modelexpress_client/python/modelexpress/trtllm_live_transfer.py
@@ -420,14 +420,12 @@ class MxLiveWeightLoader:
         ]
 
         # 7. RDMA transfer: source params → target params
-        coalesce = os.environ.get("MX_COALESCE_TRANSFERS", "0") == "1"
         xfer_timeout = int(os.environ.get("MX_TRANSFER_TIMEOUT", "900"))
         t0 = time.perf_counter()
         bytes_transferred, n_tensors, _ = nixl_mgr.receive_from_source(
             source_metadata=source_worker.nixl_metadata,
             source_tensors=src_descs_for_transfer,
             timeout_seconds=xfer_timeout,
-            coalesce_transfers=coalesce,
         )
         elapsed = time.perf_counter() - t0
         bw = (bytes_transferred * 8) / (elapsed * 1e9) if elapsed > 0 else 0

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -1,17 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for allocation discovery (cuMemGetAddressRange) and the MX_POOL_REG toggle."""
+"""Tests for allocation discovery (cuMemGetAddressRange), the MX_POOL_REG toggle,
+and receive_from_source manifest validation."""
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
+import torch
 
 from modelexpress.nixl_transfer import (
     NixlTransferManager,
     _pool_reg_enabled,
 )
-from modelexpress.types import TensorDescriptor
+from modelexpress.types import ManifestMismatchError, TensorDescriptor
 
 
 def _desc(name: str, addr: int, size: int) -> TensorDescriptor:
@@ -183,3 +187,62 @@ class TestFindCudaAllocations:
             NixlTransferManager._find_cuda_allocations(
                 [_desc("w_named", 0x1000, 64)]
             )
+
+
+class TestReceiveFromSourceManifestValidation:
+    """receive_from_source must reject size/dtype mismatches before building
+    RDMA descriptors. Catching these here prevents silent memory corruption
+    when stale source metadata or model skew sneaks past the name match.
+    """
+
+    def _make_manager(self, monkeypatch, local_tensors):
+        # Bypass torch.cuda.set_device since the test runs on a CPU host.
+        monkeypatch.setattr(torch.cuda, "set_device", lambda *args, **kwargs: None)
+        mgr = NixlTransferManager(agent_name="test", device_id=0)
+        mgr._agent = MagicMock()  # non-None so the early null check passes
+        mgr._tensors = local_tensors
+        return mgr
+
+    def test_size_mismatch_raises_manifest_mismatch(self, monkeypatch):
+        # Local tensor: 40 bytes (10 float32). Source claims 80 bytes.
+        local = torch.zeros(10, dtype=torch.float32)
+        mgr = self._make_manager(monkeypatch, {"w": local})
+        bogus = TensorDescriptor(
+            name="w", addr=0x1000, size=80, device_id=0, dtype=str(local.dtype),
+        )
+        with pytest.raises(ManifestMismatchError, match="size mismatch"):
+            mgr.receive_from_source(
+                source_metadata=b"",
+                source_tensors=[bogus],
+                remote_agent_name="dummy",
+            )
+
+    def test_dtype_mismatch_raises_manifest_mismatch(self, monkeypatch):
+        # Local tensor float32 (40 bytes). Source size matches but dtype lies.
+        local = torch.zeros(10, dtype=torch.float32)
+        mgr = self._make_manager(monkeypatch, {"w": local})
+        bogus = TensorDescriptor(
+            name="w", addr=0x1000, size=40, device_id=0, dtype="torch.bfloat16",
+        )
+        with pytest.raises(ManifestMismatchError, match="dtype mismatch"):
+            mgr.receive_from_source(
+                source_metadata=b"",
+                source_tensors=[bogus],
+                remote_agent_name="dummy",
+            )
+
+    def test_unmatched_name_skips_silently(self, monkeypatch):
+        # No matching local tensor for the source's "w". Loop should `continue`
+        # without raising; the caller decides whether the empty match list is
+        # an error. We just verify the validation doesn't fire spuriously.
+        mgr = self._make_manager(monkeypatch, {"x": torch.zeros(1, dtype=torch.float32)})
+        wrong_name = TensorDescriptor(
+            name="w", addr=0x1000, size=4, device_id=0, dtype="torch.float32",
+        )
+        # Empty match -> early-return (0, 0, 0.0); no exception.
+        result = mgr.receive_from_source(
+            source_metadata=b"",
+            source_tensors=[wrong_name],
+            remote_agent_name="dummy",
+        )
+        assert result == (0, 0, 0.0)

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for allocation discovery (cuMemGetAddressRange) and the MX_POOL_REG toggle."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from modelexpress.nixl_transfer import (
+    NixlTransferManager,
+    _pool_reg_enabled,
+)
+from modelexpress.types import TensorDescriptor
+
+
+def _desc(name: str, addr: int, size: int) -> TensorDescriptor:
+    return TensorDescriptor(
+        name=name,
+        addr=addr,
+        size=size,
+        device_id=0,
+        dtype="torch.float16",
+    )
+
+
+class _FakeCuda:
+    """Stand-in for ctypes.CDLL('libcuda.so').
+
+    Maintains a list of (alloc_base, alloc_size) regions and a return-code
+    override for the next cuMemGetAddressRange_v2 call. The mock identifies
+    which allocation an address belongs to by linear scan, mirroring what
+    cuMemGetAddressRange_v2 returns from the CUDA driver.
+    """
+
+    def __init__(self, allocations: list[tuple[int, int]], ret: int = 0) -> None:
+        self._allocations = allocations
+        self._ret = ret
+        self.calls = 0
+
+    def cuMemGetAddressRange_v2(self, base_ref, size_ref, addr) -> int:
+        self.calls += 1
+        if self._ret != 0:
+            return self._ret
+        addr_value = addr.value if hasattr(addr, "value") else int(addr)
+        for alloc_base, alloc_size in self._allocations:
+            if alloc_base <= addr_value < alloc_base + alloc_size:
+                base_ref._obj.value = alloc_base
+                size_ref._obj.value = alloc_size
+                return 0
+        return 1  # CUDA_ERROR_INVALID_VALUE
+
+
+class TestPoolRegEnabled:
+    def test_default_is_off(self, monkeypatch):
+        monkeypatch.delenv("MX_POOL_REG", raising=False)
+        assert _pool_reg_enabled() is False
+
+    def test_explicit_zero_is_off(self, monkeypatch):
+        monkeypatch.setenv("MX_POOL_REG", "0")
+        assert _pool_reg_enabled() is False
+
+    def test_one_is_on(self, monkeypatch):
+        monkeypatch.setenv("MX_POOL_REG", "1")
+        assert _pool_reg_enabled() is True
+
+    def test_arbitrary_truthy_is_off(self, monkeypatch):
+        # Strict "1" gate: only "1" enables, anything else (including "true",
+        # "yes") leaves pool registration off.
+        for value in ("true", "True", "yes", "on", "2", ""):
+            monkeypatch.setenv("MX_POOL_REG", value)
+            assert _pool_reg_enabled() is False, f"value={value!r} should not enable"
+
+    def test_read_at_call_time(self, monkeypatch):
+        # Set after the module has been imported; the function must observe
+        # the new value rather than caching a module-level constant.
+        monkeypatch.setenv("MX_POOL_REG", "1")
+        assert _pool_reg_enabled() is True
+        monkeypatch.setenv("MX_POOL_REG", "0")
+        assert _pool_reg_enabled() is False
+
+
+class TestFindCudaAllocations:
+    def test_empty_returns_empty(self):
+        assert NixlTransferManager._find_cuda_allocations([]) == []
+
+    def test_single_tensor_single_allocation(self):
+        # Tensor at 0x1100 inside a 4 KiB allocation starting at 0x1000.
+        allocations = [(0x1000, 0x1000)]
+        fake = _FakeCuda(allocations)
+        with patch("ctypes.CDLL", return_value=fake):
+            result = NixlTransferManager._find_cuda_allocations(
+                [_desc("w", 0x1100, 64)]
+            )
+        assert result == [(0x1000, 0x1000)]
+        assert fake.calls == 1
+
+    def test_multiple_tensors_same_allocation_dedup(self):
+        # Three tensors all inside the same 4 KiB allocation.
+        allocations = [(0x1000, 0x1000)]
+        fake = _FakeCuda(allocations)
+        descriptors = [
+            _desc("w0", 0x1000, 64),
+            _desc("w1", 0x1100, 64),
+            _desc("w2", 0x1200, 64),
+        ]
+        with patch("ctypes.CDLL", return_value=fake):
+            result = NixlTransferManager._find_cuda_allocations(descriptors)
+        # All three queries hit, but the result is deduplicated by alloc_base.
+        assert result == [(0x1000, 0x1000)]
+        assert fake.calls == 3
+
+    def test_multiple_allocations_sorted(self):
+        # Three distinct allocations in non-sorted order; result must be
+        # sorted by alloc_base.
+        allocations = [
+            (0x3000, 0x1000),
+            (0x1000, 0x1000),
+            (0x2000, 0x1000),
+        ]
+        fake = _FakeCuda(allocations)
+        descriptors = [
+            _desc("w0", 0x3010, 64),
+            _desc("w1", 0x1010, 64),
+            _desc("w2", 0x2010, 64),
+        ]
+        with patch("ctypes.CDLL", return_value=fake):
+            result = NixlTransferManager._find_cuda_allocations(descriptors)
+        assert result == [
+            (0x1000, 0x1000),
+            (0x2000, 0x1000),
+            (0x3000, 0x1000),
+        ]
+
+    def test_adjacent_allocations_not_merged(self):
+        # Two allocations that happen to be adjacent in virtual address space
+        # must remain separate. Merging them is what the (now-removed)
+        # MX_CONTIGUOUS_REG path did, and it broke UCX rcache rkey lookup.
+        allocations = [
+            (0x1000, 0x1000),  # ends at 0x2000
+            (0x2000, 0x1000),  # starts where the previous ends
+        ]
+        fake = _FakeCuda(allocations)
+        descriptors = [
+            _desc("w0", 0x1010, 64),
+            _desc("w1", 0x2010, 64),
+        ]
+        with patch("ctypes.CDLL", return_value=fake):
+            result = NixlTransferManager._find_cuda_allocations(descriptors)
+        assert result == [(0x1000, 0x1000), (0x2000, 0x1000)]
+
+    def test_driver_error_raises_runtime_error(self):
+        fake = _FakeCuda(allocations=[], ret=999)  # CUDA_ERROR_UNKNOWN
+        with patch("ctypes.CDLL", return_value=fake):
+            with pytest.raises(RuntimeError, match="cuMemGetAddressRange_v2 failed"):
+                NixlTransferManager._find_cuda_allocations(
+                    [_desc("w", 0x1000, 64)]
+                )
+
+    def test_driver_error_includes_tensor_name(self):
+        fake = _FakeCuda(allocations=[], ret=1)
+        with patch("ctypes.CDLL", return_value=fake):
+            with pytest.raises(RuntimeError, match="'w_named'"):
+                NixlTransferManager._find_cuda_allocations(
+                    [_desc("w_named", 0x1000, 64)]
+                )

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from modelexpress.nixl_transfer import (
@@ -26,31 +24,56 @@ def _desc(name: str, addr: int, size: int) -> TensorDescriptor:
     )
 
 
-class _FakeCuda:
-    """Stand-in for ctypes.CDLL('libcuda.so').
+class _FakeDriver:
+    """Stand-in for cuda.bindings.driver.cuMemGetAddressRange.
 
-    Maintains a list of (alloc_base, alloc_size) regions and a return-code
-    override for the next cuMemGetAddressRange_v2 call. The mock identifies
-    which allocation an address belongs to by linear scan, mirroring what
-    cuMemGetAddressRange_v2 returns from the CUDA driver.
+    Maintains a list of (alloc_base, alloc_size) regions. On each call,
+    locates the allocation containing the queried address (mirroring what
+    the real CUDA driver does) and returns the (err, base, size) triple
+    matching the cuda-python binding's signature.
     """
 
-    def __init__(self, allocations: list[tuple[int, int]], ret: int = 0) -> None:
+    def __init__(
+        self,
+        allocations: list[tuple[int, int]],
+        err_override=None,
+    ) -> None:
         self._allocations = allocations
-        self._ret = ret
+        self._err_override = err_override
         self.calls = 0
 
-    def cuMemGetAddressRange_v2(self, base_ref, size_ref, addr) -> int:
+    def cuMemGetAddressRange(self, addr: int):
+        from cuda.bindings import driver
+
         self.calls += 1
-        if self._ret != 0:
-            return self._ret
-        addr_value = addr.value if hasattr(addr, "value") else int(addr)
+        if self._err_override is not None:
+            return (self._err_override, 0, 0)
         for alloc_base, alloc_size in self._allocations:
-            if alloc_base <= addr_value < alloc_base + alloc_size:
-                base_ref._obj.value = alloc_base
-                size_ref._obj.value = alloc_size
-                return 0
-        return 1  # CUDA_ERROR_INVALID_VALUE
+            if alloc_base <= addr < alloc_base + alloc_size:
+                return (driver.CUresult.CUDA_SUCCESS, alloc_base, alloc_size)
+        return (driver.CUresult.CUDA_ERROR_INVALID_VALUE, 0, 0)
+
+
+@pytest.fixture
+def fake_driver(monkeypatch):
+    """Replace cuda.bindings.driver.cuMemGetAddressRange with a fake.
+
+    The fake is returned so tests can inspect call counts. The real
+    `CUresult` enum is preserved so `err.name` formatting in the function
+    under test exercises the same code path as production.
+    """
+    from cuda.bindings import driver
+
+    def _make(allocations, err_override=None):
+        fake = _FakeDriver(allocations, err_override)
+        monkeypatch.setattr(
+            driver,
+            "cuMemGetAddressRange",
+            fake.cuMemGetAddressRange,
+        )
+        return fake
+
+    return _make
 
 
 class TestPoolRegEnabled:
@@ -86,83 +109,77 @@ class TestFindCudaAllocations:
     def test_empty_returns_empty(self):
         assert NixlTransferManager._find_cuda_allocations([]) == []
 
-    def test_single_tensor_single_allocation(self):
+    def test_single_tensor_single_allocation(self, fake_driver):
         # Tensor at 0x1100 inside a 4 KiB allocation starting at 0x1000.
-        allocations = [(0x1000, 0x1000)]
-        fake = _FakeCuda(allocations)
-        with patch("ctypes.CDLL", return_value=fake):
-            result = NixlTransferManager._find_cuda_allocations(
-                [_desc("w", 0x1100, 64)]
-            )
+        fake = fake_driver([(0x1000, 0x1000)])
+        result = NixlTransferManager._find_cuda_allocations(
+            [_desc("w", 0x1100, 64)]
+        )
         assert result == [(0x1000, 0x1000)]
         assert fake.calls == 1
 
-    def test_multiple_tensors_same_allocation_dedup(self):
+    def test_multiple_tensors_same_allocation_dedup(self, fake_driver):
         # Three tensors all inside the same 4 KiB allocation.
-        allocations = [(0x1000, 0x1000)]
-        fake = _FakeCuda(allocations)
+        fake = fake_driver([(0x1000, 0x1000)])
         descriptors = [
             _desc("w0", 0x1000, 64),
             _desc("w1", 0x1100, 64),
             _desc("w2", 0x1200, 64),
         ]
-        with patch("ctypes.CDLL", return_value=fake):
-            result = NixlTransferManager._find_cuda_allocations(descriptors)
+        result = NixlTransferManager._find_cuda_allocations(descriptors)
         # All three queries hit, but the result is deduplicated by alloc_base.
         assert result == [(0x1000, 0x1000)]
         assert fake.calls == 3
 
-    def test_multiple_allocations_sorted(self):
+    def test_multiple_allocations_sorted(self, fake_driver):
         # Three distinct allocations in non-sorted order; result must be
         # sorted by alloc_base.
-        allocations = [
+        fake_driver([
             (0x3000, 0x1000),
             (0x1000, 0x1000),
             (0x2000, 0x1000),
-        ]
-        fake = _FakeCuda(allocations)
+        ])
         descriptors = [
             _desc("w0", 0x3010, 64),
             _desc("w1", 0x1010, 64),
             _desc("w2", 0x2010, 64),
         ]
-        with patch("ctypes.CDLL", return_value=fake):
-            result = NixlTransferManager._find_cuda_allocations(descriptors)
+        result = NixlTransferManager._find_cuda_allocations(descriptors)
         assert result == [
             (0x1000, 0x1000),
             (0x2000, 0x1000),
             (0x3000, 0x1000),
         ]
 
-    def test_adjacent_allocations_not_merged(self):
+    def test_adjacent_allocations_not_merged(self, fake_driver):
         # Two allocations that happen to be adjacent in virtual address space
         # must remain separate. Merging them is what the (now-removed)
         # MX_CONTIGUOUS_REG path did, and it broke UCX rcache rkey lookup.
-        allocations = [
+        fake_driver([
             (0x1000, 0x1000),  # ends at 0x2000
             (0x2000, 0x1000),  # starts where the previous ends
-        ]
-        fake = _FakeCuda(allocations)
+        ])
         descriptors = [
             _desc("w0", 0x1010, 64),
             _desc("w1", 0x2010, 64),
         ]
-        with patch("ctypes.CDLL", return_value=fake):
-            result = NixlTransferManager._find_cuda_allocations(descriptors)
+        result = NixlTransferManager._find_cuda_allocations(descriptors)
         assert result == [(0x1000, 0x1000), (0x2000, 0x1000)]
 
-    def test_driver_error_raises_runtime_error(self):
-        fake = _FakeCuda(allocations=[], ret=999)  # CUDA_ERROR_UNKNOWN
-        with patch("ctypes.CDLL", return_value=fake):
-            with pytest.raises(RuntimeError, match="cuMemGetAddressRange_v2 failed"):
-                NixlTransferManager._find_cuda_allocations(
-                    [_desc("w", 0x1000, 64)]
-                )
+    def test_driver_error_raises_runtime_error(self, fake_driver):
+        from cuda.bindings import driver
 
-    def test_driver_error_includes_tensor_name(self):
-        fake = _FakeCuda(allocations=[], ret=1)
-        with patch("ctypes.CDLL", return_value=fake):
-            with pytest.raises(RuntimeError, match="'w_named'"):
-                NixlTransferManager._find_cuda_allocations(
-                    [_desc("w_named", 0x1000, 64)]
-                )
+        fake_driver(allocations=[], err_override=driver.CUresult.CUDA_ERROR_UNKNOWN)
+        with pytest.raises(RuntimeError, match="cuMemGetAddressRange failed"):
+            NixlTransferManager._find_cuda_allocations(
+                [_desc("w", 0x1000, 64)]
+            )
+
+    def test_driver_error_includes_tensor_name(self, fake_driver):
+        from cuda.bindings import driver
+
+        fake_driver(allocations=[], err_override=driver.CUresult.CUDA_ERROR_INVALID_VALUE)
+        with pytest.raises(RuntimeError, match="'w_named'"):
+            NixlTransferManager._find_cuda_allocations(
+                [_desc("w_named", 0x1000, 64)]
+            )

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -595,8 +595,7 @@ class TestPublishMetadataAndReady:
 
         identity = _make_identity("my-model")
         mock_hb = MagicMock()
-        with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
+        with patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
             publish_metadata_and_ready(mx_client, nixl_manager, tensors, global_rank=2, device_id=0, identity=identity, worker_id="inst-uuid")
 
         mx_client.publish_metadata.assert_called_once()
@@ -628,8 +627,7 @@ class TestPublishMetadataAndReady:
 
         identity = _make_identity()
         mock_hb = MagicMock()
-        with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.time.sleep") as sleep_mock, \
+        with patch("modelexpress.metadata.time.sleep") as sleep_mock, \
              patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
             publish_metadata_and_ready(
                 mx_client,
@@ -668,8 +666,7 @@ class TestPublishMetadataAndReady:
 
         identity = _make_identity()
         mock_hb = MagicMock()
-        with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.time.sleep") as sleep_mock, \
+        with patch("modelexpress.metadata.time.sleep") as sleep_mock, \
              patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
             with pytest.raises(RuntimeError, match="Failed to publish metadata after 3 attempts"):
                 publish_metadata_and_ready(
@@ -700,8 +697,7 @@ class TestPublishMetadataAndReady:
 
         identity = _make_identity()
         mock_hb = MagicMock()
-        with patch.dict("os.environ", {"MX_CONTIGUOUS_REG": "0"}), \
-             patch("modelexpress.metadata.time.sleep") as sleep_mock, \
+        with patch("modelexpress.metadata.time.sleep") as sleep_mock, \
              patch("modelexpress.metadata.HeartbeatThread", return_value=mock_hb) as hb_cls:
             with pytest.raises(_FakeRpcError, match="permission denied"):
                 publish_metadata_and_ready(


### PR DESCRIPTION
Replaces the broken adjacency-based `MX_CONTIGUOUS_REG` path with truth-based pool registration: discover the cudaMalloc allocations backing the registered tensors via `cuMemGetAddressRange_v2` and register each unique allocation as a single NIXL block instead of one per tensor. Cuts NIXL registration count by 80-99% on typical vLLM models, which cuts `ibv_reg_mr` time and metadata blob size; transfer semantics unchanged. Off by default; set `MX_POOL_REG=1` to enable.

Also rips out Python-side coalescing entirely. The `coalesce_transfers` parameter on `receive_from_source`, the `_coalesce_transfers` method, and the `MX_CONTIGUOUS_REG`/`MX_COALESCE_TRANSFERS` reads in `rdma_strategy.py` and `trtllm_live_transfer.py` are all gone, since prior benchmarks showed it was slower than per-tensor: NIXL merges adjacent descriptors internally in C, and fewer coalesced descriptors drop below NIXL's multi-thread threshold.

## Validation

Validated end-to-end on nScale B200 with Qwen3-0.6B, TP=1, central-coordinator metadata mode. Source loads from disk; target loads via NIXL RDMA from the source.

| Mode | Source register_tensors | Target register_tensors | NIXL metadata blob |
|---|---|---|---|
| `MX_POOL_REG=0` | 180ms, 339 regs | 107ms, 339 regs | 32 KB |
| `MX_POOL_REG=1` | 56ms, 59 regs | 51ms, 59 regs | 6 KB |
| Speedup | 3.2x | 2.1x | 5.5x smaller |

339 tensors collapse onto 59 unique cudaMalloc allocations, 82.6% fewer NIXL registrations. The transfer itself completed cleanly on both sides with no rkey errors.

Correctness check: prompt "The capital of France is" with temperature 0 and seed 0 produced byte-identical completions on the pool-registered source and the NIXL-receiver target.

Single-QP NDR bandwidth was the same on both modes since we hit the cap on a 1.2 GB transfer regardless. The win shows up in registration time and metadata blob size, both of which dominate cold-start cost on bigger models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MX_POOL_REG` environment variable for optimized allocation-level CUDA memory registration (default: disabled).

* **Documentation**
  * Updated environment variable documentation across deployment and configuration guides.
  * Removed deprecated experimental configuration references.

* **Tests**
  * Added comprehensive test coverage for pool registration functionality.

* **Chores**
  * Updated deployment examples and Kubernetes manifests with latest configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->