### PR TITLE
fix: resolve vLLM worker device id

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -16,7 +16,7 @@ from ...adapter import EngineAdapter
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 from ...metadata.publish import build_source_identity
-from ...rank_utils import get_device_id, get_global_rank
+from ...rank_utils import get_global_rank
 from ...tensor_utils import adopt_hidden_tensors, capture_tensor_attrs, collect_module_tensors
 
 logger = logging.getLogger("modelexpress.engines.vllm.adapter")
@@ -44,7 +44,7 @@ class VllmAdapter(EngineAdapter):
         return get_global_rank(self.target_device)
 
     def get_device_id(self) -> int:
-        return get_device_id(self.target_device)
+        return _get_vllm_device_id()
 
     def get_target_device(self) -> torch.device:
         return self.target_device
@@ -179,6 +179,15 @@ def _get_vllm_worker_rank(vllm_config: VllmConfig) -> int:
         rank, worker_rank, model_parallel_size,
     )
     return worker_rank
+
+
+def _get_vllm_device_id() -> int:
+    """Return the local CUDA ordinal vLLM assigned to this worker."""
+    from vllm.platforms import current_platform
+
+    device_id = int(current_platform.current_device())
+    logger.debug("Got vLLM device id from current_platform: %d", device_id)
+    return device_id
 
 
 def build_vllm_load_context(vllm_config, model_config) -> LoadContext:

--- a/modelexpress_client/python/modelexpress/rank_utils.py
+++ b/modelexpress_client/python/modelexpress/rank_utils.py
@@ -28,10 +28,3 @@ def get_global_rank(device: torch.device) -> int:
         return device.index
 
     return 0
-
-
-def get_device_id(device: torch.device) -> int:
-    """Get the local CUDA device ordinal used for CUDA and NIXL operations."""
-    if hasattr(device, "index") and device.index is not None:
-        return device.index
-    return 0

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -3,12 +3,12 @@
 
 """Tests for the vLLM engine adapter."""
 
+import sys
 from types import SimpleNamespace
 
 import torch
 
-from modelexpress.engines.vllm.adapter import _get_vllm_worker_rank
-from modelexpress.rank_utils import get_device_id
+from modelexpress.engines.vllm.adapter import VllmAdapter, _get_vllm_worker_rank
 
 
 def _vllm_config(*, rank: int, tp_size: int, pp_size: int):
@@ -37,5 +37,17 @@ def test_worker_rank_ignores_dp_component():
     assert _get_vllm_worker_rank(dp1) == 5
 
 
-def test_device_id_uses_local_cuda_ordinal():
-    assert get_device_id(torch.device("cuda:3")) == 3
+def test_vllm_device_id_uses_current_platform_device(monkeypatch):
+    fake_platforms = SimpleNamespace(
+        current_platform=SimpleNamespace(
+            current_device=lambda: 2,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
+    vllm_config = SimpleNamespace(
+        device_config=SimpleNamespace(device="cuda"),
+        load_config=SimpleNamespace(device=None),
+    )
+    adapter = VllmAdapter(vllm_config, SimpleNamespace())
+
+    assert adapter.get_device_id() == 2


### PR DESCRIPTION
## Overview

PR #262 changed the vLLM device-id lookup to read `device.index`. In vLLM TP workers, `vllm_config.device_config.device` is shared and usually has no index, so every worker falls back to `device_id=0`. That breaks multi-GPU CUDA/NIXL paths because all workers register as if they are on the same local device.

This PR resolves the local CUDA ordinal through vLLM's platform API, `current_platform.current_device()`, so each TP worker reports the device vLLM actually assigned. It also removes the stale generic `get_device_id()` helper because that fallback was only safe for indexed `torch.device` values and is not correct for the vLLM adapter.

## Validation

- `uv run --project modelexpress_client/python --extra dev pytest modelexpress_client/python/tests/test_vllm_adapter.py`
- `pre-commit run`
- Built and pushed client image `nvcr.io/nvidian/dynamo-dev/model-express-dev-containers:client-788a3e5`
- Kubernetes e2e with vLLM TP=2 and `--load-format mx`: worker logs showed device IDs `0` and `1` from `current_platform.current_device()`, model metadata reached Ready for both worker ranks, and `/v1/chat/completions` succeeded
- Full Python suite was attempted; remaining local failures were macOS `cuda.bindings` import gaps in pool-registration tests, not this vLLM adapter path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced device detection in the vLLM engine adapter for more reliable CUDA device identification during model inference operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->