### PR TITLE
fix: keep vLLM device id aligned with target device

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -44,7 +44,7 @@ class VllmAdapter(EngineAdapter):
         return get_global_rank(self.target_device)
 
     def get_device_id(self) -> int:
-        return _get_vllm_device_id()
+        return _get_vllm_device_id(self.target_device)
 
     def get_target_device(self) -> torch.device:
         return self.target_device
@@ -181,8 +181,13 @@ def _get_vllm_worker_rank(vllm_config: VllmConfig) -> int:
     return worker_rank
 
 
-def _get_vllm_device_id() -> int:
+def _get_vllm_device_id(target_device: torch.device) -> int:
     """Return the local CUDA ordinal vLLM assigned to this worker."""
+    if target_device.index is not None:
+        device_id = int(target_device.index)
+        logger.debug("Got vLLM device id from target_device: %d", device_id)
+        return device_id
+
     from vllm.platforms import current_platform
 
     device_id = int(current_platform.current_device())

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -8,7 +8,11 @@ from types import SimpleNamespace
 
 import torch
 
-from modelexpress.engines.vllm.adapter import VllmAdapter, _get_vllm_worker_rank
+from modelexpress.engines.vllm.adapter import (
+    VllmAdapter,
+    _get_vllm_worker_rank,
+    build_vllm_load_context,
+)
 
 
 def _vllm_config(*, rank: int, tp_size: int, pp_size: int):
@@ -51,3 +55,64 @@ def test_vllm_device_id_uses_current_platform_device(monkeypatch):
     adapter = VllmAdapter(vllm_config, SimpleNamespace())
 
     assert adapter.get_device_id() == 2
+
+
+def test_build_vllm_load_context_uses_current_platform_for_bare_cuda(monkeypatch):
+    _stub_vllm_current_device(monkeypatch, current_device=2)
+    _stub_metadata_client(monkeypatch)
+    vllm_config = _context_config(load_device=None)
+
+    ctx = build_vllm_load_context(vllm_config, _model_config())
+
+    assert ctx.target_device == torch.device("cuda")
+    assert ctx.target_device.index is None
+    assert ctx.device_id == 2
+
+
+def test_build_vllm_load_context_keeps_explicit_cuda_index(monkeypatch):
+    _stub_vllm_current_device(monkeypatch, current_device=2)
+    _stub_metadata_client(monkeypatch)
+    vllm_config = _context_config(load_device="cuda:3")
+
+    ctx = build_vllm_load_context(vllm_config, _model_config())
+
+    assert ctx.target_device == torch.device("cuda:3")
+    assert ctx.target_device.index == 3
+    assert ctx.device_id == ctx.target_device.index
+
+
+def _stub_vllm_current_device(monkeypatch, *, current_device: int) -> None:
+    fake_platforms = SimpleNamespace(
+        current_platform=SimpleNamespace(
+            current_device=lambda: current_device,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
+
+
+def _stub_metadata_client(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "modelexpress.engines.vllm.adapter.create_metadata_client",
+        lambda worker_rank: object(),
+    )
+
+
+def _context_config(*, load_device):
+    return SimpleNamespace(
+        device_config=SimpleNamespace(device="cuda"),
+        load_config=SimpleNamespace(device=load_device),
+        parallel_config=SimpleNamespace(
+            rank=0,
+            tensor_parallel_size=2,
+            pipeline_parallel_size=1,
+        ),
+    )
+
+
+def _model_config():
+    return SimpleNamespace(
+        dtype=torch.bfloat16,
+        model="test-model",
+        quantization=None,
+        revision=None,
+    )


### PR DESCRIPTION
## Overview

Follow-up to #269. If vLLM is configured with an explicit `load_config.device` such as `cuda:N`, keep `ctx.device_id` aligned with `ctx.target_device.index` instead of always using `current_platform.current_device()`. Bare `cuda` devices still fall back to vLLM's platform API, which is the path needed for TP workers whose shared vLLM device config has no index.

## Validation

- `uv run --project modelexpress_client/python --extra dev pytest modelexpress_client/python/tests/test_vllm_adapter.py modelexpress_client/python/tests/test_vllm_loader.py`
- `pre-commit run --all-files`