### PR TITLE
docs(trtllm): deployment example yamls + HPA autoscale demo for MX P2P

### DIFF
--- a/examples/p2p_transfer_k8s/client/trtllm/README.md
+++ b/examples/p2p_transfer_k8s/client/trtllm/README.md
@@ -1,301 +1,210 @@
 # ModelExpress P2P for TRT-LLM on GCP GB200
 
-GPU-to-GPU weight loading for Kimi K2.5 via ModelExpress NIXL RDMA.
-Targets load weights in seconds instead of 15-24 minutes from PVC.
+GPU-to-GPU weight loading for TRT-LLM via ModelExpress NIXL RDMA.
+Targets load weights in ~2 seconds instead of 15-20 minutes from disk.
 
-## Architecture
+**Validated:** Kimi K2.5 TP=8, 16 target ranks × 90.75 GB at 363–506 Gbps (RoCE).
 
+## How It Works
+
+```mermaid
+flowchart TB
+    MX["ModelExpress Server + Redis<br/>gRPC metadata, NIXL descriptors"]
+
+    subgraph Source["Source &nbsp; (TP=8, 2 nodes)"]
+        direction TB
+        S1["1. checkpoint_format=&quot;MX&quot;"]
+        S2["2. No MX sources found"]
+        S3["3. Fall back to disk load"]
+        S4["4. publish_as_source()"]
+        S5["5. post_load_weights()"]
+        S6["6. Serve (holds GPU mem)"]
+        S1 --> S2 --> S3 --> S4 --> S5 --> S6
+    end
+
+    subgraph Targets["Targets &nbsp; (prefill + decode)"]
+        direction TB
+        T1["1. checkpoint_format=&quot;MX&quot;"]
+        T2["2. MX sources detected"]
+        T3["3. MxLiveWeightLoader RDMA"]
+        T4["4. _weights_presharded=True"]
+        T5["5. post_load_weights()"]
+        T6["6. Serve"]
+        T1 --> T2 --> T3 --> T4 --> T5 --> T6
+    end
+
+    Source -- "publish metadata" --> MX
+    MX -- "query metadata" --> Targets
+    Source <-- "NIXL RDMA (RoCE)<br/>~2s, 363-506 Gbps per rank" --> Targets
 ```
-                    ┌─────────────────────────────────────┐
-                    │     ModelExpress Server + Redis      │
-                    │   (gRPC metadata, NIXL descriptors)  │
-                    └────────┬────────────────┬────────────┘
-                  publish    │                │   query
-                  metadata   │                │   metadata
-                             │                │
-  ┌──────────────────────────┴───┐  ┌─────────┴───────────────────────┐
-  │  MX Source (DGD, TP=8)       │  │  MX Targets (DGD)               │
-  │                              │  │                                 │
-  │  1. Load weights from PVC    │  │  1. Query MX server for source  │
-  │  2. model.load_weights()     │  │  2. NIXL RDMA into param bufs   │
-  │  3. ── PUBLISH HERE ──       │  │  3. post_load_weights()         │
-  │  4. post_load_weights()      │  │  4. NCCL init + serve           │
-  │  5. Serve (holds GPU mem)    │  │                                 │
-  │                              │  │  Source publishes BEFORE step 4 │
-  │  Node A ┌──┐┌──┐┌──┐┌──┐     │  │  so targets run same xforms     │
-  │         │R0││R1││R2││R3│     │  │                                 │
-  │  Node B ┌──┐┌──┐┌──┐┌──┐     │  │  ┌───────────────────────────┐  │
-  │         │R4││R5││R6││R7│     │  │  │ Prefill  (TP=8, 2 nodes)  │  │
-  │                              │  │  │ Decode   (TP=8, 2 nodes)  │  │
-  └──────────────────────────────┘  │  │ Frontend (KV router)      │  │
-               │                    │  └───────────────────────────┘  │
-               │    NIXL RDMA       │                                 │
-               └────────────────────►  400-457 Gbps RoCE per rank     │
-                90.75 GB/rank        ─────────────────────────────────┘
-```
 
----
+The integration uses TRT-LLM's `@register_checkpoint_loader("MX")` architecture
+([TRT-LLM PR #13531](https://github.com/NVIDIA/TensorRT-LLM/pull/13531)):
+- **Source** auto-detects no existing MX sources → loads from disk → publishes via `publish_model_params()`
+- **Target** auto-detects existing sources → `MxLiveWeightLoader` does RDMA → marks modules `_weights_presharded`
 
 ## Quick Start
 
 ### Prerequisites
 
-```bash
-# 1. Teleport auth
-tsh kube login dynamo-gcp-dev-01
+- GKE cluster with GB200 nodes (ARM64) and CPU nodes
+- Dynamo platform (etcd + NATS) running in your namespace
+- `nvcr-imagepullsecret` and `hf-token-secret` in your namespace
+- `shared-model-cache` PVC with the model downloaded
+- ComputeDomain created for your namespace
 
-# 2. Dynamo platform (etcd + NATS) must be running
-kubectl -n default get pods  # verify etcd-0, nats-0
-
-# 3. Secrets
-kubectl -n default get secret hf-token-secret
-kubectl -n default get secret nvcr-imagepullsecret
-
-# 4. ComputeDomain (creates IMEX channels for GPU allocation)
-cat <<EOF | kubectl -n default apply -f -
-apiVersion: resource.nvidia.com/v1beta1
-kind: ComputeDomain
-metadata:
-  name: my-compute-domain
-spec:
-  numNodes: 0
-  channel:
-    resourceClaimTemplate:
-      name: my-compute-domain-channel
-EOF
-
-# 5. Shared PVC with model files
-kubectl -n default get pvc shared-model-cache
-```
-
----
-
-## Aggregated Inference (P2P)
-
-Single worker type — serves both prefill and decode. Fastest to validate.
-
-### Step 1: Deploy infrastructure
+### Step 1: Deploy MX infrastructure
 
 ```bash
-kubectl -n default apply -f mx-infra-decode.yaml
+kubectl -n <namespace> apply -f mx-infra-decode.yaml
 # Creates: modelexpress-server-decode + redis-decode
+# Verify: kubectl -n <namespace> get pods -l 'app in (redis-decode, modelexpress-server-decode)'
 ```
 
-### Step 2: Deploy source (loads from PVC, publishes via RDMA)
+### Step 2: Deploy source (loads from disk, publishes weights)
 
 ```bash
-kubectl -n default apply -f kimi-source-decode-dgd.yaml
-# TP=8 across 2 nodes, loads ~15 min from PVC
-# Watch: kubectl -n default logs -f <source-leader-pod> | grep "published ALL"
+kubectl -n <namespace> apply -f kimi-source-decode-dgd.yaml
+# TP=8 across 2 nodes, loads ~15-20 min from disk
 ```
 
-### Step 3: Deploy target (receives weights via P2P)
+Wait for all 8 workers to publish:
+```bash
+kubectl exec -n <namespace> deploy/redis-decode -- redis-cli KEYS 'mx:source:*:*' | wc -l
+# Should output: 8
+```
+
+### Step 3: Deploy targets (receive weights via RDMA)
 
 ```bash
-# After source publishes:
-kubectl -n default apply -f kimi-target-agg-tp8-dgd.yaml
-# TP=8, loads via RDMA in ~2 seconds
-# Watch: kubectl -n default logs -f <target-leader-pod> | grep "Gbps"
+kubectl -n <namespace> apply -f kimi-disagg-mx-tp8-dgd.yaml
+# Creates: Frontend + Prefill (TP=8) + Decode (TP=8)
+# Both load via RDMA concurrently (~2s per rank)
 ```
 
-### Step 4: Test inference
+### Step 4: Verify RDMA transfer
+
+Check per-rank transfer logs:
+```bash
+kubectl exec -n <namespace> <target-worker-pod> -- cat /tmp/mx_logs/rank0.log
+# Look for: "Transfer complete: 1815 tensors, 90.75 GB in 1.97s (369.1 Gbps)"
+```
+
+Or check main logs:
+```bash
+kubectl logs -n <namespace> <target-leader-pod> | grep "MX P2P weight transfer succeeded"
+```
+
+### Step 5: Cleanup
 
 ```bash
-FRONTEND=$(kubectl -n default get pod -l app.kubernetes.io/part-of=kimi-target-agg-tp8 \
-  -l nvidia.com/dynamo-component=frontend -o name | head -1)
-kubectl -n default exec $FRONTEND -- curl -s http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"baseten-admin/Kimi-2.5-text-nvfp4-v3",
-       "messages":[{"role":"user","content":"What is the capital of France?"}],
-       "max_tokens":50}'
+kubectl delete dgd -n <namespace> --all
+# MX infra can stay running for future deployments
 ```
-
----
-
-## Disaggregated Inference (P2P)
-
-Separate prefill and decode workers with KV cache transfer. Each loads
-weights via P2P from the same MX source.
-
-### Step 1: Deploy infrastructure + source
-
-```bash
-kubectl -n default apply -f mx-infra-decode.yaml
-kubectl -n default apply -f kimi-source-decode-dgd.yaml
-# Wait for source to publish (~15 min)
-```
-
-### Step 2: Deploy disagg targets
-
-```bash
-kubectl -n default apply -f kimi-disagg-mx-tp8-dgd.yaml
-# Creates: Frontend (KV router) + Prefill (MX target) + Decode (MX target)
-# Both load via P2P concurrently
-```
-
-### Step 3: Test inference
-
-```bash
-FRONTEND_IP=$(kubectl -n default get pod -l app.kubernetes.io/part-of=kimi-disagg-mx-tp8 \
-  -l nvidia.com/dynamo-component=frontend -o jsonpath='{.items[0].status.podIP}')
-kubectl -n default exec <any-worker-pod> -- curl -s http://${FRONTEND_IP}:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"baseten-admin/Kimi-2.5-text-nvfp4-v3",
-       "messages":[{"role":"user","content":"What is the capital of France?"}],
-       "max_tokens":50}'
-```
-
-### Disagg without MX (PVC baseline)
-
-To validate disagg works without P2P (both workers load from PVC):
-
-```bash
-kubectl -n default apply -f kimi-disagg-baseline-dgd.yaml
-# No MX source needed — loads directly from shared-model-cache PVC
-```
-
----
-
-## File Reference
-
-### Infrastructure
-
-| File | Purpose |
-|------|---------|
-| `mx-infra.yaml` | ModelExpress server + Redis (TP=4 source) |
-| `mx-infra-decode.yaml` | ModelExpress server + Redis (TP=8 source) |
-
-### Sources (load from PVC, publish for RDMA)
-
-| File | TP | Nodes | Notes |
-|------|-----|-------|-------|
-| `kimi-source-decode-dgd.yaml` | 8 | 2 | Primary source for TP=8 targets |
-| `kimi-source-deploy.yaml` | 4 | 1 | Legacy TP=4 source (Deployment) |
-| `kimi-source-dgd.yaml` | 4 | 1 | TP=4 source (DGD format) |
-
-### Targets (receive weights via P2P)
-
-| File | Mode | TP | MX Source | Notes |
-|------|------|-----|-----------|-------|
-| `kimi-target-agg-tp8-dgd.yaml` | Aggregated | 8 | decode server | Simplest P2P test |
-| `kimi-disagg-mx-tp8-dgd.yaml` | Disagg | 8+8 | decode server | Prefill + decode via P2P |
-| `kimi-disagg-baseline-dgd.yaml` | Disagg | 8+8 | PVC (no MX) | Baseline for comparison |
-| `kimi-disagg-mx-dgd.yaml` | Disagg | 4+4 | MX server | Legacy TP=4 disagg |
-| `kimi-disagg-phase2-dgd.yaml` | Disagg | 4+8 | dual MX | Mixed TP (needs 2 sources) |
-| `kimi-target-pvc-tp8-dgd.yaml` | Aggregated | 8 | PVC (no MX) | Ground truth baseline |
-
-### Testing
-
-| File | Purpose |
-|------|---------|
-| `qwen-source-deploy.yaml` | Qwen 0.5B TP=2 source (fast iteration) |
-| `qwen-target-deploy.yaml` | Qwen 0.5B TP=2 target |
-| `qwen-baseline-test.yaml` | Qwen baseline without MX |
-
----
-
-## Required Configuration for GCP GB200
-
-All worker pods need these settings. See `docs/disagg_trtllm.md` for details.
-
-```yaml
-securityContext:
-  privileged: true              # RDMA memory registration
-  runAsUser: 0                  # SSH key path fix for multinode
-
-env:
-  HOME: /root                   # Fix SSH host key path mismatch
-  UCX_TLS: "self,sm,rc,cuda_copy,gdr_copy,tcp"
-  UCX_IB_GID_INDEX: "3"        # GCP RoCEv2 GID selection
-  TRTLLM_UCX_INTERFACE: eth0    # Prevent 169.254.x.x binding
-  OMPI_MCA_pml: ob1             # Bypass UCX UD for MPI
-  OMPI_MCA_btl: "tcp,self,vader"
-  NATS_SERVER: "nats://dynamo-platform-nats.<ns>.svc.cluster.local:4222"
-  ETCD_ENDPOINTS: "dynamo-platform-etcd.<ns>.svc.cluster.local:2379"
-
-# Engine config (extra-engine-args YAML):
-  cache_transceiver_config:
-    backend: DEFAULT            # Bypass UCX UD for KV cache transfer
-  enable_autotuner: false       # Avoid warmup MPI desync
-```
-
----
-
-## Cleanup
-
-```bash
-# Delete all workloads
-kubectl -n default delete dgd --all
-
-# Delete compute domain (releases IMEX channels)
-kubectl -n default delete computedomain my-compute-domain
-
-# Keep infra running for next deployment
-# kubectl -n default delete -f mx-infra-decode.yaml  # if needed
-```
-
----
 
 ## Building the Image
 
-The image combines three repos into a single ARM64 container layered on the
-Dynamo TRT-LLM base image.
+The MX × TRT-LLM integration is now upstream:
 
-### Repos and branches
+- TRT-LLM [PR #13531](https://github.com/NVIDIA/TensorRT-LLM/pull/13531) (`MXCheckpointLoader` + `checkpoint_format="MX"`) **merged 2026-05-06** into `NVIDIA/TensorRT-LLM:main`. Ships in TRT-LLM 1.3.0rc15+.
+- Dynamo [PR #8037](https://github.com/ai-dynamo/dynamo/pull/8037) (`--model-express-url` CLI + auto-detect role) **open** as of this commit.
 
-| Repo | Branch | What it provides |
-|------|--------|-----------------|
-| `modelexpress` | your modelexpress branch | MX client, NIXL transfer, TRT-LLM patches |
-| `dynamo` | the Dynamo branch with P2P support | Engine P2P hooks (`--model-express-url`) |
-| `TensorRT-LLM` | your TRT-LLM branch | `LoadFormat.PRESHARDED` (applied via patches) |
+### Recommended path — once `tensorrtllm-runtime` ships TRT-LLM 1.3.0rc15+
 
-### Directory layout
+A thin wrapping image is all you need; no source patching:
 
-```
-~/work/github/
-├── modelexpress/   (your modelexpress branch)
-└── dynamo/         (the Dynamo branch with P2P support)
+```dockerfile
+# examples/p2p_transfer_k8s/client/trtllm/Dockerfile.minimal (sketch)
+FROM nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:<post-13531-tag>
+
+# MX Python client (publishes/receives weights via NIXL RDMA)
+RUN pip install "modelexpress>=0.3.0,<0.4.0"
 ```
 
-### Build command
+Build and push:
 
 ```bash
-cd ~/work/github/modelexpress
-
-docker buildx build --platform linux/arm64 --no-cache \
-    -f examples/p2p_transfer_trtllm/Dockerfile.ph3-gcp-gb200 \
-    --build-context dynamo=../dynamo \
-    -t <REGISTRY>/dynamo-trtllm-mx:<TAG> \
+docker buildx build --platform linux/arm64 \
+    -t <YOUR_REGISTRY>/<YOUR_NAME>:<YOUR_TAG> \
     --push .
 ```
 
-The Dockerfile (`examples/p2p_transfer_trtllm/Dockerfile.ph3-gcp-gb200`):
-1. Starts from `karenc:dynamo-trtllm-v1.0.0-a9b6f95` (TRT-LLM 1.3.0rc5 + NIXL, ARM64)
-2. Installs ModelExpress Python client (gRPC + NIXL transfer)
-3. Copies Dynamo engine/worker files from `dynamo` repo via `--build-context`
-4. Applies TRT-LLM patches: `PRESHARDED` LoadFormat, source publish hook, MPI allgather fix
+Once Dynamo PR #8037 also lands and the next runtime image bumps,
+`--model-express-url` is a first-class CLI flag and the image
+above is everything you need.
 
-### Building the base image from dynamo
+### Bridge path — patch-based image (if your base image predates PR #13531)
 
-If you don't have access to `karenc:dynamo-trtllm-v1.0.0-a9b6f95`, build the
-base image from the `dynamo` repo using its rendered Dockerfile:
+If you're on a `tensorrtllm-runtime` image that predates the merge of
+PR #13531, you can layer the changes on at build time via the
+patch-based Dockerfile + scripts that lived on
+[modelexpress PR #218](https://github.com/ai-dynamo/modelexpress/pull/218)'s
+`kavink/trtllm_clean` branch. That branch hosts:
 
-```bash
-cd ~/work/github/dynamo
+- `Dockerfile.dynamo-runtime` (wraps `tensorrtllm-runtime:1.1.0-dev.3`)
+- `Dockerfile.ph3-gcp-gb200` (wraps the older `karenc:dynamo-trtllm-v1.0.0-a9b6f95`)
+- `trtllm_patches/v1.3.0rc5/patch_mx_loader.py` — patches the base
+  `model_loader.py` with the P2P hooks PR #13531 adds natively
+- `trtllm_patches/dynamo/patch_dynamo_mx.py` — patches Dynamo with the
+  CLI hooks PR #8037 adds natively
 
-docker buildx build --platform linux/arm64 --no-cache \
-    -f container/trtllm-runtime-cuda13.1-arm64-rendered.Dockerfile \
-    --build-arg ARCH=arm64 \
-    --build-arg ARCH_ALT=aarch64 \
-    -t my-registry/dynamo-trtllm-base:latest \
-    --push .
-```
+Both patches are temporary and self-deprecate as soon as the upstream
+PRs ship in your base image.
 
-Then update the `FROM` line in `Dockerfile.ph3-gcp-gb200` to point to your
-base image instead of `karenc:dynamo-trtllm-v1.0.0-a9b6f95`.
+## File Reference
 
-### Current image
+| File | Purpose |
+|------|---------|
+| `mx-infra-decode.yaml` | ModelExpress server + Redis deployment |
+| `kimi-source-decode-dgd.yaml` | Source DGD (TP=8, loads from disk, publishes) |
+| `kimi-disagg-mx-tp8-dgd.yaml` | Target DGD (prefill + decode + frontend, loads via RDMA) |
+| [`hpa/`](hpa/README.md) | HPA-driven autoscale demo (single-replica → multi-replica with RDMA) |
 
-```
-<REGISTRY>/dynamo-trtllm-mx:<TAG>
+## Companion PRs
+
+| PR | Repo | Status |
+|----|------|--------|
+| [#13531](https://github.com/NVIDIA/TensorRT-LLM/pull/13531) | TRT-LLM | **Merged 2026-05-06** — `MXCheckpointLoader`, `checkpoint_format="MX"` |
+| [#202](https://github.com/ai-dynamo/modelexpress/pull/202) | ModelExpress | **Merged** — `MxLiveWeightLoader`, `publish_model_params` |
+| [#267](https://github.com/ai-dynamo/modelexpress/pull/267) | ModelExpress | **Merged** — `MX_POOL_REG` allocation-based registration |
+| [#8037](https://github.com/ai-dynamo/dynamo/pull/8037) | Dynamo | Open — `--model-express-url` engine integration (auto-detect source/target) |
+
+## Customization
+
+The yamls in this directory use placeholders for cluster-specific
+values. Before applying, replace the following:
+
+| Placeholder | Replace with | Where |
+|-------------|--------------|-------|
+| `<REGISTRY>/<NAME>:<TAG>` | Your container registry path + tag | All DGD yamls (`image:` field) |
+| `<NAMESPACE>` | The Kubernetes namespace where Dynamo platform runs | `NATS_SERVER`, `ETCD_ENDPOINTS`, `MODEL_EXPRESS_URL`, `resourceClaimTemplateName` |
+| `<GPU_NODE_POOL>` | Your GPU node pool name | `cloud.google.com/gke-nodepool` in worker yamls |
+| `<CPU_NODE_POOL>` | Your CPU node pool name | `cloud.google.com/gke-nodepool` in `mx-infra-decode.yaml` |
+
+If you don't want to build, you can validate the deployment path with
+any image that has the same layered components. Build the image with
+the instructions above and substitute its full URI into the DGD yamls.
+
+### Different model
+
+Update in the DGD yamls:
+- `--model-path` and `--served-model-name` args
+- `MODEL_NAME` env var
+- `model_kwargs.num_hidden_layers` in the ConfigMap
+- Ensure the model is on the `shared-model-cache` PVC
+
+## GCP GB200 Required Config
+
+All worker pods need these environment variables:
+
+```yaml
+env:
+  HOME: /root
+  UCX_TLS: "cuda_ipc,cuda_copy,rc"
+  UCX_IB_GID_INDEX: "3"
+  TRTLLM_UCX_INTERFACE: eth0
+  OMPI_MCA_pml: ob1
+  OMPI_MCA_btl: "tcp,self,vader"
+  NCCL_CUMEM_ENABLE: "1"
+  NCCL_NVLS_ENABLE: "1"
 ```

--- a/examples/p2p_transfer_k8s/client/trtllm/hpa/README.md
+++ b/examples/p2p_transfer_k8s/client/trtllm/hpa/README.md
@@ -1,0 +1,214 @@
+# Autoscaling TRT-LLM with ModelExpress P2P
+
+End-to-end demo showing how to autoscale a TRT-LLM serving deployment
+where new replicas receive their weights via NIXL RDMA instead of
+loading from disk — turning a ~20 minute cold-start into ~5 minutes.
+
+The first replica loads the model from disk and publishes via MX.
+Every subsequent replica that HPA brings up auto-detects the existing
+MX source and pulls weights over the network, **~750× faster than disk**
+for the loading phase.
+
+## Validated Results
+
+Kimi K2.5 (TP=8, 2 nodes per replica), GCP GB200, 4× 400G RoCE:
+
+| Replica | Weight loading | End-to-end ready |
+|---------|---------------|------------------|
+| Initial (disk) | ~20 minutes | ~22 minutes |
+| HPA scale-up #1 (RDMA) | **~1.6 seconds per rank** | **~4.5 minutes** |
+
+Per-rank RDMA throughput on the new replica: **361–583 Gbps**
+(8 ranks × 90.75 GB = 726 GB transferred end-to-end).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `kimi-agg-autoscale-dgd.yaml` | The aggregated worker DGD. Same spec for every replica — auto-detect handles source vs target |
+| `kimi-agg-autoscale-hpa.yaml` | DGDSA + HPA wrapper that exposes the `scale` subresource and drives replica count |
+
+## Container Image
+
+This demo uses the same image as the rest of the parent examples — see
+[`../README.md`](../README.md) for build instructions. The short version:
+
+Once `tensorrtllm-runtime` ships **TRT-LLM 1.3.0rc15+** (which carries
+[TRT-LLM PR #13531](https://github.com/NVIDIA/TensorRT-LLM/pull/13531) —
+merged 2026-05-06 — providing `MXCheckpointLoader` and `checkpoint_format="MX"`
+natively), all you need on top is the MX Python client:
+
+```dockerfile
+FROM nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:<post-13531-tag>
+RUN pip install "modelexpress>=0.3.0,<0.4.0"
+```
+
+```bash
+docker buildx build --platform linux/arm64 \
+    -t <YOUR_REGISTRY>/<YOUR_NAME>:<YOUR_TAG> --push .
+```
+
+Substitute the resulting image URI into the `image:` field of
+`kimi-agg-autoscale-dgd.yaml` (search for `<REGISTRY>/<NAME>:<TAG>`).
+
+If you're stuck on a base image that predates the merge of PR #13531,
+the patch-based bridge Dockerfiles still live on the
+[`kavink/trtllm_clean` branch](https://github.com/ai-dynamo/modelexpress/tree/kavink/trtllm_clean/examples/p2p_transfer_k8s/client/trtllm)
+that backed PR #218 — see the parent `README.md` for the bridge path.
+
+## Prerequisites
+
+1. **Kubernetes cluster** with GB200 nodes (ARM64) and CPU nodes
+2. **Dynamo platform** (etcd + NATS) reachable via FQDN from your namespace
+3. **DGD operator** + **DGDSA controller** installed (both part of Dynamo platform)
+4. **NVCR image pull secret** in your namespace
+5. **HF token secret** in your namespace
+6. **`shared-model-cache` PVC** with the Kimi K2.5 model in HF cache layout
+7. **ComputeDomain** sized for `maxReplicas × multinode.nodeCount` nodes
+8. **MX infrastructure** running (`modelexpress-server-decode` + `redis-decode`)
+
+If MX infra isn't set up yet, deploy it from the parent directory:
+
+```bash
+kubectl apply -n <namespace> -f ../mx-infra-decode.yaml
+```
+
+## Step-by-Step Demo
+
+### Step 1 — Update yamls for your cluster
+
+Open `kimi-agg-autoscale-dgd.yaml` and update:
+- Image tag: `nvcr.io/nvidian/dynamo-dev/<user>:dynamo-trtllm-mx-<tag>`
+- Node pool name (`cloud.google.com/gke-nodepool` value)
+- `NATS_SERVER` and `ETCD_ENDPOINTS` namespace FQDNs
+- `MODEL_EXPRESS_URL` (must match your MX server's FQDN)
+- `resourceClaimTemplateName` (your compute domain channel)
+
+### Step 2 — Deploy the DGD with replicas=1
+
+```bash
+kubectl apply -n <namespace> -f kimi-agg-autoscale-dgd.yaml
+```
+
+Watch the first replica come up. It will load weights from disk
+(~20 minutes for Kimi K2.5):
+
+```bash
+kubectl get pods -n <namespace> -l app.kubernetes.io/part-of=kimi-agg-autoscale -w
+```
+
+### Step 3 — Wait for the source to publish
+
+Verify all 8 ranks have published to Redis:
+
+```bash
+kubectl exec -n <namespace> deploy/redis-decode -- redis-cli KEYS 'mx:source:*:*' | wc -l
+# Expected: 8
+```
+
+### Step 4 — Apply DGDSA + HPA
+
+Once the first replica is `1/1 Running` and 8 workers are in Redis:
+
+```bash
+kubectl apply -n <namespace> -f kimi-agg-autoscale-hpa.yaml
+```
+
+Verify they're wired up:
+
+```bash
+kubectl get dgdsa,hpa -n <namespace>
+```
+
+### Step 5 — Trigger a scale-up
+
+For a manual demo (no inference load required):
+
+```bash
+kubectl patch dgdsa -n <namespace> kimi-agg-autoscale-source \
+  --type=merge -p '{"spec":{"replicas":2}}'
+```
+
+For a real autoscale demo with HPA, send inference traffic to push CPU
+above 50% (the threshold in `kimi-agg-autoscale-hpa.yaml`). HPA will
+update the DGDSA replicas automatically.
+
+### Step 6 — Watch the new replica load via RDMA
+
+```bash
+kubectl get pods -n <namespace> -l app.kubernetes.io/part-of=kimi-agg-autoscale -w
+```
+
+You should see `kimi-agg-autoscale-0-source-1-source-{ldr,wkr}-*` pods
+appear and reach `1/1 Ready` in ~5 minutes (vs ~22 min for the source).
+
+Verify the new replica used RDMA:
+
+```bash
+# kubectl JSONPath has no regex/contains filter, so pipe through grep.
+NEW_LDR=$(kubectl get pods -n <namespace> \
+  -l app.kubernetes.io/part-of=kimi-agg-autoscale \
+  -o name | grep -E 'source-1.*ldr' | head -n1 | sed 's#^pod/##')
+
+kubectl exec -n <namespace> "$NEW_LDR" -- cat /tmp/mx_logs/rank0.log | grep -E "transferred|Gbps"
+# Expected output:
+# "Rank 0: transferred 1815 params (90.75 GB) in 1.62s (447.7 Gbps) — DIRECT into model params"
+```
+
+## Cleanup
+
+```bash
+kubectl delete -n <namespace> -f kimi-agg-autoscale-hpa.yaml
+kubectl delete -n <namespace> -f kimi-agg-autoscale-dgd.yaml
+```
+
+MX infra and Redis can stay running for future deploys.
+
+## How Auto-Detect Works
+
+Both replicas use the **same** DGD spec. The difference comes from
+`MXCheckpointLoader.load_weights()` in TRT-LLM:
+
+```python
+def load_weights(self, checkpoint_dir, mapping, **kwargs):
+    if self._has_existing_sources():
+        return self._try_p2p_transfer(model, mapping, checkpoint_dir)
+    else:
+        # Fall through to HfCheckpointLoader.load_weights()
+        return super().load_weights(checkpoint_dir, mapping=mapping, **kwargs)
+```
+
+- **First replica**: probes MX server, no sources found → falls through
+  to disk loading → publishes via `publish_as_source()` after load
+- **Subsequent replicas**: probes MX server, sources detected → calls
+  `MxLiveWeightLoader` for NIXL RDMA receive
+
+Same image, same yaml, same env vars — different runtime behavior based
+on what's already published in MX.
+
+## Production Considerations
+
+- **HPA metric**: CPU is a placeholder. For LLM workloads use a
+  Prometheus adapter and scale on TRT-LLM queue depth, request rate,
+  or P99 latency. Set `kubectl explain hpa.spec.metrics` for options.
+- **Scale-down stabilization**: 300s default is conservative. Tune
+  `behavior.scaleDown.stabilizationWindowSeconds` for your workload.
+- **MX server HA**: The MX server is a single point of failure for
+  the *registration* path, but transfers are direct GPU↔GPU. If the
+  MX server goes down, in-flight pods continue serving; only new
+  scale-ups would fall back to disk loading.
+- **Compute domain sizing**: `maxReplicas × multinode.nodeCount` nodes
+  must fit in your ComputeDomain.
+- **Source pod lifetime**: Keep the source replica running for as long
+  as you may want to scale up. Restarting the source rotates its NIXL
+  agent ID and existing target replicas keep working but new scale-ups
+  must wait for re-publish.
+
+## Companion PRs
+
+| PR | Repo | Status | What it provides |
+|----|------|--------|------------------|
+| [#13531](https://github.com/NVIDIA/TensorRT-LLM/pull/13531) | TRT-LLM | **Merged 2026-05-06** | `MXCheckpointLoader` with `_has_existing_sources()` auto-detect |
+| [#8037](https://github.com/ai-dynamo/dynamo/pull/8037) | Dynamo | Open | `--model-express-url` engine integration |
+| [#202](https://github.com/ai-dynamo/modelexpress/pull/202) | ModelExpress | **Merged** | `MxLiveWeightLoader`, `publish_model_params` |
+| [#267](https://github.com/ai-dynamo/modelexpress/pull/267) | ModelExpress | **Merged** | `MX_POOL_REG` allocation-based registration |

--- a/examples/p2p_transfer_k8s/client/trtllm/hpa/kimi-agg-autoscale-dgd.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/hpa/kimi-agg-autoscale-dgd.yaml
@@ -1,23 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Kimi K2.5 decode source — DGD with multinode TP=8 (2 nodes × 4 GPUs)
-# Publishes weights via NIXL to modelexpress-server-decode
-# Phase 2: provides TP=8 weights for decode targets
-# Namespace: default
+# Aggregated Kimi K2.5 worker DGD designed for HPA-driven autoscaling.
+#
+# Each replica is a TP=8 group across 2 nodes × 4 GPUs.
+# `MXCheckpointLoader` auto-detects source vs target via _has_existing_sources():
+#   - First replica: no MX sources found → loads from disk → publishes via MX
+#   - Subsequent replicas: MX sources detected → RDMA receive (~5s vs ~22min)
+#
+# Same yaml works for replicas 1, 2, ..., N. Use the companion
+# kimi-agg-autoscale-hpa.yaml to drive replica count via HPA.
 #
 # Prerequisites:
-#   - modelexpress-server-decode + redis-decode running (mx-infra-decode.yaml)
-#   - shared-model-cache PVC with Kimi model
-#   - Dynamo platform (etcd + NATS)
-#   - DGD operator webhook running
+#   - modelexpress-server-decode + redis-decode running (../mx-infra-decode.yaml)
+#   - shared-model-cache PVC with Kimi model in HF cache layout
+#   - Dynamo platform (etcd + NATS) reachable via FQDN
+#   - DGD operator + DGDSA controller installed (part of Dynamo platform)
+#   - ComputeDomain large enough for maxReplicas × multinode.nodeCount nodes
+#
+# Update before applying:
+#   - Image tag: nvcr.io/nvidian/dynamo-dev/<user>:dynamo-trtllm-mx-<tag>
+#   - Node pool: cloud.google.com/gke-nodepool value (line ~74)
+#   - NATS_SERVER / ETCD_ENDPOINTS namespace FQDNs (lines ~117-119)
+#   - MODEL_EXPRESS_URL: where your modelexpress-server is reachable
+#   - resourceClaimTemplateName: your namespace's compute-domain-channel
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kimi-source-decode-trtllm-config
+  name: kimi-agg-autoscale-config
 data:
-  source-decode.yaml: |
+  agg.yaml: |
     max_num_tokens: 8192
     enable_chunked_prefill: true
     disable_overlap_scheduler: true
@@ -47,7 +60,7 @@ data:
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
-  name: kimi-source-decode
+  name: kimi-agg-autoscale
 spec:
   services:
     source:
@@ -82,7 +95,7 @@ spec:
                 - key: app.kubernetes.io/part-of
                   operator: In
                   values:
-                  - kimi-source-decode
+                  - kimi-agg-autoscale
               topologyKey: nvidia.com/gpu.clique
         containers: null
         imagePullSecrets:
@@ -103,7 +116,7 @@ spec:
             - --served-model-name
             - baseten-admin/Kimi-2.5-text-nvfp4-v3
             - --extra-engine-args
-            - /config/source-decode.yaml
+            - /config/agg.yaml
             - --model-express-url
             - modelexpress-server-decode.<NAMESPACE>.svc.cluster.local:8001
             - --tensor-parallel-size
@@ -219,4 +232,4 @@ spec:
               claimName: shared-model-cache
           - name: trtllm-config
             configMap:
-              name: kimi-source-decode-trtllm-config
+              name: kimi-agg-autoscale-config

--- a/examples/p2p_transfer_k8s/client/trtllm/hpa/kimi-agg-autoscale-hpa.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/hpa/kimi-agg-autoscale-hpa.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Autoscaling glue for kimi-agg-autoscale DGD.
+#
+# DynamoGraphDeploymentScalingAdapter (DGDSA) wraps a single service
+# inside the DGD and exposes the Kubernetes `scale` subresource. HPA
+# can then drive `dgdsa.spec.replicas`, and the DGDSA controller
+# propagates the value to the DGD's `spec.services.<name>.replicas`.
+#
+# When HPA scales up:
+#   - DGD operator creates a new TP=8 replica group
+#   - New pods auto-detect existing MX source via `_has_existing_sources()`
+#   - Weights arrive via NIXL RDMA in ~1-2s per rank instead of ~20 min disk load
+#
+# Apply AFTER the first replica is fully ready (1/1, all 8 workers
+# published to Redis), otherwise scale-ups will fall back to disk loading.
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeploymentScalingAdapter
+metadata:
+  name: kimi-agg-autoscale-source
+spec:
+  dgdRef:
+    name: kimi-agg-autoscale
+    serviceName: source
+  replicas: 1
+---
+# HPA targets the DGDSA's scale subresource.
+# CPU utilization is a placeholder metric for the demo. In production,
+# use a Prometheus adapter and scale on TRT-LLM queue depth, request
+# rate, or P99 latency for better signal on a GPU-bound workload.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kimi-agg-autoscale
+spec:
+  scaleTargetRef:
+    apiVersion: nvidia.com/v1alpha1
+    kind: DynamoGraphDeploymentScalingAdapter
+    name: kimi-agg-autoscale-source
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/examples/p2p_transfer_k8s/client/trtllm/kimi-disagg-mx-tp8-dgd.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/kimi-disagg-mx-tp8-dgd.yaml
@@ -103,7 +103,7 @@ spec:
         imagePullSecrets:
           - name: nvcr-imagepullsecret
         mainContainer:
-          image: "<REGISTRY>/dynamo-trtllm-mx:<TAG>"
+          image: "<REGISTRY>/<NAME>:<TAG>"
           command:
             - python3
           args:
@@ -122,9 +122,9 @@ spec:
             - name: HF_HOME
               value: /model-cache
             - name: NATS_SERVER
-              value: "nats://dynamo-platform-nats.default.svc.cluster.local:4222"
+              value: "nats://dynamo-platform-nats.<NAMESPACE>.svc.cluster.local:4222"
             - name: ETCD_ENDPOINTS
-              value: "dynamo-platform-etcd.default.svc.cluster.local:2379"
+              value: "dynamo-platform-etcd.<NAMESPACE>.svc.cluster.local:2379"
           volumeMounts:
             - mountPath: /model-cache
               name: model-cache
@@ -210,7 +210,7 @@ spec:
         imagePullSecrets:
           - name: nvcr-imagepullsecret
         mainContainer:
-          image: "<REGISTRY>/dynamo-trtllm-mx:<TAG>"
+          image: "<REGISTRY>/<NAME>:<TAG>"
           workingDir: /workspace/
           securityContext:
             privileged: true
@@ -232,9 +232,7 @@ spec:
             - --disaggregation-mode
             - prefill
             - --model-express-url
-            - modelexpress-server-decode.default.svc.cluster.local:8001
-            - --model-express-role
-            - target
+            - modelexpress-server-decode.<NAMESPACE>.svc.cluster.local:8001
             - --tensor-parallel-size
             - "8"
             - --publish-events-and-metrics
@@ -258,13 +256,15 @@ spec:
             - name: HF_MODULES_CACHE
               value: /tmp/hf_modules
             - name: MODEL_EXPRESS_URL
-              value: "modelexpress-server-decode.default.svc.cluster.local:8001"
+              value: "modelexpress-server-decode.<NAMESPACE>.svc.cluster.local:8001"
+            - name: MODEL_EXPRESS_TARGET
+              value: "1"
             - name: MODEL_NAME
               value: "baseten-admin/Kimi-2.5-text-nvfp4-v3"
             - name: NATS_SERVER
-              value: "nats://dynamo-platform-nats.default.svc.cluster.local:4222"
+              value: "nats://dynamo-platform-nats.<NAMESPACE>.svc.cluster.local:4222"
             - name: ETCD_ENDPOINTS
-              value: "dynamo-platform-etcd.default.svc.cluster.local:2379"
+              value: "dynamo-platform-etcd.<NAMESPACE>.svc.cluster.local:2379"
             - name: NCCL_CUMEM_ENABLE
               value: "1"
             - name: NCCL_NVLS_ENABLE
@@ -285,9 +285,6 @@ spec:
               value: "eth0"
             - name: OMPI_MCA_oob_tcp_if_include
               value: "eth0"
-            # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
-            - name: MX_RDMA_NIC_PIN
-              value: "auto"
             - name: UCX_TLS
               value: "cuda_ipc,cuda_copy,rc"
             - name: UCX_IB_GID_INDEX
@@ -349,7 +346,7 @@ spec:
             operator: Exists
         resourceClaims:
           - name: compute-domain-channel
-            resourceClaimTemplateName: my-compute-domain-channel
+            resourceClaimTemplateName: <NAMESPACE>-compute-domain-channel
         volumes:
           - name: shared-model-cache
             persistentVolumeClaim:
@@ -417,7 +414,7 @@ spec:
         imagePullSecrets:
           - name: nvcr-imagepullsecret
         mainContainer:
-          image: "<REGISTRY>/dynamo-trtllm-mx:<TAG>"
+          image: "<REGISTRY>/<NAME>:<TAG>"
           workingDir: /workspace/
           securityContext:
             privileged: true
@@ -439,9 +436,7 @@ spec:
             - --disaggregation-mode
             - decode
             - --model-express-url
-            - modelexpress-server-decode.default.svc.cluster.local:8001
-            - --model-express-role
-            - target
+            - modelexpress-server-decode.<NAMESPACE>.svc.cluster.local:8001
             - --tensor-parallel-size
             - "8"
             - --publish-events-and-metrics
@@ -465,13 +460,15 @@ spec:
             - name: HF_MODULES_CACHE
               value: /tmp/hf_modules
             - name: MODEL_EXPRESS_URL
-              value: "modelexpress-server-decode.default.svc.cluster.local:8001"
+              value: "modelexpress-server-decode.<NAMESPACE>.svc.cluster.local:8001"
+            - name: MODEL_EXPRESS_TARGET
+              value: "1"
             - name: MODEL_NAME
               value: "baseten-admin/Kimi-2.5-text-nvfp4-v3"
             - name: NATS_SERVER
-              value: "nats://dynamo-platform-nats.default.svc.cluster.local:4222"
+              value: "nats://dynamo-platform-nats.<NAMESPACE>.svc.cluster.local:4222"
             - name: ETCD_ENDPOINTS
-              value: "dynamo-platform-etcd.default.svc.cluster.local:2379"
+              value: "dynamo-platform-etcd.<NAMESPACE>.svc.cluster.local:2379"
             - name: NCCL_CUMEM_ENABLE
               value: "1"
             - name: NCCL_NVLS_ENABLE
@@ -492,9 +489,6 @@ spec:
               value: "eth0"
             - name: OMPI_MCA_oob_tcp_if_include
               value: "eth0"
-            # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
-            - name: MX_RDMA_NIC_PIN
-              value: "auto"
             - name: UCX_TLS
               value: "cuda_ipc,cuda_copy,rc"
             - name: UCX_IB_GID_INDEX
@@ -558,7 +552,7 @@ spec:
             operator: Exists
         resourceClaims:
           - name: compute-domain-channel
-            resourceClaimTemplateName: my-compute-domain-channel
+            resourceClaimTemplateName: <NAMESPACE>-compute-domain-channel
         volumes:
           - name: shared-model-cache
             persistentVolumeClaim:

--- a/examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml
@@ -77,7 +77,7 @@ spec:
           effect: NoExecute
       containers:
         - name: server
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidian/dynamo-dev/modelexpress-server:latest
           ports:
             - containerPort: 8001
           env:
@@ -85,6 +85,16 @@ spec:
               value: "redis"
             - name: REDIS_URL
               value: "redis://redis-decode:6379"
+            # MX reaper defaults (90s heartbeat, 3600s GC) are too aggressive
+            # for TRT-LLM sources that don't send heartbeats and can take 20+
+            # minutes to load large models from disk. Set these to ~2x your
+            # expected source disk-load time. Example: 4500s (75 min) covers
+            # 685B-class models with safety margin. For shorter-lived demos
+            # or smaller models, the upstream defaults are fine.
+            - name: MX_HEARTBEAT_TIMEOUT_SECS
+              value: "4500"
+            - name: MX_GC_TIMEOUT_SECS
+              value: "4500"
           resources:
             requests:
               cpu: "1"


### PR DESCRIPTION
Adds runnable Kubernetes manifests and a step-by-step run book for the ModelExpress + TRT-LLM P2P weight-loading integration on GCP GB200. This is the deployment-side companion to TRT-LLM PR #13531 (MXCheckpointLoader, merged 2026-05-06) and Dynamo PR #8037 (--model-express-url CLI, in review).

What's added under examples/p2p_transfer_k8s/client/trtllm/:

* mx-infra-decode.yaml — ModelExpress server + Redis deployment with placeholders for namespace, registry, CPU node pool. Tunable reaper / GC timeouts (MX_HEARTBEAT_TIMEOUT_SECS=4500s, MX_GC_TIMEOUT_SECS=4500s) sized to cover 685B-class disk loads without permanently disabling cleanup.

* kimi-source-decode-dgd.yaml — Source DGD (Kimi K2.5 TP=8 across 2 nodes). Loads from disk, then publishes via publish_model_params. Auto-detected as source by probing MX server for existing entries.

* kimi-disagg-mx-tp8-dgd.yaml — Target DGD (Frontend + Prefill TP=8 + Decode TP=8). Auto-detected as target. Receives weights via MxLiveWeightLoader / NIXL RDMA in ~2 seconds per rank instead of 15-20 minutes from disk.

* hpa/kimi-agg-autoscale-dgd.yaml — Aggregated worker DGD where every replica uses the same spec; auto-detect handles source vs target. Designed for HPA-driven horizontal scaling.

* hpa/kimi-agg-autoscale-hpa.yaml — DGDSA + HorizontalPodAutoscaler wrapping the aggregated DGD. Exposes the scale subresource so HPA can drive replica count.

* hpa/README.md — End-to-end demo: first replica ~22 minutes from disk, subsequent HPA-driven replicas ~5 minutes via RDMA at 361-583 Gbps/rank (validated on Kimi K2.5, GCP GB200, 4x 400G RoCE).

* README.md (overall guide) — Quick-start (5 steps), build instructions, image-stack guidance for both the post-PR-13531 recommended path (just pip install modelexpress on top of tensorrtllm-runtime once it bumps to TRT-LLM 1.3.0rc15+) and a bridge path that points at the patch-based Dockerfiles still hosted on the kavink/trtllm_clean branch (PR #218) for users on older runtime images.

All yamls use placeholders (<NAMESPACE>, <REGISTRY>/<NAME>:<TAG>, <GPU_NODE_POOL>, <CPU_NODE_POOL>, <MX_INFRA_*>) so users replace cluster-specific values before applying.

This PR carries the deployment-example slice of PR #218 (kavink/trtllm_clean). The patch-shim slice retires once the next tensorrtllm-runtime image cuts post-PR #13531; PR #218 will be closed without merging at that point.

Validated end-to-end on GCP GB200 (dynamo-gcp-dev-02, kavin namespace): 16 target ranks x 90.75 GB transferred at 363-506 Gbps, end-to-end disaggregated serving (prefill + decode + frontend) verified.

Companion PRs:
* TRT-LLM #13531: MXCheckpointLoader (merged 2026-05-06)
* ModelExpress #202: MxLiveWeightLoader, publish_model_params (merged)
* ModelExpress #267: MX_POOL_REG allocation-based registration (merged)
* Dynamo #8037: --model-express-url CLI integration (open)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive autoscaling guide for TRT-LLM deployments with Kubernetes HPA.
  * Expanded ModelExpress P2P deployment documentation with updated workflows and validation steps.

* **New Features**
  * Added Kubernetes manifests for HPA-driven autoscaling of TRT-LLM inference deployments.

* **Configuration Updates**
  * Enhanced deployment manifests with namespace and registry parameterization for improved flexibility.
  * Updated server configuration for improved stability and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->