### PR TITLE
feat: add SGLang ModelExpress loader integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ModelExpress orchestrates the full flow—from download to GPU memory. It ensure
 | vLLM | `--load-format mx` for P2P weight transfer |
 | NVIDIA Dynamo (vLLM) | `get_model_path` API; [aggregated K8s example](examples/aggregated_k8s/README.md) |
 | TensorRT-LLM | `LoadFormat.PRESHARDED` with `MxLiveCheckpointLoader` for P2P weight transfer (beta) — [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) |
-| SGLang | `--modelexpress-config` with `transport=nixl` — see [`docs/SGLANG.md`](docs/SGLANG.md) |
+| SGLang | `remote_instance` + `modelexpress` backend with `transport=nixl` or `transport=transfer_engine` — see [`docs/SGLANG.md`](docs/SGLANG.md) |
 
 ---
 
@@ -97,7 +97,7 @@ ModelExpress orchestrates the full flow—from download to GPU memory. It ensure
 *Source and Target exchange metadata with the server for coordination; weights transfer directly over RDMA between GPUs.*
 
 - **modelexpress_server**: gRPC server with configurable metadata backends (Redis, Kubernetes CRD).
-- **modelexpress_client**: Rust CLI for cache management; Python package with vLLM loaders and `MxClient` for gRPC.
+- **modelexpress_client**: Rust CLI for cache management; Python package with inference engine loaders and `MxClient` for gRPC.
 - **modelexpress_common**: Protobuf definitions, provider trait (HuggingFace), shared configuration.
 
 See [Architecture](docs/ARCHITECTURE.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Detailed reference document for the ModelExpress codebase. For deployment and co
 ModelExpress is a Rust-based model cache management service and GPU-to-GPU model weight transfer system. It serves two roles:
 
 - **Model Cache Service** - A sidecar alongside inference solutions (vLLM, SGLang, NVIDIA Dynamo) that accelerates model downloads from HuggingFace, NGC, and GCS. Model lifecycle state lives in a distributed registry — Redis or Kubernetes CRDs (`ModelCacheEntry`), selected via `MX_METADATA_BACKEND` — so multiple server replicas can coordinate without a shared-filesystem database. LRU cache eviction runs off the same registry.
-- **P2P Weight Transfer** - GPU-to-GPU model weight transfers between vLLM instances using NVIDIA NIXL over RDMA/InfiniBand, enabling ~15-second transfers for 681GB models.
+- **P2P Weight Transfer** - GPU-to-GPU model weight transfers between inference replicas using NVIDIA NIXL over RDMA/InfiniBand, enabling ~15-second transfers for 681GB models. The Python client includes engine adapters for vLLM and SGLang.
 
 ### Current Status
 
@@ -36,10 +36,10 @@ graph TD
 
     subgraph "P2P Transfer Mode"
         subgraph "Node A"
-            A[vLLM + MxModelLoader]
+            A[Inference Engine + MxModelLoader]
         end
         subgraph "Node B"
-            B[vLLM + MxModelLoader]
+            B[Inference Engine + MxModelLoader]
         end
         A -->|gRPC metadata| S2[ModelExpress Server]
         B -->|gRPC metadata| S2
@@ -54,7 +54,7 @@ graph TD
 |-----------|----------|----------|---------|
 | Server | Rust | `modelexpress_server/` | gRPC server: model downloads, cache eviction, P2P coordination |
 | Rust Client | Rust | `modelexpress_client/src/` | Client library and CLI tool |
-| Python Client | Python | `modelexpress_client/python/` | vLLM loaders, NIXL transfer manager, gRPC client |
+| Python Client | Python | `modelexpress_client/python/` | Inference engine loaders, NIXL transfer manager, gRPC client |
 | Common | Rust | `modelexpress_common/` | Protobuf definitions, shared types, provider trait, config |
 | Workspace Tests | Rust | `workspace-tests/` | Integration tests and Criterion benchmarks |
 
@@ -145,10 +145,14 @@ ModelExpress/
 │       │   ├── gds_strategy.py         # GdsStrategy (GPUDirect Storage)
 │       │   └── default_strategy.py     # DefaultStrategy (engine-native fallback)
 │       ├── engines/
-│       │   └── vllm/                   # vLLM integration
-│       │       ├── __init__.py         # vLLM loader registration
-│       │       ├── adapter.py          # VllmAdapter and context builder
-│       │       └── loader.py           # MxModelLoader implementation
+│       │   ├── vllm/                   # vLLM integration
+│       │   │   ├── __init__.py         # vLLM loader registration
+│       │   │   ├── adapter.py          # VllmAdapter and context builder
+│       │   │   └── loader.py           # MxModelLoader implementation
+│       │   └── sglang/                 # SGLang integration
+│       │       ├── __init__.py
+│       │       ├── adapter.py          # SglangAdapter and context builder
+│       │       └── loader.py           # MxModelLoader for remote_instance backend
 │       ├── tensor_utils.py             # Tensor collection, checksums, storage views
 │       ├── transfer_safety.py          # MLA feature gate, TransferFingerprint
 │       ├── rank_utils.py               # Rank detection utilities
@@ -511,6 +515,7 @@ Loading precedence: CLI args > environment variables > config file > defaults.
 | `metadata/` | Metadata publishing, source identity, heartbeat, worker manifest serving, metadata client selection |
 | `load_strategy/` | Engine-neutral loading strategy chain: `RdmaStrategy`, `ModelStreamerStrategy` (S3/GCS/Azure/local), `GdsStrategy`, `DefaultStrategy` |
 | `engines/vllm/` | `VllmAdapter` and `MxModelLoader` - maps strategy hooks to vLLM loader APIs and post-load lifecycle |
+| `engines/sglang/` | `SglangAdapter` and `MxModelLoader` - maps strategy hooks to SGLang's `remote_instance` backend |
 | `tensor_utils.py` | Tensor collection, checksums, storage views, `capture_tensor_attrs` |
 | `rank_utils.py` | `get_global_rank`, `get_worker_rank` |
 | `vllm_worker.py` | `ModelExpressWorker` - custom vLLM worker class (use `--worker-cls=modelexpress.vllm_worker.ModelExpressWorker`) |
@@ -548,6 +553,19 @@ Manages a NIXL agent and RDMA transfers for a single GPU worker:
 **MxModelLoader** (extends `BaseModelLoader`, registered as `--load-format mx`):
 
 Thin orchestration layer that delegates to `LoadStrategyChain.run()`. Builds a `LoadContext` from vLLM config, initializes the model, runs the strategy chain, and updates global registries.
+
+### SGLang Loader
+
+**MxModelLoader** is instantiated by SGLang's `remote_instance` loader when
+`--remote-instance-weight-loader-backend modelexpress` is used. SGLang
+initializes the model, then delegates to this loader. The loader builds a
+`LoadContext` from SGLang config, runs `LoadStrategyChain.run()`, and updates
+global registries.
+`SglangAdapter` owns SGLang-specific rank/device mapping, native fallback
+loading, quantized-weight post-processing, and tensor discovery, including the
+storage-view naming used for non-contiguous SGLang parameters.
+The SGLang side does not expose separate source and target modes; transport
+selection and source discovery remain inside the ModelExpress package.
 
 **LoadStrategyChain** (`load_strategy/`):
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -291,7 +291,7 @@ See [`../examples/aggregated_k8s/README.md`](../examples/aggregated_k8s/README.m
 
 ## P2P GPU Weight Transfers
 
-ModelExpress supports GPU-to-GPU model weight transfers between vLLM instances using NVIDIA NIXL over RDMA. Use `--load-format mx`, which auto-detects whether to load from disk or receive via RDMA.
+ModelExpress supports GPU-to-GPU model weight transfers between supported inference instances using NVIDIA NIXL over RDMA. vLLM uses `--load-format mx`, which auto-detects whether to load from disk or receive via RDMA. SGLang uses `remote_instance` with the `modelexpress` backend; see [SGLang Clients](#sglang-clients).
 
 ### Choosing a Metadata Backend
 
@@ -577,7 +577,7 @@ See [`../examples/k8s_service_sources/README.md`](../examples/k8s_service_source
 #### SGLang Clients
 
 ModelExpress also works as the remote-instance weight loader for SGLang via
-upstream [sgl-project/sglang#23105](https://github.com/sgl-project/sglang/pull/23105),
+upstream [sgl-project/sglang#24723](https://github.com/sgl-project/sglang/pull/24723),
 supporting both Mooncake TransferEngine and NIXL transports. See
 [`SGLANG.md`](SGLANG.md) for the user-facing guide.
 

--- a/docs/SGLANG.md
+++ b/docs/SGLANG.md
@@ -7,62 +7,113 @@ SPDX-License-Identifier: Apache-2.0
 
 ModelExpress can serve as the remote-instance weight loader for SGLang,
 streaming weights GPU-to-GPU over RDMA between SGLang processes instead
-of loading from disk on every replica. The integration is contributed by
-upstream [sgl-project/sglang#23105](https://github.com/sgl-project/sglang/pull/23105),
-which adds the `--modelexpress-config` flag and supports two transports:
+of loading from disk on every replica. The SGLang-side delegation hook is
+proposed in upstream [sgl-project/sglang#24723](https://github.com/sgl-project/sglang/pull/24723),
+which adds the `--modelexpress-config` flag and delegates ModelExpress loading
+to the ModelExpress package:
 
-- **Mooncake TransferEngine** — SGLang's existing remote-instance path.
-- **NIXL** — selected with `transport: "nixl"`.
+SGLang does not run separate source and target modes. Every server uses the
+same `remote_instance` command, and `modelexpress.engines.sglang.MxModelLoader`
+decides whether to load natively and publish metadata or receive weights from
+an existing ModelExpress source.
 
-## 1. Install SGLang
+## 1. Build an SGLang image
 
-Install SGLang either way:
+Use an SGLang image that contains the upstream ModelExpress delegation hook:
 
 - **Pull the official image** — use a recent `lmsysorg/sglang` tag from
-  Docker Hub. PR #23105 was merged on `main`, so any image built from
-  `main` after the merge contains it.
+  Docker Hub after PR #24723 or an equivalent delegation patch is included.
 - **Build from `main`** — follow SGLang's official install guide at
-  [docs.sglang.ai/start/install](https://docs.sglang.ai/start/install.html).
+  [docs.sglang.io/docs/get_started/install](https://docs.sglang.io/docs/get_started/install).
 
-Either way, confirm the flag is present before running:
+Install the ModelExpress Python package into the SGLang image:
 
-## 2. Install the ModelExpress Python client
+```dockerfile
+FROM lmsysorg/sglang:<tag-with-modelexpress-delegation>
 
-```bash
-pip install "modelexpress @ git+https://github.com/ai-dynamo/modelexpress.git#subdirectory=modelexpress_client/python"
+RUN python3 -m pip install --no-cache-dir \
+    "modelexpress @ git+https://github.com/ai-dynamo/modelexpress.git#subdirectory=modelexpress_client/python"
 ```
 
-## 3. Start a ModelExpress server
+If you build SGLang from a local PR branch for e2e testing, install the local
+ModelExpress package into that image:
+
+```dockerfile
+FROM sglang-source:modelexpress
+
+COPY modelexpress_client/python /tmp/modelexpress_client_python
+RUN python3 -m pip install --no-cache-dir /tmp/modelexpress_client_python
+```
+
+Confirm the SGLang delegation flag is present before running:
+
+```bash
+python -m sglang.launch_server --help | grep modelexpress-config
+```
+
+For local SGLang source builds before the delegation patch is upstream:
+
+```bash
+cd /Users/zheluo/workspace/sglang
+
+docker build --platform linux/amd64 \
+  -f docker/Dockerfile \
+  --target runtime \
+  --build-arg BRANCH_TYPE=local \
+  --build-arg CUDA_VERSION=13.0.1 \
+  --build-arg BUILD_TYPE=all \
+  -t sglang-source:modelexpress \
+  .
+```
+
+Then use the local-package Dockerfile snippet above to install ModelExpress.
+
+## 2. Start a ModelExpress server
 
 ModelExpress server should be reachable at
 `modelexpress-server:8001`. See [`DEPLOYMENT.md`](DEPLOYMENT.md) for how
 to start one (Docker, Helm, or Kubernetes).
 
-## 4. Launch SGLang
+## 3. Launch SGLang
 
-### NIXL transport
-
-**Seed:**
+Use the same command for the first and later replicas. The first replica
+finds no READY source, loads natively through SGLang, and publishes itself.
+Later replicas discover the source and load via the selected ModelExpress
+transport.
 
 ```bash
+export MODEL_EXPRESS_URL=modelexpress-server:8001
+
 python -m sglang.launch_server \
   --model-path deepseek-ai/DeepSeek-V3 --tp 8 --port 30000 \
-  --load-format auto \
-  --modelexpress-config '{"url": "modelexpress-server:8001", "source": true, "transport": "nixl"}'
-```
-
-**Client:**
-
-```bash
-python -m sglang.launch_server \
-  --model-path deepseek-ai/DeepSeek-V3 --tp 8 --port 30001 \
   --load-format remote_instance \
   --remote-instance-weight-loader-backend modelexpress \
   --modelexpress-config '{"url": "modelexpress-server:8001", "transport": "nixl"}'
 ```
 
+`modelexpress-config` is intentionally small and only controls the SGLang
+handoff into ModelExpress:
+
+- `url` sets or overrides the ModelExpress server URL for this SGLang process.
+- `transport` selects the ModelExpress package transport. Supported values are
+  `nixl` and `transfer_engine`.
+
+All other ModelExpress settings are environment variables, matching vLLM:
+`MX_METADATA_BACKEND`, `MX_MODEL_REVISION`, `MX_P2P_METADATA`,
+`MX_NIXL_BACKEND`, `MX_RDMA_NIC_PIN`, `MX_METADATA_PORT`,
+`MX_WORKER_GRPC_PORT`, and `MODEL_EXPRESS_LOG_LEVEL`.
+
+For TransferEngine, use the same command shape and change only the transport:
+
+```bash
+python -m sglang.launch_server \
+  --model-path deepseek-ai/DeepSeek-V3 --tp 8 --port 30000 \
+  --load-format remote_instance \
+  --remote-instance-weight-loader-backend modelexpress \
+  --modelexpress-config '{"url": "modelexpress-server:8001", "transport": "transfer_engine"}'
+```
 
 ## See also
 
-- Upstream PR: [sgl-project/sglang#23105](https://github.com/sgl-project/sglang/pull/23105).
+- Upstream PR: [sgl-project/sglang#24723](https://github.com/sgl-project/sglang/pull/24723).
 - [`DEPLOYMENT.md`](DEPLOYMENT.md) — running the ModelExpress server, NIXL/UCX tuning, performance reference.

--- a/docs/SGLANG.md
+++ b/docs/SGLANG.md
@@ -54,7 +54,7 @@ python -m sglang.launch_server --help | grep modelexpress-config
 For local SGLang source builds before the delegation patch is upstream:
 
 ```bash
-cd /Users/zheluo/workspace/sglang
+cd /path/to/sglang
 
 docker build --platform linux/amd64 \
   -f docker/Dockerfile \

--- a/modelexpress_client/python/modelexpress/adapter.py
+++ b/modelexpress_client/python/modelexpress/adapter.py
@@ -136,6 +136,10 @@ class EngineAdapter:
         """Return the torch device where target model state should live."""
         return torch.device(f"cuda:{self.get_device_id()}")
 
+    def is_cuda_alike(self) -> bool:
+        """Return whether this engine is running on a CUDA-like platform."""
+        return False
+
     def prepare_rdma_target(self, result: LoadResult) -> LoadResult:
         """Prepare target-side model storage before receiving RDMA weights."""
         return result

--- a/modelexpress_client/python/modelexpress/engines/sglang/__init__.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang integration for ModelExpress."""
+
+from .adapter import (
+    SglangAdapter,
+    build_sglang_load_context,
+    build_sglang_source_identity,
+)
+from .loader import MxModelLoader
+
+__all__ = [
+    "MxModelLoader",
+    "SglangAdapter",
+    "build_sglang_load_context",
+    "build_sglang_source_identity",
+]

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -47,7 +47,7 @@ class SglangAdapter(EngineAdapter):
         )
 
     def get_worker_rank(self) -> int:
-        return int(getattr(self.load_config, "tp_rank", 0) or 0)
+        return _get_sglang_worker_rank(self.load_config)
 
     def get_global_rank(self) -> int:
         if torch.distributed.is_available() and torch.distributed.is_initialized():
@@ -64,6 +64,11 @@ class SglangAdapter(EngineAdapter):
 
     def get_target_device(self) -> torch.device:
         return self.target_device
+
+    def is_cuda_alike(self) -> bool:
+        from sglang.srt.utils import is_cuda_alike
+
+        return bool(is_cuda_alike())
 
     def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
         if result.model is None:
@@ -254,6 +259,19 @@ def _get_parallel_size(name: str) -> int:
         return int(getattr(distributed, name)())
     except Exception:
         return 1
+
+
+def _get_sglang_worker_rank(load_config: LoadConfig) -> int:
+    """Return the SGLang model-parallel shard key, excluding DP replicas."""
+    try:
+        from sglang.srt import distributed
+
+        tp_rank = int(distributed.get_tensor_model_parallel_rank())
+        pp_rank = int(distributed.get_pipeline_model_parallel_rank())
+        tp_size = int(distributed.get_tensor_model_parallel_world_size())
+        return pp_rank * tp_size + tp_rank
+    except Exception:
+        return int(getattr(load_config, "tp_rank", 0) or 0)
 
 
 def build_sglang_load_context(

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang implementation of the ModelExpress engine adapter contract."""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+import uuid
+from importlib.metadata import version as pkg_version
+from typing import TYPE_CHECKING, Iterator
+
+import torch
+
+from ... import p2p_pb2
+from ...adapter import EngineAdapter
+from ...load_strategy.context import LoadContext, LoadResult
+from ...metadata.client_factory import create_metadata_client
+
+logger = logging.getLogger("modelexpress.engines.sglang.adapter")
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.device_config import DeviceConfig
+    from sglang.srt.configs.load_config import LoadConfig
+    from sglang.srt.configs.model_config import ModelConfig
+
+
+class SglangAdapter(EngineAdapter):
+    """Adapter that maps strategy hooks onto SGLang's native loader APIs."""
+
+    def __init__(
+        self,
+        load_config: LoadConfig,
+        model_config: ModelConfig,
+        device_config: DeviceConfig,
+    ):
+        self.load_config = load_config
+        self.model_config = model_config
+        self.device_config = device_config
+        self.target_device = torch.device(device_config.device)
+
+    def build_identity(self) -> p2p_pb2.SourceIdentity:
+        return build_sglang_source_identity(
+            model_config=self.model_config,
+        )
+
+    def get_worker_rank(self) -> int:
+        return int(getattr(self.load_config, "tp_rank", 0) or 0)
+
+    def get_global_rank(self) -> int:
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            return int(torch.distributed.get_rank())
+        return self.get_worker_rank()
+
+    def get_device_id(self) -> int:
+        gpu_id = getattr(self.device_config, "gpu_id", None)
+        if gpu_id is not None:
+            return int(gpu_id)
+        if self.target_device.index is not None:
+            return int(self.target_device.index)
+        return 0
+
+    def get_target_device(self) -> torch.device:
+        return self.target_device
+
+    def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
+        if result.model is None:
+            raise RuntimeError("SGLang tensor discovery requires result.model")
+        return collect_sglang_tensors(result.model)
+
+    def before_rdma_receive(self, result: LoadResult) -> LoadResult:
+        return self._process_weights_after_loading(result)
+
+    def after_rdma_receive(self, result: LoadResult) -> LoadResult:
+        return self._post_load_weights(result)
+
+    def apply_weight_iter(
+        self,
+        result: LoadResult,
+        weights_iter: Iterator[tuple[str, torch.Tensor]],
+    ) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("SGLang weight iterator loading requires result.model")
+        result.model.load_weights(weights_iter)
+        return result
+
+    def after_weight_iter_load(self, result: LoadResult) -> LoadResult:
+        return self._process_weights_after_loading(result)
+
+    def load_via_native(self, result: LoadResult) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("SGLang native loading requires result.model")
+
+        from sglang.srt.configs.load_config import LoadFormat
+        from sglang.srt.model_loader.loader import DefaultModelLoader
+
+        disk_config = copy.copy(self.load_config)
+        disk_config.load_format = LoadFormat.AUTO
+        disk_loader = DefaultModelLoader(disk_config)
+        weights_iter = disk_loader._get_all_weights(self.model_config, result.model)
+        DefaultModelLoader.load_weights_and_postprocess(
+            result.model, weights_iter, self.target_device,
+        )
+        return result
+
+    def reinit_for_retry(self, result: LoadResult) -> LoadResult:
+        from sglang.srt.model_loader.loader import (
+            _get_quantization_config,
+            _initialize_model,
+        )
+
+        old_value = result.value
+        result.value = None
+        result.model = None
+        del old_value
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        logger.info(
+            "[Worker %s] Re-initializing SGLang model after failed strategy",
+            self.get_global_rank(),
+        )
+        quant_config = _get_quantization_config(self.model_config, self.load_config)
+        with self.target_device:
+            model = _initialize_model(
+                self.model_config,
+                self.load_config,
+                quant_config,
+            )
+        return LoadResult(value=model, model=model, publishable=result.publishable)
+
+    def _process_weights_after_loading(self, result: LoadResult) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("SGLang post-load processing requires result.model")
+
+        from sglang.srt.model_loader.loader import device_loading_context
+
+        for _, module in result.model.named_modules():
+            quant_method = getattr(module, "quant_method", None)
+            if quant_method is not None:
+                with device_loading_context(module, self.target_device):
+                    quant_method.process_weights_after_loading(module)
+        return result
+
+    def _post_load_weights(self, result: LoadResult) -> LoadResult:
+        if result.model is None:
+            raise RuntimeError("SGLang post-load fixup requires result.model")
+        _call_sglang_post_load_weights(result.model)
+        return result
+
+
+def _call_sglang_post_load_weights(model: torch.nn.Module) -> None:
+    post_load_weights = getattr(model, "post_load_weights", None)
+    if callable(post_load_weights):
+        post_load_weights()
+        return
+
+    for child in model.children():
+        post_load_weights = getattr(child, "post_load_weights", None)
+        if callable(post_load_weights):
+            post_load_weights()
+
+
+def collect_sglang_tensors(model) -> dict[str, torch.Tensor]:
+    """Collect SGLang model parameters for NIXL registration.
+
+    SGLang's current NIXL path registers contiguous parameters directly and
+    registers a byte view of the underlying storage for non-contiguous
+    parameters. Keep that naming behavior so source and target descriptors
+    match the upstream integration.
+    """
+    tensors: dict[str, torch.Tensor] = {}
+    seen_ptrs: set[int] = set()
+
+    for name, param in model.named_parameters():
+        t = param.data
+        if t.is_contiguous():
+            tensor_name = name
+            registered = t
+        else:
+            tensor_name = f"{name}.__storage"
+            registered = torch.empty(0, dtype=torch.uint8, device=t.device).set_(
+                t.untyped_storage()
+            )
+
+        ptr = registered.data_ptr()
+        if ptr in seen_ptrs:
+            continue
+        seen_ptrs.add(ptr)
+        tensors[tensor_name] = registered
+
+    return tensors
+
+
+def build_sglang_source_identity(model_config: ModelConfig) -> p2p_pb2.SourceIdentity:
+    """Build a ModelExpress SourceIdentity from SGLang model state."""
+    try:
+        mx_version = pkg_version("modelexpress")
+    except Exception:
+        mx_version = "0.0.0"
+
+    return p2p_pb2.SourceIdentity(
+        mx_version=mx_version,
+        mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
+        model_name=_get_model_name(model_config),
+        backend_framework=p2p_pb2.BACKEND_FRAMEWORK_SGLANG,
+        tensor_parallel_size=_get_parallel_size(
+            "get_tensor_model_parallel_world_size"
+        ),
+        pipeline_parallel_size=_get_parallel_size(
+            "get_pipeline_model_parallel_world_size"
+        ),
+        expert_parallel_size=_get_parallel_size(
+            "get_moe_expert_parallel_world_size"
+        ),
+        dtype=_get_dtype(model_config),
+        quantization=_get_quantization(model_config),
+        revision=_get_revision(model_config),
+    )
+
+
+def _get_model_name(model_config: ModelConfig) -> str:
+    return str(
+        getattr(
+            model_config,
+            "model_path",
+            getattr(model_config, "model", ""),
+        )
+    )
+
+
+def _get_dtype(model_config: ModelConfig) -> str:
+    dtype = getattr(model_config, "dtype", "")
+    return str(dtype).replace("torch.", "")
+
+
+def _get_quantization(model_config: ModelConfig) -> str:
+    return str(getattr(model_config, "quantization", "") or "")
+
+
+def _get_revision(model_config: ModelConfig) -> str:
+    override = os.environ.get("MX_MODEL_REVISION", "")
+    if override:
+        return override
+    return str(getattr(model_config, "revision", "") or "")
+
+
+def _get_parallel_size(name: str) -> int:
+    try:
+        from sglang.srt import distributed
+
+        return int(getattr(distributed, name)())
+    except Exception:
+        return 1
+
+
+def build_sglang_load_context(
+    load_config: LoadConfig,
+    model_config: ModelConfig,
+    device_config: DeviceConfig,
+) -> LoadContext:
+    """Build a LoadContext from SGLang config objects."""
+
+    adapter = SglangAdapter(load_config, model_config, device_config)
+    worker_rank = adapter.get_worker_rank()
+    global_rank = adapter.get_global_rank()
+    server_url = getattr(load_config, "modelexpress_url", None)
+    return LoadContext(
+        model_config=model_config,
+        load_config=load_config,
+        target_device=adapter.get_target_device(),
+        global_rank=global_rank,
+        worker_rank=worker_rank,
+        device_id=adapter.get_device_id(),
+        identity=adapter.build_identity(),
+        mx_client=create_metadata_client(
+            worker_rank=worker_rank,
+            server_url=server_url,
+        ),
+        worker_id=uuid.uuid4().hex[:8],
+        adapter=adapter,
+    )

--- a/modelexpress_client/python/modelexpress/engines/sglang/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/loader.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ModelExpress loader entrypoint for SGLang's remote_instance backend."""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+
+from ... import p2p_pb2
+from ...load_strategy import LoadContext, LoadStrategyChain
+from ...load_strategy.context import LoadResult
+from ...metadata.heartbeat import HeartbeatThread
+from ...metadata.publish import _heartbeat_threads
+from ...nixl_transfer import NixlTransferManager
+from .adapter import build_sglang_load_context
+
+logger = logging.getLogger("modelexpress.engines.sglang.loader")
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.device_config import DeviceConfig
+    from sglang.srt.configs.load_config import LoadConfig
+    from sglang.srt.configs.model_config import ModelConfig
+
+
+_tensor_registry: dict[int, dict[str, torch.Tensor]] = {}
+_nixl_managers: dict[int, NixlTransferManager] = {}
+
+
+class MxModelLoader:
+    """Unified ModelExpress loader for SGLang.
+
+    SGLang instantiates this class from its ``remote_instance`` loader when
+    ``remote-instance-weight-loader-backend=modelexpress``. The class receives
+    the already-initialized SGLang model and delegates loading policy to the
+    shared ModelExpress strategy chain.
+    """
+
+    def __init__(self, load_config: LoadConfig):
+        self.load_config = load_config
+        self._ctx: LoadContext | None = None
+
+    def load_model(
+        self,
+        *,
+        model: nn.Module,
+        model_config: ModelConfig,
+        device_config: DeviceConfig,
+    ) -> nn.Module:
+        """Load model weights through the shared ModelExpress strategy chain."""
+        transport = getattr(self.load_config, "modelexpress_transport", "nixl")
+        if transport == "nixl":
+            return self._load_model_via_nixl(
+                model=model,
+                model_config=model_config,
+                device_config=device_config,
+            )
+        if transport == "transfer_engine":
+            return self._load_model_via_transfer_engine(
+                model=model,
+                model_config=model_config,
+                device_config=device_config,
+            )
+        raise ValueError(
+            "SGLang ModelExpress integration currently supports "
+            f"modelexpress transports 'nixl' and 'transfer_engine', "
+            f"got {transport!r}."
+        )
+
+    def _load_model_via_nixl(
+        self,
+        *,
+        model: nn.Module,
+        model_config: ModelConfig,
+        device_config: DeviceConfig,
+    ) -> nn.Module:
+        load_start = time.perf_counter()
+        ctx = build_sglang_load_context(
+            self.load_config,
+            model_config,
+            device_config,
+        )
+        self._ctx = ctx
+
+        logger.info(
+            "[Worker %s] SGLang MxModelLoader starting (model=%s)",
+            ctx.global_rank,
+            ctx.identity.model_name,
+        )
+        model = LoadStrategyChain.run(model, ctx)
+
+        _tensor_registry[ctx.device_id] = ctx.tensors
+        if ctx.nixl_manager is not None:
+            _nixl_managers[ctx.device_id] = ctx.nixl_manager
+        else:
+            _nixl_managers.pop(ctx.device_id, None)
+
+        total_time = time.perf_counter() - load_start
+        logger.info(
+            "[Worker %s] SGLang MxModelLoader.load_model() COMPLETE in %.2fs",
+            ctx.global_rank,
+            total_time,
+        )
+        return model.eval()
+
+    def _load_model_via_transfer_engine(
+        self,
+        *,
+        model: nn.Module,
+        model_config: ModelConfig,
+        device_config: DeviceConfig,
+    ) -> nn.Module:
+        """Load SGLang weights via ModelExpress metadata and TransferEngine."""
+        from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
+            register_memory_region,
+        )
+
+        load_start = time.perf_counter()
+        ctx = build_sglang_load_context(
+            self.load_config,
+            model_config,
+            device_config,
+        )
+        self._ctx = ctx
+
+        transfer_engine = getattr(
+            self.load_config, "remote_instance_weight_loader_transfer_engine", None
+        )
+        session_id = getattr(
+            self.load_config,
+            "remote_instance_weight_loader_transfer_engine_session_id",
+            None,
+        )
+        if transfer_engine is None or not session_id:
+            raise RuntimeError(
+                "SGLang ModelExpress transfer_engine transport requires an "
+                "initialized SGLang TransferEngine and session id."
+            )
+
+        logger.info(
+            "[Worker %s] SGLang MxModelLoader starting transfer_engine "
+            "(model=%s)",
+            ctx.global_rank,
+            ctx.identity.model_name,
+        )
+
+        result = LoadResult(value=model, model=model)
+        source_worker = self._find_transfer_engine_source(ctx)
+        weight_info = None
+        if source_worker is None:
+            logger.info(
+                "[Worker %s] No TransferEngine source available, loading natively",
+                ctx.global_rank,
+            )
+            result = ctx.adapter.load_via_native(result)
+        else:
+            result = ctx.adapter.before_rdma_receive(result)
+            weight_info = register_memory_region(result.model, transfer_engine)
+            self._receive_via_transfer_engine(
+                result.model,
+                transfer_engine,
+                source_worker,
+                ctx,
+            )
+            result = ctx.adapter.after_rdma_receive(result)
+
+        if weight_info is None:
+            weight_info = register_memory_region(result.model, transfer_engine)
+        self.remote_instance_transfer_engine_weight_info = weight_info
+        self._publish_transfer_engine_source(
+            ctx=ctx,
+            session_id=session_id,
+            weight_info=weight_info,
+        )
+
+        total_time = time.perf_counter() - load_start
+        logger.info(
+            "[Worker %s] SGLang MxModelLoader transfer_engine COMPLETE in %.2fs",
+            ctx.global_rank,
+            total_time,
+        )
+        return result.model.eval()
+
+    def _find_transfer_engine_source(self, ctx: LoadContext):
+        try:
+            response = ctx.mx_client.list_sources(
+                identity=ctx.identity,
+                status_filter=p2p_pb2.SOURCE_STATUS_READY,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Worker %s] TransferEngine source discovery failed, "
+                "falling back to native load: %s",
+                ctx.global_rank,
+                exc,
+            )
+            return None
+
+        candidates = [
+            inst for inst in response.instances if inst.worker_rank == ctx.worker_rank
+        ]
+        random.shuffle(candidates)
+        for source_ref in candidates:
+            metadata = ctx.mx_client.get_metadata(
+                mx_source_id=source_ref.mx_source_id,
+                worker_id=source_ref.worker_id,
+            )
+            if not metadata.found:
+                continue
+            worker = metadata.worker
+            if worker.WhichOneof("backend_metadata") == "transfer_engine_session_id":
+                return worker
+        return None
+
+    def _receive_via_transfer_engine(
+        self,
+        model: nn.Module,
+        transfer_engine,
+        source_worker,
+        ctx: LoadContext,
+    ) -> None:
+        seed_weight_info = {
+            tensor.name: (tensor.addr, tensor.size)
+            for tensor in source_worker.tensors
+        }
+
+        seed_ptr_list = []
+        client_ptr_list = []
+        client_len_list = []
+        for name, tensor in model.named_parameters():
+            weight_info = seed_weight_info.get(name)
+            if weight_info is None:
+                raise RuntimeError(
+                    f"ModelExpress transfer_engine: missing tensor {name!r} "
+                    "in source metadata"
+                )
+            seed_ptr, seed_size = weight_info
+            local_size = tensor.numel() * tensor.element_size()
+            if seed_size != local_size:
+                raise RuntimeError(
+                    f"ModelExpress transfer_engine: size mismatch for {name}: "
+                    f"source={seed_size} bytes, local={local_size} bytes"
+                )
+            seed_ptr_list.append(seed_ptr)
+            client_ptr_list.append(tensor.data_ptr())
+            client_len_list.append(local_size)
+
+        logger.info(
+            "[Worker %s] Receiving %d tensors via TransferEngine",
+            ctx.global_rank,
+            len(seed_ptr_list),
+        )
+        ret = transfer_engine.batch_transfer_sync_read(
+            source_worker.transfer_engine_session_id,
+            client_ptr_list,
+            seed_ptr_list,
+            client_len_list,
+        )
+        if ret < 0:
+            raise RuntimeError(
+                f"ModelExpress transfer_engine: batch_transfer_sync_read failed "
+                f"with error={ret}"
+            )
+
+    def _publish_transfer_engine_source(
+        self,
+        *,
+        ctx: LoadContext,
+        session_id: str,
+        weight_info,
+    ) -> None:
+        tensors = [
+            p2p_pb2.TensorDescriptor(
+                name=name,
+                addr=addr,
+                size=numel * element_size,
+                device_id=ctx.device_id,
+            )
+            for name, (addr, numel, element_size) in weight_info.items()
+        ]
+        worker = p2p_pb2.WorkerMetadata(
+            worker_rank=ctx.worker_rank,
+            transfer_engine_session_id=session_id,
+            tensors=tensors,
+        )
+        mx_source_id = ctx.mx_client.publish_metadata(
+            ctx.identity,
+            worker,
+            ctx.worker_id,
+        )
+        ctx.mx_client.update_status(
+            mx_source_id=mx_source_id,
+            worker_id=ctx.worker_id,
+            worker_rank=ctx.worker_rank,
+            status=p2p_pb2.SOURCE_STATUS_READY,
+        )
+        heartbeat = HeartbeatThread(
+            mx_client=ctx.mx_client,
+            mx_source_id=mx_source_id,
+            worker_id=ctx.worker_id,
+            worker_rank=ctx.worker_rank,
+            nixl_manager=None,
+        )
+        heartbeat.start()
+        _heartbeat_threads[ctx.worker_rank] = heartbeat
+        logger.info(
+            "[Worker %s] Published TransferEngine metadata to MX server "
+            "(mx_source_id=%s, worker_id=%s)",
+            ctx.global_rank,
+            mx_source_id,
+            ctx.worker_id,
+        )
+
+    @property
+    def nixl_manager(self) -> NixlTransferManager | None:
+        if self._ctx is not None:
+            return self._ctx.nixl_manager
+        return None
+
+    @property
+    def tensors(self) -> dict[str, torch.Tensor]:
+        if self._ctx is not None:
+            return self._ctx.tensors
+        return {}

--- a/modelexpress_client/python/modelexpress/engines/sglang/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/loader.py
@@ -117,10 +117,6 @@ class MxModelLoader:
         device_config: DeviceConfig,
     ) -> nn.Module:
         """Load SGLang weights via ModelExpress metadata and TransferEngine."""
-        from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
-            register_memory_region,
-        )
-
         load_start = time.perf_counter()
         ctx = build_sglang_load_context(
             self.load_config,
@@ -159,11 +155,16 @@ class MxModelLoader:
                 ctx.global_rank,
             )
             result = ctx.adapter.load_via_native(result)
+            tensors = ctx.adapter.discover_tensors(result)
         else:
             result = ctx.adapter.before_rdma_receive(result)
-            weight_info = register_memory_region(result.model, transfer_engine)
+            tensors = ctx.adapter.discover_tensors(result)
+            weight_info = self._register_transfer_engine_tensors(
+                tensors,
+                transfer_engine,
+            )
             self._receive_via_transfer_engine(
-                result.model,
+                tensors,
                 transfer_engine,
                 source_worker,
                 ctx,
@@ -171,13 +172,23 @@ class MxModelLoader:
             result = ctx.adapter.after_rdma_receive(result)
 
         if weight_info is None:
-            weight_info = register_memory_region(result.model, transfer_engine)
+            weight_info = self._register_transfer_engine_tensors(
+                tensors,
+                transfer_engine,
+            )
+        ctx.tensors = tensors
         self.remote_instance_transfer_engine_weight_info = weight_info
-        self._publish_transfer_engine_source(
+        publish_ok = self._publish_transfer_engine_source(
             ctx=ctx,
             session_id=session_id,
             weight_info=weight_info,
         )
+        if not publish_ok:
+            logger.warning(
+                "[Worker %s] TransferEngine source advertisement failed; "
+                "model load will continue",
+                ctx.global_rank,
+            )
 
         total_time = time.perf_counter() - load_start
         logger.info(
@@ -220,7 +231,7 @@ class MxModelLoader:
 
     def _receive_via_transfer_engine(
         self,
-        model: nn.Module,
+        tensors: dict[str, torch.Tensor],
         transfer_engine,
         source_worker,
         ctx: LoadContext,
@@ -233,7 +244,7 @@ class MxModelLoader:
         seed_ptr_list = []
         client_ptr_list = []
         client_len_list = []
-        for name, tensor in model.named_parameters():
+        for name, tensor in tensors.items():
             weight_info = seed_weight_info.get(name)
             if weight_info is None:
                 raise RuntimeError(
@@ -268,47 +279,112 @@ class MxModelLoader:
                 f"with error={ret}"
             )
 
+    def _register_transfer_engine_tensors(
+        self,
+        tensors: dict[str, torch.Tensor],
+        transfer_engine,
+    ) -> dict[str, tuple[int, int, int]]:
+        weight_info = {}
+        registered_ptrs = set()
+        for name, tensor in tensors.items():
+            addr = tensor.data_ptr()
+            numel = tensor.numel()
+            element_size = tensor.element_size()
+            size = numel * element_size
+            if addr not in registered_ptrs:
+                ret = transfer_engine.register_memory(addr, size)
+                if ret != 0:
+                    raise RuntimeError(
+                        "ModelExpress transfer_engine: register_memory failed "
+                        f"for tensor {name!r}, error={ret}"
+                    )
+                registered_ptrs.add(addr)
+            weight_info[name] = (addr, numel, element_size)
+        return weight_info
+
     def _publish_transfer_engine_source(
         self,
         *,
         ctx: LoadContext,
         session_id: str,
         weight_info,
-    ) -> None:
-        tensors = [
-            p2p_pb2.TensorDescriptor(
-                name=name,
-                addr=addr,
-                size=numel * element_size,
-                device_id=ctx.device_id,
+    ) -> bool:
+        try:
+            tensors = [
+                p2p_pb2.TensorDescriptor(
+                    name=name,
+                    addr=addr,
+                    size=numel * element_size,
+                    device_id=ctx.device_id,
+                )
+                for name, (addr, numel, element_size) in weight_info.items()
+            ]
+            worker = p2p_pb2.WorkerMetadata(
+                worker_rank=ctx.worker_rank,
+                transfer_engine_session_id=session_id,
+                tensors=tensors,
             )
-            for name, (addr, numel, element_size) in weight_info.items()
-        ]
-        worker = p2p_pb2.WorkerMetadata(
-            worker_rank=ctx.worker_rank,
-            transfer_engine_session_id=session_id,
-            tensors=tensors,
-        )
-        mx_source_id = ctx.mx_client.publish_metadata(
-            ctx.identity,
-            worker,
-            ctx.worker_id,
-        )
-        ctx.mx_client.update_status(
-            mx_source_id=mx_source_id,
-            worker_id=ctx.worker_id,
-            worker_rank=ctx.worker_rank,
-            status=p2p_pb2.SOURCE_STATUS_READY,
-        )
-        heartbeat = HeartbeatThread(
-            mx_client=ctx.mx_client,
-            mx_source_id=mx_source_id,
-            worker_id=ctx.worker_id,
-            worker_rank=ctx.worker_rank,
-            nixl_manager=None,
-        )
-        heartbeat.start()
-        _heartbeat_threads[ctx.worker_rank] = heartbeat
+        except Exception:
+            logger.exception(
+                "[Worker %s] TransferEngine metadata payload build failed "
+                "(worker_id=%s, worker_rank=%s)",
+                ctx.global_rank,
+                ctx.worker_id,
+                ctx.worker_rank,
+            )
+            return False
+        try:
+            mx_source_id = ctx.mx_client.publish_metadata(
+                ctx.identity,
+                worker,
+                ctx.worker_id,
+            )
+        except Exception:
+            logger.exception(
+                "[Worker %s] TransferEngine publish_metadata failed "
+                "(worker_id=%s, worker_rank=%s)",
+                ctx.global_rank,
+                ctx.worker_id,
+                ctx.worker_rank,
+            )
+            return False
+        try:
+            ctx.mx_client.update_status(
+                mx_source_id=mx_source_id,
+                worker_id=ctx.worker_id,
+                worker_rank=ctx.worker_rank,
+                status=p2p_pb2.SOURCE_STATUS_READY,
+            )
+        except Exception:
+            logger.exception(
+                "[Worker %s] TransferEngine update_status failed "
+                "(mx_source_id=%s, worker_id=%s, worker_rank=%s)",
+                ctx.global_rank,
+                mx_source_id,
+                ctx.worker_id,
+                ctx.worker_rank,
+            )
+            return False
+        try:
+            heartbeat = HeartbeatThread(
+                mx_client=ctx.mx_client,
+                mx_source_id=mx_source_id,
+                worker_id=ctx.worker_id,
+                worker_rank=ctx.worker_rank,
+                nixl_manager=None,
+            )
+            heartbeat.start()
+            _heartbeat_threads[ctx.worker_rank] = heartbeat
+        except Exception:
+            logger.exception(
+                "[Worker %s] TransferEngine heartbeat startup failed "
+                "(mx_source_id=%s, worker_id=%s, worker_rank=%s)",
+                ctx.global_rank,
+                mx_source_id,
+                ctx.worker_id,
+                ctx.worker_rank,
+            )
+            return False
         logger.info(
             "[Worker %s] Published TransferEngine metadata to MX server "
             "(mx_source_id=%s, worker_id=%s)",
@@ -316,6 +392,7 @@ class MxModelLoader:
             mx_source_id,
             ctx.worker_id,
         )
+        return True
 
     @property
     def nixl_manager(self) -> NixlTransferManager | None:

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -49,6 +49,11 @@ class VllmAdapter(EngineAdapter):
     def get_target_device(self) -> torch.device:
         return self.target_device
 
+    def is_cuda_alike(self) -> bool:
+        from vllm.platforms import current_platform
+
+        return bool(current_platform.is_cuda_alike())
+
     def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
         if result.model is None:
             raise RuntimeError("vLLM tensor discovery requires result.model")

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -202,7 +202,6 @@ def build_vllm_load_context(vllm_config, model_config) -> LoadContext:
     global_rank = adapter.get_global_rank()
     worker_rank = adapter.get_worker_rank()
     return LoadContext(
-        vllm_config=vllm_config,
         model_config=model_config,
         load_config=vllm_config.load_config,
         target_device=adapter.get_target_device(),

--- a/modelexpress_client/python/modelexpress/load_strategy/context.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/context.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
 
 import torch
 import torch.nn as nn
@@ -17,8 +17,16 @@ from ..client import MxClientBase
 if TYPE_CHECKING:
     from ..adapter import EngineAdapter
     from ..nixl_transfer import NixlTransferManager
-    from vllm.config import ModelConfig, VllmConfig
-    from vllm.config.load import LoadConfig
+    from sglang.srt.configs.load_config import LoadConfig as SglangLoadConfig
+    from sglang.srt.configs.model_config import ModelConfig as SglangModelConfig
+    from vllm.config import ModelConfig as VllmModelConfig
+    from vllm.config.load import LoadConfig as VllmLoadConfig
+
+    EngineModelConfig: TypeAlias = VllmModelConfig | SglangModelConfig
+    EngineLoadConfig: TypeAlias = VllmLoadConfig | SglangLoadConfig
+else:
+    EngineModelConfig = object
+    EngineLoadConfig = object
 
 
 T = TypeVar("T")
@@ -42,9 +50,8 @@ class LoadResult(Generic[T]):
 class LoadContext:
     """Shared state passed to all loading strategies."""
 
-    vllm_config: VllmConfig
-    model_config: ModelConfig
-    load_config: LoadConfig
+    model_config: EngineModelConfig
+    load_config: EngineLoadConfig
     target_device: torch.device
     global_rank: int
     worker_rank: int

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -140,12 +140,10 @@ class ModelStreamerStrategy(LoadStrategy):
             f"from {model_uri}"
         )
 
-        from vllm.platforms import current_platform
-
-        tp_size = getattr(ctx.vllm_config.parallel_config, "tensor_parallel_size", 1)
+        tp_size = getattr(ctx.identity, "tensor_parallel_size", 1) or 1
         distributed = (
             tp_size > 1
-            and current_platform.is_cuda_alike()
+            and ctx.target_device.type == "cuda"
             and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
         )
         stream_kwargs: dict = {}

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -143,7 +143,8 @@ class ModelStreamerStrategy(LoadStrategy):
         tp_size = getattr(ctx.identity, "tensor_parallel_size", 1) or 1
         distributed = (
             tp_size > 1
-            and ctx.target_device.type == "cuda"
+            and ctx.adapter is not None
+            and ctx.adapter.is_cuda_alike()
             and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
         )
         stream_kwargs: dict = {}

--- a/modelexpress_client/python/modelexpress/metadata/client_factory.py
+++ b/modelexpress_client/python/modelexpress/metadata/client_factory.py
@@ -36,6 +36,7 @@ _K8S_SERVICE_ALIASES = frozenset({"k8s-service", "service"})
 
 def create_metadata_client(
     worker_rank: int | None = None,
+    server_url: str | None = None,
 ) -> MxClientBase:
     """Create the metadata client dictated by ``MX_METADATA_BACKEND``.
 
@@ -46,7 +47,7 @@ def create_metadata_client(
     backend = os.environ.get("MX_METADATA_BACKEND", "").lower().strip()
     if backend in _CENTRAL_BACKEND_ALIASES:
         logger.debug("create_metadata_client: central MxClient (backend=%r)", backend)
-        return MxClient()
+        return MxClient(server_url=server_url)
     if backend in _K8S_SERVICE_ALIASES:
         logger.info(
             "create_metadata_client: MxK8sServiceClient "

--- a/modelexpress_client/python/modelexpress/metadata/heartbeat.py
+++ b/modelexpress_client/python/modelexpress/metadata/heartbeat.py
@@ -39,8 +39,9 @@ class HeartbeatThread:
         mx_client: gRPC client for UpdateStatus calls.
         mx_source_id: Source identity hash returned by PublishMetadata.
         worker_id: Unique worker identifier.
-        worker_rank: Global rank of this worker.
-        nixl_manager: NIXL transfer manager for agent health checks.
+        worker_rank: Model-shard rank used for metadata/status keying.
+        nixl_manager: Optional NIXL transfer manager for agent health checks.
+            Non-NIXL transports pass None and heartbeat unconditionally.
     """
 
     def __init__(
@@ -49,8 +50,7 @@ class HeartbeatThread:
         mx_source_id: str,
         worker_id: str,
         worker_rank: int,
-        nixl_manager: NixlTransferManager,
-
+        nixl_manager: NixlTransferManager | None,
     ):
         self._mx_client = mx_client
         self._mx_source_id = mx_source_id
@@ -121,7 +121,7 @@ class HeartbeatThread:
         """Single heartbeat tick: check health and send READY if healthy."""
         from .. import p2p_pb2
 
-        if not self._nixl_manager.is_healthy():
+        if self._nixl_manager is not None and not self._nixl_manager.is_healthy():
             return
 
         self._update_status(p2p_pb2.SOURCE_STATUS_READY)

--- a/modelexpress_client/python/tests/test_gds_loader.py
+++ b/modelexpress_client/python/tests/test_gds_loader.py
@@ -220,7 +220,6 @@ class TestGdsStrategyIntegration:
     def _make_context(self):
         from modelexpress.load_strategy import LoadContext
         return LoadContext(
-            vllm_config=MagicMock(),
             model_config=MagicMock(),
             load_config=MagicMock(),
             target_device=torch.device("cpu"),

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -20,8 +20,14 @@ from modelexpress.load_strategy.context import LoadResult
 
 
 class _FakeAdapter(EngineAdapter):
+    def __init__(self, *, is_cuda_alike: bool = True):
+        self._is_cuda_alike = is_cuda_alike
+
     def discover_tensors(self, result: LoadResult):
         return {}
+
+    def is_cuda_alike(self) -> bool:
+        return self._is_cuda_alike
 
     def after_weight_iter_load(self, result: LoadResult):
         return result
@@ -295,11 +301,11 @@ class TestStreamWeights:
         self,
         tp_size: int,
         device_id: int = 2,
-        device: str = "cuda",
+        is_cuda_alike: bool = True,
     ):
         return _make_load_context(
+            adapter=_FakeAdapter(is_cuda_alike=is_cuda_alike),
             device_id=device_id,
-            target_device=torch.device(device),
             identity=p2p_pb2.SourceIdentity(
                 model_name="test-model",
                 tensor_parallel_size=tp_size,
@@ -347,9 +353,13 @@ class TestStreamWeights:
 
         streamer_instance.stream_files.assert_called_once_with(file_uris)
 
-    def test_distributed_disabled_on_non_cuda_platform(self):
+    def test_distributed_disabled_when_adapter_is_not_cuda_alike(self):
         strategy = self._make_strategy()
-        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2, device="cpu")
+        ctx = self._make_ctx_with_tp(
+            tp_size=4,
+            device_id=2,
+            is_cuda_alike=False,
+        )
         file_uris = ["s3://bucket/model.safetensors"]
         tensors = [("w", torch.randn(2, 2))]
 

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -37,14 +37,16 @@ def _make_load_context(**overrides):
     from modelexpress.load_strategy import LoadContext
 
     defaults = dict(
-        vllm_config=MagicMock(),
         model_config=MagicMock(),
         load_config=MagicMock(),
         target_device=torch.device("cpu"),
         global_rank=0,
         worker_rank=0,
         device_id=0,
-        identity=p2p_pb2.SourceIdentity(model_name="test-model"),
+        identity=p2p_pb2.SourceIdentity(
+            model_name="test-model",
+            tensor_parallel_size=1,
+        ),
         mx_client=MagicMock(),
         worker_id="test-worker",
         adapter=_FakeAdapter(),
@@ -289,19 +291,20 @@ class TestStreamWeights:
             with pytest.raises(FileNotFoundError, match="No safetensors files found"):
                 list(strategy._stream_weights("s3://empty-bucket/model", ctx))
 
-    def _make_ctx_with_tp(self, tp_size: int, device_id: int = 2):
-        ctx = _make_load_context(device_id=device_id)
-        parallel_config = MagicMock()
-        parallel_config.tensor_parallel_size = tp_size
-        ctx.vllm_config.parallel_config = parallel_config
-        return ctx
-
-    def _patch_cuda_alike(self, is_cuda: bool):
-        mock_platform = MagicMock()
-        mock_platform.is_cuda_alike.return_value = is_cuda
-        mock_platforms_mod = MagicMock()
-        mock_platforms_mod.current_platform = mock_platform
-        return patch.dict("sys.modules", {"vllm.platforms": mock_platforms_mod})
+    def _make_ctx_with_tp(
+        self,
+        tp_size: int,
+        device_id: int = 2,
+        device: str = "cuda",
+    ):
+        return _make_load_context(
+            device_id=device_id,
+            target_device=torch.device(device),
+            identity=p2p_pb2.SourceIdentity(
+                model_name="test-model",
+                tensor_parallel_size=tp_size,
+            ),
+        )
 
     def test_distributed_disabled_by_default(self):
         strategy = self._make_strategy()
@@ -311,9 +314,8 @@ class TestStreamWeights:
 
         module, streamer_instance = self._make_streamer_module(file_uris, tensors)
         with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with self._patch_cuda_alike(True):
-                with patch.dict("os.environ", {}, clear=True):
-                    list(strategy._stream_weights("s3://bucket/model", ctx))
+            with patch.dict("os.environ", {}, clear=True):
+                list(strategy._stream_weights("s3://bucket/model", ctx))
 
         streamer_instance.stream_files.assert_called_once_with(file_uris)
 
@@ -325,9 +327,8 @@ class TestStreamWeights:
 
         module, streamer_instance = self._make_streamer_module(file_uris, tensors)
         with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with self._patch_cuda_alike(True):
-                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                    list(strategy._stream_weights("s3://bucket/model", ctx))
+            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                list(strategy._stream_weights("s3://bucket/model", ctx))
 
         streamer_instance.stream_files.assert_called_once_with(
             file_uris, device="cuda:2", is_distributed=True
@@ -341,23 +342,21 @@ class TestStreamWeights:
 
         module, streamer_instance = self._make_streamer_module(file_uris, tensors)
         with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with self._patch_cuda_alike(True):
-                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                    list(strategy._stream_weights("s3://bucket/model", ctx))
+            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                list(strategy._stream_weights("s3://bucket/model", ctx))
 
         streamer_instance.stream_files.assert_called_once_with(file_uris)
 
     def test_distributed_disabled_on_non_cuda_platform(self):
         strategy = self._make_strategy()
-        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2)
+        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2, device="cpu")
         file_uris = ["s3://bucket/model.safetensors"]
         tensors = [("w", torch.randn(2, 2))]
 
         module, streamer_instance = self._make_streamer_module(file_uris, tensors)
         with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with self._patch_cuda_alike(False):
-                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                    list(strategy._stream_weights("s3://bucket/model", ctx))
+            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                list(strategy._stream_weights("s3://bucket/model", ctx))
 
         streamer_instance.stream_files.assert_called_once_with(file_uris)
 
@@ -369,9 +368,8 @@ class TestStreamWeights:
 
         module, streamer_instance = self._make_streamer_module(file_uris, tensors)
         with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with self._patch_cuda_alike(True):
-                with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                    list(strategy._stream_weights("s3://bucket/model", ctx))
+            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+                list(strategy._stream_weights("s3://bucket/model", ctx))
 
         streamer_instance.stream_files.assert_called_once_with(
             file_uris, device="cuda:5", is_distributed=True

--- a/modelexpress_client/python/tests/test_sglang_loader.py
+++ b/modelexpress_client/python/tests/test_sglang_loader.py
@@ -3,6 +3,8 @@
 
 """Tests for the SGLang ModelExpress adapter and loader entrypoint."""
 
+import sys
+from types import ModuleType
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -77,6 +79,47 @@ def test_sglang_context_uses_tp_rank_for_matching_and_url_override():
     assert ctx.worker_rank == 5
     assert ctx.global_rank == 5
     assert ctx.mx_client.server_url == "mx.example:9000"
+
+
+def test_sglang_context_separates_worker_rank_from_global_rank(monkeypatch):
+    sglang_mod = ModuleType("sglang")
+    srt_mod = ModuleType("sglang.srt")
+    distributed_mod = ModuleType("sglang.srt.distributed")
+    distributed_mod.get_tensor_model_parallel_rank = lambda: 1
+    distributed_mod.get_pipeline_model_parallel_rank = lambda: 2
+    distributed_mod.get_tensor_model_parallel_world_size = lambda: 4
+    srt_mod.distributed = distributed_mod
+
+    monkeypatch.setitem(sys.modules, "sglang", sglang_mod)
+    monkeypatch.setitem(sys.modules, "sglang.srt", srt_mod)
+    monkeypatch.setitem(sys.modules, "sglang.srt.distributed", distributed_mod)
+
+    with patch("torch.distributed.is_available", return_value=True), patch(
+        "torch.distributed.is_initialized", return_value=True,
+    ), patch("torch.distributed.get_rank", return_value=17):
+        ctx = build_sglang_load_context(
+            _load_config(tp_rank=5, modelexpress_url="mx.example:9000"),
+            _model_config(),
+            _device_config(),
+        )
+
+    assert ctx.worker_rank == 9
+    assert ctx.global_rank == 17
+    assert ctx.mx_client.server_url == "mx.example:9000"
+
+
+def test_sglang_is_cuda_alike_uses_sglang_platform_helper(monkeypatch):
+    adapter = SglangAdapter(_load_config(), _model_config(), _device_config())
+    sglang_mod = ModuleType("sglang")
+    srt_mod = ModuleType("sglang.srt")
+    utils_mod = ModuleType("sglang.srt.utils")
+    utils_mod.is_cuda_alike = lambda: True
+
+    monkeypatch.setitem(sys.modules, "sglang", sglang_mod)
+    monkeypatch.setitem(sys.modules, "sglang.srt", srt_mod)
+    monkeypatch.setitem(sys.modules, "sglang.srt.utils", utils_mod)
+
+    assert adapter.is_cuda_alike() is True
 
 
 def test_collect_sglang_tensors_preserves_non_contiguous_storage_names():
@@ -227,6 +270,77 @@ def test_mx_model_loader_rejects_unknown_transport_in_mx_package():
         raise AssertionError("Expected unsupported transport to fail")
 
 
+def test_transfer_engine_registers_discovered_tensor_map():
+    loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
+    tensor = torch.randn(2, 3)
+    calls = []
+
+    class FakeTransferEngine:
+        def register_memory(self, addr, size):
+            calls.append((addr, size))
+            return 0
+
+    weight_info = loader._register_transfer_engine_tensors(
+        {"weight.__storage": tensor},
+        FakeTransferEngine(),
+    )
+
+    assert calls == [(tensor.data_ptr(), tensor.numel() * tensor.element_size())]
+    assert weight_info == {
+        "weight.__storage": (
+            tensor.data_ptr(),
+            tensor.numel(),
+            tensor.element_size(),
+        )
+    }
+
+
+def test_transfer_engine_receive_uses_discovered_tensor_map():
+    loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
+    tensor = torch.randn(2, 3)
+    ctx = SimpleNamespace(global_rank=0)
+    transferred = {}
+    source_worker = p2p_pb2.WorkerMetadata(
+        transfer_engine_session_id="te-session",
+        tensors=[
+            p2p_pb2.TensorDescriptor(
+                name="weight.__storage",
+                addr=1234,
+                size=tensor.numel() * tensor.element_size(),
+                device_id=0,
+            )
+        ],
+    )
+
+    class FakeTransferEngine:
+        def batch_transfer_sync_read(
+            self,
+            session_id,
+            client_ptr_list,
+            seed_ptr_list,
+            client_len_list,
+        ):
+            transferred["session_id"] = session_id
+            transferred["client_ptr_list"] = client_ptr_list
+            transferred["seed_ptr_list"] = seed_ptr_list
+            transferred["client_len_list"] = client_len_list
+            return 0
+
+    loader._receive_via_transfer_engine(
+        {"weight.__storage": tensor},
+        FakeTransferEngine(),
+        source_worker,
+        ctx,
+    )
+
+    assert transferred == {
+        "session_id": "te-session",
+        "client_ptr_list": [tensor.data_ptr()],
+        "seed_ptr_list": [1234],
+        "client_len_list": [tensor.numel() * tensor.element_size()],
+    }
+
+
 def test_transfer_engine_publish_starts_non_nixl_heartbeat():
     loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
     ctx = SimpleNamespace(
@@ -263,13 +377,36 @@ def test_transfer_engine_publish_starts_non_nixl_heartbeat():
         "modelexpress.engines.sglang.loader.HeartbeatThread",
         FakeHeartbeat,
     ):
-        loader._publish_transfer_engine_source(
+        published_ok = loader._publish_transfer_engine_source(
             ctx=ctx,
             session_id="te-session",
             weight_info={"weight": (1000, 4, 2)},
         )
 
+    assert published_ok
     assert published["worker"].transfer_engine_session_id == "te-session"
     assert published["status"]["status"] == p2p_pb2.SOURCE_STATUS_READY
     assert published["heartbeat"]["nixl_manager"] is None
     assert published["heartbeat_started"]
+
+
+def test_transfer_engine_publish_failure_is_non_fatal():
+    loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
+    ctx = SimpleNamespace(
+        global_rank=9,
+        worker_rank=3,
+        worker_id="worker-id",
+        device_id=1,
+        identity=p2p_pb2.SourceIdentity(model_name="sglang-model"),
+        mx_client=SimpleNamespace(
+            publish_metadata=lambda *args: (_ for _ in ()).throw(
+                RuntimeError("metadata down")
+            )
+        ),
+    )
+
+    assert not loader._publish_transfer_engine_source(
+        ctx=ctx,
+        session_id="te-session",
+        weight_info={"weight": (1000, 4, 2)},
+    )

--- a/modelexpress_client/python/tests/test_sglang_loader.py
+++ b/modelexpress_client/python/tests/test_sglang_loader.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SGLang ModelExpress adapter and loader entrypoint."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+
+from modelexpress import p2p_pb2
+from modelexpress.engines.sglang.adapter import (
+    SglangAdapter,
+    build_sglang_load_context,
+    collect_sglang_tensors,
+)
+from modelexpress.engines.sglang.loader import MxModelLoader
+
+
+def _load_config(**overrides):
+    defaults = dict(
+        tp_rank=3,
+        modelexpress_url="modelexpress-server:8001",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _model_config(**overrides):
+    defaults = dict(
+        model_path="deepseek-ai/DeepSeek-V3",
+        dtype=torch.bfloat16,
+        quantization="fp8",
+        revision="abc123",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _device_config(**overrides):
+    defaults = dict(device="cpu", gpu_id=0)
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_sglang_adapter_builds_identity_from_sglang_configs():
+    adapter = SglangAdapter(_load_config(), _model_config(), _device_config())
+
+    with patch(
+        "modelexpress.engines.sglang.adapter._get_parallel_size",
+        side_effect=lambda name: {
+            "get_tensor_model_parallel_world_size": 8,
+            "get_pipeline_model_parallel_world_size": 2,
+            "get_moe_expert_parallel_world_size": 4,
+        }[name],
+    ):
+        identity = adapter.build_identity()
+
+    assert identity.model_name == "deepseek-ai/DeepSeek-V3"
+    assert identity.backend_framework == p2p_pb2.BACKEND_FRAMEWORK_SGLANG
+    assert identity.tensor_parallel_size == 8
+    assert identity.pipeline_parallel_size == 2
+    assert identity.expert_parallel_size == 4
+    assert identity.dtype == "bfloat16"
+    assert identity.quantization == "fp8"
+    assert identity.revision == "abc123"
+
+
+def test_sglang_context_uses_tp_rank_for_matching_and_url_override():
+    ctx = build_sglang_load_context(
+        _load_config(tp_rank=5, modelexpress_url="mx.example:9000"),
+        _model_config(),
+        _device_config(),
+    )
+
+    assert ctx.worker_rank == 5
+    assert ctx.global_rank == 5
+    assert ctx.mx_client.server_url == "mx.example:9000"
+
+
+def test_collect_sglang_tensors_preserves_non_contiguous_storage_names():
+    model = nn.Module()
+    model.weight_t = nn.Parameter(torch.randn(4, 3).T)
+
+    tensors = collect_sglang_tensors(model)
+
+    assert "weight_t.__storage" in tensors
+    assert tensors["weight_t.__storage"].dtype == torch.uint8
+
+
+def test_collect_sglang_tensors_deduplicates_tied_parameters():
+    model = nn.Module()
+    shared = nn.Parameter(torch.randn(4, 3))
+    model.first = shared
+    model.second = shared
+
+    tensors = collect_sglang_tensors(model)
+
+    assert list(tensors) == ["first"]
+
+
+def test_sglang_adapter_post_load_delegates_to_child_module():
+    adapter = SglangAdapter(_load_config(), _model_config(), _device_config())
+
+    class ChildModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.post_load_called = False
+
+        def post_load_weights(self):
+            self.post_load_called = True
+
+    model = nn.Module()
+    model.child = ChildModel()
+
+    adapter.after_rdma_receive(SimpleNamespace(model=model))
+
+    assert model.child.post_load_called
+
+
+def test_sglang_adapter_post_load_prefers_top_level_hook():
+    adapter = SglangAdapter(_load_config(), _model_config(), _device_config())
+
+    class TopLevelModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.child = nn.Module()
+            self.child.post_load_called = False
+            self.post_load_called = False
+
+        def post_load_weights(self):
+            self.post_load_called = True
+
+    def child_post_load_weights():
+        model.child.post_load_called = True
+
+    model = TopLevelModel()
+    model.child.post_load_weights = child_post_load_weights
+
+    adapter.after_rdma_receive(SimpleNamespace(model=model))
+
+    assert model.post_load_called
+    assert not model.child.post_load_called
+
+
+def test_mx_model_loader_delegates_to_shared_strategy_chain():
+    model = nn.Linear(2, 2)
+    loader = MxModelLoader(_load_config(modelexpress_transport="nixl"))
+
+    with patch.object(
+        MxModelLoader,
+        "_load_model_via_nixl",
+        return_value=model,
+    ) as load_via_nixl:
+        loaded = loader.load_model(
+            model=model,
+            model_config=_model_config(),
+            device_config=_device_config(),
+        )
+
+    assert loaded is model
+    load_via_nixl.assert_called_once_with(
+        model=model,
+        model_config=_model_config(),
+        device_config=_device_config(),
+    )
+
+
+def test_mx_model_loader_nixl_path_delegates_to_shared_strategy_chain():
+    model = nn.Linear(2, 2)
+    loader = MxModelLoader(_load_config(modelexpress_transport="nixl"))
+
+    with patch(
+        "modelexpress.engines.sglang.loader.LoadStrategyChain.run",
+        return_value=model,
+    ) as run:
+        loaded = loader._load_model_via_nixl(
+            model=model,
+            model_config=_model_config(),
+            device_config=_device_config(),
+        )
+
+    assert loaded is model
+    run.assert_called_once()
+    assert run.call_args.args[0] is model
+    ctx = run.call_args.args[1]
+    assert ctx.adapter.__class__ is SglangAdapter
+    assert ctx.identity.backend_framework == p2p_pb2.BACKEND_FRAMEWORK_SGLANG
+
+
+def test_mx_model_loader_delegates_transfer_engine_transport_in_mx_package():
+    model = nn.Linear(2, 2)
+    loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
+
+    with patch.object(
+        MxModelLoader,
+        "_load_model_via_transfer_engine",
+        return_value=model,
+    ) as load_via_transfer_engine:
+        loaded = loader.load_model(
+            model=model,
+            model_config=_model_config(),
+            device_config=_device_config(),
+        )
+
+    assert loaded is model
+    load_via_transfer_engine.assert_called_once_with(
+        model=model,
+        model_config=_model_config(),
+        device_config=_device_config(),
+    )
+
+
+def test_mx_model_loader_rejects_unknown_transport_in_mx_package():
+    loader = MxModelLoader(_load_config(modelexpress_transport="unknown"))
+
+    try:
+        loader.load_model(
+            model=nn.Linear(2, 2),
+            model_config=_model_config(),
+            device_config=_device_config(),
+        )
+    except ValueError as exc:
+        assert "unknown" in str(exc)
+    else:
+        raise AssertionError("Expected unsupported transport to fail")
+
+
+def test_transfer_engine_publish_starts_non_nixl_heartbeat():
+    loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
+    ctx = SimpleNamespace(
+        global_rank=9,
+        worker_rank=3,
+        worker_id="worker-id",
+        device_id=1,
+        identity=p2p_pb2.SourceIdentity(model_name="sglang-model"),
+        mx_client=SimpleNamespace(),
+    )
+    published = {}
+
+    def publish_metadata(identity, worker, worker_id):
+        published["identity"] = identity
+        published["worker"] = worker
+        published["worker_id"] = worker_id
+        return "mx-source-id"
+
+    def update_status(**kwargs):
+        published["status"] = kwargs
+        return True
+
+    ctx.mx_client.publish_metadata = publish_metadata
+    ctx.mx_client.update_status = update_status
+
+    class FakeHeartbeat:
+        def __init__(self, **kwargs):
+            published["heartbeat"] = kwargs
+
+        def start(self):
+            published["heartbeat_started"] = True
+
+    with patch(
+        "modelexpress.engines.sglang.loader.HeartbeatThread",
+        FakeHeartbeat,
+    ):
+        loader._publish_transfer_engine_source(
+            ctx=ctx,
+            session_id="te-session",
+            weight_info={"weight": (1000, 4, 2)},
+        )
+
+    assert published["worker"].transfer_engine_session_id == "te-session"
+    assert published["status"]["status"] == p2p_pb2.SOURCE_STATUS_READY
+    assert published["heartbeat"]["nixl_manager"] is None
+    assert published["heartbeat_started"]

--- a/modelexpress_client/python/tests/test_tracing.py
+++ b/modelexpress_client/python/tests/test_tracing.py
@@ -26,7 +26,6 @@ def tracer_and_exporter():
 
 def _ctx():
     return LoadContext(
-        vllm_config=MagicMock(),
         model_config=MagicMock(),
         load_config=MagicMock(),
         target_device=torch.device("cpu"),

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import torch
 
 from modelexpress.engines.vllm.adapter import (
+    VllmAdapter,
     _get_vllm_device_id,
     _get_vllm_worker_rank,
     build_vllm_load_context,
@@ -50,6 +51,18 @@ def test_vllm_device_id_uses_current_platform_device(monkeypatch):
     monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
 
     assert _get_vllm_device_id(torch.device("cuda")) == 2
+
+
+def test_vllm_is_cuda_alike_uses_current_platform(monkeypatch):
+    fake_platforms = SimpleNamespace(
+        current_platform=SimpleNamespace(
+            is_cuda_alike=lambda: True,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+
+    assert adapter.is_cuda_alike() is True
 
 
 def test_build_vllm_load_context_uses_current_platform_for_bare_cuda(monkeypatch):

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import torch
 
 from modelexpress.engines.vllm.adapter import (
-    VllmAdapter,
+    _get_vllm_device_id,
     _get_vllm_worker_rank,
     build_vllm_load_context,
 )
@@ -48,13 +48,8 @@ def test_vllm_device_id_uses_current_platform_device(monkeypatch):
         ),
     )
     monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
-    vllm_config = SimpleNamespace(
-        device_config=SimpleNamespace(device="cuda"),
-        load_config=SimpleNamespace(device=None),
-    )
-    adapter = VllmAdapter(vllm_config, SimpleNamespace())
 
-    assert adapter.get_device_id() == 2
+    assert _get_vllm_device_id(torch.device("cuda")) == 2
 
 
 def test_build_vllm_load_context_uses_current_platform_for_bare_cuda(monkeypatch):

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -104,7 +104,6 @@ def _make_load_context(**overrides):
     """Return a LoadContext with mocked dependencies."""
     from modelexpress.load_strategy import LoadContext
     defaults = dict(
-        vllm_config=MagicMock(),
         model_config=MagicMock(),
         load_config=MagicMock(),
         target_device=torch.device("cpu"),


### PR DESCRIPTION
## Overview

Adds the ModelExpress-owned side of the SGLang integration. This pairs with [sgl-project/sglang#24723](https://github.com/sgl-project/sglang/pull/24723), where SGLang keeps only the minimal `remote_instance + backend=modelexpress` delegation surface.

With this PR, SGLang passes its initialized model and config objects into `modelexpress.engines.sglang.loader.MxModelLoader`. The ModelExpress package owns the loading policy, metadata lookup/publication, NIXL transfer, TransferEngine compatibility path, and SGLang-specific post-load hooks.

SGLang does not have separate source and target modes. Every server starts the same way; the first server loads natively and publishes metadata, and later servers can receive weights from a compatible ready source.

## What changed

**SGLang adapter and loader:** adds `modelexpress.engines.sglang` with `SglangAdapter` and `MxModelLoader`. The NIXL path runs through the shared `LoadStrategyChain`; the TransferEngine path stays in the ModelExpress package for compatibility with SGLang's existing TransferEngine objects/session ids.

**Shared context cleanup:** removes the vLLM-only `vllm_config` field from `LoadContext`. Shared strategies now use engine-neutral context fields, while engine-native configs remain adapter-owned.

**Metadata and heartbeat support:** lets SGLang pass a per-loader ModelExpress server URL into `create_metadata_client()` and allows heartbeat publication for non-NIXL transports by making the NIXL manager optional.

**Docs:** updates README, architecture/deployment docs, and `docs/SGLANG.md` for the unified SGLang server flow. `modelexpress-config` is intentionally limited to `url` and `transport`; other ModelExpress settings remain environment-variable driven like vLLM.

## Compatibility notes

- Requires an SGLang build with the delegation hook from [sgl-project/sglang#24723](https://github.com/sgl-project/sglang/pull/24723) or equivalent.
- SGLang users still launch with `--load-format remote_instance --remote-instance-weight-loader-backend modelexpress`.
- Transfer selection is controlled by `--modelexpress-config '{"url": "...", "transport": "nixl"}'` or `"transfer_engine"`.
- The existing vLLM adapter path remains supported; related test fixtures were updated only to remove the shared-context vLLM leak.

## Testing

### Unit tests

Focused Python coverage for the shared strategy chain, vLLM compatibility, and new SGLang adapter:

```bash
UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest \
  tests/test_model_streamer_strategy.py \
  tests/test_sglang_loader.py \
  tests/test_vllm_adapter.py \
  tests/test_vllm_loader.py \
  tests/test_gds_loader.py \
  tests/test_tracing.py
```

Result: **114 passed, 8 skipped**.

Touched-file precommit:

```bash
pre-commit run --files README.md docs/ARCHITECTURE.md docs/DEPLOYMENT.md docs/SGLANG.md \
  modelexpress_client/python/modelexpress/engines/sglang/__init__.py \
  modelexpress_client/python/modelexpress/engines/sglang/adapter.py \
  modelexpress_client/python/modelexpress/engines/sglang/loader.py \
  modelexpress_client/python/modelexpress/engines/vllm/adapter.py \
  modelexpress_client/python/modelexpress/load_strategy/context.py \
  modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py \
  modelexpress_client/python/modelexpress/metadata/client_factory.py \
  modelexpress_client/python/modelexpress/metadata/heartbeat.py \
  modelexpress_client/python/tests/test_gds_loader.py \
  modelexpress_client/python/tests/test_model_streamer_strategy.py \
  modelexpress_client/python/tests/test_sglang_loader.py \
  modelexpress_client/python/tests/test_tracing.py \
  modelexpress_client/python/tests/test_vllm_adapter.py \
  modelexpress_client/python/tests/test_vllm_loader.py
```

Result: passed.

### SGLang e2e

Validated on the nscale cluster with a source-built SGLang image plus this
ModelExpress package.

| Check | Result |
|---|---|
| NIXL transport | Source startup, P2P target startup, target metadata publication, and target inference verified |
| Image | `nvcr.io/nvidian/dynamo-dev/model-express-dev-containers:sglang-mx-b9bfb58`, digest `sha256:4edc309e0968bc58dea08109cb0c8a1dd6a390c362fbb277ea196b0d672c6b66` |
| Large-model source | `nvidia/Kimi-K2.5-NVFP4`, `TP=8`; source cold-loaded from disk and published 8 READY metadata entries |
| Large-model NIXL transfer | Target found matching source workers for all 8 ranks; each rank transferred `2944 tensors`, `84.28 GB` in `3.105s` to `3.553s` at `189.8` to `217.1 Gbps` |
| Large-model target load | `SGLang MxModelLoader.load_model()` completed in `21.13s` to `29.97s` per rank; target did not fall back to disk |
| Large-model inference | Target sanity check for `17 + 25` returned `42` |
| TransferEngine transport | Verified with `Qwen/Qwen3-0.6B` |
| TransferEngine target load | Target received `226 tensors via TransferEngine`; `SGLang MxModelLoader transfer_engine` completed in `0.63s` |
| TransferEngine inference | Target sanity check for `17 + 25` returned `42` |

Note: K2.5 still spends several minutes in SGLang/FlashInfer post-load
autotune/JIT before serving. That happens after ModelExpress transfer is
complete and is not part of the MX weight transfer path.

## Follow-ups

- Keep the example Kubernetes/Docker assets out of this PR until the SGLang image build path is finalized.
- Revisit `LoadContext` later with a normalized ModelExpress-owned runtime config before adding a TRT-LLM strategy-chain adapter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SGLang integration with ModelExpress for model loading with GPU-to-GPU weight streaming.
  * Support for NIXL and TransferEngine weight-transfer transports.

* **Documentation**
  * Updated architecture documentation to reflect SGLang support and engine-agnostic design.
  * Added comprehensive SGLang integration guide with build and deployment instructions.
  * Corrected upstream reference links.

* **Tests**
  * Added test coverage for SGLang adapter and loader functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
