### PR TITLE
feat: use native engine streamer loaders

### DIFF
--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-streamer-azure.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-streamer-azure.yaml
@@ -2,24 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Single-node vLLM deployment with ModelExpress ModelStreamer.
-# Streams weights from S3 via runai-model-streamer — no disk, no PVC.
+# Streams weights from Azure Blob Storage via runai-model-streamer; no model PVC.
 #
 # Prerequisites:
-#   - Model weights uploaded to S3 bucket
-#   - A vLLM image with ModelExpress and ModelStreamer support
-#   - kubectl create secret generic aws-creds \
-#       --from-literal=AWS_ACCESS_KEY_ID=<key> \
-#       --from-literal=AWS_SECRET_ACCESS_KEY=<secret> \
-#       --from-literal=AWS_SESSION_TOKEN=<token>
+#   - Model weights uploaded to Azure Blob Storage
+#   - A vLLM image with ModelExpress and vLLM >= 0.18.0
+#   - Azure credentials available to DefaultAzureCredential, for example:
+#     kubectl create secret generic azure-storage-creds \
+#       --from-literal=AZURE_STORAGE_ACCOUNT_NAME=<storage-account> \
+#       --from-literal=AZURE_CLIENT_ID=<client-id> \
+#       --from-literal=AZURE_TENANT_ID=<tenant-id> \
+#       --from-literal=AZURE_CLIENT_SECRET=<client-secret>
 #
-# For P2P RDMA serving after S3 load, also set MX_SERVER_ADDRESS
+# The Azure identity needs at least Storage Blob Data Reader on the storage account
+# or container. For AKS workload identity, replace envFrom with the appropriate
+# serviceAccountName/annotations and keep AZURE_STORAGE_ACCOUNT_NAME available.
+#
+# For P2P RDMA serving after Azure Blob load, also set MX_SERVER_ADDRESS
 # and add RDMA resources (rdma/ib), UCX env vars — see vllm-single-node-p2p.yaml.
 apiVersion: v1
 kind: Service
 metadata:
-  name: mx-vllm-s3
+  name: mx-vllm-azure
   labels:
-    app: mx-vllm-s3
+    app: mx-vllm-azure
 spec:
   type: ClusterIP
   ports:
@@ -27,23 +33,23 @@ spec:
       targetPort: 8000
       name: http
   selector:
-    app: mx-vllm-s3
+    app: mx-vllm-azure
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mx-vllm-s3
+  name: mx-vllm-azure
   labels:
-    app: mx-vllm-s3
+    app: mx-vllm-azure
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mx-vllm-s3
+      app: mx-vllm-azure
   template:
     metadata:
       labels:
-        app: mx-vllm-s3
+        app: mx-vllm-azure
     spec:
       tolerations:
         - key: nvidia.com/gpu
@@ -52,7 +58,7 @@ spec:
       containers:
         - name: vllm
           # Use a vLLM + ModelExpress client image.
-          image: <your-registry>/modelexpress-client:latest
+          image: <your-registry>/modelexpress-client-vllm0180:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -63,24 +69,23 @@ spec:
               value: "7200000"
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-V3"
-            # S3 path format: s3://<bucket>/<model-prefix>
+            # Azure Blob path format: az://<container>/<model-prefix>
             - name: MX_MODEL_URI
-              value: "s3://my-bucket/deepseek-ai/DeepSeek-V3"
-            - name: AWS_DEFAULT_REGION
-              value: "us-west-2"
+              value: "az://models/models/deepseek-ai/DeepSeek-V3"
             - name: VLLM_PLUGINS
               value: "modelexpress"
             - name: MX_MS_DISTRIBUTED
               value: "1"
             - name: RUNAI_STREAMER_CONCURRENCY
               value: "32"
-            # Optional: enable P2P serving after S3 load (requires MX server + RDMA)
+            # Optional: enable P2P serving after Azure Blob load (requires MX server + RDMA)
             # - name: MX_SERVER_ADDRESS
             #   value: "modelexpress-server:8001"
-          # AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
+          # Azure credentials for DefaultAzureCredential.
+          # For workload identity, use serviceAccountName/annotations instead.
           envFrom:
             - secretRef:
-                name: aws-creds
+                name: azure-storage-creds
           args:
             - --model
             - $(MX_MODEL_URI)

--- a/modelexpress_client/python/modelexpress/adapter.py
+++ b/modelexpress_client/python/modelexpress/adapter.py
@@ -117,6 +117,21 @@ class EngineAdapter:
         ...
 
     @gated_capability
+    def build_model_streamer_weight_iter(
+        self,
+        model_uri: str,
+        model: torch.nn.Module | None = None,
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        """Return the engine-native ModelStreamer weight iterator.
+
+        The shared strategy owns fallback and registration policy. Engines own
+        the concrete ModelStreamer integration because native loader APIs and
+        distributed-device selection are framework-specific. Some engine-native
+        loaders need the initialized model to discover secondary weight sources.
+        """
+        ...
+
+    @gated_capability
     def load_via_native(self, result: LoadResult) -> LoadResult:
         """Load the model using the engine's native disk/checkpoint loader."""
         ...

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -91,6 +91,33 @@ class SglangAdapter(EngineAdapter):
         result.model.load_weights(weights_iter)
         return result
 
+    def build_model_streamer_weight_iter(
+        self,
+        model_uri: str,
+        model: torch.nn.Module | None = None,
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        if model is None:
+            raise RuntimeError("SGLang ModelStreamer loading requires result.model")
+
+        from sglang.srt.configs.load_config import LoadFormat
+        from sglang.srt.model_loader.loader import RunaiModelStreamerLoader
+
+        stream_config = copy.copy(self.load_config)
+        _set_load_config_attr(stream_config, "load_format", LoadFormat.RUNAI_STREAMER)
+        extra_config = dict(
+            getattr(stream_config, "model_loader_extra_config", None) or {}
+        )
+        if self._model_streamer_distributed_enabled():
+            extra_config["distributed"] = True
+        _set_load_config_attr(stream_config, "model_loader_extra_config", extra_config)
+
+        stream_model_config = copy.copy(self.model_config)
+        _set_load_config_attr(stream_model_config, "model_weights", model_uri)
+
+        loader = RunaiModelStreamerLoader(stream_config)
+        loader.target_device_str = str(self.target_device)
+        return loader._get_all_weights(stream_model_config, model)
+
     def after_weight_iter_load(self, result: LoadResult) -> LoadResult:
         return self._process_weights_after_loading(result)
 
@@ -154,6 +181,21 @@ class SglangAdapter(EngineAdapter):
             raise RuntimeError("SGLang post-load fixup requires result.model")
         _call_sglang_post_load_weights(result.model)
         return result
+
+    def _model_streamer_distributed_enabled(self) -> bool:
+        tp_size = int(getattr(self.build_identity(), "tensor_parallel_size", 1) or 1)
+        return (
+            tp_size > 1
+            and self.is_cuda_alike()
+            and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
+        )
+
+
+def _set_load_config_attr(obj, name: str, value) -> None:
+    try:
+        setattr(obj, name, value)
+    except AttributeError:
+        object.__setattr__(obj, name, value)
 
 
 def _call_sglang_post_load_weights(model: torch.nn.Module) -> None:

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import os
 import uuid
 from typing import TYPE_CHECKING, Iterator
 
@@ -87,6 +88,25 @@ class VllmAdapter(EngineAdapter):
         result.model.load_weights(weights_iter)
         return result
 
+    def build_model_streamer_weight_iter(
+        self,
+        model_uri: str,
+        model: torch.nn.Module | None = None,
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        from vllm.model_executor.model_loader.runai_streamer_loader import (
+            RunaiModelStreamerLoader,
+        )
+
+        load_config = copy.copy(self.load_config)
+        extra_config = dict(getattr(load_config, "model_loader_extra_config", None) or {})
+        if self._model_streamer_distributed_enabled():
+            extra_config["distributed"] = True
+        _set_load_config_extra_config(load_config, extra_config)
+
+        loader = RunaiModelStreamerLoader(load_config)
+        revision = getattr(self.model_config, "revision", None)
+        return loader._get_weights_iterator(model_uri, revision)
+
     def load_via_native(self, result: LoadResult) -> LoadResult:
         if result.model is None:
             raise RuntimeError("vLLM native loading requires result.model")
@@ -163,6 +183,20 @@ class VllmAdapter(EngineAdapter):
         compilation_config.disabled_custom_ops.clear()
         compilation_config.traced_files.clear()
         compilation_config.compilation_time = 0.0
+
+    def _model_streamer_distributed_enabled(self) -> bool:
+        tp_size = getattr(self.vllm_config.parallel_config, "tensor_parallel_size", 1)
+        return (
+            tp_size > 1
+            and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
+        )
+
+
+def _set_load_config_extra_config(load_config, extra_config: dict) -> None:
+    try:
+        load_config.model_loader_extra_config = extra_config
+    except AttributeError:
+        object.__setattr__(load_config, "model_loader_extra_config", extra_config)
 
 
 def _get_vllm_worker_rank(vllm_config: VllmConfig) -> int:

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -31,7 +31,6 @@ import torch.nn as nn
 
 from ... import configure_vllm_logging
 from ...load_strategy import LoadContext, LoadStrategyChain
-from ...load_strategy.model_streamer_strategy import _patch_vllm_s3_format_check
 from ...nixl_transfer import NixlTransferManager
 from .adapter import build_vllm_load_context
 
@@ -44,6 +43,43 @@ from vllm.model_executor.model_loader.utils import initialize_model
 from vllm.utils.torch_utils import set_default_torch_dtype
 
 logger = logging.getLogger("modelexpress.engines.vllm.loader")
+
+
+def _patch_vllm_s3_format_check() -> None:
+    """Allow 'mx' as a valid load format when model weights use object storage.
+
+    vLLM's verification path only allows object-storage `model_weights` for its
+    native RunAI load formats. The MX loader still delegates the ModelStreamer
+    path back to vLLM after strategy selection, so verification needs to accept
+    the temporary `load_format == "mx"` configuration.
+    """
+    try:
+        from vllm.transformers_utils.runai_utils import is_runai_obj_uri
+    except ImportError:
+        return
+
+    original = VllmConfig.try_verify_and_update_config
+
+    def patched(self: VllmConfig) -> None:
+        if (
+            self.load_config.load_format == "mx"
+            and hasattr(self.model_config, "model_weights")
+            and is_runai_obj_uri(self.model_config.model_weights)
+        ):
+            saved = self.model_config.model_weights
+            del self.model_config.model_weights
+            try:
+                original(self)
+            finally:
+                self.model_config.model_weights = saved
+        else:
+            original(self)
+
+    VllmConfig.try_verify_and_update_config = patched
+    logger.debug(
+        "Patched VllmConfig.try_verify_and_update_config to allow 'mx' "
+        "for object storage URIs"
+    )
 
 
 # Global storage for tensor metadata, keyed by device_id (local CUDA ordinal).

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -105,12 +105,26 @@ def _as_load_result(result_or_model: LoadResult | nn.Module) -> LoadResult:
     return LoadResult(value=result_or_model, model=result_or_model)
 
 
+def _metadata_publication_configured(ctx: LoadContext) -> bool:
+    """Return whether this worker has a metadata path for P2P serving."""
+    server_addr = os.environ.get("MODEL_EXPRESS_URL") or os.environ.get("MX_SERVER_ADDRESS")
+    if server_addr:
+        return True
+    return getattr(ctx.mx_client, "REQUIRES_P2P_METADATA", False) is True
+
+
 def register_tensors(result_or_model: LoadResult | nn.Module, ctx: LoadContext) -> None:
     """Collect model tensors and register them with NIXL.
 
     Failures are logged but do not raise — the worker continues without
     P2P serving capability.
     """
+    if not _metadata_publication_configured(ctx):
+        logger.info(
+            f"[Worker {ctx.global_rank}] No MX metadata path configured, "
+            "skipping NIXL registration"
+        )
+        return
     if not is_nixl_available():
         logger.warning(f"[Worker {ctx.global_rank}] NIXL not available, skipping registration")
         return
@@ -158,9 +172,7 @@ def publish_metadata(ctx: LoadContext) -> None:
     # Only bail on missing MODEL_EXPRESS_URL / MX_SERVER_ADDRESS when the
     # client actually needs a central coordinator. Strict `is True`
     # check so MagicMock's auto-attribute doesn't masquerade as the flag.
-    server_addr = os.environ.get("MODEL_EXPRESS_URL") or os.environ.get("MX_SERVER_ADDRESS")
-    requires_p2p = getattr(ctx.mx_client, "REQUIRES_P2P_METADATA", False) is True
-    if not server_addr and not requires_p2p:
+    if not _metadata_publication_configured(ctx):
         logger.info(
             f"[Worker {ctx.global_rank}] No MX server configured, skipping metadata publish"
         )

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -4,8 +4,8 @@
 """ModelStreamer loading strategy: stream safetensors via runai-model-streamer.
 
 Supports object storage (S3, GCS, Azure Blob) and local filesystem paths.
-File resolution is delegated to runai_model_streamer.list_safetensors(),
-which handles all backends transparently.
+File resolution and tensor iteration are delegated to the engine adapter so
+native loader integrations stay engine-specific.
 """
 
 from __future__ import annotations
@@ -13,7 +13,6 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
-import time
 from typing import Iterator
 
 import torch
@@ -24,51 +23,6 @@ from .context import LoadResult
 
 logger = logging.getLogger("modelexpress.strategy_model_streamer")
 
-_LOG_INTERVAL_SECS = 30
-
-
-def _patch_vllm_s3_format_check() -> None:
-    """Allow 'mx' as a valid load format when the model path is an object storage URI.
-
-    vllm's `try_verify_and_update_config` rejects any `load_format` other than
-    'runai_streamer'/'runai_streamer_sharded' when `model_config.model_weights`
-    is an object-storage URI. The guard is the only place inside that method
-    that consults `model_weights`, so we temporarily detach the attribute for
-    the duration of the call and restore it afterwards. This keeps
-    `load_format == 'mx'` truthful throughout verification.
-
-    Co-located with ModelStreamerStrategy because that strategy is the only
-    consumer of object-storage URIs in the mx pathway. Installed eagerly from
-    `vllm_loader` at module-import time, before vllm runs verification.
-
-    No-ops gracefully if the vllm version does not have this check.
-    """
-    try:
-        from vllm.config import VllmConfig
-        from vllm.transformers_utils.runai_utils import is_runai_obj_uri
-    except ImportError:
-        return
-
-    original = VllmConfig.try_verify_and_update_config
-
-    def patched(self: VllmConfig) -> None:
-        if (
-            self.load_config.load_format == "mx"
-            and hasattr(self.model_config, "model_weights")
-            and is_runai_obj_uri(self.model_config.model_weights)
-        ):
-            saved = self.model_config.model_weights
-            del self.model_config.model_weights
-            try:
-                original(self)
-            finally:
-                self.model_config.model_weights = saved
-        else:
-            original(self)
-
-    VllmConfig.try_verify_and_update_config = patched
-    logger.debug("Patched VllmConfig.try_verify_and_update_config to allow 'mx' for object storage URIs")
-
 
 class ModelStreamerStrategy(LoadStrategy):
     """Load weights by streaming safetensors via runai-model-streamer.
@@ -77,11 +31,14 @@ class ModelStreamerStrategy(LoadStrategy):
     stream weights is taken from `model_config.model_weights` if set
     (object-storage URIs: s3://, gs://, az://) and falls back to
     `model_config.model` otherwise (local paths, HF-resolved snapshots).
-    This mirrors vllm's runai_streamer_loader.
+    Engine adapters provide the concrete ModelStreamer iterator.
     """
 
     name = "model_streamer"
-    requires = (EngineAdapter.apply_weight_iter,)
+    requires = (
+        EngineAdapter.apply_weight_iter,
+        EngineAdapter.build_model_streamer_weight_iter,
+    )
 
     def is_available(self, ctx: LoadContext) -> bool:
         if not super().is_available(ctx):
@@ -106,7 +63,7 @@ class ModelStreamerStrategy(LoadStrategy):
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting model streamer loading from {model_uri}")
         try:
-            weights_iter = self._stream_weights(model_uri, ctx)
+            weights_iter = self._stream_weights(model_uri, ctx, result.model)
         except Exception as e:
             logger.warning(
                 f"[Worker {ctx.global_rank}] Model streamer loading failed, falling through: {e}"
@@ -127,53 +84,13 @@ class ModelStreamerStrategy(LoadStrategy):
         return result
 
     def _stream_weights(
-        self, model_uri: str, ctx: LoadContext
+        self,
+        model_uri: str,
+        ctx: LoadContext,
+        model: torch.nn.Module | None = None,
     ) -> Iterator[tuple[str, torch.Tensor]]:
-        from runai_model_streamer import SafetensorsStreamer, list_safetensors
-
-        file_uris = list_safetensors(model_uri)
-        if not file_uris:
-            raise FileNotFoundError(f"No safetensors files found at {model_uri}")
-
-        logger.info(
-            f"[Worker {ctx.global_rank}] Streaming {len(file_uris)} safetensors files "
-            f"from {model_uri}"
+        logger.info(f"[Worker {ctx.global_rank}] Streaming weights from {model_uri}")
+        yield from ctx.adapter.build_model_streamer_weight_iter(
+            model_uri,
+            model=model,
         )
-
-        tp_size = getattr(ctx.identity, "tensor_parallel_size", 1) or 1
-        distributed = (
-            tp_size > 1
-            and ctx.adapter is not None
-            and ctx.adapter.is_cuda_alike()
-            and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
-        )
-        stream_kwargs: dict = {}
-        if distributed:
-            stream_kwargs["device"] = f"cuda:{ctx.device_id}"
-            stream_kwargs["is_distributed"] = True
-
-        start = time.perf_counter()
-        with SafetensorsStreamer() as streamer:
-            streamer.stream_files(file_uris, **stream_kwargs)
-            total_tensors = sum(
-                len(meta) for meta in streamer.files_to_tensors_metadata.values()
-            )
-            count = 0
-            last_log = start
-            for name, tensor in streamer.get_tensors():
-                count += 1
-                now = time.perf_counter()
-                if now - last_log >= _LOG_INTERVAL_SECS or count == total_tensors:
-                    pct = count / total_tensors * 100 if total_tensors else 0
-                    elapsed = now - start
-                    logger.info(
-                        f"[Worker {ctx.global_rank}] Streaming: "
-                        f"{count}/{total_tensors} tensors ({pct:.0f}%) "
-                        f"in {elapsed:.0f}s"
-                    )
-                    last_log = now
-                # clone() ensures safety when RUNAI_STREAMER_MEMORY_LIMIT=0
-                # (single-buffer mode reuses memory on next iteration)
-                yield name, tensor.clone()
-        elapsed = time.perf_counter() - start
-        logger.info(f"[Worker {ctx.global_rank}] Streamed all weights in {elapsed:.1f}s")

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -3,6 +3,8 @@
 
 """Tests for ModelStreamerStrategy."""
 
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,6 +38,9 @@ class _FakeAdapter(EngineAdapter):
         if result.model is not None:
             result.model.load_weights(weights_iter)
         return result
+
+    def build_model_streamer_weight_iter(self, model_uri: str, model=None):
+        return iter(())
 
 
 def _make_load_context(**overrides):
@@ -155,7 +160,7 @@ class TestModelStreamerLoad:
 
         assert isinstance(result, LoadResult)
         assert result.model is model
-        mock_stream.assert_called_once_with("s3://bucket/model", ctx)
+        mock_stream.assert_called_once_with("s3://bucket/model", ctx, model)
         model.load_weights.assert_called_once()
         mock_register.assert_called_once_with(result, ctx)
 
@@ -176,7 +181,7 @@ class TestModelStreamerLoad:
             result = strategy.load(model, ctx)
 
         assert isinstance(result, LoadResult)
-        mock_stream.assert_called_once_with("/models/llama", ctx)
+        mock_stream.assert_called_once_with("/models/llama", ctx, model)
 
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
     def test_uri_from_model_weights_not_from_env(self, mock_register):
@@ -196,7 +201,7 @@ class TestModelStreamerLoad:
                 with pytest.raises(StrategyFailed, match="expected"):
                     strategy.load(model, ctx)
 
-        mock_stream.assert_called_once_with("s3://bucket/from-config", ctx)
+        mock_stream.assert_called_once_with("s3://bucket/from-config", ctx, model)
 
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
     def test_raises_strategy_failed_on_error(self, mock_register):
@@ -266,124 +271,92 @@ class TestStreamWeights:
         from modelexpress.load_strategy.model_streamer_strategy import ModelStreamerStrategy
         return ModelStreamerStrategy()
 
-    def _make_streamer_module(self, file_uris, tensors):
-        mock_streamer_instance = MagicMock()
-        mock_streamer_instance.__enter__ = MagicMock(return_value=mock_streamer_instance)
-        mock_streamer_instance.__exit__ = MagicMock(return_value=False)
-        mock_streamer_instance.files_to_tensors_metadata = {f: [MagicMock()] for f in file_uris}
-        mock_streamer_instance.get_tensors.return_value = iter(tensors)
-        mock_streamer_cls = MagicMock(return_value=mock_streamer_instance)
-        return (
-            MagicMock(
-                list_safetensors=MagicMock(return_value=file_uris),
-                SafetensorsStreamer=mock_streamer_cls,
-            ),
-            mock_streamer_instance,
+    def test_delegates_to_adapter_without_cloning(self):
+        strategy = self._make_strategy()
+        tensor = torch.randn(2, 2)
+        adapter = _FakeAdapter()
+        adapter.build_model_streamer_weight_iter = MagicMock(
+            return_value=iter([("w", tensor)])
         )
+        ctx = _make_load_context(adapter=adapter)
 
-    def test_raises_when_no_files(self):
-        strategy = self._make_strategy()
-        ctx = _make_load_context()
+        model = torch.nn.Module()
+        weights = list(strategy._stream_weights("s3://bucket/model", ctx, model))
 
-        mock_list = MagicMock(return_value=[])
-        mock_streamer = MagicMock()
-
-        with patch.dict("sys.modules", {
-            "runai_model_streamer": MagicMock(
-                list_safetensors=mock_list,
-                SafetensorsStreamer=mock_streamer,
-            ),
-        }):
-            with pytest.raises(FileNotFoundError, match="No safetensors files found"):
-                list(strategy._stream_weights("s3://empty-bucket/model", ctx))
-
-    def _make_ctx_with_tp(
-        self,
-        tp_size: int,
-        device_id: int = 2,
-        is_cuda_alike: bool = True,
-    ):
-        return _make_load_context(
-            adapter=_FakeAdapter(is_cuda_alike=is_cuda_alike),
-            device_id=device_id,
-            identity=p2p_pb2.SourceIdentity(
-                model_name="test-model",
-                tensor_parallel_size=tp_size,
-            ),
+        adapter.build_model_streamer_weight_iter.assert_called_once_with(
+            "s3://bucket/model",
+            model=model,
         )
+        assert weights[0][0] == "w"
+        assert weights[0][1] is tensor
 
-    def test_distributed_disabled_by_default(self):
-        strategy = self._make_strategy()
-        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2)
-        file_uris = ["s3://bucket/model.safetensors"]
-        tensors = [("w", torch.randn(2, 2))]
 
-        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
-        with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with patch.dict("os.environ", {}, clear=True):
-                list(strategy._stream_weights("s3://bucket/model", ctx))
+class TestVllmModelStreamerIterator:
+    def _make_adapter(self, *, tp_size: int = 8, extra_config=None):
+        from modelexpress.engines.vllm.adapter import VllmAdapter
 
-        streamer_instance.stream_files.assert_called_once_with(file_uris)
-
-    def test_distributed_enabled_by_mx_ms_distributed_1(self):
-        strategy = self._make_strategy()
-        ctx = self._make_ctx_with_tp(tp_size=4, device_id=2)
-        file_uris = ["s3://bucket/model.safetensors"]
-        tensors = [("w", torch.randn(2, 2))]
-
-        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
-        with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                list(strategy._stream_weights("s3://bucket/model", ctx))
-
-        streamer_instance.stream_files.assert_called_once_with(
-            file_uris, device="cuda:2", is_distributed=True
+        load_config = SimpleNamespace(
+            device=None,
+            model_loader_extra_config=extra_config,
         )
+        vllm_config = MagicMock()
+        vllm_config.load_config = load_config
+        vllm_config.device_config.device = "cuda"
+        vllm_config.parallel_config.tensor_parallel_size = tp_size
+        model_config = SimpleNamespace(revision="main")
+        return VllmAdapter(vllm_config, model_config), load_config
 
-    def test_distributed_disabled_when_tp_is_1(self):
-        strategy = self._make_strategy()
-        ctx = self._make_ctx_with_tp(tp_size=1, device_id=0)
-        file_uris = ["s3://bucket/model.safetensors"]
-        tensors = [("w", torch.randn(2, 2))]
+    def _patch_runai_loader(self, tensors):
+        loader_instance = MagicMock()
+        loader_instance._get_weights_iterator.return_value = iter(tensors)
+        loader_cls = MagicMock(return_value=loader_instance)
+        module = SimpleNamespace(RunaiModelStreamerLoader=loader_cls)
+        return patch.dict(
+            sys.modules,
+            {"vllm.model_executor.model_loader.runai_streamer_loader": module},
+        ), loader_cls, loader_instance
 
-        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
-        with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                list(strategy._stream_weights("s3://bucket/model", ctx))
+    def test_uses_vllm_native_iterator_and_enables_distributed(self):
+        tensor = torch.randn(2, 2)
+        adapter, _load_config = self._make_adapter(tp_size=8)
+        patcher, loader_cls, loader_instance = self._patch_runai_loader([("w", tensor)])
 
-        streamer_instance.stream_files.assert_called_once_with(file_uris)
+        with patcher, patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+            weights = list(adapter.build_model_streamer_weight_iter("az://models/model"))
 
-    def test_distributed_disabled_when_adapter_is_not_cuda_alike(self):
-        strategy = self._make_strategy()
-        ctx = self._make_ctx_with_tp(
-            tp_size=4,
-            device_id=2,
-            is_cuda_alike=False,
+        native_load_config = loader_cls.call_args.args[0]
+        assert native_load_config.model_loader_extra_config["distributed"] is True
+        loader_instance._get_weights_iterator.assert_called_once_with(
+            "az://models/model", "main"
         )
-        file_uris = ["s3://bucket/model.safetensors"]
-        tensors = [("w", torch.randn(2, 2))]
+        assert weights[0][0] == "w"
+        assert weights[0][1] is tensor
 
-        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
-        with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                list(strategy._stream_weights("s3://bucket/model", ctx))
-
-        streamer_instance.stream_files.assert_called_once_with(file_uris)
-
-    def test_distributed_device_id_used_in_cuda_device(self):
-        strategy = self._make_strategy()
-        ctx = self._make_ctx_with_tp(tp_size=8, device_id=5)
-        file_uris = ["s3://bucket/model.safetensors"]
-        tensors = [("w", torch.randn(2, 2))]
-
-        module, streamer_instance = self._make_streamer_module(file_uris, tensors)
-        with patch.dict("sys.modules", {"runai_model_streamer": module}):
-            with patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
-                list(strategy._stream_weights("s3://bucket/model", ctx))
-
-        streamer_instance.stream_files.assert_called_once_with(
-            file_uris, device="cuda:5", is_distributed=True
+    def test_preserves_existing_extra_config_when_distributed_disabled(self):
+        adapter, _load_config = self._make_adapter(
+            tp_size=1,
+            extra_config={"concurrency": 4},
         )
+        patcher, loader_cls, _loader_instance = self._patch_runai_loader([])
+
+        with patcher, patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "1"}):
+            list(adapter.build_model_streamer_weight_iter("az://models/model"))
+
+        native_load_config = loader_cls.call_args.args[0]
+        assert native_load_config.model_loader_extra_config == {"concurrency": 4}
+
+    def test_distributed_disabled_by_default_even_with_tp_gt_one(self):
+        adapter, _load_config = self._make_adapter(
+            tp_size=8,
+            extra_config={"concurrency": 4},
+        )
+        patcher, loader_cls, _loader_instance = self._patch_runai_loader([])
+
+        with patcher, patch.dict("os.environ", {}, clear=True):
+            list(adapter.build_model_streamer_weight_iter("az://models/model"))
+
+        native_load_config = loader_cls.call_args.args[0]
+        assert native_load_config.model_loader_extra_config == {"concurrency": 4}
 
 
 # ---------------------------------------------------------------------------

--- a/modelexpress_client/python/tests/test_sglang_loader.py
+++ b/modelexpress_client/python/tests/test_sglang_loader.py
@@ -6,7 +6,7 @@
 import sys
 from types import ModuleType
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch.nn as nn
@@ -185,6 +185,113 @@ def test_sglang_adapter_post_load_prefers_top_level_hook():
 
     assert model.post_load_called
     assert not model.child.post_load_called
+
+
+def _install_sglang_runai_loader_modules(monkeypatch, loader_cls, load_format):
+    sglang_mod = ModuleType("sglang")
+    srt_mod = ModuleType("sglang.srt")
+    configs_mod = ModuleType("sglang.srt.configs")
+    load_config_mod = ModuleType("sglang.srt.configs.load_config")
+    model_loader_mod = ModuleType("sglang.srt.model_loader")
+    loader_mod = ModuleType("sglang.srt.model_loader.loader")
+
+    load_config_mod.LoadFormat = load_format
+    loader_mod.RunaiModelStreamerLoader = loader_cls
+
+    monkeypatch.setitem(sys.modules, "sglang", sglang_mod)
+    monkeypatch.setitem(sys.modules, "sglang.srt", srt_mod)
+    monkeypatch.setitem(sys.modules, "sglang.srt.configs", configs_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.configs.load_config",
+        load_config_mod,
+    )
+    monkeypatch.setitem(sys.modules, "sglang.srt.model_loader", model_loader_mod)
+    monkeypatch.setitem(sys.modules, "sglang.srt.model_loader.loader", loader_mod)
+
+
+def test_sglang_adapter_uses_native_model_streamer_loader(monkeypatch):
+    tensor = torch.randn(2, 2)
+    loader_instance = MagicMock()
+    loader_instance._get_all_weights.return_value = iter([("w", tensor)])
+    loader_cls = MagicMock(return_value=loader_instance)
+    load_format = SimpleNamespace(RUNAI_STREAMER="runai_streamer")
+    _install_sglang_runai_loader_modules(monkeypatch, loader_cls, load_format)
+
+    load_config = _load_config(model_loader_extra_config={"concurrency": 4})
+    model_config = _model_config()
+    adapter = SglangAdapter(
+        load_config,
+        model_config,
+        _device_config(device="cuda:2", gpu_id=2),
+    )
+    model = nn.Linear(2, 2)
+
+    weights = list(
+        adapter.build_model_streamer_weight_iter(
+            "az://models/deepseek-ai/DeepSeek-V3",
+            model=model,
+        )
+    )
+
+    stream_config = loader_cls.call_args.args[0]
+    assert stream_config is not load_config
+    assert stream_config.load_format == "runai_streamer"
+    assert stream_config.model_loader_extra_config == {"concurrency": 4}
+    stream_model_config = loader_instance._get_all_weights.call_args.args[0]
+    assert stream_model_config is not model_config
+    assert stream_model_config.model_weights == "az://models/deepseek-ai/DeepSeek-V3"
+    assert loader_instance._get_all_weights.call_args.args[1] is model
+    assert loader_instance.target_device_str == "cuda:2"
+    assert weights == [("w", tensor)]
+
+
+def test_sglang_adapter_enables_distributed_model_streamer(monkeypatch):
+    loader_instance = MagicMock()
+    loader_instance._get_all_weights.return_value = iter([])
+    loader_cls = MagicMock(return_value=loader_instance)
+    load_format = SimpleNamespace(RUNAI_STREAMER="runai_streamer")
+    _install_sglang_runai_loader_modules(monkeypatch, loader_cls, load_format)
+
+    adapter = SglangAdapter(
+        _load_config(model_loader_extra_config={"concurrency": 4}),
+        _model_config(),
+        _device_config(device="cuda:0", gpu_id=0),
+    )
+
+    with patch(
+        "modelexpress.engines.sglang.adapter._get_parallel_size",
+        return_value=8,
+    ), patch.object(adapter, "is_cuda_alike", return_value=True), patch.dict(
+        "os.environ", {"MX_MS_DISTRIBUTED": "1"}
+    ):
+        list(
+            adapter.build_model_streamer_weight_iter(
+                "s3://bucket/deepseek-ai/DeepSeek-V3",
+                model=nn.Linear(2, 2),
+            )
+        )
+
+    stream_config = loader_cls.call_args.args[0]
+    assert stream_config.model_loader_extra_config == {
+        "concurrency": 4,
+        "distributed": True,
+    }
+
+
+def test_sglang_model_streamer_requires_initialized_model(monkeypatch):
+    loader_cls = MagicMock()
+    load_format = SimpleNamespace(RUNAI_STREAMER="runai_streamer")
+    _install_sglang_runai_loader_modules(monkeypatch, loader_cls, load_format)
+
+    adapter = SglangAdapter(_load_config(), _model_config(), _device_config())
+
+    try:
+        list(adapter.build_model_streamer_weight_iter("s3://bucket/model"))
+    except RuntimeError as exc:
+        assert "requires result.model" in str(exc)
+    else:
+        raise AssertionError("Expected missing model to fail")
 
 
 def test_mx_model_loader_delegates_to_shared_strategy_chain():

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -304,20 +304,31 @@ class TestInitNixlManager:
 class TestRegisterTensorsErrorHandling:
     """Verify register_tensors never raises — failures are logged as warnings."""
 
+    @patch("modelexpress.load_strategy.base.is_nixl_available")
+    def test_skips_when_no_metadata_path_configured(self, mock_available):
+        from modelexpress.load_strategy.base import register_tensors
+        ctx = _make_load_context()
+        model = MagicMock()
+        register_tensors(model, ctx)
+        mock_available.assert_not_called()
+        assert ctx.nixl_manager is None
+
     @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=False)
     def test_skips_when_nixl_unavailable(self, _mock):
         from modelexpress.load_strategy.base import register_tensors
         ctx = _make_load_context()
         model = MagicMock()
-        register_tensors(model, ctx)
+        with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
+            register_tensors(model, ctx)
         assert ctx.nixl_manager is None
 
     @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
     def test_requires_adapter_when_nixl_available(self, _mock):
         from modelexpress.load_strategy.base import register_tensors
         ctx = _make_load_context(adapter=None)
-        with pytest.raises(RuntimeError, match="engine adapter"):
-            register_tensors(MagicMock(), ctx)
+        with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
+            with pytest.raises(RuntimeError, match="engine adapter"):
+                register_tensors(MagicMock(), ctx)
 
     @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
     @patch(
@@ -328,7 +339,8 @@ class TestRegisterTensorsErrorHandling:
         from modelexpress.load_strategy.base import register_tensors
         ctx = _make_load_context()
         model = MagicMock()
-        register_tensors(model, ctx)
+        with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
+            register_tensors(model, ctx)
         assert ctx.nixl_manager is None
 
     @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
@@ -342,7 +354,8 @@ class TestRegisterTensorsErrorHandling:
         ctx = _make_load_context()
         ctx.adapter.discover_tensors = MagicMock(return_value={"t": MagicMock()})
         model = MagicMock()
-        register_tensors(model, ctx)
+        with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
+            register_tensors(model, ctx)
 
 
 class TestPublishMetadataErrorHandling:
@@ -359,7 +372,8 @@ class TestPublishMetadataErrorHandling:
         from modelexpress.load_strategy.base import publish_metadata
         ctx = _make_load_context()
         ctx.nixl_manager = MagicMock()
-        publish_metadata(ctx)
+        with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
+            publish_metadata(ctx)
 
     def test_unpublish_uses_worker_rank_for_heartbeat_lifecycle(self):
         from modelexpress.load_strategy.base import unpublish_metadata


### PR DESCRIPTION
## Overview

Moves ModelStreamer tensor iteration behind the engine adapter boundary. The shared strategy now delegates to engine adapters, so vLLM and SGLang can use their native RunAI ModelStreamer loader paths instead of duplicated shared loader logic.

Also adds an Azure Blob-backed vLLM example and keeps the S3 example aligned with the same serving parameters.

## What changed

**Engine adapters:** adds an adapter-owned ModelStreamer iterator hook.

**vLLM:** uses vLLM's native `RunaiModelStreamerLoader` for `--load-format mx`, including distributed streaming configuration.

**SGLang:** adds the matching native RunAI ModelStreamer loader path with the initialized model object.

**Examples:** adds `vllm-single-node-streamer-azure.yaml` and aligns the S3 manifest around DeepSeek-V3, TP8, expert parallelism, `--served-model-name`, and distributed streaming.

**Standalone loading:** skips NIXL tensor registration/publication when no metadata backend is configured.

## Compatibility notes

- Azure requires vLLM with Azure Blob support in the native RunAI ModelStreamer loader.
- SGLang ModelStreamer loading requires the initialized model object.

## Testing

### Azure AKS e2e

Validated on AKS with 8x A100-SXM4-80GB, vLLM 0.18.0, TP8, Azure Blob model URIs, and distributed ModelStreamer enabled.

| Model | Loader | API ready | vLLM model load |
|---|---:|---:|---:|
| `nvidia/Kimi-K2.5-NVFP4` | ModelExpress + Azure Blob ModelStreamer | 6m38s | 250.1s |
| `nvidia/Kimi-K2.5-NVFP4` | vanilla vLLM cold HF load | 29m24s | 1563.3s |
| `Qwen/Qwen3.5-122B-A10B` | ModelExpress + Azure Blob ModelStreamer | 6m26s | 95.1s |
| `Qwen/Qwen3.5-122B-A10B` | vanilla vLLM cold HF load | 12m01s | 417.9s |
| `Qwen/Qwen3.5-27B` | ModelExpress + Azure Blob ModelStreamer | 5m09s | 36.9s |
| `Qwen/Qwen3.5-27B` | vanilla vLLM cold HF load | 6m19s | 90.2s |

K2.5 `/v1/models` returned the served model name after startup. The MX runs skipped NIXL registration as expected because no metadata backend was configured.

### Local validation

Focused unit coverage, touched-file precommit, and Azure/S3 YAML parsing passed.
