### PR TITLE
chore(p2p): log manifest byte size on source and target

### DIFF
--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -236,7 +236,7 @@ class RdmaStrategy(LoadStrategy):
                 f"[Worker {ctx.global_rank}] P2P mode: fetching tensor manifest from "
                 f"{source_worker.worker_grpc_endpoint}"
             )
-            tensor_protos = fetch_tensor_manifest(
+            tensor_protos, manifest_bytes = fetch_tensor_manifest(
                 endpoint=source_worker.worker_grpc_endpoint,
                 mx_source_id=mx_source_id,
             )
@@ -250,7 +250,8 @@ class RdmaStrategy(LoadStrategy):
             ]
             logger.info(
                 f"[Worker {ctx.global_rank}] [TIMING] P2P tensor manifest: "
-                f"{manifest_time:.3f}s ({len(source_tensors)} tensors)"
+                f"{manifest_time:.3f}s ({len(source_tensors)} tensors, "
+                f"{manifest_bytes} bytes)"
             )
 
             nixl_fetch_start = time.perf_counter()

--- a/modelexpress_client/python/modelexpress/metadata/worker_server.py
+++ b/modelexpress_client/python/modelexpress/metadata/worker_server.py
@@ -47,13 +47,18 @@ class WorkerServiceServicer(p2p_pb2_grpc.WorkerServiceServicer):
                 f"mx_source_id mismatch: expected {self._mx_source_id}, "
                 f"got {request.mx_source_id}",
             )
-        return p2p_pb2.GetTensorManifestResponse(
+        response = p2p_pb2.GetTensorManifestResponse(
             tensors=self._tensor_protos,
             mx_source_id=self._mx_source_id,
             metadata_endpoint=self._metadata_endpoint,
             agent_name=self._agent_name,
             worker_rank=self._worker_rank,
         )
+        logger.info(
+            f"GetTensorManifest served: {len(self._tensor_protos)} tensors, "
+            f"{response.ByteSize()} bytes (worker_rank={self._worker_rank})"
+        )
+        return response
 
 
 class WorkerGrpcServer:
@@ -116,14 +121,21 @@ def fetch_tensor_manifest(
     endpoint: str,
     mx_source_id: str,
     timeout: float = 30.0,
-) -> list[p2p_pb2.TensorDescriptor]:
-    """Fetch tensor descriptors directly from a source worker's WorkerService."""
+) -> tuple[list[p2p_pb2.TensorDescriptor], int]:
+    """Fetch tensor descriptors directly from a source worker's WorkerService.
+
+    Returns a `(tensors, response_bytes)` tuple. `response_bytes` is the
+    wire size of the protobuf response (`response.ByteSize()`); callers
+    use it to instrument manifest fetch timing.
+    """
     channel = grpc.insecure_channel(endpoint)
     stub = p2p_pb2_grpc.WorkerServiceStub(channel)
     request = p2p_pb2.GetTensorManifestRequest(mx_source_id=mx_source_id)
     response = stub.GetTensorManifest(request, timeout=timeout)
+    response_bytes = response.ByteSize()
     channel.close()
     logger.info(
-        f"Fetched {len(response.tensors)} tensors from worker at {endpoint}"
+        f"Fetched {len(response.tensors)} tensors from worker at {endpoint} "
+        f"({response_bytes} bytes)"
     )
-    return list(response.tensors)
+    return list(response.tensors), response_bytes


### PR DESCRIPTION
Adds wire-size visibility to the GetTensorManifest RPC. The source-
side WorkerServiceServicer.GetTensorManifest now logs the served
response size (via response.ByteSize()) and fetch_tensor_manifest
returns the wire byte count to its caller. RDMA strategy's
'[TIMING] P2P tensor manifest' log line now reports both tensor
count and bytes.

Sample on Qwen3-30B-A3B-FP8: 820 tensors, 59 646 bytes (~73 B /
tensor). This was previously inferable only from instrumented
runs; the log line bakes it in so any operator can answer 'how
big is the manifest' without re-instrumenting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced observability for P2P manifest transfers with manifest payload size logging.
  * Improved tensor manifest operation logging to include tensor count and payload size metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/278)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->