### PR TITLE
feat: Support modelexpress vLLM load format

### DIFF
--- a/modelexpress_client/python/modelexpress/__init__.py
+++ b/modelexpress_client/python/modelexpress/__init__.py
@@ -14,7 +14,7 @@ Quick Start (vLLM):
     from modelexpress import register_modelexpress_loaders
     register_modelexpress_loaders()
 
-    # vllm serve model --load-format mx
+    # vllm serve model --load-format modelexpress
     # Auto-detects: RDMA -> GDS -> disk
 """
 
@@ -54,7 +54,8 @@ def register_modelexpress_loaders():
     multiple times safely (idempotent).
 
     Enables:
-        --load-format mx  (auto-detect: RDMA -> GDS -> disk)
+        --load-format modelexpress  (auto-detect: RDMA -> GDS -> disk)
+        --load-format mx            (backward-compatible alias)
     """
     global _loaders_registered
     if _loaders_registered:
@@ -65,7 +66,7 @@ def register_modelexpress_loaders():
     register_vllm_loaders()
 
     _loaders_registered = True
-    _logger.debug("ModelExpress loader registered: mx")
+    _logger.debug("ModelExpress loaders registered")
 
 
 from .client import MxClient  # noqa: F401

--- a/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
@@ -9,13 +9,13 @@ _loaders_registered = False
 
 
 def register_modelexpress_loaders() -> None:
-    """Register ModelExpress's vLLM loader when vLLM lacks native MX."""
+    """Register ModelExpress's vLLM loader for plugin-based vLLM integration."""
     global _loaders_registered
     if _loaders_registered:
         return
     from .registration import register_plugin_model_loader
 
-    # Needed for older vLLM versions before native `--load-format mx`
+    # Needed for older vLLM versions before native ModelExpress loader
     # registration is available.
     register_plugin_model_loader()
 

--- a/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
@@ -9,11 +9,15 @@ _loaders_registered = False
 
 
 def register_modelexpress_loaders() -> None:
-    """Register ModelExpress's vLLM loader."""
+    """Register ModelExpress's vLLM loader when vLLM lacks native MX."""
     global _loaders_registered
     if _loaders_registered:
         return
-    from . import loader  # noqa: F401
+    from .registration import register_plugin_model_loader
+
+    # Needed for older vLLM versions before native `--load-format mx`
+    # registration is available.
+    register_plugin_model_loader()
 
     _loaders_registered = True
 

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -37,50 +37,12 @@ from .adapter import build_vllm_load_context
 
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
-from vllm.model_executor.model_loader import register_model_loader
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 from vllm.model_executor.model_loader.utils import initialize_model
 from vllm.utils.torch_utils import set_default_torch_dtype
 
-logger = logging.getLogger("modelexpress.engines.vllm.loader")
-
-
-def _patch_vllm_s3_format_check() -> None:
-    """Allow 'mx' as a valid load format when model weights use object storage.
-
-    vLLM's verification path only allows object-storage `model_weights` for its
-    native RunAI load formats. The MX loader still delegates the ModelStreamer
-    path back to vLLM after strategy selection, so verification needs to accept
-    the temporary `load_format == "mx"` configuration.
-    """
-    try:
-        from vllm.transformers_utils.runai_utils import is_runai_obj_uri
-    except ImportError:
-        return
-
-    original = VllmConfig.try_verify_and_update_config
-
-    def patched(self: VllmConfig) -> None:
-        if (
-            self.load_config.load_format == "mx"
-            and hasattr(self.model_config, "model_weights")
-            and is_runai_obj_uri(self.model_config.model_weights)
-        ):
-            saved = self.model_config.model_weights
-            del self.model_config.model_weights
-            try:
-                original(self)
-            finally:
-                self.model_config.model_weights = saved
-        else:
-            original(self)
-
-    VllmConfig.try_verify_and_update_config = patched
-    logger.debug(
-        "Patched VllmConfig.try_verify_and_update_config to allow 'mx' "
-        "for object storage URIs"
-    )
+logger = logging.getLogger(__name__)
 
 
 # Global storage for tensor metadata, keyed by device_id (local CUDA ordinal).
@@ -88,12 +50,6 @@ _tensor_registry: dict[int, dict[str, torch.Tensor]] = {}
 _nixl_managers: dict[int, NixlTransferManager] = {}
 
 
-# Install eagerly: vllm calls try_verify_and_update_config during engine init,
-# before LoadStrategyChain.run() would lazily import the strategy module.
-_patch_vllm_s3_format_check()
-
-
-@register_model_loader("mx")
 class MxModelLoader(BaseModelLoader):
     """
     Auto-detecting model loader for ModelExpress.
@@ -110,21 +66,34 @@ class MxModelLoader(BaseModelLoader):
         self._ctx: LoadContext | None = None
 
     def load_model(
-        self, vllm_config: VllmConfig, model_config: ModelConfig
+        self,
+        vllm_config: VllmConfig,
+        model_config: ModelConfig,
+        prefix: str = "",
     ) -> nn.Module:
-        """Load model, auto-detecting the best loading strategy."""
+        """Load model, auto-detecting the best loading strategy.
+
+        `prefix` is vLLM's BaseModelLoader.load_model argument for initializing
+        a model subtree. ModelExpress does not interpret it; it is passed through
+        to vLLM's initialize_model().
+        """
         load_start = time.perf_counter()
 
         ctx = build_vllm_load_context(vllm_config, model_config)
         self._ctx = ctx
 
-        logger.info(f"[Worker {ctx.global_rank}] MxModelLoader starting (model={ctx.identity.model_name})")
+        logger.info(
+            f"[Worker {ctx.global_rank}] MxModelLoader starting "
+            f"(model={ctx.identity.model_name})"
+        )
 
         with maybe_enter_vmm_arena(ctx):
             with set_default_torch_dtype(model_config.dtype):
                 with ctx.target_device:
                     model = initialize_model(
-                        vllm_config=vllm_config, model_config=model_config
+                        vllm_config=vllm_config,
+                        model_config=model_config,
+                        prefix=prefix,
                     )
 
                 model = LoadStrategyChain.run(model, ctx)
@@ -148,6 +117,7 @@ class MxModelLoader(BaseModelLoader):
     def download_model(self, model_config: ModelConfig) -> None:
         """Download the model so it can be loaded immediately."""
         import copy
+
         disk_config = copy.copy(self.load_config)
         try:
             disk_config.load_format = "auto"
@@ -158,6 +128,7 @@ class MxModelLoader(BaseModelLoader):
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
         """Load weights into an already-initialized model (standalone API)."""
         import copy
+
         disk_config = copy.copy(self.load_config)
         try:
             disk_config.load_format = "auto"

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -18,7 +18,8 @@ Uses LoadStrategyChain to auto-detect the best loading strategy:
     4. Default (vLLM DefaultModelLoader) - standard CPU-staged loading
 
 Usage:
-    --load-format mx  (auto-detect: RDMA -> ModelStreamer -> GDS -> default)
+    --load-format modelexpress
+    --load-format mx  (backward-compatible alias)
 """
 
 from __future__ import annotations

--- a/modelexpress_client/python/modelexpress/engines/vllm/registration.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/registration.py
@@ -12,8 +12,11 @@ from vllm.model_executor.model_loader import register_model_loader
 logger = logging.getLogger(__name__)
 
 
+_PLUGIN_LOAD_FORMATS = ("modelexpress", "mx")
+
+
 def _patch_vllm_s3_format_check() -> None:
-    """Allow 'mx' as a valid load format for object storage on older vLLM."""
+    """Allow ModelExpress load formats for object storage on older vLLM."""
     try:
         from vllm.config import VllmConfig
         from vllm.transformers_utils.runai_utils import is_runai_obj_uri
@@ -26,7 +29,7 @@ def _patch_vllm_s3_format_check() -> None:
 
     def patched(self: VllmConfig) -> None:
         if (
-            self.load_config.load_format == "mx"
+            self.load_config.load_format in _PLUGIN_LOAD_FORMATS
             and hasattr(self.model_config, "model_weights")
             and is_runai_obj_uri(self.model_config.model_weights)
         ):
@@ -42,20 +45,14 @@ def _patch_vllm_s3_format_check() -> None:
     patched.__modelexpress_patched__ = True
     VllmConfig.try_verify_and_update_config = patched
     logger.debug(
-        "Patched VllmConfig.try_verify_and_update_config to allow 'mx' "
+        "Patched VllmConfig.try_verify_and_update_config to allow ModelExpress "
         "for object storage URIs"
     )
 
 
 def register_plugin_model_loader() -> None:
-    """Register `mx` through vLLM's plugin registry when vLLM lacks native MX."""
+    """Register ModelExpress loaders through vLLM's plugin registry."""
     import vllm.model_executor.model_loader as model_loader
-
-    if "mx" in model_loader._LOAD_FORMAT_TO_MODEL_LOADER:
-        # Native vLLM integration owns `mx` in newer versions; the plugin path
-        # stays active only for older vLLM releases.
-        logger.debug("vLLM already provides native 'mx' loader registration")
-        return
 
     # Older vLLM still needs the plugin registration side effects that used to
     # happen when importing loader.py directly.
@@ -63,4 +60,10 @@ def register_plugin_model_loader() -> None:
 
     from .loader import MxModelLoader
 
-    register_model_loader("mx")(MxModelLoader)
+    for load_format in _PLUGIN_LOAD_FORMATS:
+        if load_format in model_loader._LOAD_FORMAT_TO_MODEL_LOADER:
+            logger.debug(
+                "vLLM already provides '%s' loader registration", load_format
+            )
+            continue
+        register_model_loader(load_format)(MxModelLoader)

--- a/modelexpress_client/python/modelexpress/engines/vllm/registration.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/registration.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plugin registration for vLLM versions without native ModelExpress support."""
+
+from __future__ import annotations
+
+import logging
+
+from vllm.model_executor.model_loader import register_model_loader
+
+logger = logging.getLogger(__name__)
+
+
+def _patch_vllm_s3_format_check() -> None:
+    """Allow 'mx' as a valid load format for object storage on older vLLM."""
+    try:
+        from vllm.config import VllmConfig
+        from vllm.transformers_utils.runai_utils import is_runai_obj_uri
+    except ImportError:
+        return
+
+    original = VllmConfig.try_verify_and_update_config
+    if getattr(original, "__modelexpress_patched__", False):
+        return
+
+    def patched(self: VllmConfig) -> None:
+        if (
+            self.load_config.load_format == "mx"
+            and hasattr(self.model_config, "model_weights")
+            and is_runai_obj_uri(self.model_config.model_weights)
+        ):
+            saved = self.model_config.model_weights
+            del self.model_config.model_weights
+            try:
+                original(self)
+            finally:
+                self.model_config.model_weights = saved
+        else:
+            original(self)
+
+    patched.__modelexpress_patched__ = True
+    VllmConfig.try_verify_and_update_config = patched
+    logger.debug(
+        "Patched VllmConfig.try_verify_and_update_config to allow 'mx' "
+        "for object storage URIs"
+    )
+
+
+def register_plugin_model_loader() -> None:
+    """Register `mx` through vLLM's plugin registry when vLLM lacks native MX."""
+    import vllm.model_executor.model_loader as model_loader
+
+    if "mx" in model_loader._LOAD_FORMAT_TO_MODEL_LOADER:
+        # Native vLLM integration owns `mx` in newer versions; the plugin path
+        # stays active only for older vLLM releases.
+        logger.debug("vLLM already provides native 'mx' loader registration")
+        return
+
+    # Older vLLM still needs the plugin registration side effects that used to
+    # happen when importing loader.py directly.
+    _patch_vllm_s3_format_check()
+
+    from .loader import MxModelLoader
+
+    register_model_loader("mx")(MxModelLoader)

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -287,29 +287,46 @@ class TestAbstractMethodCompleteness:
 
         assert "mx" not in model_loader._LOAD_FORMAT_TO_MODEL_LOADER
 
-    def test_plugin_registration_skips_when_vllm_has_native_mx(self, monkeypatch):
+    def test_plugin_registration_preserves_native_modelexpress(self, monkeypatch):
         import importlib
         import vllm.model_executor.model_loader as model_loader
 
         sentinel = object()
         registry = dict(model_loader._LOAD_FORMAT_TO_MODEL_LOADER)
-        registry["mx"] = sentinel
+        registry["modelexpress"] = sentinel
+        registry.pop("mx", None)
         monkeypatch.setattr(model_loader, "_LOAD_FORMAT_TO_MODEL_LOADER", registry)
 
         registration = importlib.import_module(
             "modelexpress.engines.vllm.registration"
         )
+        patch_check = MagicMock()
+        registered = {}
+
+        def fake_register_model_loader(load_format):
+            def register(loader_cls):
+                registered[load_format] = loader_cls
+                return loader_cls
+
+            return register
+
+        monkeypatch.setattr(registration, "_patch_vllm_s3_format_check", patch_check)
         monkeypatch.setattr(
             registration,
-            "_patch_vllm_s3_format_check",
-            MagicMock(side_effect=AssertionError("patch should not run")),
+            "register_model_loader",
+            fake_register_model_loader,
         )
 
         registration.register_plugin_model_loader()
 
-        assert model_loader._LOAD_FORMAT_TO_MODEL_LOADER["mx"] is sentinel
+        from modelexpress.engines.vllm.loader import MxModelLoader
 
-    def test_plugin_registration_registers_mx_without_native_vllm(
+        patch_check.assert_called_once_with()
+        assert model_loader._LOAD_FORMAT_TO_MODEL_LOADER["modelexpress"] is sentinel
+        assert registered["mx"] is MxModelLoader
+        assert "modelexpress" not in registered
+
+    def test_plugin_registration_registers_load_formats_without_native_vllm(
         self, monkeypatch
     ):
         import importlib
@@ -317,6 +334,7 @@ class TestAbstractMethodCompleteness:
 
         registry = dict(model_loader._LOAD_FORMAT_TO_MODEL_LOADER)
         registry.pop("mx", None)
+        registry.pop("modelexpress", None)
         monkeypatch.setattr(model_loader, "_LOAD_FORMAT_TO_MODEL_LOADER", registry)
 
         registration = importlib.import_module(
@@ -348,6 +366,7 @@ class TestAbstractMethodCompleteness:
         from modelexpress.engines.vllm.loader import MxModelLoader
 
         patch_check.assert_called_once_with()
+        assert registered["modelexpress"] is MxModelLoader
         assert registered["mx"] is MxModelLoader
 
 

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -275,6 +275,81 @@ class TestAbstractMethodCompleteness:
             loader_mod._nixl_managers.pop(3, None)
             loader_mod._tensor_registry.pop(3, None)
 
+    def test_loader_import_does_not_register_mx(self, monkeypatch):
+        import importlib
+        import vllm.model_executor.model_loader as model_loader
+
+        registry = dict(model_loader._LOAD_FORMAT_TO_MODEL_LOADER)
+        registry.pop("mx", None)
+        monkeypatch.setattr(model_loader, "_LOAD_FORMAT_TO_MODEL_LOADER", registry)
+
+        importlib.import_module("modelexpress.engines.vllm.loader")
+
+        assert "mx" not in model_loader._LOAD_FORMAT_TO_MODEL_LOADER
+
+    def test_plugin_registration_skips_when_vllm_has_native_mx(self, monkeypatch):
+        import importlib
+        import vllm.model_executor.model_loader as model_loader
+
+        sentinel = object()
+        registry = dict(model_loader._LOAD_FORMAT_TO_MODEL_LOADER)
+        registry["mx"] = sentinel
+        monkeypatch.setattr(model_loader, "_LOAD_FORMAT_TO_MODEL_LOADER", registry)
+
+        registration = importlib.import_module(
+            "modelexpress.engines.vllm.registration"
+        )
+        monkeypatch.setattr(
+            registration,
+            "_patch_vllm_s3_format_check",
+            MagicMock(side_effect=AssertionError("patch should not run")),
+        )
+
+        registration.register_plugin_model_loader()
+
+        assert model_loader._LOAD_FORMAT_TO_MODEL_LOADER["mx"] is sentinel
+
+    def test_plugin_registration_registers_mx_without_native_vllm(
+        self, monkeypatch
+    ):
+        import importlib
+        import vllm.model_executor.model_loader as model_loader
+
+        registry = dict(model_loader._LOAD_FORMAT_TO_MODEL_LOADER)
+        registry.pop("mx", None)
+        monkeypatch.setattr(model_loader, "_LOAD_FORMAT_TO_MODEL_LOADER", registry)
+
+        registration = importlib.import_module(
+            "modelexpress.engines.vllm.registration"
+        )
+        patch_check = MagicMock()
+        registered = {}
+
+        def fake_register_model_loader(load_format):
+            def register(loader_cls):
+                registered[load_format] = loader_cls
+                return loader_cls
+
+            return register
+
+        monkeypatch.setattr(
+            registration,
+            "_patch_vllm_s3_format_check",
+            patch_check,
+        )
+        monkeypatch.setattr(
+            registration,
+            "register_model_loader",
+            fake_register_model_loader,
+        )
+
+        registration.register_plugin_model_loader()
+
+        from modelexpress.engines.vllm.loader import MxModelLoader
+
+        patch_check.assert_called_once_with()
+        assert registered["mx"] is MxModelLoader
+
 
 # ---------------------------------------------------------------------------
 # register_tensors (load_strategy.base)


### PR DESCRIPTION
## Overview

This PR updates the ModelExpress vLLM integration to work with native upstream vLLM `--load-format modelexpress` registration while keeping the existing plugin path for older vLLM versions.

Upstream vLLM PR: https://github.com/vllm-project/vllm/pull/43105

## Changes

- Keep `modelexpress.engines.vllm.loader.MxModelLoader` as the real implementation used by both paths.
- Move plugin registration into `modelexpress.engines.vllm.registration`.
- Make importing `modelexpress.engines.vllm.loader` side-effect free so native vLLM can import and instantiate the loader without plugin registration.
- Keep plugin registration available through `register_modelexpress_loaders()` for older vLLM versions that do not have native ModelExpress registration.
- Register both `modelexpress` and `mx` in the plugin path; `mx` remains a backward-compatible alias.
- Preserve the object-storage validation patch only for the older plugin registration path.
- Accept vLLM's `prefix` argument in `MxModelLoader.load_model()` and pass it through to vLLM model initialization.

## Test Plan

- Verify loader import does not register `mx` by side effect.
- Verify plugin registration preserves native vLLM `modelexpress` registration.
- Verify plugin registration adds `mx` as a backward-compatible alias when native `modelexpress` is already present.
- Verify plugin registration registers both `modelexpress` and `mx` for older vLLM versions.
- Verify `load_model()` clears stale NIXL managers when the current load path does not publish one.
- Verify existing vLLM loader and strategy tests continue to pass.

## Test Result

- Passed:
  - `.venv/bin/python -m pytest tests/test_vllm_loader.py -q`
  - Result: 58 passed, 8 skipped
- Passed:
  - `PYTHONPYCACHEPREFIX=/private/tmp/mx-pycache python3 -m py_compile modelexpress_client/python/modelexpress/engines/vllm/registration.py modelexpress_client/python/modelexpress/engines/vllm/__init__.py modelexpress_client/python/modelexpress/__init__.py modelexpress_client/python/tests/test_vllm_loader.py`

End-to-end validation shared with the upstream vLLM PR:

- `Qwen/Qwen3.5-0.8B` smoke test on nscale B200 passed through both paths before the upstream load-format rename:
  - native vLLM loader: `vllm.model_executor.model_loader.mx_loader.MxModelLoader`
  - ModelExpress plugin loader: `modelexpress.engines.vllm.loader.MxModelLoader`
- `mistralai/Mistral-Small-4-119B-2603` native vLLM P2P test on nscale B200 passed with TP=4, DP=1, non-eager:
  - source disk load: about 27s per worker
  - target P2P transfer: 30.49 GiB per rank in about 1.12-1.14s at about 214-218 Gbps
  - target serving verified through `/v1/models` and `/v1/chat/completions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced explicit plugin registration for the vLLM loader, enabling dynamic integration management.
  * Enhanced model loading with additional configuration parameters for improved control and flexibility.

* **Tests**
  * Added comprehensive test coverage for vLLM plugin registration behavior, including validation of loader detection and registration in various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
