### PR TITLE
fix(RL/NemoRL): drop v2 sidecar TensorDescriptors before NIXL register

### DIFF
--- a/modelexpress_client/python/modelexpress/refit_receiver.py
+++ b/modelexpress_client/python/modelexpress/refit_receiver.py
@@ -261,6 +261,11 @@ class MxRefitReceiver:
             )
 
         worker = meta_resp.worker
+        # Filter out V2 sidecar TensorDescriptors (name="__mx_v2_meta__",
+        # addr=0, size=0). The V2 publisher uses them to smuggle metadata
+        # past the MX server's field-dropping; they aren't real RDMA
+        # targets. Leaving them in the source_tensors list propagates a
+        # (0,0,0) descriptor into prep_xfer_dlist which UCX rejects.
         source_tensors = [
             TensorDescriptor(
                 name=t.name,
@@ -270,6 +275,7 @@ class MxRefitReceiver:
                 dtype=t.dtype,
             )
             for t in worker.tensors
+            if not t.name.startswith("__mx_") and t.size > 0
         ]
 
         transferred, skipped, elapsed = self._nixl.receive_from_source(
@@ -328,6 +334,11 @@ class MxRefitReceiver:
             )
 
         worker = meta_resp.worker
+        # Filter out V2 sidecar TensorDescriptors (name="__mx_v2_meta__",
+        # addr=0, size=0). The V2 publisher uses them to smuggle metadata
+        # past the MX server's field-dropping; they aren't real RDMA
+        # targets. Leaving them in the source_tensors list propagates a
+        # (0,0,0) descriptor into prep_xfer_dlist which UCX rejects.
         source_tensors = [
             TensorDescriptor(
                 name=t.name,
@@ -337,6 +348,7 @@ class MxRefitReceiver:
                 dtype=t.dtype,
             )
             for t in worker.tensors
+            if not t.name.startswith("__mx_") and t.size > 0
         ]
 
         scratch_tensors: dict[str, torch.Tensor] = {}


### PR DESCRIPTION
## Summary

The V2 publisher emits a synthetic
`TensorDescriptor(name="__mx_v2_meta__", addr=0, size=0, dtype=<json>)` to
smuggle metadata past the Rust MX server's `GetMetadata` echo, which drops
most string fields but preserves `TensorDescriptors`. The sidecar is
consumed by the V2 sidecar parser earlier in the receive path and was
never meant to be RDMA-transferred — but `receive_weights` and
`receive_weights_scratch` copy `worker.tensors` verbatim into
`source_tensors`, so the `(addr=0, size=0)` descriptor propagates into
`nixl_transfer.receive_from_source`, then into `prep_xfer_dlist`. UCX
rejects any descriptor list that contains a `size=0` entry with
`NIXL_ERR_NOT_FOUND`, poisoning the whole transfer.

This PR filters sidecars (`name` starts with `__mx_`, `size == 0`) out of
`source_tensors` in both entrypoints, before NIXL registration. Metadata
consumption via the existing sidecar parser is unaffected.

## Empirical evidence

Standalone cross-pod two-process repro (GB300 + RoCE + dma-buf), no
modelexpress, no vLLM, no Ray — reproduces the failure deterministically:

| descs                                              | result |
|----------------------------------------------------|:------:|
| `[(real_addr, real_size, 0)]`                      | ✅ OK |
| `[(real_addr, real_size, 0), (0, 0, 0)]`           | ❌ `NIXL_ERR_NOT_FOUND` |
| `[(0, 0, 0), (real_addr, real_size, 0)]`           | ❌ `NIXL_ERR_NOT_FOUND` |
| `[(0, 0, 0)]`                                      | ❌ `NIXL_ERR_NOT_FOUND` |

Order doesn't matter; a single `(0, 0, 0)` poisons the whole list.

In-engine diagnostic also captured exactly
`remote_descs[399] = (addr=0x0, size=0, device_id=0)` on the failing
runs.

## End-to-end validation

Qwen3-4B-Thinking + Dynamo vLLM v1 GRPO smoke (2 steps), both refit
cycles succeed after the fix:

| Step | Result |
|---|---|
| 1 | RDMA transfer complete: 8.82 GB, 399 tensors, 0.20 s, **360.8 Gbps** |
| 2 | RDMA transfer complete: 8.82 GB, 399 tensors, 0.18 s, **383.7 Gbps** |

## Scope

The fix is local to `MxRefitReceiver.receive_weights` and
`MxRefitReceiver.receive_weights_scratch`. The underlying
`nixl_transfer` module is unchanged.

## Test plan

- [x] Standalone cross-pod NIXL repro (validates the bug and the fix on bare metal NIXL).
- [x] Two-step end-to-end GRPO smoke on GB300 with Dynamo vLLM v1 backend.
- [ ] Existing unit tests (`tests/python/v2/test_v2_*`) — should be unaffected; sidecar metadata path is unchanged.