### PR TITLE
fix: accept bare ModelExpress gRPC endpoints

### DIFF
--- a/modelexpress_common/src/cache.rs
+++ b/modelexpress_common/src/cache.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    Utils, constants,
+    Utils,
+    config::normalize_grpc_endpoint,
+    constants,
     models::ModelProvider,
     providers::{
         gcs::GcsProviderCache, huggingface::HuggingFaceProviderCache, ngc::NgcProviderCache,
@@ -97,7 +99,9 @@ impl CacheConfig {
 
         Ok(Self {
             local_path,
-            server_endpoint: server_endpoint.unwrap_or_else(Self::get_default_server_endpoint),
+            server_endpoint: normalize_grpc_endpoint(
+                server_endpoint.unwrap_or_else(Self::get_default_server_endpoint),
+            ),
             timeout_secs: None,
             shared_storage: constants::DEFAULT_SHARED_STORAGE,
             transfer_chunk_size: constants::DEFAULT_TRANSFER_CHUNK_SIZE,
@@ -132,8 +136,10 @@ impl CacheConfig {
         let content = fs::read_to_string(&config_path)
             .with_context(|| format!("Failed to read config file: {config_path:?}"))?;
 
-        let config: Self = serde_yaml::from_str(&content)
+        let mut config: Self = serde_yaml::from_str(&content)
             .with_context(|| format!("Failed to parse config file: {config_path:?}"))?;
+        config.server_endpoint =
+            normalize_grpc_endpoint(std::mem::take(&mut config.server_endpoint));
 
         Ok(config)
     }
@@ -209,8 +215,10 @@ impl CacheConfig {
 
     /// Get default server endpoint
     fn get_default_server_endpoint() -> String {
-        env::var("MODEL_EXPRESS_SERVER_ENDPOINT")
-            .unwrap_or_else(|_| format!("http://localhost:{}", constants::DEFAULT_GRPC_PORT))
+        normalize_grpc_endpoint(
+            env::var("MODEL_EXPRESS_SERVER_ENDPOINT")
+                .unwrap_or_else(|_| format!("http://localhost:{}", constants::DEFAULT_GRPC_PORT)),
+        )
     }
 
     /// Get configuration file path
@@ -477,6 +485,19 @@ mod tests {
             config.transfer_chunk_size,
             constants::DEFAULT_TRANSFER_CHUNK_SIZE
         );
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_cache_config_new_accepts_bare_host_port() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let config = CacheConfig::new(
+            temp_dir.path().join("cache"),
+            Some("modelexpress-server:8001".to_string()),
+        )
+        .expect("Failed to create cache config");
+
+        assert_eq!(config.server_endpoint, "http://modelexpress-server:8001");
     }
 
     #[test]

--- a/modelexpress_common/src/client_config.rs
+++ b/modelexpress_common/src/client_config.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cache::CacheConfig;
-use crate::config::{ConnectionConfig, LogFormat, LogLevel, load_layered_config};
+use crate::config::{
+    ConnectionConfig, LogFormat, LogLevel, load_layered_config, normalize_grpc_endpoint,
+};
 use anyhow::Result;
 use clap::Parser;
 use config::ConfigError;
@@ -128,7 +130,7 @@ impl ClientConfig {
 
         // Connection settings
         if let Some(endpoint) = args.endpoint {
-            config.connection.endpoint = endpoint;
+            config.connection.endpoint = normalize_grpc_endpoint(endpoint);
         }
 
         if let Some(timeout) = args.timeout {
@@ -170,6 +172,11 @@ impl ClientConfig {
         }
 
         // ==================== END CLI ARGUMENT OVERRIDES ====================
+
+        config.connection.endpoint =
+            normalize_grpc_endpoint(std::mem::take(&mut config.connection.endpoint));
+        config.cache.server_endpoint =
+            normalize_grpc_endpoint(std::mem::take(&mut config.cache.server_endpoint));
 
         // Validate configuration
         config.validate()?;
@@ -243,6 +250,7 @@ impl ClientConfig {
 
     /// Set the server endpoint for both connection and cache
     pub fn with_endpoint(mut self, endpoint: String) -> Self {
+        let endpoint = normalize_grpc_endpoint(endpoint);
         self.connection.endpoint = endpoint.clone();
         self.cache.server_endpoint = endpoint;
         self
@@ -273,6 +281,17 @@ mod tests {
     fn test_client_config_with_endpoint() {
         let config =
             ClientConfig::default().with_endpoint("http://custom.example.com:5678".to_string());
+
+        assert_eq!(config.connection.endpoint, "http://custom.example.com:5678");
+        assert_eq!(
+            config.cache.server_endpoint,
+            "http://custom.example.com:5678"
+        );
+    }
+
+    #[test]
+    fn test_client_config_with_endpoint_accepts_bare_host_port() {
+        let config = ClientConfig::default().with_endpoint("custom.example.com:5678".to_string());
 
         assert_eq!(config.connection.endpoint, "http://custom.example.com:5678");
         assert_eq!(
@@ -379,7 +398,7 @@ mod tests {
         // Test that ClientConfig::load() properly applies CLI arguments
         let args = ClientArgs {
             config: None,
-            endpoint: Some("http://cli-override:7777".to_string()),
+            endpoint: Some("cli-override:7777".to_string()),
             timeout: Some(120),
             cache_path: None,
             log_level: None,

--- a/modelexpress_common/src/config.rs
+++ b/modelexpress_common/src/config.rs
@@ -337,6 +337,16 @@ pub struct ConnectionConfig {
     pub retry_delay_secs: Option<u64>,
 }
 
+pub fn normalize_grpc_endpoint(endpoint: impl Into<String>) -> String {
+    let endpoint = endpoint.into();
+    let endpoint = endpoint.trim();
+    if endpoint.is_empty() || endpoint.contains("://") {
+        endpoint.to_string()
+    } else {
+        format!("http://{endpoint}")
+    }
+}
+
 impl Default for ConnectionConfig {
     fn default() -> Self {
         Self {
@@ -351,7 +361,7 @@ impl Default for ConnectionConfig {
 impl ConnectionConfig {
     pub fn new(endpoint: impl Into<String>) -> Self {
         Self {
-            endpoint: endpoint.into(),
+            endpoint: normalize_grpc_endpoint(endpoint),
             timeout_secs: Some(crate::constants::DEFAULT_TIMEOUT_SECS),
             max_retries: Some(3),
             retry_delay_secs: Some(1),
@@ -413,6 +423,27 @@ mod tests {
         let config = ConnectionConfig::default();
         assert!(config.endpoint.contains("8001"));
         assert_eq!(config.timeout_secs, Some(30));
+    }
+
+    #[test]
+    fn test_normalize_grpc_endpoint_accepts_bare_host_port() {
+        assert_eq!(
+            normalize_grpc_endpoint("modelexpress-server:8001"),
+            "http://modelexpress-server:8001"
+        );
+        assert_eq!(
+            normalize_grpc_endpoint("http://modelexpress-server:8001"),
+            "http://modelexpress-server:8001"
+        );
+        assert_eq!(
+            normalize_grpc_endpoint(" modelexpress-server:8001 "),
+            "http://modelexpress-server:8001"
+        );
+        assert_eq!(
+            normalize_grpc_endpoint(" http://modelexpress-server:8001 "),
+            "http://modelexpress-server:8001"
+        );
+        assert_eq!(normalize_grpc_endpoint(" "), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Normalize ModelExpress Rust gRPC endpoints so callers can pass either `host:port` or `http://host:port`.

This matches the Python P2P client behavior and fixes cases where Dynamo sets `MODEL_EXPRESS_URL=modelexpress-server:8001`: Python P2P can connect, but the Rust client previously passed the bare value into tonic and failed with a transport error.

## Changes

- Add shared `normalize_grpc_endpoint()` helper in `modelexpress_common::config`.
- Apply normalization in `ConnectionConfig::new`, `ClientConfig::load`, `ClientConfig::with_endpoint`, and cache server endpoint construction/loading.
- Add regression coverage for bare `host:port` endpoint inputs.

## Validation

- `cargo fmt --check`
- `cargo test -p modelexpress-common --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency in gRPC server endpoint normalization across configuration layers.

* **Tests**
  * Expanded test coverage for endpoint configuration handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->