### PR TITLE
chore: remove stale UCX_TLS settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ docker-compose up --build
 | `MX_METADATA_BACKEND` | (required) | `redis` \| `kubernetes` |
 | `REDIS_URL` | `redis://localhost:6379` | Redis connection URL (`redis` backend only) |
 | `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server (P2P) |
-| `UCX_TLS` | `rc_x,rc,dc_x,dc,cuda_copy` | InfiniBand transports |
 
 ```bash
 cargo run --bin config_gen -- --output model-express.yaml

--- a/ci/k8s/client/sgl/manifest-azure.yaml
+++ b/ci/k8s/client/sgl/manifest-azure.yaml
@@ -15,7 +15,6 @@
 #
 # Azure A100-specific differences vs GCP/upstream:
 #   - rdma/ib resource limit exposes the InfiniBand RDMA device
-#   - UCX_TLS=rc_x,rc,dc_x,dc,cuda_copy for InfiniBand
 #   - MX_RDMA_NIC_PIN=auto for per-rank IB NIC pinning (ucx#11259)
 #   - nvidia.com/gpu + no-datadog tolerations for AKS A100 node pools
 #
@@ -112,8 +111,6 @@ spec:
               value: "mx-server:8000"
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/ci/k8s/client/trt-llm/manifest-azure.yaml
+++ b/ci/k8s/client/trt-llm/manifest-azure.yaml
@@ -20,7 +20,6 @@
 # Azure-specific differences vs GCP manifest:
 #   - No GKE multi-network annotations
 #   - rdma/ib resource limit exposes InfiniBand RDMA device (A100 SXM4 nodes)
-#   - UCX_TLS=rc_x,rc,dc_x,dc,cuda_copy for InfiniBand (no GID index needed)
 #   - MX_RDMA_NIC_PIN=auto for per-rank IB NIC pinning (workaround for ucx#11259)
 #   - nvidia.com/gpu + no-datadog tolerations for AKS A100 node pools (amd64)
 #
@@ -120,8 +119,6 @@ spec:
               value: "0.20"
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/ci/k8s/client/vllm/dynamo/manifest-azure-aggregated.yaml
+++ b/ci/k8s/client/vllm/dynamo/manifest-azure-aggregated.yaml
@@ -160,8 +160,6 @@ spec:
         # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
         - name: MX_RDMA_NIC_PIN
           value: "auto"
-        - name: UCX_TLS
-          value: "rc_x,rc,dc_x,dc,cuda_copy"
         - name: UCX_RNDV_SCHEME
           value: "get_zcopy"
         - name: UCX_RNDV_THRESH

--- a/ci/k8s/client/vllm/manifest-azure-multi-node-tp2.yaml
+++ b/ci/k8s/client/vllm/manifest-azure-multi-node-tp2.yaml
@@ -240,8 +240,6 @@ spec:
               value: "0"
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/ci/k8s/client/vllm/manifest-azure-tp2.yaml
+++ b/ci/k8s/client/vllm/manifest-azure-tp2.yaml
@@ -101,8 +101,6 @@ spec:
               value: "0"
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/ci/k8s/client/vllm/manifest-azure.yaml
+++ b/ci/k8s/client/vllm/manifest-azure.yaml
@@ -15,7 +15,6 @@
 # Azure-specific differences vs manifest-gcp.yaml:
 #   - No GKE multi-network annotations (not supported on AKS)
 #   - rdma/ib resource limit exposes InfiniBand RDMA device (A100 SXM4 nodes)
-#   - UCX_TLS=rc_x,rc,dc_x,dc,cuda_copy for InfiniBand (no GID index needed)
 #   - MX_RDMA_NIC_PIN=auto for per-rank IB NIC pinning (workaround for ucx#11259)
 #   - nvidia.com/gpu + no-datadog tolerations for AKS A100 node pools (amd64)
 #
@@ -110,8 +109,6 @@ spec:
               value: "0"
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/ci/k8s/client/vllm/manifest-gcp.yaml
+++ b/ci/k8s/client/vllm/manifest-gcp.yaml
@@ -15,7 +15,7 @@
 # GCP-specific additions vs the generic manifest:
 #   - GKE multi-network RDMA annotations attach rdma0-rdma3 interfaces
 #   - networking.gke.io.networks/rdma-* resource limits expose RDMA devices
-#   - UCX_TLS=cuda_ipc,cuda_copy,rc + UCX_IB_GID_INDEX=3 for GKE RoCE
+#   - UCX_IB_GID_INDEX=3 for GKE RoCE
 #   - 64Gi /dev/shm emptyDir for vLLM inter-process shared memory
 #
 # Environment variables substituted by envsubst before each apply:
@@ -89,8 +89,6 @@ spec:
               value: "mx-server:8000"
             - name: MX_CONTIGUOUS_REG
               value: "0"
-            - name: UCX_TLS
-              value: "cuda_ipc,cuda_copy,rc"
             - name: UCX_IB_GID_INDEX
               value: "3"
             - name: UCX_RNDV_SCHEME

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -754,7 +754,6 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 
 | Variable | Recommended | Description |
 |----------|-------------|-------------|
-| `UCX_TLS` | `rc_x,rc,dc_x,dc,cuda_copy` | Transport layers for InfiniBand |
 | `UCX_RNDV_SCHEME` | `get_zcopy` | Zero-copy RDMA reads |
 | `UCX_RNDV_THRESH` | `0` | Force rendezvous for all transfers |
 | `NIXL_LOG_LEVEL` | `INFO` | NIXL logging (DEBUG for troubleshooting) |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -487,7 +487,6 @@ Credentials are auto-detected by the underlying cloud SDKs. No credentials flow 
 
 | Variable | Recommended | Description |
 |----------|-------------|-------------|
-| `UCX_TLS` | `rc_x,rc,dc_x,dc,cuda_copy` | Transport layers for InfiniBand |
 | `UCX_RNDV_SCHEME` | `get_zcopy` | Zero-copy RDMA reads |
 | `UCX_RNDV_THRESH` | `0` | Force rendezvous for all transfers |
 | `NIXL_LOG_LEVEL` | `INFO` | NIXL logging (DEBUG for troubleshooting) |

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -118,8 +118,6 @@ spec:
           value: "INFO"
         - name: UCX_LOG_LEVEL
           value: "INFO"
-        - name: UCX_TLS
-          value: "rc_x,rc,dc_x,dc,cuda_copy"
         # Optional: pin UCX to specific compute-fabric HCAs if your cluster
         # exposes multiple IB fabrics. Device list is cluster-specific.
         # - name: UCX_NET_DEVICES

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -106,8 +106,6 @@ spec:
           value: "INFO"
         - name: UCX_LOG_LEVEL
           value: "INFO"
-        - name: UCX_TLS
-          value: "rc_x,rc,dc_x,dc,cuda_copy"
         # Optional: pin UCX to specific compute-fabric HCAs if your cluster
         # exposes multiple IB fabrics. Device list is cluster-specific.
         # - name: UCX_NET_DEVICES
@@ -180,9 +178,7 @@ spec:
           value: "INFO"
         - name: UCX_LOG_LEVEL
           value: "INFO"
-        - name: UCX_TLS
-          value: "rc_x,rc,dc_x,dc,cuda_copy"
-        # Optional UCX_NET_DEVICES — see decode block.
+        # Optional UCX_NET_DEVICES - see decode block.
         - name: UCX_RNDV_SCHEME
           value: "get_zcopy"
         - name: UCX_RNDV_THRESH

--- a/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
@@ -89,8 +89,6 @@ spec:
               value: "INFO"
             - name: UCX_LOG_LEVEL
               value: "INFO"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/examples/p2p_transfer_k8s/client/trtllm/README.md
+++ b/examples/p2p_transfer_k8s/client/trtllm/README.md
@@ -205,7 +205,6 @@ securityContext:
 
 env:
   HOME: /root                   # Fix SSH host key path mismatch
-  UCX_TLS: "self,sm,rc,cuda_copy,gdr_copy,tcp"
   UCX_IB_GID_INDEX: "3"        # GCP RoCEv2 GID selection
   TRTLLM_UCX_INTERFACE: eth0    # Prevent 169.254.x.x binding
   OMPI_MCA_pml: ob1             # Bypass UCX UD for MPI

--- a/examples/p2p_transfer_k8s/client/trtllm/kimi-disagg-mx-tp8-dgd.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/kimi-disagg-mx-tp8-dgd.yaml
@@ -288,8 +288,6 @@ spec:
             # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "cuda_ipc,cuda_copy,rc"
             - name: UCX_IB_GID_INDEX
               value: "3"
             - name: UCX_RC_TIMEOUT
@@ -495,8 +493,6 @@ spec:
             # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "cuda_ipc,cuda_copy,rc"
             - name: UCX_IB_GID_INDEX
               value: "3"
             - name: UCX_RC_TIMEOUT

--- a/examples/p2p_transfer_k8s/client/trtllm/kimi-source-decode-dgd.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/kimi-source-decode-dgd.yaml
@@ -144,8 +144,6 @@ spec:
             # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
             - name: MX_RDMA_NIC_PIN
               value: "auto"
-            - name: UCX_TLS
-              value: "self,sm,rc,cuda_copy,gdr_copy,tcp"
             - name: UCX_IB_GID_INDEX
               value: "3"
             - name: OMPI_MCA_pml

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-multi-node.yaml
@@ -107,8 +107,6 @@ spec:
               value: "INFO"
             - name: UCX_LOG_LEVEL
               value: "INFO"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node-p2p.yaml
@@ -83,8 +83,6 @@ spec:
               value: "INFO"
             - name: UCX_LOG_LEVEL
               value: "INFO"
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/vllm-single-node.yaml
@@ -78,9 +78,6 @@ spec:
               value: "INFO"
             - name: UCX_LOG_LEVEL
               value: "INFO"
-            # UCX transport settings for GPUDirect RDMA
-            - name: UCX_TLS
-              value: "rc_x,rc,dc_x,dc,cuda_copy"
             - name: UCX_RNDV_SCHEME
               value: "get_zcopy"
             - name: UCX_RNDV_THRESH

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -92,7 +92,6 @@ register_modelexpress_loaders()
 
 | Variable | Recommended | Description |
 |----------|-------------|-------------|
-| `UCX_TLS` | `rc_x,rc,dc_x,dc,cuda_copy` | Transport layers for InfiniBand |
 | `UCX_RNDV_SCHEME` | `get_zcopy` | Zero-copy RDMA reads |
 | `UCX_RNDV_THRESH` | `0` | Force rendezvous for all transfers |
 | `NIXL_LOG_LEVEL` | `INFO` | NIXL logging level |


### PR DESCRIPTION
The MX python helper at modelexpress_client/python/modelexpress/nixl_transfer.py
lets UCX auto-detect transports and only touches UCX_TLS to strip the
legacy "tcp" value or honor NIXL_UCX_TLS overrides. Example and CI
manifests, plus the env-var tables in docs, still carried explicit
UCX_TLS values from earlier iterations, mostly rc_x,rc,dc_x,dc,cuda_copy
with a few non-default variants, which conflicts with library intent
and can cause UCX wireup to fail with `select.c:657 no active messages
transport` when the allowlist omits an AM-capable transport for any
source/destination pair.

Removed UCX_TLS env entries from 7 example manifests under
examples/p2p_transfer_k8s and examples/dynamo_p2p_transfer_k8s and 7 CI
manifests under ci/k8s/client, along with the matching header-comment
lines that described UCX_TLS as part of the Azure/GCP per-cluster
config. Removed the UCX_TLS row from the env-var recommendation tables
in README.md, docs/DEPLOYMENT.md, docs/ARCHITECTURE.md, and
modelexpress_client/python/README.md. Dropped the UCX_TLS line from
the env example block in examples/p2p_transfer_k8s/client/trtllm/README.md.
Fixed an unrelated em-dash in a comment in
vllm-single-node-disaggregated.yaml encountered while editing the same
block.

The MX_RDMA_NIC_PIN=auto and UCX_RNDV_* / UCX_IB_GID_INDEX env vars
stay - they are real recommendations or cluster-specific requirements.
The nixl_transfer.py save/restore behavior is unchanged.

Signed-off-by: Nicolas 'Pixel' Noble <nicolas@nobis-crew.org>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guides, architecture documentation, and configuration references with refreshed environment variable settings.
  * Refreshed all Kubernetes manifest examples and sample configurations with current recommended practices.

* **Configuration Updates**
  * Modified container environment variables across CI/CD jobs and deployment examples for improved performance and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->