### PR TITLE
chore: bump version from 0.3.0 to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "model-express-workspace-tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Model Express: High-performance model serving and management"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -38,9 +38,9 @@ hf-hub = { version = "0.4.3", default-features = false, features = [
     "rustls-tls",
 ] }
 jiff = { version = "0.2.15", features = ["serde"] }
-modelexpress-common = { path = "modelexpress_common", version = "0.3.0" }
-modelexpress-client = { path = "modelexpress_client", version = "0.3.0" }
-modelexpress-server = { path = "modelexpress_server", version = "0.3.0" }
+modelexpress-common = { path = "modelexpress_common", version = "0.4.0" }
+modelexpress-client = { path = "modelexpress_client", version = "0.4.0" }
+modelexpress-server = { path = "modelexpress_server", version = "0.4.0" }
 once_cell = "1.21.3"
 prost = "0.13"
 rustls = { version = "0.23.37", default-features = false, features = ["ring", "std"] }

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -30,7 +30,7 @@ Every source is identified by a `SourceIdentity` proto containing all fields tha
 
 | Field | Example | Purpose |
 |-------|---------|---------|
-| `mx_version` | `"0.3.0"` | Format compatibility across upgrades |
+| `mx_version` | `"0.4.0"` | Format compatibility across upgrades |
 | `mx_source_type` | `WEIGHTS`, `LORA`, `CUDA_GRAPH` | Type of tensors being served |
 | `model_name` | `"deepseek-ai/DeepSeek-V3"` | Model identifier |
 | `backend_framework` | `VLLM`, `SGLANG`, `TRT_LLM` | Inference framework |
@@ -189,7 +189,7 @@ No Redis TTL is applied to keys. P2P stale detection and cleanup are handled by 
 ```
 # Source index -- identity stored once, workers as presence markers
 mx:source:a1b2c3d4e5f67890
-  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.3.0",...}
+  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.4.0",...}
   f3a2b1c4        ->  "0"    # worker_id f3a2b1c4, global rank 0
   e7d6c5b8        ->  "1"    # worker_id e7d6c5b8, global rank 1
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: modelexpress
 description: A Helm chart for ModelExpress - a AI model cache management service
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"
 keywords:
   - model-serving
   - ai

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modelexpress"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python client for ModelExpress P2P GPU transfer service"
 readme = "README.md"
 license = "Apache-2.0"

--- a/modelexpress_client/python/tests/test_k8s_service_client.py
+++ b/modelexpress_client/python/tests/test_k8s_service_client.py
@@ -22,7 +22,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.3.0",
+        mx_version="0.4.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/tests/test_source_id.py
+++ b/modelexpress_client/python/tests/test_source_id.py
@@ -17,7 +17,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.3.0",
+        mx_version="0.4.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/tests/test_source_id.py
+++ b/modelexpress_client/python/tests/test_source_id.py
@@ -75,13 +75,13 @@ def test_extra_parameters_sorted():
 # ---------------------------------------------------------------------------
 
 def test_pinned_hash_base_identity():
-    assert compute_mx_source_id(_base_identity()) == "b0c2c67edeaefc20"
+    assert compute_mx_source_id(_base_identity()) == "e2438ef16adcf628"
 
 
 def test_pinned_hash_with_revision():
     pinned = _base_identity()
     pinned.revision = "abc123def4567890"
-    assert compute_mx_source_id(pinned) == "40704b34e4b7deaa"
+    assert compute_mx_source_id(pinned) == "7b7803769825576e"
 
 
 def test_case_colliding_extra_parameters_are_deterministic():
@@ -97,4 +97,4 @@ def test_case_colliding_extra_parameters_are_deterministic():
     b.extra_parameters["foo"] = "b"
     b.extra_parameters["Foo"] = "a"
     assert compute_mx_source_id(a) == compute_mx_source_id(b)
-    assert compute_mx_source_id(a) == "bd9ea6c70d83fef1"
+    assert compute_mx_source_id(a) == "deecf6684507f09c"

--- a/modelexpress_client/python/uv.lock
+++ b/modelexpress_client/python/uv.lock
@@ -893,7 +893,7 @@ wheels = [
 
 [[package]]
 name = "modelexpress"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },

--- a/modelexpress_server/src/p2p/backend/redis.rs
+++ b/modelexpress_server/src/p2p/backend/redis.rs
@@ -682,7 +682,7 @@ mod tests {
 
     fn test_identity() -> modelexpress_common::grpc::p2p::SourceIdentity {
         modelexpress_common::grpc::p2p::SourceIdentity {
-            mx_version: "0.3.0".to_string(),
+            mx_version: "0.4.0".to_string(),
             mx_source_type: 0,
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1,
@@ -702,7 +702,7 @@ mod tests {
         let attr = SourceAttributesJson::from(&id);
 
         assert_eq!(attr.model_name, "deepseek-ai/DeepSeek-V3");
-        assert_eq!(attr.mx_version, "0.3.0");
+        assert_eq!(attr.mx_version, "0.4.0");
         assert_eq!(attr.tensor_parallel_size, 8);
         assert_eq!(attr.pipeline_parallel_size, 2);
         assert_eq!(attr.expert_parallel_size, 4);

--- a/modelexpress_server/src/p2p/service.rs
+++ b/modelexpress_server/src/p2p/service.rs
@@ -298,7 +298,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.3.0".to_string(),
+            mx_version: "0.4.0".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,

--- a/modelexpress_server/src/p2p/source_identity.rs
+++ b/modelexpress_server/src/p2p/source_identity.rs
@@ -69,7 +69,7 @@ mod tests {
 
     fn base_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.3.0".to_string(),
+            mx_version: "0.4.0".to_string(),
             mx_source_type: 0, // Weights (default)
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1, // vllm

--- a/modelexpress_server/src/p2p/source_identity.rs
+++ b/modelexpress_server/src/p2p/source_identity.rs
@@ -180,14 +180,14 @@ mod tests {
     // the mismatch is caught in CI.
     #[test]
     fn test_python_cross_check_base_identity() {
-        assert_eq!(compute_mx_source_id(&base_identity()), "b0c2c67edeaefc20");
+        assert_eq!(compute_mx_source_id(&base_identity()), "e2438ef16adcf628");
     }
 
     #[test]
     fn test_python_cross_check_with_revision() {
         let mut pinned = base_identity();
         pinned.revision = "abc123def4567890".to_string();
-        assert_eq!(compute_mx_source_id(&pinned), "40704b34e4b7deaa");
+        assert_eq!(compute_mx_source_id(&pinned), "7b7803769825576e");
     }
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
             .insert("Foo".to_string(), "a".to_string());
         id.extra_parameters
             .insert("foo".to_string(), "b".to_string());
-        assert_eq!(compute_mx_source_id(&id), "bd9ea6c70d83fef1");
+        assert_eq!(compute_mx_source_id(&id), "deecf6684507f09c");
     }
 
     #[test]

--- a/modelexpress_server/src/p2p/state.rs
+++ b/modelexpress_server/src/p2p/state.rs
@@ -199,7 +199,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.3.0".to_string(),
+            mx_version: "0.4.0".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,


### PR DESCRIPTION
## Summary
- Bumps workspace package version, Cargo.lock, Python client `pyproject.toml`, and helm `Chart.yaml` (version + appVersion) from 0.3.0 to 0.4.0
- Updates `mx_version` test fixtures across `modelexpress_server/src/p2p/*` and `modelexpress_client/python/tests/` and example values in `docs/metadata.md`
- Public-image references are intentionally **not** bumped here: `examples/**/*.yaml` image tags, `helm/values*.yaml` `image.tag`, `helm/README.md` image refs, and the CI manifest comment in `ci/k8s/client/vllm/dynamo/manifest-azure-aggregated.yaml` all stay at 0.3.0. Those land on the `release3` branch once the 0.4.0 container image is published and get merged back to main.

## Test plan
- [ ] `cargo check --workspace` (already run locally during bump)
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes (covers the bumped `mx_version` fixtures)
- [ ] Python client tests pass with the new fixture version
- [ ] `helm lint helm/` against the bumped Chart.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped from 0.3.0 to 0.4.0 across the entire application, documentation, and deployment infrastructure.
  * Updated Helm chart versions, client package versions, and internal dependency references to maintain consistency across the workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->