### PR TITLE
fix(vllm): use torch.distributed world rank for MX worker_rank

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -39,7 +39,7 @@ class VllmAdapter(EngineAdapter):
         return build_source_identity(self.vllm_config, self.model_config)
 
     def get_worker_rank(self) -> int:
-        return _get_vllm_worker_rank(self.vllm_config)
+        return _get_vllm_worker_rank(self.vllm_config, self.target_device)
 
     def get_global_rank(self) -> int:
         return get_global_rank(self.target_device)
@@ -199,24 +199,19 @@ def _set_load_config_extra_config(load_config, extra_config: dict) -> None:
         object.__setattr__(load_config, "model_loader_extra_config", extra_config)
 
 
-def _get_vllm_worker_rank(vllm_config: VllmConfig) -> int:
-    """Return the vLLM model-shard key used for source/target matching.
+def _get_vllm_worker_rank(
+    vllm_config: VllmConfig, target_device: torch.device
+) -> int:
+    """Return the vLLM model-shard key (torch.distributed world rank).
 
-    vLLM's parallel_config.rank is flattened in model-parallel order. Modulo the
-    model-parallel size keeps the TP/PP shard identity and ignores DP replicas,
-    whose weights are interchangeable.
+    Falls back to vllm_config.parallel_config.rank when torch.distributed is
+    not initialised and the target device has no index (pre-init / bare-cuda
+    test paths), so workers in the same DP still get distinct keys.
     """
-    parallel_config = vllm_config.parallel_config
-    rank = parallel_config.rank
-    tp_size = int(parallel_config.tensor_parallel_size)
-    pp_size = int(parallel_config.pipeline_parallel_size)
-    model_parallel_size = max(1, tp_size * pp_size)
-    worker_rank = int(rank) % model_parallel_size
-    logger.debug(
-        "Got vLLM worker rank from parallel_config: "
-        "rank=%d worker_rank=%d model_parallel_size=%d",
-        rank, worker_rank, model_parallel_size,
-    )
+    worker_rank = get_global_rank(target_device)
+    if worker_rank == 0 and target_device.index is None:
+        worker_rank = int(vllm_config.parallel_config.rank)
+    logger.debug("vLLM worker rank: %d", worker_rank)
     return worker_rank
 
 

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -5,6 +5,7 @@
 
 import sys
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
@@ -26,20 +27,43 @@ def _vllm_config(*, rank: int, tp_size: int, pp_size: int):
     )
 
 
-def test_worker_rank_uses_vllm_model_parallel_rank():
-    # vLLM rank layout is DP x PP x TP. Modulo TP*PP keeps PP/TP shard
-    # identity and drops the DP component.
-    config = _vllm_config(rank=6, tp_size=4, pp_size=2)
+def test_worker_rank_uses_torch_distributed_global_rank():
+    config = _vllm_config(rank=2, tp_size=4, pp_size=2)
+    device = torch.device("cuda", 0)
 
-    assert _get_vllm_worker_rank(config) == 6
+    with patch("torch.distributed.is_initialized", return_value=True), patch(
+        "torch.distributed.get_rank", return_value=6,
+    ):
+        assert _get_vllm_worker_rank(config, device) == 6
 
 
-def test_worker_rank_ignores_dp_component():
-    dp0 = _vllm_config(rank=5, tp_size=4, pp_size=2)
-    dp1 = _vllm_config(rank=13, tp_size=4, pp_size=2)
+def test_worker_rank_distinguishes_dp_replicas():
+    config = _vllm_config(rank=0, tp_size=4, pp_size=2)
+    device = torch.device("cuda", 0)
 
-    assert _get_vllm_worker_rank(dp0) == 5
-    assert _get_vllm_worker_rank(dp1) == 5
+    with patch("torch.distributed.is_initialized", return_value=True), patch(
+        "torch.distributed.get_rank", return_value=5,
+    ):
+        dp0_rank = _get_vllm_worker_rank(config, device)
+
+    with patch("torch.distributed.is_initialized", return_value=True), patch(
+        "torch.distributed.get_rank", return_value=13,
+    ):
+        dp1_rank = _get_vllm_worker_rank(config, device)
+
+    assert dp0_rank == 5
+    assert dp1_rank == 13
+
+
+def test_worker_rank_falls_back_to_parallel_config_rank_pre_init():
+    # Pre-init / bare-cuda path: torch.distributed not initialised AND device
+    # has no index. Falls back to parallel_config.rank so workers in the same
+    # DP still get distinct keys.
+    config = _vllm_config(rank=3, tp_size=4, pp_size=2)
+    bare_device = torch.device("cuda")
+
+    with patch("torch.distributed.is_initialized", return_value=False):
+        assert _get_vllm_worker_rank(config, bare_device) == 3
 
 
 def test_vllm_device_id_uses_current_platform_device(monkeypatch):


### PR DESCRIPTION
## Summary

`worker_rank` in the vLLM adapter now uses `torch.distributed.get_rank()` (world rank) instead of `parallel_config.rank % (tp_size * pp_size)`. Fixes MX P2P weight loading for MoE deployments with DP > 1.

## Validation

Mistral-Small-4-119B-2603, TP=4 DP=2, FP8 MoE, GSM8K 5-shot.

| Condition | Iters | Byte-identical | Mean acc drop |
|---|---|---|---|
| Pre-fix (EP off) | 24 | 4 / 24 | +0.173 (worst +0.70) |
| Post-fix EP off | 32 | 32 / 32 | -0.001 |
| Post-fix EP on  | 10 | 10 / 10 | +0.002 |

## Test plan

- [x] vLLM adapter unit tests updated
- [x] 42 / 42 post-fix GSM8K iters byte-identical with acc within noise vs seed

SGLang adapter not changed in this PR (defer to a follow-up once a SGLang multi-DP MoE deployment is available to validate against).