### PR TITLE
ci: add ci-status-check umbrella job for branch protection

### DIFF
--- a/.github/workflows/modelexpress-ci-tests.yml
+++ b/.github/workflows/modelexpress-ci-tests.yml
@@ -3,7 +3,7 @@
 
 # ModelExpress K8s CI.
 #
-# Eight jobs:
+# Nine jobs:
 #   build-server        — builds and pushes the MX coordination server image
 #                         from ci/k8s/server/Dockerfile.server. Runs on the
 #                         self-hosted builder runner
@@ -63,6 +63,12 @@
 #                          launch command. Uncomment the sglang matrix entry
 #                          once both are addressed.
 #
+#   ci-status-check     — umbrella job that needs every gating job above.
+#                         Single check that the branch-protection rule on
+#                         `main` requires; adding a new gating job means
+#                         appending it to this job's `needs:` list, no
+#                         branch-protection reconfigure needed.
+#
 # To add a new inference engine:
 #   1. Add ci/k8s/client/<engine>/Dockerfile
 #   2. Add ci/k8s/client/<engine>/manifest-*.yaml + test_p2p_k8s.py
@@ -73,6 +79,9 @@
 #   5. If the engine also runs under a Dynamo DGD (`dynamo-<engine>`), add it
 #      to the build-client matrix with the dynamo-specific Dockerfile and
 #      consider extending test-with-dynamo to a matrix.
+#   6. If you add a new top-level test job (not just a matrix entry), add
+#      its job key to `ci-status-check`'s `needs:` list so it's covered by
+#      the branch-protection gate.
 #
 # Required secrets:
 #   AZURE_AKS_CI_KUBECONFIG_B64   — base64-encoded kubeconfig for the AKS host cluster
@@ -684,3 +693,44 @@ jobs:
           s3_bucket: ${{ env.MX_CI_S3_BUCKET }}
           s3_region: ${{ env.MX_CI_S3_REGION }}
           hf_token: ${{ secrets.HF_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Umbrella status check for branch protection.
+  #
+  # Aggregates the result of every gating job in this workflow into a single
+  # check that GitHub's branch-protection rule on `main` requires. The
+  # indirection lets us add or remove gating jobs by editing only the `needs:`
+  # list below — no need to update the branch-protection configuration in the
+  # GitHub repo settings every time.
+  #
+  # `if: always()` is load-bearing: without it, a failed dependency would
+  # mark this job as `skipped`, which GitHub branch protection treats as
+  # `pending` indefinitely, blocking the PR forever. With `always()`, the
+  # job runs and the bash check below decides pass/fail based on each
+  # dependency's `.result`.
+  #
+  # `success` and `skipped` are both accepted as "passing":
+  #   - `success` is the happy path
+  #   - `skipped` accommodates conditional jobs (e.g., a job behind a
+  #     changed-files filter that legitimately didn't need to run). None of
+  #     our gating jobs are skippable today, but the allowance future-proofs
+  #     the gate without forcing a reconfigure.
+  # ---------------------------------------------------------------------------
+  ci-status-check:
+    name: CI status check
+    runs-on: ubuntu-latest
+    needs:
+      - build-server
+      - build-client
+      - ensure-vcluster
+      - test-p2p
+      - test-tp
+      - test-with-dynamo
+      - test-stale-metadata
+      - model-streamer
+    if: always()
+    steps:
+      - name: All dependent jobs succeeded (or skipped)
+        run: |
+          echo '${{ toJson(needs) }}' \
+            | jq -e 'to_entries | map(.value.result) | all(. as $r | ["success", "skipped"] | any($r == .))'

--- a/ci/k8s/client/kube_utils.py
+++ b/ci/k8s/client/kube_utils.py
@@ -58,14 +58,27 @@ def port_forward(namespace: str, target: str, local_port: int, remote_port: int)
     )
     try:
         deadline = time.perf_counter() + 60
+        ready = False
         while time.perf_counter() < deadline:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.settimeout(2)
                 try:
                     sock.connect(("localhost", local_port))
+                    ready = True
                     break
                 except (ConnectionRefusedError, socket.timeout, OSError):
                     time.sleep(1)
+        if not ready:
+            # Without this raise, the with-block proceeds with a port that
+            # nothing's listening on, and the caller's first operation
+            # surfaces an opaque "connection refused" several frames removed
+            # from the real cause. Failing loudly here keeps the blame on
+            # the port-forward setup rather than on the test logic.
+            raise TimeoutError(
+                f"kubectl port-forward in namespace {namespace} to {target} "
+                f"(local:{local_port} -> remote:{remote_port}) "
+                f"not ready after 60s"
+            )
         yield local_port
     finally:
         proc.terminate()


### PR DESCRIPTION
## Summary

Two small CI follow-ups, bundled because they're both low-risk and addressed via the same workflow + test infrastructure that landed in #297.

The first adds a `ci-status-check` umbrella job to `modelexpress-ci-tests.yml`. It depends on every gating job in the workflow and reports a single status that the branch-protection rule on `main` will reference. The indirection means adding or removing gating jobs only requires editing the `needs:` list here — no need to touch the GitHub branch-protection configuration each time. Pattern is adopted from [ai-dynamo/dynamo's pr.yaml](https://github.com/ai-dynamo/dynamo/blob/main/.github/workflows/pr.yaml#L52-L81).

The second tightens the failure mode of the shared `port_forward` context manager in `kube_utils.py`. Previously the readiness loop polled for up to 60s and then yielded the local port regardless of whether kubectl actually established the forward — the caller's first operation would surface an opaque "connection refused" several frames removed from the real cause. Now a `ready` flag is tracked across the loop, and if the deadline elapses without a successful TCP connect, the context manager raises `TimeoutError` with the namespace, target, and ports in the message. The `finally` block still tears down the kubectl process on the raise.

## Changes

- `.github/workflows/modelexpress-ci-tests.yml` — new `ci-status-check` job at the end of the file; `if: always()` + a bash/jq check that asserts every dependency's `.result` is `success` or `skipped`. Header comment bumped from 8 jobs → 9 with the new job described; "to add a new inference engine" section gains a step reminding to append new gating jobs to `needs:`.
- `ci/k8s/client/kube_utils.py` — `port_forward` raises `TimeoutError` when the readiness probe never succeeds within the 60s window.

## Branch protection follow-up (repo settings, not in this PR)

After this lands:
1. Repo → Settings → Branches → Edit the `main` rule
2. Enable "Require status checks to pass before merging"
3. Search for `CI status check` and tick it
4. Save


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port forwarding timeout detection with explicit error reporting when connections fail to establish within 60 seconds.

* **Chores**
  * Enhanced CI/CD workflow documentation and added umbrella status gate to ensure all tests pass before allowing merges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->