### PR TITLE
chore(release): bump example and helm image tags to 0.4.0

### DIFF
--- a/examples/dynamo_model_cache_k8s/agg.yaml
+++ b/examples/dynamo_model_cache_k8s/agg.yaml
@@ -97,7 +97,7 @@ spec:
           runAsGroup: 1000
           fsGroup: 1000
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: MODEL_EXPRESS_SERVER_PORT

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -49,7 +49,7 @@ spec:
       extraPodSpec:
         serviceAccountName: modelexpress
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
           command:
             - /bin/sh
             - -c

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -43,7 +43,7 @@ spec:
       extraPodSpec:
         serviceAccountName: modelexpress
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
           command:
             - /bin/sh
             - -c

--- a/examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml
@@ -77,7 +77,7 @@ spec:
           effect: NoExecute
       containers:
         - name: server
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
           ports:
             - containerPort: 8001
           env:

--- a/examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml
+++ b/examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: modelexpress
       containers:
         - name: modelexpress-server
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8001

--- a/examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml
+++ b/examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml
@@ -75,7 +75,7 @@ spec:
 
       containers:
         - name: modelexpress-server
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8001

--- a/helm/README.md
+++ b/helm/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the ModelExpress chart 
 | `replicaCount`                               | Number of ModelExpress replicas                | `1`     |
 | `image.repository`                           | ModelExpress image repository                  | `nvcr.io/nvidia/ai-dynamo/modelexpress-server` |
 | `image.pullPolicy`                           | Image pull policy                              | `IfNotPresent` |
-| `image.tag`                                  | ModelExpress image tag                         | `0.3.0` |
+| `image.tag`                                  | ModelExpress image tag                         | `0.4.0` |
 | `imagePullSecrets`                           | Image pull secrets for nvcr.io access          | `[]`     |
 | `nameOverride`                               | Override the chart name                        | `""`     |
 | `fullnameOverride`                           | Override the full app name                     | `""`     |
@@ -295,7 +295,7 @@ The Helm chart uses the official NVIDIA ModelExpress image from the NVIDIA Conta
 docker login nvcr.io -u '$oauthtoken' -p 'YOUR_NVCR_API_KEY'
 
 # Pull the image
-docker pull nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+docker pull nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
 ```
 
 **Note:** The default image requires authentication. See the [Installation](#installation) section for creating the required Kubernetes secret.

--- a/helm/test-values.yaml
+++ b/helm/test-values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  tag: "0.4.0"
 
 serviceAccount:
   create: true

--- a/helm/values-development.yaml
+++ b/helm/values-development.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  tag: "0.4.0"
 
 serviceAccount:
   create: true

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -7,7 +7,7 @@ replicaCount: 3
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: Always
-  tag: "0.3.0"
+  tag: "0.4.0"
 
 serviceAccount:
   create: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  tag: "0.4.0"
 
 imagePullSecrets:
   - name: nvcr-secret


### PR DESCRIPTION
## Summary

Release housekeeping for the `release/0.4.0` branch — bumps the `modelexpress-server` NGC image tag from `0.3.0` to `0.4.0` in places that were deferred until the release branch was cut.

**Examples (6 manifests):**
- `examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml`
- `examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml`
- `examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml`
- `examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml`
- `examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml`
- `examples/dynamo_model_cache_k8s/agg.yaml`

**Helm (5 files):**
- `helm/values.yaml`, `helm/values-development.yaml`, `helm/values-production.yaml`, `helm/test-values.yaml` — default `image.tag`
- `helm/README.md` — default-tag column + a `docker pull` example

`helm/Chart.yaml` was already on `0.4.0`; only the image-tag defaults inside the `values*.yaml` files were stale.

Out of scope (flagged but intentionally not bumped):
- `vllm-runtime:1.0.1` in `examples/dynamo_p2p_transfer_k8s/Dockerfile` is older than the `1.1.x` used elsewhere — that's a separate compatibility decision, not MX 0.4.0 housekeeping.
- Other non-MX pins (`redis:7-alpine`, `python:3.11-slim`, `curlimages/curl:8.9.1`, EFA `3.0.0g`, vLLM `0.18.0` mentions) — left alone.
- Cargo crate versions in `ATTRIBUTIONS_Rust.md` that incidentally contain `0.3.0` — unrelated.
- One CI manifest comment that explicitly contrasts against `nvcr.io/0.3.0` — bumping would invert the meaning.

## Test plan

- [x] `grep -rn "modelexpress-server:0\.3\.0" .` returns zero hits.
- [x] `grep -rn "tag: \"0\.3\.0\"" helm/` returns zero hits.
- [ ] Smoke-deploy with `helm install … helm/` and confirm the `0.4.0` image pulls (will require nvcr auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)