### PR TITLE
chore: bump version from 0.4.0 to 0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,89 @@ Client CLI arguments are defined in a shared struct to avoid duplication:
 4. Implement the service trait in `modelexpress_server/src/` (new file or existing)
 5. Register the service in `modelexpress_server/src/main.rs` during server startup
 
+## Bumping the ModelExpress Version
+
+ModelExpress version strings split into two categories with different bump
+cadences. **Confusing them is the most common mistake** — public-image
+references on `main` pointing at a tag that doesn't yet exist sends users
+at a broken pull.
+
+### On `main` (e.g. 0.4.0 → 0.5.0)
+
+Bump the workspace/chart version and the protocol-version fixtures. **Do
+not** touch any reference to the public release container image.
+
+Files to bump:
+
+- `Cargo.toml` — `[workspace.package].version` and the three internal
+  `modelexpress-{common,client,server}` path-dep `version =` entries.
+- `Cargo.lock` — regenerate with `cargo update --workspace` (touches only
+  our four crates: `modelexpress-{common,client,server}` plus
+  `model-express-workspace-tests`).
+- `modelexpress_client/python/pyproject.toml` — `[project].version`.
+- `modelexpress_client/python/uv.lock` — regenerate with `uv lock`
+  (from `modelexpress_client/python/`).
+- `helm/Chart.yaml` — `version` and `appVersion` (chart version tracks
+  the workspace; chart image tag does not — see below).
+- `docs/metadata.md` — `mx_version` example values (search the file for
+  the old version literal; expect ~2 hits).
+- `modelexpress_server/src/p2p/{source_identity,state,service}.rs` and
+  `modelexpress_server/src/p2p/backend/redis.rs` — `mx_version` strings
+  in `mod tests` fixtures.
+- `modelexpress_client/python/tests/test_source_id.py` and
+  `test_k8s_service_client.py` — `mx_version` strings in test fixtures.
+
+`mx_version` is part of the `SourceIdentity` proto, which is hashed into
+the `mx_source_id`. After bumping the version literals, the pinned
+source-id assertions break. Capture the new hashes by running the
+failing tests:
+
+```bash
+cd modelexpress_client/python && .venv/bin/python -m pytest \
+  tests/test_source_id.py -v -k "pinned_hash or case_colliding"
+```
+
+Update the three Python assertions in `tests/test_source_id.py` and the
+three matching Rust assertions in
+`modelexpress_server/src/p2p/source_identity.rs` (search for
+`test_python_cross_check_*`) so both sides cross-check on the new hashes.
+
+Verify end-to-end before committing:
+
+```bash
+cargo check --workspace --tests
+cd modelexpress_client/python && .venv/bin/python -m pytest tests/
+```
+
+### Public-image tag references — separate cadence
+
+These references point at the public release container on NGC. They lag
+behind the workspace version because the container has to be built and
+published first:
+
+- `examples/**/*.yaml` — `image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:<tag>`
+- `helm/values*.yaml` — `image.tag`
+- `helm/README.md` — `image.tag` row + `docker pull` example
+- Any CI manifest comment that contrasts against `nvcr.io/<old_tag>` for
+  context (e.g. `ci/k8s/client/vllm/dynamo/manifest-azure-aggregated.yaml`)
+
+Lifecycle:
+
+1. Bump the workspace/Python/Helm-chart version on `main` (this section's
+   primary procedure). Image-tag references are left untouched.
+2. Cut the `release/<X.Y.Z>` branch from `main`. The branch inherits the
+   still-stale image-tag references.
+3. After the release tag is set and the container is published on NGC,
+   bump the image-tag references on the release branch
+   (e.g. `harrison/bump-examples-<X.Y.Z>` against `release/<X.Y.Z>`).
+4. Cherry-pick that image-tag-bump commit back to `main`. This is the
+   only time image-tag refs change on `main`, and only ever after the
+   container actually exists on NGC.
+
+Pulling references at a tag that doesn't yet exist on NGC sends users
+at a broken `docker pull`, which is why these never move ahead of the
+container publish.
+
 ## Git Workflow
 
 Feature branches use `<username>/feature-name` format, forked from `main`.
@@ -100,5 +183,6 @@ When making changes, update the appropriate documentation files:
 | Dev setup, scripts, pre-commit hooks | `CONTRIBUTING.md` |
 | Contribution process, DCO | `CONTRIBUTING.md` |
 | New binary targets, crates, Python modules | `docs/ARCHITECTURE.md` |
+| Version-bump procedure changes | `CLAUDE.md` (Bumping the ModelExpress Version section) |
 
 **A feature is incomplete until documentation is updated.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "model-express-workspace-tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "Model Express: High-performance model serving and management"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -38,9 +38,9 @@ hf-hub = { version = "0.4.3", default-features = false, features = [
     "rustls-tls",
 ] }
 jiff = { version = "0.2.15", features = ["serde"] }
-modelexpress-common = { path = "modelexpress_common", version = "0.4.0" }
-modelexpress-client = { path = "modelexpress_client", version = "0.4.0" }
-modelexpress-server = { path = "modelexpress_server", version = "0.4.0" }
+modelexpress-common = { path = "modelexpress_common", version = "0.5.0" }
+modelexpress-client = { path = "modelexpress_client", version = "0.5.0" }
+modelexpress-server = { path = "modelexpress_server", version = "0.5.0" }
 once_cell = "1.21.3"
 prost = "0.13"
 rustls = { version = "0.23.37", default-features = false, features = ["ring", "std"] }

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -30,7 +30,7 @@ Every source is identified by a `SourceIdentity` proto containing all fields tha
 
 | Field | Example | Purpose |
 |-------|---------|---------|
-| `mx_version` | `"0.4.0"` | Format compatibility across upgrades |
+| `mx_version` | `"0.5.0"` | Format compatibility across upgrades |
 | `mx_source_type` | `WEIGHTS`, `LORA`, `CUDA_GRAPH` | Type of tensors being served |
 | `model_name` | `"deepseek-ai/DeepSeek-V3"` | Model identifier |
 | `backend_framework` | `VLLM`, `SGLANG`, `TRT_LLM` | Inference framework |
@@ -189,7 +189,7 @@ No Redis TTL is applied to keys. P2P stale detection and cleanup are handled by 
 ```
 # Source index -- identity stored once, workers as presence markers
 mx:source:a1b2c3d4e5f67890
-  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.4.0",...}
+  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.5.0",...}
   f3a2b1c4        ->  "0"    # worker_id f3a2b1c4, global rank 0
   e7d6c5b8        ->  "1"    # worker_id e7d6c5b8, global rank 1
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: modelexpress
 description: A Helm chart for ModelExpress - a AI model cache management service
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 keywords:
   - model-serving
   - ai

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modelexpress"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python client for ModelExpress P2P GPU transfer service"
 readme = "README.md"
 license = "Apache-2.0"

--- a/modelexpress_client/python/tests/test_k8s_service_client.py
+++ b/modelexpress_client/python/tests/test_k8s_service_client.py
@@ -22,7 +22,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.4.0",
+        mx_version="0.5.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/tests/test_source_id.py
+++ b/modelexpress_client/python/tests/test_source_id.py
@@ -17,7 +17,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.4.0",
+        mx_version="0.5.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
@@ -75,13 +75,13 @@ def test_extra_parameters_sorted():
 # ---------------------------------------------------------------------------
 
 def test_pinned_hash_base_identity():
-    assert compute_mx_source_id(_base_identity()) == "e2438ef16adcf628"
+    assert compute_mx_source_id(_base_identity()) == "5a5f555570065064"
 
 
 def test_pinned_hash_with_revision():
     pinned = _base_identity()
     pinned.revision = "abc123def4567890"
-    assert compute_mx_source_id(pinned) == "7b7803769825576e"
+    assert compute_mx_source_id(pinned) == "d0c184b2a9a34c82"
 
 
 def test_case_colliding_extra_parameters_are_deterministic():
@@ -97,4 +97,4 @@ def test_case_colliding_extra_parameters_are_deterministic():
     b.extra_parameters["foo"] = "b"
     b.extra_parameters["Foo"] = "a"
     assert compute_mx_source_id(a) == compute_mx_source_id(b)
-    assert compute_mx_source_id(a) == "deecf6684507f09c"
+    assert compute_mx_source_id(a) == "bf71fb9340cd940a"

--- a/modelexpress_client/python/uv.lock
+++ b/modelexpress_client/python/uv.lock
@@ -893,7 +893,7 @@ wheels = [
 
 [[package]]
 name = "modelexpress"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },

--- a/modelexpress_server/src/p2p/backend/redis.rs
+++ b/modelexpress_server/src/p2p/backend/redis.rs
@@ -682,7 +682,7 @@ mod tests {
 
     fn test_identity() -> modelexpress_common::grpc::p2p::SourceIdentity {
         modelexpress_common::grpc::p2p::SourceIdentity {
-            mx_version: "0.4.0".to_string(),
+            mx_version: "0.5.0".to_string(),
             mx_source_type: 0,
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1,
@@ -702,7 +702,7 @@ mod tests {
         let attr = SourceAttributesJson::from(&id);
 
         assert_eq!(attr.model_name, "deepseek-ai/DeepSeek-V3");
-        assert_eq!(attr.mx_version, "0.4.0");
+        assert_eq!(attr.mx_version, "0.5.0");
         assert_eq!(attr.tensor_parallel_size, 8);
         assert_eq!(attr.pipeline_parallel_size, 2);
         assert_eq!(attr.expert_parallel_size, 4);

--- a/modelexpress_server/src/p2p/service.rs
+++ b/modelexpress_server/src/p2p/service.rs
@@ -298,7 +298,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.4.0".to_string(),
+            mx_version: "0.5.0".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,

--- a/modelexpress_server/src/p2p/source_identity.rs
+++ b/modelexpress_server/src/p2p/source_identity.rs
@@ -69,7 +69,7 @@ mod tests {
 
     fn base_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.4.0".to_string(),
+            mx_version: "0.5.0".to_string(),
             mx_source_type: 0, // Weights (default)
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1, // vllm
@@ -180,14 +180,14 @@ mod tests {
     // the mismatch is caught in CI.
     #[test]
     fn test_python_cross_check_base_identity() {
-        assert_eq!(compute_mx_source_id(&base_identity()), "e2438ef16adcf628");
+        assert_eq!(compute_mx_source_id(&base_identity()), "5a5f555570065064");
     }
 
     #[test]
     fn test_python_cross_check_with_revision() {
         let mut pinned = base_identity();
         pinned.revision = "abc123def4567890".to_string();
-        assert_eq!(compute_mx_source_id(&pinned), "7b7803769825576e");
+        assert_eq!(compute_mx_source_id(&pinned), "d0c184b2a9a34c82");
     }
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
             .insert("Foo".to_string(), "a".to_string());
         id.extra_parameters
             .insert("foo".to_string(), "b".to_string());
-        assert_eq!(compute_mx_source_id(&id), "deecf6684507f09c");
+        assert_eq!(compute_mx_source_id(&id), "bf71fb9340cd940a");
     }
 
     #[test]

--- a/modelexpress_server/src/p2p/state.rs
+++ b/modelexpress_server/src/p2p/state.rs
@@ -199,7 +199,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.4.0".to_string(),
+            mx_version: "0.5.0".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,


### PR DESCRIPTION
## Summary

Two commits, matching the structure of #339 plus an agent skill.

### Commit 1 — `chore: bump version from 0.4.0 to 0.5.0`

Same shape as #339. Bumps the workspace, Python client, and Helm chart versions in lockstep, refreshes the `mx_version` test fixtures, and updates the pinned `mx_source_id` cross-check hashes (Python ↔ Rust).

- `Cargo.toml`, `Cargo.lock` (via `cargo update --workspace`)
- `modelexpress_client/python/pyproject.toml`, `modelexpress_client/python/uv.lock` (via `uv lock`)
- `helm/Chart.yaml` (`version` + `appVersion`)
- `docs/metadata.md` (`mx_version` examples)
- `modelexpress_server/src/p2p/{source_identity,state,service}.rs` + `backend/redis.rs` (test fixtures + 3 pinned hash assertions)
- `modelexpress_client/python/tests/test_{source_id,k8s_service_client}.py` (test fixtures + 3 pinned hash assertions)

New pinned source-id hashes:
- base identity: `e2438ef16adcf628` → `5a5f555570065064`
- with revision: `7b7803769825576e` → `d0c184b2a9a34c82`
- case-colliding extra params: `deecf6684507f09c` → `bf71fb9340cd940a`

**Intentionally not bumped:** `examples/**/*.yaml` image tags, `helm/values*.yaml` `image.tag`, `helm/README.md` image refs. Those stay at `0.4.0` until the `0.5.0` container is published to NGC, get bumped on the `release/0.5.0` branch, and then cherry-picked back to `main`. See commit 2.

### Commit 2 — `docs(claude): add version-bump procedure to agent instructions`

Adds a new `## Bumping the ModelExpress Version` section to `CLAUDE.md` documenting the two-cadence model (workspace on `main`; public-image refs on the release branch post-publish → cherry-pick back). Includes the exact file list, the test-hash recapture command, and a note explaining why image-tag refs lag behind the workspace version. Future agents picking up the bump task have a single place to read instead of re-deriving the convention.

## Test plan

- [x] `cargo check --workspace --tests` — passes on a clean Cargo.lock at 0.5.0
- [x] `cd modelexpress_client/python && pytest tests/test_source_id.py tests/test_k8s_service_client.py` — 42 passed (after updating the 3 pinned hashes; previously 2 failing, now green)
- [ ] CI passes
- [ ] Sanity-check that the new section in CLAUDE.md is visible at the right place (between "Adding gRPC Services" and "Git Workflow")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.5.0 across workspace, Python client, Helm chart, and documentation examples.

* **Documentation**
  * Added detailed version-bumping procedure documentation including guidance on fixture updates, dependency regeneration, hash synchronization, and verification commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->