### PR TITLE
docs: recommend `MX_SERVER_ADDRESS`, mark `MODEL_EXPRESS_URL` deprecated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,8 @@ Cache directory resolution order: `MODEL_EXPRESS_CACHE_DIRECTORY` -> `HF_HUB_CAC
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server address |
+| `MX_SERVER_ADDRESS` | `localhost:8001` | gRPC server address (recommended) |
+| `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 | `MX_POOL_REG` | `0` | Allocation-level NIXL registration (registers cudaMalloc blocks instead of individual tensors) |
 | `MX_EXPECTED_WORKERS` | `8` | Number of GPU workers to wait for |
 | `MX_SYNC_PUBLISH` | `1` | Source: wait for all workers before publishing |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ docker-compose up --build
 | `MODEL_EXPRESS_CACHE_DIRECTORY` | `./cache` | Cache root |
 | `MX_METADATA_BACKEND` | (required) | `redis` \| `kubernetes` |
 | `REDIS_URL` | `redis://localhost:6379` | Redis connection URL (`redis` backend only) |
-| `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server (P2P) |
+| `MX_SERVER_ADDRESS` | `localhost:8001` | Client-side gRPC server address (P2P). Recommended. |
+| `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 
 ```bash
 cargo run --bin config_gen -- --output model-express.yaml

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -729,8 +729,8 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server address |
-| `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
+| `MX_SERVER_ADDRESS` | `localhost:8001` | gRPC server address (recommended) |
+| `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 | `MX_METADATA_BACKEND` | (required on server; `""` on client) | Server: `redis` or `kubernetes`. Client: `""` / `server` / `redis` / `kubernetes` (central server) or `k8s-service` (decentralized via K8s Service routing) |
 | `MX_POOL_REG` | `0` | Discover cudaMalloc allocations via `cuMemGetAddressRange` and register each as a single NIXL block instead of registering tensors individually. Reduces NIXL registration count by 80-99% on typical vLLM models, cutting `ibv_reg_mr` time and metadata blob size; transfer semantics unchanged. Not required for `MX_VMM_ARENA=1`, which registers the arena directly |
 | `MX_VMM_ARENA` | `0` | Install a `CUDAPluggableAllocator` that routes weight-loading allocations into a CUDA VMM arena, then registers the used arena range once through dmabuf at end-of-load. Reserves 16.0 TiB of VA by default and commits physical memory only for mapped allocations. See [VMM Arena](#vmm-arena-cudapluggableallocator-hook) |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -323,11 +323,13 @@ See [`K8S_SERVICE_BACKEND.md`](K8S_SERVICE_BACKEND.md) for the design rationale,
 
 ### P2P Environment Variables
 
+`MX_SERVER_ADDRESS` is the variable ModelExpress is standardizing on for the client's gRPC server address; `MODEL_EXPRESS_URL` is deprecated and will be removed in a future release. During the transition, set both to the same value: some client paths (notably the TRT-LLM live-transfer integration) currently read only `MODEL_EXPRESS_URL`, and when both are set `MODEL_EXPRESS_URL` takes precedence. Do not drop `MODEL_EXPRESS_URL` yet.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MX_METADATA_BACKEND` | (required on server; `""` on client) | Server: `redis` or `kubernetes`. Client: `""`/`server`/`redis`/`kubernetes` (central server) or `k8s-service` (decentralized via K8s Service routing). |
-| `MODEL_EXPRESS_URL` | `localhost:8001` | gRPC server address (ignored when client uses `k8s-service` backend) |
-| `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compat alias for `MODEL_EXPRESS_URL` |
+| `MX_SERVER_ADDRESS` | `localhost:8001` | Client's gRPC server address (recommended; ignored when client uses `k8s-service` backend) |
+| `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 | `MX_POOL_REG` | `0` | Allocation-level NIXL registration via `cuMemGetAddressRange`. Registers each unique cudaMalloc block instead of each tensor, typically 80-99% fewer registrations, without changing transfer semantics. `MX_VMM_ARENA=1` uses direct arena registration and does not require pool-reg. |
 | `MX_VMM_ARENA` | `0` | Route weight allocations into a CUDA VMM arena via PyTorch's `CUDAPluggableAllocator`, then register the used arena range as one NIXL MR with dmabuf at end-of-load. Reserves 16.0 TiB of VA by default, with no physical commit until allocations are mapped. Requires the `modelexpress.vmm._alloc_ext` C extension to have built at install time; if it did not, this flag is a no-op with a warning and the loader falls back to the pool-reg path. See [VMM Arena](#vmm-arena-single-mr-registration). |
 | `UCX_CUDA_COPY_REG_WHOLE_ALLOC` | (UCX default) | Set to `off` with `MX_VMM_ARENA=1` until the upstream UCX `cuda_copy_md` length-truncation fix ships. |

--- a/docs/SGLANG.md
+++ b/docs/SGLANG.md
@@ -84,7 +84,7 @@ Later replicas discover the source and load via the selected ModelExpress
 transport.
 
 ```bash
-export MODEL_EXPRESS_URL=modelexpress-server:8001
+export MX_SERVER_ADDRESS=modelexpress-server:8001
 
 python -m sglang.launch_server \
   --model-path deepseek-ai/DeepSeek-V3 --tp 8 --port 30000 \

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -380,7 +380,8 @@ The `backend_type` discriminator is persisted in storage for unambiguous deseria
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MX_METADATA_BACKEND` | (required) | `redis` or `kubernetes` |
-| `MX_SERVER_ADDRESS` | `modelexpress-server:8001` | gRPC server address |
+| `MX_SERVER_ADDRESS` | `localhost:8001` | gRPC server address (recommended) |
+| `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 | `MX_REDIS_HOST` / `REDIS_HOST` | `localhost` | Redis host |
 | `MX_REDIS_PORT` / `REDIS_PORT` | `6379` | Redis port |
 | `REDIS_URL` | (computed) | Full Redis URL (overrides host/port) |

--- a/examples/dynamo_p2p_transfer_k8s/README.md
+++ b/examples/dynamo_p2p_transfer_k8s/README.md
@@ -45,6 +45,8 @@ graph LR
 - **Frontend**: Dynamo's HTTP entry point; routes to decode workers round-robin.
 - **Workers**: `--load-format modelexpress` means the first replica loads from disk and publishes metadata; every subsequent replica receives weights from a Ready source over RDMA. The `mx` load format is kept as a backward-compatible alias.
 
+> **ModelExpress server address.** These examples set `MODEL_EXPRESS_URL`. ModelExpress is standardizing on `MX_SERVER_ADDRESS` as the recommended variable going forward, but Dynamo's ModelExpress integration (operator injection and the native `mx-source` / `mx-target` load formats) currently uses `MODEL_EXPRESS_URL`. The `modelexpress` plugin loader used here accepts either, so for Dynamo deployments set `MODEL_EXPRESS_URL` for now.
+
 ## Prerequisites
 
 1. **Dynamo operator** installed (provides the `DynamoGraphDeployment` CRD).

--- a/examples/dynamo_p2p_transfer_k8s/README.md
+++ b/examples/dynamo_p2p_transfer_k8s/README.md
@@ -45,7 +45,7 @@ graph LR
 - **Frontend**: Dynamo's HTTP entry point; routes to decode workers round-robin.
 - **Workers**: `--load-format modelexpress` means the first replica loads from disk and publishes metadata; every subsequent replica receives weights from a Ready source over RDMA. The `mx` load format is kept as a backward-compatible alias.
 
-> **ModelExpress server address.** These examples set `MODEL_EXPRESS_URL`. ModelExpress is standardizing on `MX_SERVER_ADDRESS` as the recommended variable going forward, but Dynamo's ModelExpress integration (operator injection and the native `mx-source` / `mx-target` load formats) currently uses `MODEL_EXPRESS_URL`. The `modelexpress` plugin loader used here accepts either, so for Dynamo deployments set `MODEL_EXPRESS_URL` for now.
+> **ModelExpress server address.** These examples set `MODEL_EXPRESS_URL`. ModelExpress is standardizing on `MX_SERVER_ADDRESS` as the recommended variable going forward, but Dynamo's ModelExpress integration currently uses `MODEL_EXPRESS_URL`. The `modelexpress` plugin loader used here accepts either, so for Dynamo deployments set `MODEL_EXPRESS_URL` for now.
 
 ## Prerequisites
 

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -109,7 +109,9 @@ spec:
           value: "nvidia/Kimi-K2.5-NVFP4"
         - name: VLLM_PLUGINS
           value: "modelexpress"
-        - name: MX_SERVER_ADDRESS
+        # Dynamo's ModelExpress integration uses MODEL_EXPRESS_URL today; MX is
+        # standardizing on MX_SERVER_ADDRESS going forward (see README).
+        - name: MODEL_EXPRESS_URL
           value: "mx-vllm-modelexpress:8000"
         # Per-rank IB NIC pinning. Workaround for openucx/ucx#11259.
         - name: MX_RDMA_NIC_PIN

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -100,7 +100,9 @@ spec:
           value: "nvidia/Kimi-K2.5-NVFP4"
         - name: VLLM_PLUGINS
           value: "modelexpress"
-        - name: MX_SERVER_ADDRESS
+        # Dynamo's ModelExpress integration uses MODEL_EXPRESS_URL today; MX is
+        # standardizing on MX_SERVER_ADDRESS going forward (see README).
+        - name: MODEL_EXPRESS_URL
           value: "mx-vllm-disagg-sn-modelexpress:8000"
         - name: NIXL_LOG_LEVEL
           value: "INFO"
@@ -172,7 +174,9 @@ spec:
           value: "nvidia/Kimi-K2.5-NVFP4"
         - name: VLLM_PLUGINS
           value: "modelexpress"
-        - name: MX_SERVER_ADDRESS
+        # Dynamo's ModelExpress integration uses MODEL_EXPRESS_URL today; MX is
+        # standardizing on MX_SERVER_ADDRESS going forward (see README).
+        - name: MODEL_EXPRESS_URL
           value: "mx-vllm-disagg-sn-modelexpress:8000"
         - name: NIXL_LOG_LEVEL
           value: "INFO"

--- a/examples/p2p_transfer_k8s/README.md
+++ b/examples/p2p_transfer_k8s/README.md
@@ -63,7 +63,7 @@ For ModelStreamer-only startup examples that stream weights from Azure Blob Stor
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `MODEL_EXPRESS_URL` / `MX_SERVER_ADDRESS` | ModelExpress server address used by the engine integration | `modelexpress-server:8001` |
+| `MX_SERVER_ADDRESS` | ModelExpress server address used by the engine integration (recommended). `MODEL_EXPRESS_URL` is deprecated and pending removal, but is still required by some paths today and takes precedence when both are set; set both during the transition. | `modelexpress-server:8001` |
 | `MX_RDMA_NIC_PIN` | Per-rank NIC pinning for RDMA-capable deployments | `auto` |
 
 ### ModelExpress Server

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -29,7 +29,7 @@ pip install -e ".[dev]"
 ModelExpress integrates with vLLM via custom model loaders. vLLM can discover the package through its `vllm.general_plugins` entrypoint; set `VLLM_PLUGINS=modelexpress` if your vLLM deployment requires explicit plugin selection. For manual registration, call `register_modelexpress_loaders()` in your code.
 
 ```bash
-export MODEL_EXPRESS_URL="modelexpress-server:8001"
+export MX_SERVER_ADDRESS="modelexpress-server:8001"
 
 vllm serve deepseek-ai/DeepSeek-V3 \
     --load-format modelexpress \
@@ -79,8 +79,8 @@ register_modelexpress_loaders()
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MODEL_EXPRESS_URL` | `localhost:8001` | ModelExpress gRPC server address |
-| `MX_SERVER_ADDRESS` | `localhost:8001` | Backward-compatible alias for `MODEL_EXPRESS_URL` |
+| `MX_SERVER_ADDRESS` | `localhost:8001` | ModelExpress gRPC server address (recommended) |
+| `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 | `MX_EXPECTED_WORKERS` | Auto-detected from TP size | Number of GPU workers to coordinate |
 | `MX_SYNC_PUBLISH` | `0` | Source: wait for all workers before publishing metadata |
 | `MX_SYNC_START` | `1` | Target: wait for all source workers before transferring |


### PR DESCRIPTION
  ## Problem

  The client gRPC server address has two env vars, MX_SERVER_ADDRESS and
  MODEL_EXPRESS_URL, documented inconsistently: different docs listed only one or
  the other, defaults disagreed (localhost:8001 vs modelexpress-server:8001), and
  some called MX_SERVER_ADDRESS a "backward-compat alias" with no migration
  direction.

  ## Change (docs only, no behavior change)

  - Reference docs now recommend MX_SERVER_ADDRESS and mark MODEL_EXPRESS_URL
    deprecated (pending removal), default unified to localhost:8001. They stay
    truthful that MODEL_EXPRESS_URL is still read by all client paths, some paths
    (TRT-LLM live transfer) read only it, and it takes precedence, so keep it set
    during the transition.
  - Dynamo P2P examples (examples/dynamo_p2p_transfer_k8s) explicitly use
    MODEL_EXPRESS_URL, since Dynamo's MX integration only honors that today.

  ## Note for reviewers

  This documents the intended direction, not the running state. Today
  MODEL_EXPRESS_URL is what every consumer uses end to end (Dynamo sets only it;
  the MX client prefers it). MX_SERVER_ADDRESS is a partial fallback in the MX
  client and absent from Dynamo. Making it primary needs follow-up code changes
  in both repos (and fixing the stale CI default mx-server:8000 / operator :8000
  vs docs :8001).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced `MX_SERVER_ADDRESS` as the recommended environment variable for gRPC server address configuration across configuration guides and examples.
  * Documented deprecation of `MODEL_EXPRESS_URL`; it remains supported during the transition period and takes precedence when both variables are set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->