### PR TITLE
 fix: bind SGLang P2P example to 0.0.0.0:8000 to match its Service

### DIFF
--- a/examples/p2p_transfer_k8s/client/README.md
+++ b/examples/p2p_transfer_k8s/client/README.md
@@ -39,3 +39,19 @@ After loading, every worker publishes its metadata so future instances can disco
 - ModelExpress server deployed (see [`../server/`](../server/))
 - HuggingFace token secret: `kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token>`
 - PVC with model weights (see [`../model-download.yaml`](../model-download.yaml))
+
+## Verify
+
+The SGLang deployment defines a readiness probe on `/health`, so it reports
+Ready only after warmup completes. Wait for that, then confirm the
+OpenAI-compatible API serves the expected model:
+
+```bash
+kubectl rollout status deployment/mx-sglang --timeout=20m
+kubectl exec deployment/mx-sglang -c sglang -- \
+  curl -sS http://localhost:8000/v1/models
+```
+
+The vLLM examples do not define a readiness probe, so `rollout status` returns
+as soon as the container starts. Poll the same `curl` (swapping in the vLLM
+deployment and container names) until it returns the model list.

--- a/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
@@ -56,8 +56,7 @@ spec:
           args:
             - --model-path
             - $(MODEL_NAME)
-            # Bind all interfaces on the Service port. SGLang defaults to
-            # 127.0.0.1:30000, which the Service (port 8000) cannot reach.
+            # SGLang defaults to 127.0.0.1:30000; bind the advertised Service port.
             - --host
             - "0.0.0.0"
             - --port
@@ -78,16 +77,13 @@ spec:
           ports:
             - containerPort: 8000
               protocol: TCP
-          # Gate Service traffic on the HTTP API being up. Without a probe the
-          # pod reports Ready at container start, masking bind/port mismatches.
-          # Large-model startup is slow, so allow a wide failure window.
+          # SGLang's /health does a 1-token generation (~1s), so timeoutSeconds
+          # must exceed the 1s K8s default or the pod never becomes Ready.
           readinessProbe:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 60
-            periodSeconds: 15
-            failureThreshold: 60
+            timeoutSeconds: 10
           env:
             - name: HF_HOME
               value: "/models"

--- a/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
@@ -56,6 +56,12 @@ spec:
           args:
             - --model-path
             - $(MODEL_NAME)
+            # Bind all interfaces on the Service port. SGLang defaults to
+            # 127.0.0.1:30000, which the Service (port 8000) cannot reach.
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
             - --load-format
             - remote_instance
             - --remote-instance-weight-loader-backend
@@ -72,6 +78,16 @@ spec:
           ports:
             - containerPort: 8000
               protocol: TCP
+          # Gate Service traffic on the HTTP API being up. Without a probe the
+          # pod reports Ready at container start, masking bind/port mismatches.
+          # Large-model startup is slow, so allow a wide failure window.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 60
           env:
             - name: HF_HOME
               value: "/models"


### PR DESCRIPTION
  ## Problem
  The SGLang single-node P2P example declares a Service and containerPort on 8000
  but passes no `--host`/`--port`, so `sglang.launch_server` uses its defaults
  `127.0.0.1:30000` (`server_args.py:369-370`). P2P weight transfer still succeeds
  (it rides MX gRPC `:8001` + NIXL/RDMA, not the HTTP port), but the OpenAI API is
  unreachable through the Service: bind port 30000 never matches Service port 8000,
  and the loopback bind rejects non-localhost traffic regardless. The vLLM sibling
  example works only because vLLM defaults to `0.0.0.0:8000`.

  ## Fix
  - Add `--host 0.0.0.0 --port 8000` so the engine binds the advertised Service address.
  - Add a readinessProbe on `/health` so a bind/port mismatch surfaces as NotReady
    instead of silently routing Service traffic to a dead endpoint.
  - Add a `Verify` section to the client README (rollout-status wait + `/v1/models` smoke check).

  ## Testing
  Reproduced on K8s (Qwen3-0.6B TP=2; DeepSeek-V3 TP=8): default config binds
  `127.0.0.1:30000`, Service `:8000` refused. With the fix, `/v1/models` returns the
  model and P2P RDMA transfer completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive verification guide with specific commands to confirm SGLang and vLLM ModelExpress P2P deployments are ready and serving models through OpenAI-compatible API endpoints

* **Infrastructure**
  * Optimized Kubernetes single-node deployment configuration for SGLang + ModelExpress P2P transfers with improved readiness probes, timeout adjustments, and explicit port binding for enhanced deployment stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/modelexpress/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->