### PR TITLE
 fix: bind SGLang P2P example to 0.0.0.0:8000 to match its Service

### DIFF
--- a/examples/p2p_transfer_k8s/client/README.md
+++ b/examples/p2p_transfer_k8s/client/README.md
@@ -39,3 +39,19 @@ After loading, every worker publishes its metadata so future instances can disco
 - ModelExpress server deployed (see [`../server/`](../server/))
 - HuggingFace token secret: `kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token>`
 - PVC with model weights (see [`../model-download.yaml`](../model-download.yaml))
+
+## Verify
+
+The SGLang deployment defines a readiness probe on `/health`, so it reports
+Ready only after warmup completes. Wait for that, then confirm the
+OpenAI-compatible API serves the expected model:
+
+```bash
+kubectl rollout status deployment/mx-sglang --timeout=20m
+kubectl exec deployment/mx-sglang -c sglang -- \
+  curl -sS http://localhost:8000/v1/models
+```
+
+The vLLM examples do not define a readiness probe, so `rollout status` returns
+as soon as the container starts. Poll the same `curl` (swapping in the vLLM
+deployment and container names) until it returns the model list.

--- a/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
+++ b/examples/p2p_transfer_k8s/client/sglang/sglang-single-node-p2p.yaml
@@ -56,6 +56,11 @@ spec:
           args:
             - --model-path
             - $(MODEL_NAME)
+            # SGLang defaults to 127.0.0.1:30000; bind the advertised Service port.
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
             - --load-format
             - remote_instance
             - --remote-instance-weight-loader-backend
@@ -72,6 +77,13 @@ spec:
           ports:
             - containerPort: 8000
               protocol: TCP
+          # SGLang's /health does a 1-token generation (~1s), so timeoutSeconds
+          # must exceed the 1s K8s default or the pod never becomes Ready.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            timeoutSeconds: 10
           env:
             - name: HF_HOME
               value: "/models"


### PR DESCRIPTION

  Backport of #397 to `release/0.4.0`. Cherry-picked from afb43df;
  clean apply, no conflicts (the two touched files are identical between
  `release/0.4.0` and main's pre-fix state).

nvbug 6240801 / MX-358.

  ## Fix
  - Add `--host 0.0.0.0 --port 8000` so the engine binds the advertised Service address.
  - Add a readinessProbe on `/health` with `timeoutSeconds: 10`. SGLang's `/health`
    runs a 1-token generation with a ~1s floor, so the K8s default 1s timeout fails
    and the pod never becomes Ready.
  - Add a `Verify` section to the client README (rollout-status wait plus
    `/v1/models` smoke check).

  ## Validation
  Validated on `main` (PR #397) on-cluster: both Services return HTTP 200,
  inference works, and P2P RDMA weight transfer completes. The backport is
  byte-identical to the merged commit.
