### PR TITLE
fix(examples): align AWS EFA vLLM DeepSeek defaults

### DIFF
--- a/examples/p2p_transfer_k8s/client/vllm/aws_efa/README.md
+++ b/examples/p2p_transfer_k8s/client/vllm/aws_efa/README.md
@@ -45,6 +45,9 @@ docker push <YOUR_REGISTRY>/modelexpress-aws-efa:latest
 ```
 
 Edit the `image:` field in `vllm-aws-efa.yaml` to point at your pushed tag.
+The manifest defaults to `deepseek-ai/DeepSeek-V3` with
+`--tensor-parallel-size 8` and eight GPUs. If you switch models, update the
+tensor-parallel size and GPU request/limit to match that model.
 
 ## Deploy
 

--- a/examples/p2p_transfer_k8s/client/vllm/aws_efa/vllm-aws-efa.yaml
+++ b/examples/p2p_transfer_k8s/client/vllm/aws_efa/vllm-aws-efa.yaml
@@ -117,17 +117,17 @@ spec:
             - --load-format
             - modelexpress
             - --tensor-parallel-size
-            - "1"
+            - "8"
           ports:
             - name: http
               containerPort: 8000
           resources:
             limits:
-              nvidia.com/gpu: 1
+              nvidia.com/gpu: 8
               # Number of EFA NICs to expose to the pod. p6e-gb200.36xlarge
               # has 4 EFA NICs per node; p5.48xlarge has 32. Pick a count
               # that matches what your workload can saturate.
               vpc.amazonaws.com/efa: 4
             requests:
-              nvidia.com/gpu: 1
+              nvidia.com/gpu: 8
               vpc.amazonaws.com/efa: 4


### PR DESCRIPTION
## Summary
- backport the AWS EFA vLLM example fix to `release/0.4.0`
- keep the example on `deepseek-ai/DeepSeek-V3`
- align the default deployment shape by setting TP=8 and requesting/limiting 8 GPUs
- document that model changes require matching tensor-parallel and GPU resource updates

## Root Cause
The AWS EFA example defaulted to DeepSeek V3 but kept the manifest at TP=1 with one GPU, making the example inconsistent with the large-model default and not runnable out of the box.

## Backport
Cherry-picked from mainline commit `261e55d` with `-x`.

## Validation
- Parsed `examples/p2p_transfer_k8s/client/vllm/aws_efa/vllm-aws-efa.yaml` with Ruby `YAML.load_stream`
- Asserted the Deployment defaults are `model=deepseek-ai/DeepSeek-V3`, `tp=8`, `gpu=8`
- Ran `git diff origin/release/0.4.0 --check`