### PR TITLE
fix(clear): remove registry record and verify disk on cache hit

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -299,8 +299,11 @@ Four proto files define four services, all compiled via `tonic-build` in `modele
 | `EnsureModelDownloaded` | `ModelDownloadRequest` | stream `ModelStatusUpdate` | Trigger download, stream progress |
 | `StreamModelFiles` | `ModelFilesRequest` | stream `FileChunk` | Stream model file contents (1MB chunks) |
 | `ListModelFiles` | `ModelFilesRequest` | `ModelFileList` | List files with sizes |
+| `DeleteModel` | `DeleteModelRequest` | `DeleteModelResponse` | Remove a model record from the registry (used by `model clear`) |
 
 Key message types: `ModelProvider` (HuggingFace, NGC, GCS), `ModelStatus` (Downloading, Downloaded, Error), `ModelStatusUpdate`, `FileChunk`.
+
+`EnsureModelDownloaded` verifies that a `DOWNLOADED` registry record still has its files on disk before honoring it as a cache hit. If the files are missing (for example after a `model clear` that only removed local storage), the stale record is deleted and the download is re-claimed so the model is actually re-fetched rather than returning a false success.
 
 ### p2p.proto - P2pService
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -119,7 +119,11 @@ modelexpress-cli model list --detailed
 # Check model storage status
 modelexpress-cli model status
 
-# Clear specific model from storage
+# Clear specific model from storage. This removes the local files and also
+# deletes the model's record from the server-side registry, so a later
+# `model download` re-fetches the model instead of returning a false cache hit.
+# If the server is unreachable, the local files are still cleared and a warning
+# notes that the registry record may remain.
 modelexpress-cli model clear google-t5/t5-small
 
 # Clear a Google Cloud Storage model from storage

--- a/modelexpress_client/go/gen/modelexpress/model/model.pb.go
+++ b/modelexpress_client/go/gen/modelexpress/model/model.pb.go
@@ -124,6 +124,112 @@ func (ModelProvider) EnumDescriptor() ([]byte, []int) {
 	return file_model_proto_rawDescGZIP(), []int{1}
 }
 
+// Request to delete a model record from the registry
+type DeleteModelRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModelName     string                 `protobuf:"bytes,1,opt,name=model_name,json=modelName,proto3" json:"model_name,omitempty"`
+	Provider      ModelProvider          `protobuf:"varint,2,opt,name=provider,proto3,enum=model_express.model.ModelProvider" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteModelRequest) Reset() {
+	*x = DeleteModelRequest{}
+	mi := &file_model_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteModelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteModelRequest) ProtoMessage() {}
+
+func (x *DeleteModelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_model_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteModelRequest.ProtoReflect.Descriptor instead.
+func (*DeleteModelRequest) Descriptor() ([]byte, []int) {
+	return file_model_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *DeleteModelRequest) GetModelName() string {
+	if x != nil {
+		return x.ModelName
+	}
+	return ""
+}
+
+func (x *DeleteModelRequest) GetProvider() ModelProvider {
+	if x != nil {
+		return x.Provider
+	}
+	return ModelProvider_HUGGING_FACE
+}
+
+// Response for a model deletion request
+type DeleteModelResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Message       *string                `protobuf:"bytes,2,opt,name=message,proto3,oneof" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteModelResponse) Reset() {
+	*x = DeleteModelResponse{}
+	mi := &file_model_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteModelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteModelResponse) ProtoMessage() {}
+
+func (x *DeleteModelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_model_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteModelResponse.ProtoReflect.Descriptor instead.
+func (*DeleteModelResponse) Descriptor() ([]byte, []int) {
+	return file_model_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *DeleteModelResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *DeleteModelResponse) GetMessage() string {
+	if x != nil && x.Message != nil {
+		return *x.Message
+	}
+	return ""
+}
+
 // Request to ensure a model is downloaded
 type ModelDownloadRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -136,7 +242,7 @@ type ModelDownloadRequest struct {
 
 func (x *ModelDownloadRequest) Reset() {
 	*x = ModelDownloadRequest{}
-	mi := &file_model_proto_msgTypes[0]
+	mi := &file_model_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -148,7 +254,7 @@ func (x *ModelDownloadRequest) String() string {
 func (*ModelDownloadRequest) ProtoMessage() {}
 
 func (x *ModelDownloadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_model_proto_msgTypes[0]
+	mi := &file_model_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -161,7 +267,7 @@ func (x *ModelDownloadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelDownloadRequest.ProtoReflect.Descriptor instead.
 func (*ModelDownloadRequest) Descriptor() ([]byte, []int) {
-	return file_model_proto_rawDescGZIP(), []int{0}
+	return file_model_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ModelDownloadRequest) GetModelName() string {
@@ -199,7 +305,7 @@ type ModelStatusUpdate struct {
 
 func (x *ModelStatusUpdate) Reset() {
 	*x = ModelStatusUpdate{}
-	mi := &file_model_proto_msgTypes[1]
+	mi := &file_model_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -211,7 +317,7 @@ func (x *ModelStatusUpdate) String() string {
 func (*ModelStatusUpdate) ProtoMessage() {}
 
 func (x *ModelStatusUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_model_proto_msgTypes[1]
+	mi := &file_model_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -224,7 +330,7 @@ func (x *ModelStatusUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelStatusUpdate.ProtoReflect.Descriptor instead.
 func (*ModelStatusUpdate) Descriptor() ([]byte, []int) {
-	return file_model_proto_rawDescGZIP(), []int{1}
+	return file_model_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ModelStatusUpdate) GetModelName() string {
@@ -272,7 +378,7 @@ type ModelFilesRequest struct {
 
 func (x *ModelFilesRequest) Reset() {
 	*x = ModelFilesRequest{}
-	mi := &file_model_proto_msgTypes[2]
+	mi := &file_model_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -284,7 +390,7 @@ func (x *ModelFilesRequest) String() string {
 func (*ModelFilesRequest) ProtoMessage() {}
 
 func (x *ModelFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_model_proto_msgTypes[2]
+	mi := &file_model_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -297,7 +403,7 @@ func (x *ModelFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelFilesRequest.ProtoReflect.Descriptor instead.
 func (*ModelFilesRequest) Descriptor() ([]byte, []int) {
-	return file_model_proto_rawDescGZIP(), []int{2}
+	return file_model_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ModelFilesRequest) GetModelName() string {
@@ -339,7 +445,7 @@ type ModelFileSelector struct {
 
 func (x *ModelFileSelector) Reset() {
 	*x = ModelFileSelector{}
-	mi := &file_model_proto_msgTypes[3]
+	mi := &file_model_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -351,7 +457,7 @@ func (x *ModelFileSelector) String() string {
 func (*ModelFileSelector) ProtoMessage() {}
 
 func (x *ModelFileSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_model_proto_msgTypes[3]
+	mi := &file_model_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -364,7 +470,7 @@ func (x *ModelFileSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelFileSelector.ProtoReflect.Descriptor instead.
 func (*ModelFileSelector) Descriptor() ([]byte, []int) {
-	return file_model_proto_rawDescGZIP(), []int{3}
+	return file_model_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ModelFileSelector) GetPaths() []string {
@@ -397,7 +503,7 @@ type FileChunk struct {
 
 func (x *FileChunk) Reset() {
 	*x = FileChunk{}
-	mi := &file_model_proto_msgTypes[4]
+	mi := &file_model_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -409,7 +515,7 @@ func (x *FileChunk) String() string {
 func (*FileChunk) ProtoMessage() {}
 
 func (x *FileChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_model_proto_msgTypes[4]
+	mi := &file_model_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -422,7 +528,7 @@ func (x *FileChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileChunk.ProtoReflect.Descriptor instead.
 func (*FileChunk) Descriptor() ([]byte, []int) {
-	return file_model_proto_rawDescGZIP(), []int{4}
+	return file_model_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *FileChunk) GetRelativePath() string {
@@ -489,7 +595,7 @@ type ModelFileList struct {
 
 func (x *ModelFileList) Reset() {
 	*x = ModelFileList{}
-	mi := &file_model_proto_msgTypes[5]
+	mi := &file_model_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -501,7 +607,7 @@ func (x *ModelFileList) String() string {
 func (*ModelFileList) ProtoMessage() {}
 
 func (x *ModelFileList) ProtoReflect() protoreflect.Message {
-	mi := &file_model_proto_msgTypes[5]
+	mi := &file_model_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -514,7 +620,7 @@ func (x *ModelFileList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelFileList.ProtoReflect.Descriptor instead.
 func (*ModelFileList) Descriptor() ([]byte, []int) {
-	return file_model_proto_rawDescGZIP(), []int{5}
+	return file_model_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ModelFileList) GetModelName() string {
@@ -551,7 +657,7 @@ type ModelFileInfo struct {
 
 func (x *ModelFileInfo) Reset() {
 	*x = ModelFileInfo{}
-	mi := &file_model_proto_msgTypes[6]
+	mi := &file_model_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -563,7 +669,7 @@ func (x *ModelFileInfo) String() string {
 func (*ModelFileInfo) ProtoMessage() {}
 
 func (x *ModelFileInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_model_proto_msgTypes[6]
+	mi := &file_model_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -576,7 +682,7 @@ func (x *ModelFileInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelFileInfo.ProtoReflect.Descriptor instead.
 func (*ModelFileInfo) Descriptor() ([]byte, []int) {
-	return file_model_proto_rawDescGZIP(), []int{6}
+	return file_model_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ModelFileInfo) GetRelativePath() string {
@@ -597,7 +703,16 @@ var File_model_proto protoreflect.FileDescriptor
 
 const file_model_proto_rawDesc = "" +
 	"\n" +
-	"\vmodel.proto\x12\x13model_express.model\"\x9c\x01\n" +
+	"\vmodel.proto\x12\x13model_express.model\"s\n" +
+	"\x12DeleteModelRequest\x12\x1d\n" +
+	"\n" +
+	"model_name\x18\x01 \x01(\tR\tmodelName\x12>\n" +
+	"\bprovider\x18\x02 \x01(\x0e2\".model_express.model.ModelProviderR\bprovider\"Z\n" +
+	"\x13DeleteModelResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x1d\n" +
+	"\amessage\x18\x02 \x01(\tH\x00R\amessage\x88\x01\x01B\n" +
+	"\n" +
+	"\b_message\"\x9c\x01\n" +
 	"\x14ModelDownloadRequest\x12\x1d\n" +
 	"\n" +
 	"model_name\x18\x01 \x01(\tR\tmodelName\x12>\n" +
@@ -649,11 +764,12 @@ const file_model_proto_rawDesc = "" +
 	"\rModelProvider\x12\x10\n" +
 	"\fHUGGING_FACE\x10\x00\x12\a\n" +
 	"\x03NGC\x10\x01\x12\a\n" +
-	"\x03GCS\x10\x022\xb8\x02\n" +
+	"\x03GCS\x10\x022\x9a\x03\n" +
 	"\fModelService\x12l\n" +
 	"\x15EnsureModelDownloaded\x12).model_express.model.ModelDownloadRequest\x1a&.model_express.model.ModelStatusUpdate0\x01\x12\\\n" +
 	"\x10StreamModelFiles\x12&.model_express.model.ModelFilesRequest\x1a\x1e.model_express.model.FileChunk0\x01\x12\\\n" +
-	"\x0eListModelFiles\x12&.model_express.model.ModelFilesRequest\x1a\".model_express.model.ModelFileListb\x06proto3"
+	"\x0eListModelFiles\x12&.model_express.model.ModelFilesRequest\x1a\".model_express.model.ModelFileList\x12`\n" +
+	"\vDeleteModel\x12'.model_express.model.DeleteModelRequest\x1a(.model_express.model.DeleteModelResponseb\x06proto3"
 
 var (
 	file_model_proto_rawDescOnce sync.Once
@@ -668,36 +784,41 @@ func file_model_proto_rawDescGZIP() []byte {
 }
 
 var file_model_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_model_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_model_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_model_proto_goTypes = []any{
 	(ModelStatus)(0),             // 0: model_express.model.ModelStatus
 	(ModelProvider)(0),           // 1: model_express.model.ModelProvider
-	(*ModelDownloadRequest)(nil), // 2: model_express.model.ModelDownloadRequest
-	(*ModelStatusUpdate)(nil),    // 3: model_express.model.ModelStatusUpdate
-	(*ModelFilesRequest)(nil),    // 4: model_express.model.ModelFilesRequest
-	(*ModelFileSelector)(nil),    // 5: model_express.model.ModelFileSelector
-	(*FileChunk)(nil),            // 6: model_express.model.FileChunk
-	(*ModelFileList)(nil),        // 7: model_express.model.ModelFileList
-	(*ModelFileInfo)(nil),        // 8: model_express.model.ModelFileInfo
+	(*DeleteModelRequest)(nil),   // 2: model_express.model.DeleteModelRequest
+	(*DeleteModelResponse)(nil),  // 3: model_express.model.DeleteModelResponse
+	(*ModelDownloadRequest)(nil), // 4: model_express.model.ModelDownloadRequest
+	(*ModelStatusUpdate)(nil),    // 5: model_express.model.ModelStatusUpdate
+	(*ModelFilesRequest)(nil),    // 6: model_express.model.ModelFilesRequest
+	(*ModelFileSelector)(nil),    // 7: model_express.model.ModelFileSelector
+	(*FileChunk)(nil),            // 8: model_express.model.FileChunk
+	(*ModelFileList)(nil),        // 9: model_express.model.ModelFileList
+	(*ModelFileInfo)(nil),        // 10: model_express.model.ModelFileInfo
 }
 var file_model_proto_depIdxs = []int32{
-	1, // 0: model_express.model.ModelDownloadRequest.provider:type_name -> model_express.model.ModelProvider
-	0, // 1: model_express.model.ModelStatusUpdate.status:type_name -> model_express.model.ModelStatus
-	1, // 2: model_express.model.ModelStatusUpdate.provider:type_name -> model_express.model.ModelProvider
-	1, // 3: model_express.model.ModelFilesRequest.provider:type_name -> model_express.model.ModelProvider
-	5, // 4: model_express.model.ModelFilesRequest.file_selector:type_name -> model_express.model.ModelFileSelector
-	8, // 5: model_express.model.ModelFileList.files:type_name -> model_express.model.ModelFileInfo
-	2, // 6: model_express.model.ModelService.EnsureModelDownloaded:input_type -> model_express.model.ModelDownloadRequest
-	4, // 7: model_express.model.ModelService.StreamModelFiles:input_type -> model_express.model.ModelFilesRequest
-	4, // 8: model_express.model.ModelService.ListModelFiles:input_type -> model_express.model.ModelFilesRequest
-	3, // 9: model_express.model.ModelService.EnsureModelDownloaded:output_type -> model_express.model.ModelStatusUpdate
-	6, // 10: model_express.model.ModelService.StreamModelFiles:output_type -> model_express.model.FileChunk
-	7, // 11: model_express.model.ModelService.ListModelFiles:output_type -> model_express.model.ModelFileList
-	9, // [9:12] is the sub-list for method output_type
-	6, // [6:9] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	1,  // 0: model_express.model.DeleteModelRequest.provider:type_name -> model_express.model.ModelProvider
+	1,  // 1: model_express.model.ModelDownloadRequest.provider:type_name -> model_express.model.ModelProvider
+	0,  // 2: model_express.model.ModelStatusUpdate.status:type_name -> model_express.model.ModelStatus
+	1,  // 3: model_express.model.ModelStatusUpdate.provider:type_name -> model_express.model.ModelProvider
+	1,  // 4: model_express.model.ModelFilesRequest.provider:type_name -> model_express.model.ModelProvider
+	7,  // 5: model_express.model.ModelFilesRequest.file_selector:type_name -> model_express.model.ModelFileSelector
+	10, // 6: model_express.model.ModelFileList.files:type_name -> model_express.model.ModelFileInfo
+	4,  // 7: model_express.model.ModelService.EnsureModelDownloaded:input_type -> model_express.model.ModelDownloadRequest
+	6,  // 8: model_express.model.ModelService.StreamModelFiles:input_type -> model_express.model.ModelFilesRequest
+	6,  // 9: model_express.model.ModelService.ListModelFiles:input_type -> model_express.model.ModelFilesRequest
+	2,  // 10: model_express.model.ModelService.DeleteModel:input_type -> model_express.model.DeleteModelRequest
+	5,  // 11: model_express.model.ModelService.EnsureModelDownloaded:output_type -> model_express.model.ModelStatusUpdate
+	8,  // 12: model_express.model.ModelService.StreamModelFiles:output_type -> model_express.model.FileChunk
+	9,  // 13: model_express.model.ModelService.ListModelFiles:output_type -> model_express.model.ModelFileList
+	3,  // 14: model_express.model.ModelService.DeleteModel:output_type -> model_express.model.DeleteModelResponse
+	11, // [11:15] is the sub-list for method output_type
+	7,  // [7:11] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_model_proto_init() }
@@ -706,14 +827,15 @@ func file_model_proto_init() {
 		return
 	}
 	file_model_proto_msgTypes[1].OneofWrappers = []any{}
-	file_model_proto_msgTypes[4].OneofWrappers = []any{}
+	file_model_proto_msgTypes[3].OneofWrappers = []any{}
+	file_model_proto_msgTypes[6].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_model_proto_rawDesc), len(file_model_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/modelexpress_client/go/gen/modelexpress/model/model_grpc.pb.go
+++ b/modelexpress_client/go/gen/modelexpress/model/model_grpc.pb.go
@@ -25,6 +25,7 @@ const (
 	ModelService_EnsureModelDownloaded_FullMethodName = "/model_express.model.ModelService/EnsureModelDownloaded"
 	ModelService_StreamModelFiles_FullMethodName      = "/model_express.model.ModelService/StreamModelFiles"
 	ModelService_ListModelFiles_FullMethodName        = "/model_express.model.ModelService/ListModelFiles"
+	ModelService_DeleteModel_FullMethodName           = "/model_express.model.ModelService/DeleteModel"
 )
 
 // ModelServiceClient is the client API for ModelService service.
@@ -39,6 +40,8 @@ type ModelServiceClient interface {
 	StreamModelFiles(ctx context.Context, in *ModelFilesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[FileChunk], error)
 	// Get list of files for a model (useful for resumable transfers)
 	ListModelFiles(ctx context.Context, in *ModelFilesRequest, opts ...grpc.CallOption) (*ModelFileList, error)
+	// Delete a model record from the server-side registry (used by `model clear`)
+	DeleteModel(ctx context.Context, in *DeleteModelRequest, opts ...grpc.CallOption) (*DeleteModelResponse, error)
 }
 
 type modelServiceClient struct {
@@ -97,6 +100,16 @@ func (c *modelServiceClient) ListModelFiles(ctx context.Context, in *ModelFilesR
 	return out, nil
 }
 
+func (c *modelServiceClient) DeleteModel(ctx context.Context, in *DeleteModelRequest, opts ...grpc.CallOption) (*DeleteModelResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteModelResponse)
+	err := c.cc.Invoke(ctx, ModelService_DeleteModel_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ModelServiceServer is the server API for ModelService service.
 // All implementations must embed UnimplementedModelServiceServer
 // for forward compatibility.
@@ -109,6 +122,8 @@ type ModelServiceServer interface {
 	StreamModelFiles(*ModelFilesRequest, grpc.ServerStreamingServer[FileChunk]) error
 	// Get list of files for a model (useful for resumable transfers)
 	ListModelFiles(context.Context, *ModelFilesRequest) (*ModelFileList, error)
+	// Delete a model record from the server-side registry (used by `model clear`)
+	DeleteModel(context.Context, *DeleteModelRequest) (*DeleteModelResponse, error)
 	mustEmbedUnimplementedModelServiceServer()
 }
 
@@ -127,6 +142,9 @@ func (UnimplementedModelServiceServer) StreamModelFiles(*ModelFilesRequest, grpc
 }
 func (UnimplementedModelServiceServer) ListModelFiles(context.Context, *ModelFilesRequest) (*ModelFileList, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListModelFiles not implemented")
+}
+func (UnimplementedModelServiceServer) DeleteModel(context.Context, *DeleteModelRequest) (*DeleteModelResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteModel not implemented")
 }
 func (UnimplementedModelServiceServer) mustEmbedUnimplementedModelServiceServer() {}
 func (UnimplementedModelServiceServer) testEmbeddedByValue()                      {}
@@ -189,6 +207,24 @@ func _ModelService_ListModelFiles_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ModelService_DeleteModel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteModelRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ModelServiceServer).DeleteModel(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ModelService_DeleteModel_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ModelServiceServer).DeleteModel(ctx, req.(*DeleteModelRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ModelService_ServiceDesc is the grpc.ServiceDesc for ModelService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -199,6 +235,10 @@ var ModelService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListModelFiles",
 			Handler:    _ModelService_ListModelFiles_Handler,
+		},
+		{
+			MethodName: "DeleteModel",
+			Handler:    _ModelService_DeleteModel_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/modelexpress_client/src/bin/modules/handlers.rs
+++ b/modelexpress_client/src/bin/modules/handlers.rs
@@ -15,7 +15,7 @@ use std::borrow::Cow;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 fn format_model_line(stats: &CacheStats, model: &ModelInfo, detailed: bool) -> String {
     if detailed {
@@ -178,9 +178,18 @@ pub async fn handle_model_command(
         ModelCommands::Clear {
             provider,
             model_name,
-        } => clear_model(storage_path_override, provider, &model_name, format).await,
+        } => {
+            clear_model(
+                storage_path_override,
+                provider,
+                &model_name,
+                server_config,
+                format,
+            )
+            .await
+        }
         ModelCommands::ClearAll { yes } => {
-            clear_all_models(storage_path_override, yes, format).await
+            clear_all_models(storage_path_override, yes, server_config, format).await
         }
         ModelCommands::Validate { model_name } => {
             validate_models(storage_path_override, model_name, format).await
@@ -495,15 +504,45 @@ async fn show_model_status(
     Ok(())
 }
 
+/// Best-effort deletion of a model's server-side registry record. Removing the local
+/// files is the primary intent of `model clear`, so a server that is unreachable or
+/// returns an error is surfaced as a warning rather than failing the command. Returns
+/// `Ok(())` when the record was deleted, `Err(reason)` otherwise.
+async fn delete_model_registry_record(
+    server_config: &ClientConfig,
+    model_name: &str,
+    provider: ModelProvider,
+) -> Result<(), String> {
+    let mut client = Client::new(server_config.clone())
+        .await
+        .map_err(|e| format!("could not connect to server: {e}"))?;
+    client
+        .delete_model_on_server(model_name, provider)
+        .await
+        .map_err(|e| format!("server registry delete failed: {e}"))
+}
+
 async fn clear_model(
     storage_path_override: Option<PathBuf>,
     provider: ModelProvider,
     model_name: &str,
+    server_config: ClientConfig,
     format: &OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let storage_config = get_storage_config(storage_path_override)?;
 
     storage_config.clear_model(model_name, provider)?;
+
+    // Also drop the server-side registry record so a later `model download` re-fetches
+    // the files instead of hitting a stale DOWNLOADED record and returning a false success.
+    let registry_warning =
+        match delete_model_registry_record(&server_config, model_name, provider).await {
+            Ok(()) => None,
+            Err(reason) => {
+                warn!("Cleared local files for '{model_name}' but {reason}");
+                Some(reason)
+            }
+        };
 
     match format {
         OutputFormat::Human => {
@@ -511,13 +550,22 @@ async fn clear_model(
                 "✅ Model '{model_name}' cleared from storage for provider {}",
                 provider
             );
+            match &registry_warning {
+                None => println!("   Server registry record removed"),
+                Some(reason) => println!(
+                    "{}",
+                    format!("⚠️  Server registry record NOT removed: {reason}").yellow()
+                ),
+            }
         }
         _ => {
             let output = serde_json::json!({
                 "success": true,
                 "message": format!("Model '{}' cleared from storage", model_name),
                 "model_name": model_name,
-                "provider": provider.to_string()
+                "provider": provider.to_string(),
+                "registry_cleared": registry_warning.is_none(),
+                "registry_warning": registry_warning,
             });
             print_output(&output, format);
         }
@@ -529,6 +577,7 @@ async fn clear_model(
 async fn clear_all_models(
     storage_path_override: Option<PathBuf>,
     yes: bool,
+    server_config: ClientConfig,
     format: &OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let storage_config = get_storage_config(storage_path_override)?;
@@ -546,16 +595,49 @@ async fn clear_all_models(
         }
     }
 
+    // Capture the cached models before clearing so we can drop their registry records too.
+    let cached = storage_config
+        .get_cache_stats()
+        .map(|stats| {
+            stats
+                .models
+                .into_iter()
+                .map(|model| (model.name, model.provider))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
     storage_config.clear_all()?;
+
+    let mut registry_failures = 0usize;
+    for (name, provider) in &cached {
+        if let Err(reason) = delete_model_registry_record(&server_config, name, *provider).await {
+            warn!("Cleared local files for '{name}' but {reason}");
+            registry_failures = registry_failures.saturating_add(1);
+        }
+    }
 
     match format {
         OutputFormat::Human => {
             println!("✅ All models cleared from storage");
+            if registry_failures == 0 {
+                println!("   Server registry records removed");
+            } else {
+                println!(
+                    "{}",
+                    format!(
+                        "⚠️  {registry_failures} server registry record(s) NOT removed (see warnings)"
+                    )
+                    .yellow()
+                );
+            }
         }
         _ => {
             let output = serde_json::json!({
                 "success": true,
-                "message": "All models cleared from storage"
+                "message": "All models cleared from storage",
+                "registry_records_cleared": cached.len().saturating_sub(registry_failures),
+                "registry_records_failed": registry_failures,
             });
             print_output(&output, format);
         }

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -10,7 +10,8 @@ use modelexpress_common::{
         api::{ApiRequest, api_service_client::ApiServiceClient},
         health::{HealthRequest, health_service_client::HealthServiceClient},
         model::{
-            ModelDownloadRequest, ModelFilesRequest, model_service_client::ModelServiceClient,
+            DeleteModelRequest, ModelDownloadRequest, ModelFilesRequest,
+            ModelProvider as GrpcModelProvider, model_service_client::ModelServiceClient,
         },
     },
     models::{ModelStatus, Status},
@@ -242,6 +243,34 @@ impl Client {
         cache_config.clear_all().map_err(|e| {
             modelexpress_common::Error::Server(format!("Failed to clear cache: {e}")).into()
         })
+    }
+
+    /// Delete a model's record from the server-side registry. This complements
+    /// `clear_cached_model` (which only removes local files) so a cleared model does
+    /// not leave behind a stale `DOWNLOADED` record that would satisfy a later download
+    /// request without re-fetching the files.
+    pub async fn delete_model_on_server(
+        &mut self,
+        model_name: &str,
+        provider: ModelProvider,
+    ) -> CommonResult<()> {
+        let request = tonic::Request::new(DeleteModelRequest {
+            model_name: model_name.to_string(),
+            provider: GrpcModelProvider::from(provider) as i32,
+        });
+
+        let response = self.model_client.delete_model(request).await?;
+        let inner = response.into_inner();
+        if inner.success {
+            Ok(())
+        } else {
+            Err(modelexpress_common::Error::Server(
+                inner
+                    .message
+                    .unwrap_or_else(|| "Failed to delete model from registry".to_string()),
+            )
+            .into())
+        }
     }
 
     pub async fn get_model_path(
@@ -741,7 +770,8 @@ mod tests {
     use modelexpress_common::{
         cache::CacheConfig,
         grpc::model::{
-            FileChunk, ModelDownloadRequest, ModelFileList, ModelFilesRequest, ModelStatusUpdate,
+            DeleteModelRequest, DeleteModelResponse, FileChunk, ModelDownloadRequest,
+            ModelFileList, ModelFilesRequest, ModelStatusUpdate,
             model_service_server::{ModelService, ModelServiceServer},
         },
     };
@@ -794,6 +824,15 @@ mod tests {
                 "list_model_files is not used in this test",
             ))
         }
+
+        async fn delete_model(
+            &self,
+            _request: Request<DeleteModelRequest>,
+        ) -> Result<Response<DeleteModelResponse>, Status> {
+            Err(Status::unimplemented(
+                "delete_model is not used in this test",
+            ))
+        }
     }
 
     #[tonic::async_trait]
@@ -824,6 +863,15 @@ mod tests {
         ) -> Result<Response<ModelFileList>, Status> {
             Err(Status::unimplemented(
                 "list_model_files is not used in this test",
+            ))
+        }
+
+        async fn delete_model(
+            &self,
+            _request: Request<DeleteModelRequest>,
+        ) -> Result<Response<DeleteModelResponse>, Status> {
+            Err(Status::unimplemented(
+                "delete_model is not used in this test",
             ))
         }
     }
@@ -858,6 +906,15 @@ mod tests {
         ) -> Result<Response<ModelFileList>, Status> {
             Err(Status::unimplemented(
                 "list_model_files is not used in this test",
+            ))
+        }
+
+        async fn delete_model(
+            &self,
+            _request: Request<DeleteModelRequest>,
+        ) -> Result<Response<DeleteModelResponse>, Status> {
+            Err(Status::unimplemented(
+                "delete_model is not used in this test",
             ))
         }
     }
@@ -903,6 +960,15 @@ mod tests {
         ) -> Result<Response<ModelFileList>, Status> {
             Err(Status::unimplemented(
                 "list_model_files is not used in this test",
+            ))
+        }
+
+        async fn delete_model(
+            &self,
+            _request: Request<DeleteModelRequest>,
+        ) -> Result<Response<DeleteModelResponse>, Status> {
+            Err(Status::unimplemented(
+                "delete_model is not used in this test",
             ))
         }
     }
@@ -954,6 +1020,15 @@ mod tests {
         ) -> Result<Response<ModelFileList>, Status> {
             Err(Status::unimplemented(
                 "list_model_files is not used in this test",
+            ))
+        }
+
+        async fn delete_model(
+            &self,
+            _request: Request<DeleteModelRequest>,
+        ) -> Result<Response<DeleteModelResponse>, Status> {
+            Err(Status::unimplemented(
+                "delete_model is not used in this test",
             ))
         }
     }

--- a/modelexpress_common/proto/model.proto
+++ b/modelexpress_common/proto/model.proto
@@ -15,6 +15,21 @@ service ModelService {
 
   // Get list of files for a model (useful for resumable transfers)
   rpc ListModelFiles(ModelFilesRequest) returns (ModelFileList);
+
+  // Delete a model record from the server-side registry (used by `model clear`)
+  rpc DeleteModel(DeleteModelRequest) returns (DeleteModelResponse);
+}
+
+// Request to delete a model record from the registry
+message DeleteModelRequest {
+  string model_name = 1;
+  ModelProvider provider = 2;
+}
+
+// Response for a model deletion request
+message DeleteModelResponse {
+  bool success = 1;
+  optional string message = 2;
 }
 
 // Request to ensure a model is downloaded

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -10,8 +10,9 @@ use modelexpress_common::{
         api::{ApiRequest, ApiResponse, api_service_server::ApiService},
         health::{HealthRequest, HealthResponse, health_service_server::HealthService},
         model::{
-            FileChunk, ModelDownloadRequest, ModelFileInfo, ModelFileList, ModelFileSelector,
-            ModelFilesRequest, ModelProvider as GrpcModelProvider, ModelStatusUpdate,
+            DeleteModelRequest, DeleteModelResponse, FileChunk, ModelDownloadRequest,
+            ModelFileInfo, ModelFileList, ModelFileSelector, ModelFilesRequest,
+            ModelProvider as GrpcModelProvider, ModelStatusUpdate,
             model_service_server::ModelService,
         },
     },
@@ -41,6 +42,25 @@ fn get_server_cache_dir() -> Option<std::path::PathBuf> {
             .ok()
             .map(std::path::PathBuf::from)
     }
+}
+
+/// Returns true if the model's files are present in the given cache directory. Used to
+/// guard against stale `DOWNLOADED` registry records that point at a cache entry which no
+/// longer exists on disk (e.g. left behind by a client-side `model clear`). When no cache
+/// directory is configured we cannot verify, so we assume the files are present to preserve
+/// existing behavior rather than loop re-downloading forever.
+async fn model_files_present(
+    cache_dir: Option<std::path::PathBuf>,
+    model_name: &str,
+    provider: ModelProvider,
+) -> bool {
+    let Some(cache_dir) = cache_dir else {
+        return true;
+    };
+    download::get_provider(provider)
+        .get_model_path(model_name, cache_dir)
+        .await
+        .is_ok()
 }
 
 /// Health service implementation
@@ -494,6 +514,37 @@ impl ModelService for ModelServiceImpl {
             total_size,
         }))
     }
+
+    async fn delete_model(
+        &self,
+        request: Request<DeleteModelRequest>,
+    ) -> Result<Response<DeleteModelResponse>, Status> {
+        let delete_request = request.into_inner();
+
+        let grpc_provider = GrpcModelProvider::try_from(delete_request.provider).map_err(|_| {
+            Status::invalid_argument(format!(
+                "Invalid provider value: {}",
+                delete_request.provider
+            ))
+        })?;
+        let provider = ModelProvider::from(grpc_provider);
+        let model_name = download::canonical_model_name(&delete_request.model_name, provider)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+
+        let Some(tracker) = model_tracker() else {
+            return Err(Status::unavailable(
+                "server startup incomplete: model tracker not initialized",
+            ));
+        };
+
+        tracker.delete_status(&model_name).await;
+        info!("Deleted registry record for model '{model_name}'");
+
+        Ok(Response::new(DeleteModelResponse {
+            success: true,
+            message: Some(format!("Model '{model_name}' removed from registry")),
+        }))
+    }
 }
 
 /// Type alias for the complex waiting channels type
@@ -670,24 +721,49 @@ impl ModelDownloadTracker {
         // Atomically try to claim this model for download. The `ClaimOutcome` tells us
         // whether THIS replica won the claim or is observing someone else's claim —
         // status alone (`DOWNLOADING`) can't distinguish those cases across replicas.
-        let (status, is_owner) = match self
-            .registry
-            .try_claim_for_download(model_name, provider)
-            .await
-        {
-            Ok(ClaimOutcome::Claimed) => (ModelStatus::DOWNLOADING, true),
-            Ok(ClaimOutcome::AlreadyExists(existing)) => (existing, false),
-            Err(e) => {
-                error!("Failed to claim model for download: {e}");
-                let error_update = ModelStatusUpdate {
-                    model_name: model_name.to_string(),
-                    status: modelexpress_common::grpc::model::ModelStatus::from(ModelStatus::ERROR)
-                        as i32,
-                    message: Some("Registry error occurred".to_string()),
-                    provider: GrpcModelProvider::from(provider) as i32,
-                };
-                let _ = tx.send(Ok(error_update)).await;
-                return ModelStatus::ERROR;
+        // A claim may report an existing `DOWNLOADED` record whose files no longer exist
+        // on disk (e.g. after a client-side `model clear` that only removed local files).
+        // When that happens we drop the stale record and re-claim once, so the download
+        // path runs instead of returning a false success. Bounded to two attempts to
+        // avoid looping if the delete or a concurrent re-claim keeps the record around.
+        const MAX_CLAIM_ATTEMPTS: usize = 2;
+        let mut attempt: usize = 0;
+        let (status, is_owner) = loop {
+            attempt = attempt.saturating_add(1);
+            match self
+                .registry
+                .try_claim_for_download(model_name, provider)
+                .await
+            {
+                Ok(ClaimOutcome::Claimed) => break (ModelStatus::DOWNLOADING, true),
+                Ok(ClaimOutcome::AlreadyExists(existing)) => {
+                    if existing == ModelStatus::DOWNLOADED
+                        && attempt < MAX_CLAIM_ATTEMPTS
+                        && !model_files_present(get_server_cache_dir(), model_name, provider).await
+                    {
+                        error!(
+                            "Registry reports model '{model_name}' as DOWNLOADED but its files \
+                             are missing from the cache; clearing the stale record and \
+                             re-downloading"
+                        );
+                        self.delete_status(model_name).await;
+                        continue;
+                    }
+                    break (existing, false);
+                }
+                Err(e) => {
+                    error!("Failed to claim model for download: {e}");
+                    let error_update = ModelStatusUpdate {
+                        model_name: model_name.to_string(),
+                        status: modelexpress_common::grpc::model::ModelStatus::from(
+                            ModelStatus::ERROR,
+                        ) as i32,
+                        message: Some("Registry error occurred".to_string()),
+                        provider: GrpcModelProvider::from(provider) as i32,
+                    };
+                    let _ = tx.send(Ok(error_update)).await;
+                    return ModelStatus::ERROR;
+                }
             }
         };
 
@@ -1210,6 +1286,40 @@ mod tests {
             response.total_size,
             br#"{"model":"test"}"#.len() as u64 + b"nested".len() as u64
         );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_model_files_present_reflects_disk_state() {
+        let env_lock = acquire_env_mutex();
+        let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let cache_dir = temp_dir.path().to_path_buf();
+
+        // No files on disk: a stale DOWNLOADED record must not be honored.
+        assert!(
+            !model_files_present(
+                Some(cache_dir.clone()),
+                "test/model",
+                ModelProvider::HuggingFace
+            )
+            .await
+        );
+
+        // Once the snapshot exists, the cache hit is real.
+        let model_dir = cache_dir.join("models--test--model/snapshots/abc123");
+        std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+        std::fs::write(model_dir.join("config.json"), b"{}").expect("Failed to write config");
+        assert!(
+            model_files_present(Some(cache_dir), "test/model", ModelProvider::HuggingFace).await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_model_files_present_assumes_present_without_cache_dir() {
+        // With no configured cache directory we cannot verify, so we must not force a
+        // re-download loop: assume the files are present.
+        assert!(model_files_present(None, "test/model", ModelProvider::HuggingFace).await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`model clear` deletes only the local cache files; it never removes the server-side registry record. The cleared model keeps an orphaned `status=DOWNLOADED` record in Redis. A subsequent default `model download` (smart-fallback) then hits that stale record and returns `✅ SUCCESS / downloaded successfully` without downloading anything — the cache directory is still absent and `model list` still reports the model missing.

### Reproduce
```
modelexpress-cli model download Qwen/Qwen3-0.6B
modelexpress-cli model clear Qwen/Qwen3-0.6B -p hugging-face
modelexpress-cli model download Qwen/Qwen3-0.6B   # ✅ SUCCESS but nothing on disk
```

### Root cause
1. `clear_model` (`handlers.rs`) → `cache.rs` deletes local files only; there was no delete RPC, so the registry record was reachable only via LRU eviction and became orphaned.
2. `ensure_model_downloaded` (`services.rs`) returned the `AlreadyExists(DOWNLOADED)` claim without ever checking that the files exist on disk.

## Fix

**A — `clear` removes the registry record too**
- New `DeleteModel` RPC on `ModelService` (reuses `delete_status`/`delete_model`).
- `model clear` and `model clear-all` now delete the registry record(s) alongside local storage. Best-effort: if the server is unreachable, local files are still cleared and a warning notes the record may remain.

**B — verify disk before honoring a `DOWNLOADED` cache hit**
- `ensure_model_downloaded` checks that the cached files exist before honoring a `DOWNLOADED` claim. If they are missing, it drops the stale record and re-claims so the model is actually re-downloaded. Bounded to two attempts.

Both together: A fixes the clear-side registry leak; B is a backstop for any registry-vs-storage inconsistency.

## Tests
- New server unit tests for `model_files_present` (present / missing / no-cache-dir).
- Updated the 5 mock `ModelService` impls for the new RPC.
- `cargo build`, `cargo clippy --workspace --all-targets` (no warnings), `cargo fmt --check`, and `cargo test --workspace` all pass (server tests 165 → 167).

## Docs
- `docs/ARCHITECTURE.md` — RPC table + behavior note.
- `docs/CLI.md` — `model clear` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `model clear` now removes server-side model registry records to prevent false cache hits on future downloads.
  * Extended `model clear --all` to also remove registry records for all cached models.
  * Graceful fallback: local files are cleared even if the server is unreachable, with a warning about potential stale registry records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->