### PR TITLE
fix(registry): scope model keys by provider to prevent cross-provider false cache hits (backport to 0.4.0)

### DIFF
--- a/modelexpress_server/src/registry/backend/kubernetes.rs
+++ b/modelexpress_server/src/registry/backend/kubernetes.rs
@@ -3,16 +3,14 @@
 
 //! Kubernetes CRD backend for the model registry.
 //!
-//! One `ModelCacheEntry` CR per cached model, with lifecycle state stored in the status
-//! subresource. etcd's name-uniqueness enforces the claim atomicity that Redis gets from
-//! `HSETNX`: the first replica to `create` a given CR wins; others see a 409 Conflict and
-//! read back the existing status.
+//! One `ModelCacheEntry` CR per (provider, cached model), state in the status subresource.
+//! etcd name-uniqueness gives claim atomicity (first to `create` wins; others see 409), the
+//! analogue of Redis `HSETNX`.
 //!
-//! CR names must be DNS-1123 compliant; model names like `meta-llama/Llama-3.1-70B` run
-//! through [`sanitize_registry_name`] (lowercase + `/` -> `--`, trailing dashes
-//! trimmed, sha256 suffix when over the 253-char budget) and gain a `mx-cache-` prefix
-//! so they don't share a name space with the P2P `ModelMetadata` CRs. The original
-//! model name lives in `spec.modelName` for human readability.
+//! CR name: `mx-cache-{sanitize(provider/model_name)}` (DNS-1123, sha256 suffix). The
+//! provider is in the name so the same model under different providers maps to distinct CRs;
+//! `spec.modelName`/`spec.provider` keep the originals. Pre-0.5.0 name-only CRs are migrated
+//! lazily on claim (see `try_claim_for_download`); name-addressed reads cover both forms.
 
 use super::{ClaimOutcome, ModelRecord, RegistryBackend, RegistryResult};
 use crate::registry::k8s_types::{ModelCacheEntry, ModelCacheEntrySpec, phase};
@@ -28,6 +26,13 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 const CR_NAME_PREFIX: &str = "mx-cache-";
+
+/// Every provider, for enumerating candidate CR names in name-addressed lookups.
+const ALL_PROVIDERS: [ModelProvider; 3] = [
+    ModelProvider::HuggingFace,
+    ModelProvider::Ngc,
+    ModelProvider::Gcs,
+];
 
 /// DNS-1123 `metadata.name` hard limit.
 const K8S_NAME_MAX: usize = 253;
@@ -102,8 +107,110 @@ impl KubernetesRegistryBackend {
         Api::namespaced(self.client.clone(), &self.namespace)
     }
 
-    fn cr_name_for(model_name: &str) -> String {
+    /// Provider-scoped CR name: `sanitize("{provider}/{model_name}")`, so the sha256 suffix
+    /// binds (provider, name) and providers never collide.
+    fn cr_name_for(provider: ModelProvider, model_name: &str) -> String {
+        format!(
+            "{CR_NAME_PREFIX}{}",
+            sanitize_registry_name(&format!("{}/{model_name}", Self::provider_str(provider)))
+        )
+    }
+
+    /// Legacy name-only CR name, pre-provider-scoped CRs.
+    /// TODO(0.5.0 migration): remove once no deployment has pre-0.5.0 CRs; see
+    /// `try_claim_for_download`.
+    fn legacy_cr_name_for(model_name: &str) -> String {
         format!("{CR_NAME_PREFIX}{}", sanitize_registry_name(model_name))
+    }
+
+    /// CR names a record for `model_name` may live under when the provider isn't known up
+    /// front: the provider-scoped name for every provider, plus the legacy name-only name.
+    fn candidate_cr_names(model_name: &str) -> Vec<String> {
+        let mut names: Vec<String> = ALL_PROVIDERS
+            .iter()
+            .map(|p| Self::cr_name_for(*p, model_name))
+            .collect();
+        names.push(Self::legacy_cr_name_for(model_name));
+        names
+    }
+
+    /// First existing CR among the candidates (provider-scoped keys, then legacy). Used by
+    /// name-addressed reads; in practice a name maps to a single provider.
+    async fn find_existing_cr(&self, model_name: &str) -> RegistryResult<Option<ModelCacheEntry>> {
+        for cr_name in Self::candidate_cr_names(model_name) {
+            if let Some(cr) = self.get_cr(&cr_name).await? {
+                return Ok(Some(cr));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Lazy migration: if a matching-provider legacy CR exists, recreate it under the
+    /// provider-scoped name (copying status), delete the legacy CR, return `AlreadyExists`.
+    /// `None` if no legacy CR or it's a different provider (caller then claims fresh).
+    /// TODO(0.5.0 migration): remove once all deployments have drained legacy CRs.
+    async fn adopt_legacy_cr(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        scoped_name: &str,
+    ) -> RegistryResult<Option<ClaimOutcome>> {
+        let legacy_name = Self::legacy_cr_name_for(model_name);
+        let Some(legacy_cr) = self.get_cr(&legacy_name).await? else {
+            return Ok(None);
+        };
+        if Self::provider_from_str(&legacy_cr.spec.provider)? != provider {
+            return Ok(None);
+        }
+
+        let legacy_status = legacy_cr.status.clone().unwrap_or_default();
+        let new_cr = ModelCacheEntry::new(
+            scoped_name,
+            ModelCacheEntrySpec {
+                model_name: legacy_cr.spec.model_name.clone(),
+                provider: legacy_cr.spec.provider.clone(),
+            },
+        );
+        // create is atomic; a 409 means a concurrent claim/migration already made the
+        // provider-scoped CR, so we adopt whatever it holds.
+        match self.api().create(&PostParams::default(), &new_cr).await {
+            Ok(_) => {
+                self.patch_status(
+                    scoped_name,
+                    Some(Self::phase_from_status(Self::status_from_phase(
+                        &legacy_status.phase,
+                    ))),
+                    legacy_status.last_used_at.as_deref(),
+                    legacy_status.created_at.as_deref(),
+                    Some(legacy_status.message.as_deref()),
+                )
+                .await?;
+            }
+            Err(kube::Error::Api(e)) if e.code == 409 => {
+                debug!("{scoped_name} already exists during legacy migration; adopting it");
+            }
+            Err(e) => return Err(e.into()),
+        }
+
+        // Best-effort delete of the now-migrated legacy CR (idempotent; tolerate 404).
+        if let Err(e) = self
+            .api()
+            .delete(&legacy_name, &kube::api::DeleteParams::default())
+            .await
+            && !matches!(&e, kube::Error::Api(a) if a.code == 404)
+        {
+            warn!("Failed to delete legacy CR {legacy_name} after migration: {e}");
+        }
+
+        let phase = self
+            .get_cr(scoped_name)
+            .await?
+            .and_then(|cr| cr.status)
+            .unwrap_or_default()
+            .phase;
+        Ok(Some(ClaimOutcome::AlreadyExists(Self::status_from_phase(
+            &phase,
+        ))))
     }
 
     fn provider_str(p: ModelProvider) -> &'static str {
@@ -237,8 +344,7 @@ impl RegistryBackend for KubernetesRegistryBackend {
     }
 
     async fn get_status(&self, model_name: &str) -> RegistryResult<Option<ModelStatus>> {
-        let cr_name = Self::cr_name_for(model_name);
-        match self.get_cr(&cr_name).await? {
+        match self.find_existing_cr(model_name).await? {
             Some(cr) => {
                 let phase = cr.status.unwrap_or_default().phase;
                 Ok(Some(Self::status_from_phase(&phase)))
@@ -248,8 +354,7 @@ impl RegistryBackend for KubernetesRegistryBackend {
     }
 
     async fn get_model_record(&self, model_name: &str) -> RegistryResult<Option<ModelRecord>> {
-        let cr_name = Self::cr_name_for(model_name);
-        match self.get_cr(&cr_name).await? {
+        match self.find_existing_cr(model_name).await? {
             Some(cr) => Ok(Some(Self::record_from_cr(&cr)?)),
             None => Ok(None),
         }
@@ -262,7 +367,7 @@ impl RegistryBackend for KubernetesRegistryBackend {
         status: ModelStatus,
         message: Option<String>,
     ) -> RegistryResult<()> {
-        let cr_name = Self::cr_name_for(model_name);
+        let cr_name = Self::cr_name_for(provider, model_name);
         let now = Utc::now().to_rfc3339();
 
         // Track whether the CR is brand new so we only stamp createdAt on first write —
@@ -305,27 +410,33 @@ impl RegistryBackend for KubernetesRegistryBackend {
     }
 
     async fn touch_model(&self, model_name: &str) -> RegistryResult<()> {
-        let cr_name = Self::cr_name_for(model_name);
-        if self.get_cr(&cr_name).await?.is_none() {
+        // Provider-agnostic: patch lastUsedAt on whichever candidate CR holds the record.
+        let Some(cr) = self.find_existing_cr(model_name).await? else {
             return Ok(()); // no-op on missing record
-        }
+        };
+        let Some(cr_name) = cr.metadata.name.as_deref() else {
+            return Ok(());
+        };
         let now = Utc::now().to_rfc3339();
-        self.patch_status(&cr_name, None, Some(&now), None, None)
+        self.patch_status(cr_name, None, Some(&now), None, None)
             .await?;
         Ok(())
     }
 
     async fn delete_model(&self, model_name: &str) -> RegistryResult<()> {
-        let cr_name = Self::cr_name_for(model_name);
-        match self
-            .api()
-            .delete(&cr_name, &kube::api::DeleteParams::default())
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(kube::Error::Api(e)) if e.code == 404 => Ok(()), // no-op
-            Err(e) => Err(e.into()),
+        // Delete every variant (all providers + legacy); 404 is a no-op.
+        for cr_name in Self::candidate_cr_names(model_name) {
+            match self
+                .api()
+                .delete(&cr_name, &kube::api::DeleteParams::default())
+                .await
+            {
+                Ok(_) => {}
+                Err(kube::Error::Api(e)) if e.code == 404 => {}
+                Err(e) => return Err(e.into()),
+            }
         }
+        Ok(())
     }
 
     async fn get_models_by_last_used(
@@ -375,7 +486,21 @@ impl RegistryBackend for KubernetesRegistryBackend {
         model_name: &str,
         provider: ModelProvider,
     ) -> RegistryResult<ClaimOutcome> {
-        let cr_name = Self::cr_name_for(model_name);
+        let cr_name = Self::cr_name_for(provider, model_name);
+
+        // Fast path (mirrors Redis's scoped-first check): a non-mutating GET returns the
+        // existing status without committing a claim, skipping the legacy lookup in steady state.
+        if let Some(cr) = self.get_cr(&cr_name).await? {
+            let phase = cr.status.unwrap_or_default().phase;
+            return Ok(ClaimOutcome::AlreadyExists(Self::status_from_phase(&phase)));
+        }
+
+        // Scoped CR absent: adopt a matching-provider legacy CR if present; a different-provider
+        // legacy CR is left untouched (the fix: a GCS record can't answer a HuggingFace claim).
+        if let Some(outcome) = self.adopt_legacy_cr(model_name, provider, &cr_name).await? {
+            return Ok(outcome);
+        }
+
         let cr = ModelCacheEntry::new(
             &cr_name,
             ModelCacheEntrySpec {
@@ -423,8 +548,8 @@ impl RegistryBackend for KubernetesRegistryBackend {
                 Ok(ClaimOutcome::Claimed)
             }
             Err(kube::Error::Api(e)) if e.code == 409 => {
-                // Already exists: someone else claimed it (or an earlier run did). Read
-                // back the current phase.
+                // Lost a race: another replica created the scoped CR between our fast-path
+                // GET and this create. Read back the current phase.
                 let existing = self
                     .get_cr(&cr_name)
                     .await?
@@ -441,9 +566,11 @@ impl RegistryBackend for KubernetesRegistryBackend {
     async fn try_reset_error_for_retry(
         &self,
         model_name: &str,
-        _provider: ModelProvider,
+        provider: ModelProvider,
     ) -> RegistryResult<bool> {
-        let cr_name = Self::cr_name_for(model_name);
+        // Retry only runs after a claim observed AlreadyExists (which already migrated any
+        // legacy CR), so the CAS targets the provider-scoped CR directly.
+        let cr_name = Self::cr_name_for(provider, model_name);
         let Some(existing) = self.get_cr(&cr_name).await? else {
             return Ok(false);
         };
@@ -543,9 +670,44 @@ mod tests {
     #[test]
     fn cr_name_stays_within_k8s_limit() {
         let long = "a".repeat(300);
-        let name = KubernetesRegistryBackend::cr_name_for(&long);
+        let name = KubernetesRegistryBackend::cr_name_for(ModelProvider::HuggingFace, &long);
         assert!(name.len() <= K8S_NAME_MAX);
         assert!(name.starts_with(CR_NAME_PREFIX));
+    }
+
+    #[test]
+    fn cr_name_distinguishes_provider_and_legacy() {
+        let n = "google-t5/t5-small";
+        let hf = KubernetesRegistryBackend::cr_name_for(ModelProvider::HuggingFace, n);
+        let ngc = KubernetesRegistryBackend::cr_name_for(ModelProvider::Ngc, n);
+        let gcs = KubernetesRegistryBackend::cr_name_for(ModelProvider::Gcs, n);
+        let legacy = KubernetesRegistryBackend::legacy_cr_name_for(n);
+        // Same name, different provider -> distinct CR names, all distinct from legacy.
+        assert_ne!(hf, ngc);
+        assert_ne!(hf, gcs);
+        assert_ne!(ngc, gcs);
+        assert_ne!(hf, legacy);
+        assert_ne!(ngc, legacy);
+        assert_ne!(gcs, legacy);
+        for name in [&hf, &ngc, &gcs, &legacy] {
+            assert!(name.starts_with(CR_NAME_PREFIX));
+            assert!(name.len() <= K8S_NAME_MAX);
+        }
+    }
+
+    #[test]
+    fn candidate_cr_names_cover_all_providers_and_legacy() {
+        let n = "org/model";
+        let candidates = KubernetesRegistryBackend::candidate_cr_names(n);
+        assert_eq!(candidates.len(), 4);
+        for p in [
+            ModelProvider::HuggingFace,
+            ModelProvider::Ngc,
+            ModelProvider::Gcs,
+        ] {
+            assert!(candidates.contains(&KubernetesRegistryBackend::cr_name_for(p, n)));
+        }
+        assert!(candidates.contains(&KubernetesRegistryBackend::legacy_cr_name_for(n)));
     }
 
     #[test]

--- a/modelexpress_server/src/registry/backend/redis.rs
+++ b/modelexpress_server/src/registry/backend/redis.rs
@@ -3,12 +3,17 @@
 
 //! Redis backend for the model registry.
 //!
-//! One Redis Hash per cached model at `mx:model:{model_name}`, with fields `provider`,
-//! `status`, `created_at`, `last_used_at`, and optional `message`. LRU and status tallies
-//! use on-demand `SCAN` + pipelined reads (no secondary indexes).
+//! One Redis Hash per cached model at `mx:model:{provider}:{model_name}`, fields
+//! `provider`, `status`, `created_at`, `last_used_at`, optional `message`. The provider is
+//! in the key so the same name under different providers stays distinct (a `gs://` GCS
+//! object can't satisfy a HuggingFace claim). LRU/status tallies use `SCAN` + pipelined
+//! reads.
 //!
-//! Lua scripts combine claim/retry/set-status mutations into single atomic EVALs so
-//! concurrent readers never see a partially-written record.
+//! Pre-0.5.0 records live at the legacy name-only key `mx:model:{model_name}`; they are
+//! migrated lazily on claim (see [`CLAIM_LUA`]) and read transparently meanwhile.
+//!
+//! Mutations run as single atomic EVALs. Multi-key EVALs (e.g. the claim's RENAME) assume
+//! a single Redis instance (`ConnectionManager`, not a cluster) so all keys share a slot.
 
 use super::{ClaimOutcome, ModelRecord, RegistryBackend, RegistryResult};
 use async_trait::async_trait;
@@ -33,8 +38,33 @@ mod fields {
     pub const MESSAGE: &str = "message";
 }
 
-fn model_key(model_name: &str) -> String {
+/// Every provider, for enumerating candidate keys in name-addressed lookups.
+const ALL_PROVIDERS: [ModelProvider; 3] = [
+    ModelProvider::HuggingFace,
+    ModelProvider::Ngc,
+    ModelProvider::Gcs,
+];
+
+/// Provider-scoped key: `mx:model:{Provider}:{model_name}`.
+fn model_key(provider: ModelProvider, model_name: &str) -> String {
+    format!("{KEY_PREFIX}{}:{model_name}", provider_str(provider))
+}
+
+/// Legacy name-only key, pre-provider-scoped keys.
+/// TODO(0.5.0 migration): remove once no deployment has pre-0.5.0 keys; see [`CLAIM_LUA`].
+fn legacy_model_key(model_name: &str) -> String {
     format!("{KEY_PREFIX}{model_name}")
+}
+
+/// Keys a record for `model_name` may live under when the provider isn't known up front
+/// (status/eviction/deletion): one per provider plus the legacy key. Fixed fan-out, no SCAN.
+fn candidate_keys(model_name: &str) -> Vec<String> {
+    let mut keys: Vec<String> = ALL_PROVIDERS
+        .iter()
+        .map(|p| model_key(*p, model_name))
+        .collect();
+    keys.push(legacy_model_key(model_name));
+    keys
 }
 
 fn provider_str(p: ModelProvider) -> &'static str {
@@ -157,8 +187,21 @@ impl RedisRegistryBackend {
         Ok(keys)
     }
 
+    /// Model name from a scanned key, for both `mx:model:{Provider}:{name}` and legacy
+    /// `mx:model:{name}`. A leading known-provider token + `:` is the prefix; else the
+    /// whole remainder is the name. Real names never collide (GCS is `gs://`, HF/NGC
+    /// `org/...`), and the provider is read from the hash field regardless.
     fn model_name_from_key(key: &str) -> Option<&str> {
-        key.strip_prefix(KEY_PREFIX)
+        let rest = key.strip_prefix(KEY_PREFIX)?;
+        for p in ALL_PROVIDERS {
+            if let Some(name) = rest
+                .strip_prefix(provider_str(p))
+                .and_then(|r| r.strip_prefix(':'))
+            {
+                return Some(name);
+            }
+        }
+        Some(rest)
     }
 
     fn record_from_hash(
@@ -200,8 +243,14 @@ impl RegistryBackend for RedisRegistryBackend {
 
     async fn get_status(&self, model_name: &str) -> RegistryResult<Option<ModelStatus>> {
         let mut conn = self.get_conn().await?;
-        let value: Option<String> = conn.hget(model_key(model_name), fields::STATUS).await?;
-        match value {
+        // Provider-agnostic: the caller may not know the provider, so HGET every candidate
+        // key in one round-trip and take the first that exists (a name maps to one provider).
+        let mut pipe = redis::pipe();
+        for k in candidate_keys(model_name) {
+            pipe.hget(k, fields::STATUS);
+        }
+        let values: Vec<Option<String>> = pipe.query_async(&mut conn).await?;
+        match values.into_iter().flatten().next() {
             Some(s) => Ok(Some(status_from_str(&s)?)),
             None => Ok(None),
         }
@@ -209,11 +258,19 @@ impl RegistryBackend for RedisRegistryBackend {
 
     async fn get_model_record(&self, model_name: &str) -> RegistryResult<Option<ModelRecord>> {
         let mut conn = self.get_conn().await?;
-        let pairs: Vec<(String, String)> = conn.hgetall(model_key(model_name)).await?;
-        if pairs.is_empty() {
-            return Ok(None);
+        // Provider-agnostic: how eviction discovers the provider from a bare name. First
+        // non-empty hash wins; its `provider` field is authoritative.
+        let mut pipe = redis::pipe();
+        for k in candidate_keys(model_name) {
+            pipe.hgetall(k);
         }
-        Ok(Some(Self::record_from_hash(model_name, pairs)?))
+        let hashes: Vec<Vec<(String, String)>> = pipe.query_async(&mut conn).await?;
+        for pairs in hashes {
+            if !pairs.is_empty() {
+                return Ok(Some(Self::record_from_hash(model_name, pairs)?));
+            }
+        }
+        Ok(None)
     }
 
     async fn set_status(
@@ -225,7 +282,7 @@ impl RegistryBackend for RedisRegistryBackend {
     ) -> RegistryResult<()> {
         let mut conn = self.get_conn().await?;
         let now = Utc::now().to_rfc3339();
-        let key = model_key(model_name);
+        let key = model_key(provider, model_name);
         // A single EVAL so the status/provider/last_used_at/message/created_at updates
         // are atomic: concurrent get_model_record calls see either the pre- or post-
         // update record, never a half-written one (HGETALL never interleaves with the
@@ -250,20 +307,22 @@ impl RegistryBackend for RedisRegistryBackend {
     async fn touch_model(&self, model_name: &str) -> RegistryResult<()> {
         let mut conn = self.get_conn().await?;
         let now = Utc::now().to_rfc3339();
-        // HSET on a missing key would create a malformed record (last_used_at only).
-        // Gate on EXISTS so touch is purely an update, never a create.
-        let key = model_key(model_name);
-        let exists: bool = conn.exists(&key).await?;
-        if !exists {
-            return Ok(());
+        // Provider-agnostic: bump last_used_at on whichever candidate key exists. The EVAL
+        // gates each HSET on EXISTS so touch never creates a (last_used_at-only) record.
+        let keys = candidate_keys(model_name);
+        let script = redis::Script::new(TOUCH_LUA);
+        let mut invocation = script.prepare_invoke();
+        for k in &keys {
+            invocation.key(k);
         }
-        let _: () = conn.hset(&key, fields::LAST_USED_AT, now).await?;
+        let _: i32 = invocation.arg(&now).invoke_async(&mut conn).await?;
         Ok(())
     }
 
     async fn delete_model(&self, model_name: &str) -> RegistryResult<()> {
         let mut conn = self.get_conn().await?;
-        let _: () = conn.del(model_key(model_name)).await?;
+        // Delete every variant (all providers + legacy); DEL ignores absent keys.
+        let _: () = conn.del(candidate_keys(model_name)).await?;
         Ok(())
     }
 
@@ -334,15 +393,15 @@ impl RegistryBackend for RedisRegistryBackend {
         provider: ModelProvider,
     ) -> RegistryResult<ClaimOutcome> {
         let mut conn = self.get_conn().await?;
-        let key = model_key(model_name);
+        let key = model_key(provider, model_name);
+        let legacy = legacy_model_key(model_name);
         let now = Utc::now().to_rfc3339();
-        // Atomic claim + populate: a single EVAL so readers never see a partially-written
-        // record. The script returns a sentinel string — `CLAIM_WON_SENTINEL` if we
-        // created the record, or the existing status string if someone else already
-        // claimed it. This distinction is what lets callers know which replica owns
-        // the download (status alone can't — both claimer and observer see DOWNLOADING).
+        // Single atomic EVAL: returns CLAIM_WON_SENTINEL if we created the record, else the
+        // existing status, so callers know which replica owns the download (status alone
+        // can't — both see DOWNLOADING). KEYS[2] is the legacy key for migration (see below).
         let result: String = redis::Script::new(CLAIM_LUA)
             .key(&key)
+            .key(&legacy)
             .arg(CLAIM_WON_SENTINEL)
             .arg(status_str(ModelStatus::DOWNLOADING))
             .arg(provider_str(provider))
@@ -363,7 +422,9 @@ impl RegistryBackend for RedisRegistryBackend {
         provider: ModelProvider,
     ) -> RegistryResult<bool> {
         let mut conn = self.get_conn().await?;
-        let key = model_key(model_name);
+        // Retry only runs after a claim observed AlreadyExists (which already migrated any
+        // legacy record), so the CAS targets the provider-scoped key directly.
+        let key = model_key(provider, model_name);
         let now = Utc::now().to_rfc3339();
         // Atomic CAS: flip status from ERROR to DOWNLOADING. Returns 1 on win, 0 on
         // miss. Only the winner spawns the retry download.
@@ -384,13 +445,26 @@ impl RegistryBackend for RedisRegistryBackend {
 /// it cannot be confused with any real `ModelStatus` string.
 const CLAIM_WON_SENTINEL: &str = "__MX_CLAIM_WON__";
 
-/// Atomic claim: if the hash has no `status` field, populate all fields in one shot and
-/// return the win sentinel; otherwise return the existing `status` unchanged.
+/// Atomic claim against the provider-scoped key, lazily migrating legacy records:
+///   1. provider-scoped key exists -> return its status (normal hit);
+///   2. matching-provider legacy record -> RENAME onto the new key, adopt it. A
+///      different-provider legacy record is left alone and does NOT satisfy the claim
+///      (the fix: a GCS record can't answer a HuggingFace claim);
+///   3. else populate fields, return the win sentinel.
 ///
-/// KEYS[1] = model key, ARGV = [win_sentinel, status, provider, now, message]
+/// TODO(0.5.0 migration): drop the KEYS[2] arm once all deployments have drained legacy keys.
+///
+/// KEYS = [provider-scoped, legacy]; ARGV = [win_sentinel, status, provider, now, message]
 const CLAIM_LUA: &str = r#"
 local existing = redis.call("HGET", KEYS[1], "status")
 if existing then return existing end
+local legacy_status = redis.call("HGET", KEYS[2], "status")
+if legacy_status then
+    if redis.call("HGET", KEYS[2], "provider") == ARGV[3] then
+        redis.call("RENAME", KEYS[2], KEYS[1])
+        return legacy_status
+    end
+end
 redis.call("HSET", KEYS[1],
     "status", ARGV[2],
     "provider", ARGV[3],
@@ -398,6 +472,18 @@ redis.call("HSET", KEYS[1],
     "last_used_at", ARGV[4],
     "message", ARGV[5])
 return ARGV[1]
+"#;
+
+/// Bump `last_used_at` on the first existing candidate key. KEYS = candidate keys,
+/// ARGV[1] = now. Returns 1 if a record was touched, 0 if none existed.
+const TOUCH_LUA: &str = r#"
+for i = 1, #KEYS do
+    if redis.call("EXISTS", KEYS[i]) == 1 then
+        redis.call("HSET", KEYS[i], "last_used_at", ARGV[1])
+        return 1
+    end
+end
+return 0
 "#;
 
 /// Atomic CAS: flip status from `from_status` to `to_status` (also refreshing
@@ -470,12 +556,43 @@ mod tests {
 
     #[test]
     fn model_key_and_parse() {
-        let k = model_key("meta-llama/Llama-3.1-70B");
-        assert_eq!(k, "mx:model:meta-llama/Llama-3.1-70B");
+        // Provider-scoped key round-trips through model_name_from_key.
+        let k = model_key(ModelProvider::HuggingFace, "meta-llama/Llama-3.1-70B");
+        assert_eq!(k, "mx:model:HuggingFace:meta-llama/Llama-3.1-70B");
         assert_eq!(
             RedisRegistryBackend::model_name_from_key(&k),
             Some("meta-llama/Llama-3.1-70B")
         );
+
+        // A GCS gs:// name is not mistaken for the `Gcs` provider segment.
+        let g = model_key(ModelProvider::Gcs, "gs://bucket/org/model/rev");
+        assert_eq!(g, "mx:model:Gcs:gs://bucket/org/model/rev");
+        assert_eq!(
+            RedisRegistryBackend::model_name_from_key(&g),
+            Some("gs://bucket/org/model/rev")
+        );
+
+        // Legacy name-only keys (no provider segment) parse to the whole remainder.
+        let legacy = legacy_model_key("gs://bucket/org/model/rev");
+        assert_eq!(legacy, "mx:model:gs://bucket/org/model/rev");
+        assert_eq!(
+            RedisRegistryBackend::model_name_from_key(&legacy),
+            Some("gs://bucket/org/model/rev")
+        );
+        assert_eq!(
+            RedisRegistryBackend::model_name_from_key("mx:model:meta-llama/Llama-3.1-70B"),
+            Some("meta-llama/Llama-3.1-70B")
+        );
+    }
+
+    #[test]
+    fn candidate_keys_cover_all_providers_and_legacy() {
+        let keys = candidate_keys("org/model");
+        assert_eq!(keys.len(), 4);
+        assert!(keys.contains(&"mx:model:HuggingFace:org/model".to_string()));
+        assert!(keys.contains(&"mx:model:Ngc:org/model".to_string()));
+        assert!(keys.contains(&"mx:model:Gcs:org/model".to_string()));
+        assert!(keys.contains(&"mx:model:org/model".to_string())); // legacy
     }
 
     #[test]

--- a/workspace-tests/tests/registry_backend_redis.rs
+++ b/workspace-tests/tests/registry_backend_redis.rs
@@ -347,3 +347,139 @@ async fn get_status_counts_reflects_stored_records() {
 
     flushdb(15);
 }
+
+/// Open a raw async connection for tests that must inspect or seed keys directly,
+/// bypassing the backend's provider-scoped write path.
+async fn raw_conn() -> redis::aio::MultiplexedConnection {
+    redis::Client::open(redis_url().as_str())
+        .expect("open redis client")
+        .get_multiplexed_async_connection()
+        .await
+        .expect("async redis connection")
+}
+
+async fn key_exists(key: &str) -> bool {
+    let mut conn = raw_conn().await;
+    redis::cmd("EXISTS")
+        .arg(key)
+        .query_async::<i64>(&mut conn)
+        .await
+        .expect("EXISTS")
+        == 1
+}
+
+/// Seed a pre-0.5.0 legacy name-only record (`mx:model:{name}`) directly, to exercise
+/// lazy migration on claim.
+async fn seed_legacy_record(name: &str, provider: &str, status: &str) {
+    let mut conn = raw_conn().await;
+    let now = "2026-01-01T00:00:00+00:00";
+    let _: () = redis::cmd("HSET")
+        .arg(format!("mx:model:{name}"))
+        .arg("status")
+        .arg(status)
+        .arg("provider")
+        .arg(provider)
+        .arg("created_at")
+        .arg(now)
+        .arg("last_used_at")
+        .arg(now)
+        .query_async(&mut conn)
+        .await
+        .expect("seed legacy record");
+}
+
+/// Regression test for the MX 0.4.0 name-only-key collision: the same model name
+/// requested under two providers must yield two independent records, never a false
+/// cache hit against the record stored under a different provider.
+#[tokio::test]
+#[ignore = "requires a live Redis at REDIS_URL"]
+async fn cross_provider_claims_do_not_collide() {
+    let backend = fresh_backend().await;
+    let name = unique_name("cross/model");
+
+    let first = backend
+        .try_claim_for_download(&name, ModelProvider::Gcs)
+        .await
+        .expect("gcs claim");
+    assert_eq!(first, ClaimOutcome::Claimed);
+
+    // The SAME name under a different provider must win its OWN fresh claim, not observe
+    // the GCS record as AlreadyExists.
+    let second = backend
+        .try_claim_for_download(&name, ModelProvider::HuggingFace)
+        .await
+        .expect("hf claim");
+    assert_eq!(
+        second,
+        ClaimOutcome::Claimed,
+        "HuggingFace claim must not collide with the existing GCS record"
+    );
+
+    // Both provider-scoped records exist; no legacy name-only key was written.
+    assert!(key_exists(&format!("mx:model:Gcs:{name}")).await);
+    assert!(key_exists(&format!("mx:model:HuggingFace:{name}")).await);
+    assert!(!key_exists(&format!("mx:model:{name}")).await);
+
+    // delete_model clears every variant.
+    backend.delete_model(&name).await.expect("delete");
+    assert!(!key_exists(&format!("mx:model:Gcs:{name}")).await);
+    assert!(!key_exists(&format!("mx:model:HuggingFace:{name}")).await);
+}
+
+/// A legacy record claimed under its OWN provider is adopted and migrated to the
+/// provider-scoped key (the legacy key is removed).
+#[tokio::test]
+#[ignore = "requires a live Redis at REDIS_URL"]
+async fn legacy_record_migrates_on_matching_provider_claim() {
+    let backend = fresh_backend().await;
+    let name = unique_name("legacy/match");
+    seed_legacy_record(&name, "Gcs", "DOWNLOADED").await;
+
+    let outcome = backend
+        .try_claim_for_download(&name, ModelProvider::Gcs)
+        .await
+        .expect("gcs claim over legacy");
+    assert_eq!(
+        outcome,
+        ClaimOutcome::AlreadyExists(ModelStatus::DOWNLOADED)
+    );
+
+    // Migrated: lives at the provider-scoped key, legacy key gone, fields preserved.
+    assert!(key_exists(&format!("mx:model:Gcs:{name}")).await);
+    assert!(!key_exists(&format!("mx:model:{name}")).await);
+    let rec = backend
+        .get_model_record(&name)
+        .await
+        .expect("record")
+        .expect("present");
+    assert_eq!(rec.provider, ModelProvider::Gcs);
+    assert_eq!(rec.status, ModelStatus::DOWNLOADED);
+
+    backend.delete_model(&name).await.expect("delete");
+}
+
+/// A legacy record claimed under a DIFFERENT provider must not be adopted: the claim
+/// wins fresh under its own key and the legacy record is left untouched.
+#[tokio::test]
+#[ignore = "requires a live Redis at REDIS_URL"]
+async fn legacy_record_ignored_on_mismatched_provider_claim() {
+    let backend = fresh_backend().await;
+    let name = unique_name("legacy/mismatch");
+    seed_legacy_record(&name, "Gcs", "DOWNLOADED").await;
+
+    let outcome = backend
+        .try_claim_for_download(&name, ModelProvider::HuggingFace)
+        .await
+        .expect("hf claim over mismatched legacy");
+    assert_eq!(outcome, ClaimOutcome::Claimed);
+
+    // HF record created; the mismatched GCS legacy record remains.
+    assert!(key_exists(&format!("mx:model:HuggingFace:{name}")).await);
+    assert!(
+        key_exists(&format!("mx:model:{name}")).await,
+        "mismatched-provider legacy record must remain untouched"
+    );
+
+    backend.delete_model(&name).await.expect("delete");
+    assert!(!key_exists(&format!("mx:model:{name}")).await);
+}


### PR DESCRIPTION
  Backport of #410 to `release/0.4.0`.

  The model registry keyed records by name only, so a download request's `--provider`
  was silently ignored when a record with that name already existed: a mismatched
  provider/name resolved to a false cache-hit success instead of failing clearly. This
  scopes the registry key by provider in both backends:

  - Redis: `mx:model:{provider}:{model_name}`
  - Kubernetes: the CR name folds in the provider (`mx-cache-{sanitize(provider/model_name)}`)

  Pre-0.5.0 name-only records migrate lazily on claim; name-addressed reads and deletes
  still resolve over both forms, so eviction keeps working with no flush or manual migration.

  Clean cherry-pick of 7e6e41b, no conflicts; pre-commit (fmt/clippy/check) green.

  Original PR: #410