### PR TITLE
ci: expand vCluster diagnostics + dump on test-job failure

### DIFF
--- a/.github/actions/dump-vcluster-diagnostics/action.yml
+++ b/.github/actions/dump-vcluster-diagnostics/action.yml
@@ -148,14 +148,20 @@ runs:
             | tail -30 \
             || echo "(no error/warn entries)"
           echo "--- ${POD} syncer (previous, if any — error/warn in last 500 lines) ---"
+          # Per-job + per-pod temp path. ${RUNNER_TEMP} is isolated per
+          # GitHub Actions job; without it, concurrent jobs landing on
+          # the same self-hosted runner host would race on /tmp and
+          # garble each other's diagnostics (test-p2p alone has
+          # max-parallel=3, plus the other test jobs).
+          PREV_LOG="${RUNNER_TEMP:-/tmp}/prev_syncer_${POD}.log"
           if ${KCTL} logs -n "${VCLUSTER_NAMESPACE}" "${POD}" -c syncer --previous --tail=500 \
-               > /tmp/prev_syncer.log 2>/dev/null; then
-            grep -iE '\b(error|warn|panic|fatal)\b' /tmp/prev_syncer.log \
+               > "${PREV_LOG}" 2>/dev/null; then
+            grep -iE '\b(error|warn|panic|fatal)\b' "${PREV_LOG}" \
               | tail -30 \
               || echo "(no error/warn entries in the previous container log)"
           else
             echo "(no previous container log)"
           fi
-          rm -f /tmp/prev_syncer.log
+          rm -f "${PREV_LOG}"
         done
         echo "::endgroup::"

--- a/.github/actions/dump-vcluster-diagnostics/action.yml
+++ b/.github/actions/dump-vcluster-diagnostics/action.yml
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Dump vCluster diagnostics'
+description: |
+  Snapshot vCluster control-plane state (pod status, conditions, recent events,
+  controller-identity overlay for disruption events, syncer logs). Used in two
+  places:
+
+    1. The `ensure-vcluster` job runs this with `if: always()` to establish a
+       baseline of vCluster health BEFORE any test fires.
+    2. Each test job runs it again with `if: failure()` so that whenever a
+       test step fails for any reason, we capture the vCluster's state at
+       that moment — useful when the failure was actually caused by infra-
+       side disruption (mid-run eviction, syncer hiccup, etc.), which the
+       baseline at job-start can't show.
+
+  All groups use `set +e` + `|| true` so the diagnostic itself never gates
+  the calling step's exit code.
+
+  Uses the host kubeconfig because the vCluster pod is a host-cluster
+  resource (the vCluster API server, which `KUBECONFIG=.kubeconfig-vcluster`
+  points to, doesn't see its own pod).
+
+inputs:
+  vcluster_name:
+    description: 'Name of the vCluster (used in the app=vcluster,release=<name> selector)'
+    required: true
+  vcluster_namespace:
+    description: 'Host namespace the vCluster lives in'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Dump vCluster diagnostics
+      shell: bash
+      env:
+        VCLUSTER_NAME: ${{ inputs.vcluster_name }}
+        VCLUSTER_NAMESPACE: ${{ inputs.vcluster_namespace }}
+      run: |
+        set +e
+        SELECTOR="app=vcluster,release=${VCLUSTER_NAME}"
+        # Always read from the host kubeconfig written by connect-vcluster.
+        KCTL="kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-host"
+
+        echo "::group::vCluster pod summary"
+        ${KCTL} get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
+          -o wide 2>&1 || true
+        echo "::endgroup::"
+
+        echo "::group::vCluster container restart count + last termination"
+        # Restart count > 0 or any non-empty lastState.terminated is a smoking
+        # gun for a recent crash — most likely OOM or a control-plane bug.
+        ${KCTL} get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
+          -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .status.containerStatuses[*]}  {.name}: restartCount={.restartCount}, lastState={.lastState}{"\n"}{end}{end}' 2>&1 || true
+        echo
+        echo "::endgroup::"
+
+        echo "::group::vCluster pod conditions"
+        # status.conditions shows the why behind Ready=False / PodScheduled=False
+        # (e.g., "Unschedulable: 0/N nodes are available"). Tiny output, high
+        # signal — usually one line tells you everything.
+        ${KCTL} get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
+          -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .status.conditions[*]}  {.type}={.status} reason={.reason} message={.message}{"\n"}{end}{end}' 2>&1 || true
+        echo
+        echo "::endgroup::"
+
+        echo "::group::Recent events in ${VCLUSTER_NAMESPACE} (last 50)"
+        # Catches scheduler/eviction/probe-failure events for the vCluster
+        # pod and any sibling resources.
+        ${KCTL} get events -n "${VCLUSTER_NAMESPACE}" \
+          --sort-by='.lastTimestamp' 2>&1 | tail -50 || true
+        echo "::endgroup::"
+
+        echo "::group::Warning events in ${VCLUSTER_NAMESPACE} (signal-only view)"
+        # Same window as above but filtered to Warning type — easier to scan
+        # for "what's broken" without the noise of routine Normal events.
+        ${KCTL} get events -n "${VCLUSTER_NAMESPACE}" \
+          --field-selector type=Warning \
+          --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+        echo "::endgroup::"
+
+        NODE=$(${KCTL} get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
+          -o jsonpath='{.items[0].spec.nodeName}' 2>/dev/null)
+
+        echo "::group::Events on the node hosting the vCluster pod"
+        # Node-level disruption events (cordon, drain, taint changes,
+        # autoscaler decisions like Drifted / Underutilized) fire on the
+        # Node object — cluster-scoped — so namespace-scoped event queries
+        # miss them. Filter by involvedObject=Node to catch them.
+        if [ -n "${NODE}" ]; then
+          echo "Node: ${NODE}"
+          ${KCTL} get events --all-namespaces \
+            --field-selector "involvedObject.kind=Node,involvedObject.name=${NODE}" \
+            --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+        else
+          echo "(no node assigned to vCluster pod yet)"
+        fi
+        echo "::endgroup::"
+
+        echo "::group::Recent disruption-related events with source.component (who emitted them)"
+        # The default `kubectl get events` output doesn't show
+        # source.component / reportingController — the fields that name
+        # the controller that emitted each event. Those are the most
+        # diagnostic pieces of info for "what controller is causing
+        # this": karpenter / cluster-autoscaler / descheduler / kubelet
+        # / something custom. We capture all four "this pod's life is
+        # being disturbed" reasons we've seen in the wild, plus a
+        # couple more standard ones, so the dump catches the full
+        # disruption sequence (eviction trigger → kubelet container
+        # stop → readiness probe failures during shutdown → mount/IO
+        # errors on the replacement pod).
+        #
+        # Scoped to ${VCLUSTER_NAMESPACE}: this is where the vCluster pod
+        # and every synced-from-vCluster pod lives, so the pod-side
+        # disruption signals (Evicted / Killing / Unhealthy) all land
+        # here. Node-level disruption events are captured separately by
+        # the node-events group above; scoping this view tightly avoids
+        # noise from unrelated workloads in other host namespaces.
+        #
+        # `--field-selector` doesn't OR across reasons, so we drop it
+        # and use awk to keep the header line plus any matching rows.
+        # The full list is shown in the existing event groups above;
+        # this view is just the controller-identity overlay on top.
+        ${KCTL} get events -n "${VCLUSTER_NAMESPACE}" \
+          --sort-by='.lastTimestamp' \
+          -o custom-columns='LAST-SEEN:.lastTimestamp,OBJECT:.involvedObject.name,REASON:.reason,SOURCE:.source.component,REPORTING:.reportingController,MESSAGE:.message' \
+          2>&1 | awk 'NR==1 || /Evicted|Killing|Preempted|TaintManagerEviction|NodeNotReady|Unhealthy|FailedMount|Drained|Drifted|Underutilized|Consolidating|Expired/' \
+          | tail -30 || true
+        echo "::endgroup::"
+
+        echo "::group::vCluster syncer error/warn entries (current + previous container)"
+        # The syncer logs every reconciliation, so an unfiltered tail is
+        # 95% routine INFO chatter and 5% signal. Filter to lines that
+        # contain a level token (error / warn / panic / fatal) — that's
+        # what we'd actually look at when triaging.
+        #
+        # Time-based bound (--since=30m) on the current container so we
+        # see the last ~half-hour of activity regardless of throughput.
+        # Previous container is a static log (the container is dead), so
+        # use --tail=500 to bound by lines instead.
+        for POD in $(${KCTL} get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
+            -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+          echo "--- ${POD} syncer (current, error/warn in last 30m) ---"
+          ${KCTL} logs -n "${VCLUSTER_NAMESPACE}" "${POD}" -c syncer --since=30m 2>&1 \
+            | grep -iE '\b(error|warn|panic|fatal)\b' \
+            | tail -30 \
+            || echo "(no error/warn entries)"
+          echo "--- ${POD} syncer (previous, if any — error/warn in last 500 lines) ---"
+          if ${KCTL} logs -n "${VCLUSTER_NAMESPACE}" "${POD}" -c syncer --previous --tail=500 \
+               > /tmp/prev_syncer.log 2>/dev/null; then
+            grep -iE '\b(error|warn|panic|fatal)\b' /tmp/prev_syncer.log \
+              | tail -30 \
+              || echo "(no error/warn entries in the previous container log)"
+          else
+            echo "(no previous container log)"
+          fi
+          rm -f /tmp/prev_syncer.log
+        done
+        echo "::endgroup::"

--- a/.github/workflows/modelexpress-ci-tests.yml
+++ b/.github/workflows/modelexpress-ci-tests.yml
@@ -277,40 +277,14 @@ jobs:
         # tells us whether the vCluster was already showing signs of strain
         # (restarts, OOMs, evictions, low headroom) or was healthy at the start
         # — pointing the investigation at either cluster-health or test-load.
-        # Uses the host kubeconfig (set by connect-vcluster) since the vCluster
-        # pod itself is a host-cluster resource.
+        # Same action is invoked with `if: failure()` from each test job to
+        # capture state at the moment a test failed (which may post-date
+        # this baseline).
         if: always()
-        shell: bash
-        run: |
-          set +e
-          SELECTOR="app=vcluster,release=${VCLUSTER_NAME}"
-
-          echo "::group::vCluster pod summary"
-          kubectl get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
-            -o wide 2>&1 || true
-          echo "::endgroup::"
-
-          echo "::group::vCluster container restart count + last termination"
-          # Restart count > 0 or any non-empty lastState.terminated is a smoking
-          # gun for a recent crash — most likely OOM or a control-plane bug.
-          kubectl get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
-            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .status.containerStatuses[*]}  {.name}: restartCount={.restartCount}, lastState={.lastState}{"\n"}{end}{end}' 2>&1 || true
-          echo
-          echo "::endgroup::"
-
-          echo "::group::vCluster pod resource usage (kubectl top)"
-          # Requires metrics-server in the host cluster. Failure here is fine —
-          # the diagnostic is best-effort and shouldn't gate the job.
-          kubectl top pod -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" 2>&1 || \
-            echo "(kubectl top unavailable — metrics-server not installed or not ready)"
-          echo "::endgroup::"
-
-          echo "::group::Recent events in ${VCLUSTER_NAMESPACE} (last 30)"
-          # Catches scheduler/eviction/probe-failure events for the vCluster
-          # pod and any sibling resources.
-          kubectl get events -n "${VCLUSTER_NAMESPACE}" \
-            --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
-          echo "::endgroup::"
+        uses: ./.github/actions/dump-vcluster-diagnostics
+        with:
+          vcluster_name: ${{ env.VCLUSTER_NAME }}
+          vcluster_namespace: ${{ env.VCLUSTER_NAMESPACE }}
 
       - name: Reap vCluster port-forward
         # connect-vcluster backgrounds a `kubectl port-forward` and exports
@@ -403,6 +377,17 @@ jobs:
           source_port: ${{ matrix.source_port }}
           worker_port: ${{ matrix.worker_port }}
           pytest_args: ${{ matrix.pytest_args }}
+
+      - name: Dump vCluster diagnostics on failure
+        # Captures vCluster control-plane state at the moment of failure
+        # (pod status, recent events, syncer logs, controller-identity
+        # overlay) — surfaces infra-side disruption that may be the real
+        # cause rather than the test itself.
+        if: failure()
+        uses: ./.github/actions/dump-vcluster-diagnostics
+        with:
+          vcluster_name: ${{ env.VCLUSTER_NAME }}
+          vcluster_namespace: ${{ env.VCLUSTER_NAMESPACE }}
 
       - name: Reap vCluster port-forward
         # connect-vcluster backgrounds a `kubectl port-forward` and exports
@@ -508,6 +493,13 @@ jobs:
           worker_port: ${{ matrix.worker_port }}
           tp_size: ${{ matrix.tp_size }}
 
+      - name: Dump vCluster diagnostics on failure
+        if: failure()
+        uses: ./.github/actions/dump-vcluster-diagnostics
+        with:
+          vcluster_name: ${{ env.VCLUSTER_NAME }}
+          vcluster_namespace: ${{ env.VCLUSTER_NAMESPACE }}
+
       - name: Reap vCluster port-forward
         # connect-vcluster backgrounds a `kubectl port-forward` and exports
         # VCLUSTER_PF_PID via $GITHUB_ENV. Kill it before the job ends so
@@ -576,6 +568,13 @@ jobs:
           model: ${{ env.MX_CI_MODEL }}
           hf_token: ${{ secrets.HF_TOKEN }}
 
+      - name: Dump vCluster diagnostics on failure
+        if: failure()
+        uses: ./.github/actions/dump-vcluster-diagnostics
+        with:
+          vcluster_name: ${{ env.VCLUSTER_NAME }}
+          vcluster_namespace: ${{ env.VCLUSTER_NAMESPACE }}
+
       - name: Reap vCluster port-forward
         if: always()
         run: |
@@ -636,6 +635,13 @@ jobs:
           worker_registry: nvcr.io
           ngc_api_key: ${{ secrets.NGC_API_KEY }}
           source_port: ${{ matrix.source_port }}
+
+      - name: Dump vCluster diagnostics on failure
+        if: failure()
+        uses: ./.github/actions/dump-vcluster-diagnostics
+        with:
+          vcluster_name: ${{ env.VCLUSTER_NAME }}
+          vcluster_namespace: ${{ env.VCLUSTER_NAMESPACE }}
 
       - name: Reap vCluster port-forward
         if: always()


### PR DESCRIPTION
## Summary

Builds out the vCluster diagnostic step we already had in `ensure-vcluster`,
then makes it run on every vCluster-using test job's failure path so we
capture state at the moment a test breaks — not just at the start of the
workflow run when everything still looks healthy.

The motivation is the recurring vCluster instability we've been seeing on
the shared AKS test cluster (tracked in [MX-359][mx-359]). When the
vCluster pod gets evicted mid-run, the kubectl port-forward downstream
tests hold goes dead, kubectl calls start returning `connection refused`,
and pytest tests fail in ways that look like real bugs. This PR is the diagnostic
groundwork that turns "test failed, no idea why" into "test failed because
the syncer went away at HH:MM:SS, here's the eviction event and who
emitted it."

The diagnostic step was inline in the workflow before, only ran in
`ensure-vcluster` at job start, and was missing some important signals.
This PR extracts it into a reusable composite action, expands what it
captures, and wires it as `if: failure()` into every vCluster-using
test job.

[mx-359]: https://linear.app/nvidia/issue/MX-359/investigate-vcluster-pod-evictions-disrupting-ci-runs

## Changes

### New composite action

- `.github/actions/dump-vcluster-diagnostics/action.yml` — encapsulates
  the diagnostic groups so we have one source of truth, invoked from
  multiple places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD diagnostics with automatic vCluster health snapshots captured when tests fail, providing comprehensive cluster state information for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->