### PR TITLE
fix: Fix SGLang ModelStreamer model path fallback

### DIFF
--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -24,6 +24,15 @@ from .context import LoadResult
 logger = logging.getLogger("modelexpress.strategy_model_streamer")
 
 
+def _resolve_model_uri(ctx: LoadContext) -> str:
+    """Resolve the model URI used by ModelStreamer across engine configs."""
+    for attr in ("model_weights", "model", "model_path"):
+        value = getattr(ctx.model_config, attr, None)
+        if value:
+            return value
+    return os.environ.get("MX_MODEL_URI", "")
+
+
 class ModelStreamerStrategy(LoadStrategy):
     """Load weights by streaming safetensors via runai-model-streamer.
 
@@ -59,7 +68,9 @@ class ModelStreamerStrategy(LoadStrategy):
 
     def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
         result = _as_load_result(result)
-        model_uri = getattr(ctx.model_config, "model_weights", None) or ctx.model_config.model
+        model_uri = _resolve_model_uri(ctx)
+        if not model_uri:
+            raise StrategyFailed("ModelStreamer model URI is not configured", mutated=False)
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting model streamer loading from {model_uri}")
         try:

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -184,6 +184,29 @@ class TestModelStreamerLoad:
         mock_stream.assert_called_once_with("/models/llama", ctx, model)
 
     @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
+    def test_success_path_sglang_model_path_without_model(self, mock_register):
+        """SGLang ModelConfig exposes model_path, not model."""
+        model = MagicMock()
+        model_config = SimpleNamespace(
+            model_weights=None,
+            model_path="/models/deepseek",
+        )
+        ctx = _make_load_context(model_config=model_config)
+        strategy = self._make_strategy()
+
+        with patch(
+            "modelexpress.load_strategy.model_streamer_strategy."
+            "ModelStreamerStrategy._stream_weights"
+        ) as mock_stream:
+            mock_stream.return_value = iter([
+                ("layer.0.weight", torch.randn(4, 4)),
+            ])
+            result = strategy.load(model, ctx)
+
+        assert isinstance(result, LoadResult)
+        mock_stream.assert_called_once_with("/models/deepseek", ctx, model)
+
+    @patch("modelexpress.load_strategy.model_streamer_strategy.register_tensors")
     def test_uri_from_model_weights_not_from_env(self, mock_register):
         """The streaming URI comes from model_config, not from MX_MODEL_URI."""
         model = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #414.

This updates ModelStreamer URI resolution so SGLang configs that expose `model_path` instead of `model` can use the ModelStreamer fallback when `MX_MODEL_URI` is set.

## Problem

With SGLang `remote_instance` + ModelExpress, RDMA correctly falls through when no source exists, but ModelStreamer then fails before loading starts:

```text
[Worker 0] Strategy rdma failed, trying next: No RDMA source available
[Worker 0] Strategy model_streamer raised unexpected error, trying next: 'ModelConfig' object has no attribute 'model'
```

The strategy assumed a vLLM-style `model_config.model` field. SGLang's `ModelConfig` uses `model_path`.

## Fix

ModelStreamer now resolves the model URI in this order:

```text
model_weights -> model -> model_path -> MX_MODEL_URI
```

A regression test covers the SGLang `model_path` case.

## Fixed behavior

After applying the fix, SGLang reaches Runai Model Streamer:

```text
[2026-06-03 14:02:23] Loading safetensors using Runai Model Streamer:   0% Completed | 0/69143 [00:00<?, ?it/s]
[2026-06-03 14:02:28] Loading safetensors using Runai Model Streamer:   0% Completed | 1/69143 [00:14<283:07:32, 14.74s/it]
[2026-06-03 14:02:34] Loading safetensors using Runai Model Streamer:   3% Completed | 2306/69143 [00:16<06:01, 184.72it/s]
```

## Verification

- `python -m py_compile modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py modelexpress_client/python/tests/test_model_streamer_strategy.py`

Could not run the targeted pytest locally because this machine is missing `torch`, which is imported by the Python test `conftest.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ModelStreamer model loading with improved configuration resolution supporting multiple attribute sources.

* **Bug Fixes**
  * Added explicit validation with clearer error messages when model URI configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->