### PR TITLE
feat(server): in-memory backend behind `memory-backend` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
     - name: Run unit tests
       run: cargo test --verbose --lib
 
+    - name: Run server memory-backend unit tests
+      run: cargo test -p modelexpress-server --features memory-backend --lib
+
     - name: Build release
       run: cargo build --release --verbose
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "mockall 0.14.0",
+ "modelexpress-client",
  "modelexpress-common",
  "once_cell",
  "prost 0.13.5",

--- a/modelexpress_server/Cargo.toml
+++ b/modelexpress_server/Cargo.toml
@@ -13,6 +13,11 @@ repository.workspace = true
 keywords.workspace = true
 
 
+[features]
+# In-memory backend for tests and local dev (MX_METADATA_BACKEND=memory). Off by
+# default; enable explicitly with `--features memory-backend` to run its unit tests.
+memory-backend = []
+
 [dependencies]
 modelexpress-common = { workspace = true }
 anyhow = { workspace = true }
@@ -51,6 +56,7 @@ mockall = { workspace = true }
 tempfile = "3.20"
 tokio-test = "0.4"
 tonic-build = { workspace = true }
+modelexpress-client.workspace = true
 
 [lints]
 workspace = true

--- a/modelexpress_server/src/backend_config.rs
+++ b/modelexpress_server/src/backend_config.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Shared backend selection for distributed stores (Redis and Kubernetes CRDs).
+//! Shared backend selection for the metadata stores (Redis, Kubernetes CRDs, and an
+//! in-memory backend behind the `memory-backend` feature for tests and local dev).
 //!
 //! A single `BackendConfig` type and a single env var (`MX_METADATA_BACKEND`) drive both
 //! the P2P metadata backend and the model registry backend. Deployments that need one
@@ -17,6 +18,9 @@ pub enum BackendConfig {
     Redis { url: String },
     /// Kubernetes CRD backend — native K8s integration
     Kubernetes { namespace: String },
+    /// In-memory backend for tests and local dev (off in production).
+    #[cfg(feature = "memory-backend")]
+    Memory,
 }
 
 impl std::fmt::Display for BackendConfig {
@@ -24,6 +28,8 @@ impl std::fmt::Display for BackendConfig {
         match self {
             Self::Redis { .. } => write!(f, "redis"),
             Self::Kubernetes { .. } => write!(f, "kubernetes"),
+            #[cfg(feature = "memory-backend")]
+            Self::Memory => write!(f, "memory"),
         }
     }
 }
@@ -32,7 +38,7 @@ impl BackendConfig {
     /// Create backend config from `MX_METADATA_BACKEND`. Used by both the P2P state
     /// manager and the registry manager so they share a single env-var contract.
     ///
-    /// Valid values: `redis`, `kubernetes` | `k8s` | `crd`.
+    /// Valid values: `redis`, `kubernetes` | `k8s` | `crd`, `memory`.
     ///
     /// Errors if `MX_METADATA_BACKEND` is unset/invalid, or if the connection env for
     /// the selected backend is missing (no silent fallback to `localhost:6379` /
@@ -46,9 +52,20 @@ impl BackendConfig {
             "kubernetes" | "k8s" | "crd" => Ok(Self::Kubernetes {
                 namespace: Self::k8s_namespace_from_env()?,
             }),
+            #[cfg(feature = "memory-backend")]
+            "memory" => Ok(Self::Memory),
             other => Err(format!(
-                "MX_METADATA_BACKEND='{other}' is not valid. Use 'redis' or 'kubernetes'."
+                "MX_METADATA_BACKEND='{other}' is not valid. {}",
+                Self::valid_backends_hint()
             )),
+        }
+    }
+
+    fn valid_backends_hint() -> &'static str {
+        if cfg!(feature = "memory-backend") {
+            "Use 'redis', 'kubernetes', or 'memory'."
+        } else {
+            "Use 'redis' or 'kubernetes'."
         }
     }
 
@@ -69,8 +86,11 @@ impl BackendConfig {
             "kubernetes" | "k8s" | "crd" => Ok(Self::Kubernetes {
                 namespace: k8s_namespace.to_string(),
             }),
+            #[cfg(feature = "memory-backend")]
+            "memory" => Ok(Self::Memory),
             other => Err(format!(
-                "{env_name}='{other}' is not valid. Use 'redis' or 'kubernetes'."
+                "{env_name}='{other}' is not valid. {}",
+                Self::valid_backends_hint()
             )),
         }
     }
@@ -134,16 +154,24 @@ mod tests {
 
     #[test]
     fn rejects_unknown_and_includes_env_name() {
-        let err = BackendConfig::from_type_str("MX_WHATEVER", "memory", "", "")
+        let err = BackendConfig::from_type_str("MX_WHATEVER", "sqlite", "", "")
             .expect_err("should reject");
         assert!(
             err.contains("MX_WHATEVER"),
             "error should name the env var: {err}"
         );
         assert!(
-            err.contains("'memory'"),
+            err.contains("'sqlite'"),
             "error should echo bad value: {err}"
         );
+    }
+
+    #[cfg(feature = "memory-backend")]
+    #[test]
+    fn parses_memory_backend() {
+        let cfg = BackendConfig::from_type_str("X", "memory", "", "").expect("memory");
+        assert!(matches!(cfg, BackendConfig::Memory));
+        assert_eq!(cfg.to_string(), "memory");
     }
 
     #[test]

--- a/modelexpress_server/src/p2p/backend.rs
+++ b/modelexpress_server/src/p2p/backend.rs
@@ -3,17 +3,21 @@
 
 //! Metadata backend abstraction for P2P model metadata.
 //!
-//! Supports two persistent backends:
+//! Backends:
 //! - **Redis**: Persistent storage via Redis keys + atomic Lua merge
 //! - **Kubernetes**: CRDs and ConfigMaps for native K8s integration
+//! - **Memory** (`memory-backend` feature): non-persistent, single-process, for tests
+//!   and local dev
 //!
-//! Select the backend via `MX_METADATA_BACKEND=redis` or `MX_METADATA_BACKEND=kubernetes`.
+//! Select the backend via `MX_METADATA_BACKEND=redis`, `=kubernetes`, or `=memory`.
 
 use async_trait::async_trait;
 use modelexpress_common::grpc::p2p::{SourceIdentity, SourceStatus, WorkerMetadata};
 use std::sync::Arc;
 
 pub mod kubernetes;
+#[cfg(feature = "memory-backend")]
+pub mod memory;
 pub mod redis;
 
 /// Result type for metadata operations
@@ -232,7 +236,8 @@ pub trait MetadataBackend: Send + Sync {
 
     /// List available workers, optionally filtered by source_id and status.
     /// `source_id`: if `Some`, return only workers for that source; if `None`, all sources.
-    /// `status_filter`: if `Some(s)`, return only workers where all workers have status `s`.
+    /// `status_filter`: if `Some(s)`, return only workers where at least one rank has
+    /// status `s`.
     async fn list_workers(
         &self,
         source_id: Option<String>,
@@ -272,6 +277,12 @@ pub async fn create_backend(config: BackendConfig) -> MetadataResult<Arc<dyn Met
         }
         BackendConfig::Kubernetes { namespace } => {
             let backend = kubernetes::KubernetesBackend::new(&namespace).await?;
+            backend.connect().await?;
+            Ok(Arc::new(backend) as Arc<dyn MetadataBackend>)
+        }
+        #[cfg(feature = "memory-backend")]
+        BackendConfig::Memory => {
+            let backend = memory::InMemoryMetadataBackend::new();
             backend.connect().await?;
             Ok(Arc::new(backend) as Arc<dyn MetadataBackend>)
         }

--- a/modelexpress_server/src/p2p/backend/memory.rs
+++ b/modelexpress_server/src/p2p/backend/memory.rs
@@ -1,0 +1,429 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory P2P metadata backend for tests and local dev. Not persistent, single
+//! process. Mirrors the Redis backend's key layout (`(source_id, worker_id)` ->
+//! `rank -> record`, plus a per-worker reported rank), but is not behaviorally
+//! identical: `remove_worker` drops a source once its last worker is gone, where Redis
+//! leaves the orphaned source index behind. So `list_sources` here won't report empty
+//! sources.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Mutex, PoisonError};
+
+use async_trait::async_trait;
+use modelexpress_common::grpc::p2p::{SourceIdentity, SourceStatus, WorkerMetadata};
+
+use crate::p2p::backend::{
+    MetadataBackend, MetadataResult, ModelMetadataRecord, SourceInstanceInfo, WorkerRecord,
+};
+
+#[derive(Default)]
+struct WorkerEntry {
+    ranks: BTreeMap<u32, WorkerRecord>,
+    // the rank list_workers reports for this worker
+    index_rank: u32,
+}
+
+#[derive(Default)]
+struct SourceEntry {
+    model_name: String,
+    workers: HashMap<String, WorkerEntry>,
+}
+
+#[derive(Default)]
+pub struct InMemoryMetadataBackend {
+    sources: Mutex<HashMap<String, SourceEntry>>,
+}
+
+impl InMemoryMetadataBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, SourceEntry>> {
+        // poisoned just means someone panicked mid-write; the map is still usable
+        self.sources.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[async_trait]
+impl MetadataBackend for InMemoryMetadataBackend {
+    async fn connect(&self) -> MetadataResult<()> {
+        Ok(())
+    }
+
+    async fn publish_metadata(
+        &self,
+        identity: &SourceIdentity,
+        worker_id: &str,
+        worker: WorkerMetadata,
+    ) -> MetadataResult<()> {
+        let source_id = crate::p2p::source_identity::compute_mx_source_id(identity);
+        let record = WorkerRecord::from(worker);
+        let rank = record.worker_rank;
+
+        let mut sources = self.lock();
+        let source = sources.entry(source_id).or_default();
+        source.model_name = identity.model_name.clone();
+        let entry = source.workers.entry(worker_id.to_string()).or_default();
+        entry.ranks.insert(rank, record);
+        entry.index_rank = rank;
+        Ok(())
+    }
+
+    async fn get_metadata(
+        &self,
+        source_id: &str,
+        worker_id: &str,
+    ) -> MetadataResult<Option<ModelMetadataRecord>> {
+        let sources = self.lock();
+        let Some(source) = sources.get(source_id) else {
+            return Ok(None);
+        };
+        let Some(entry) = source.workers.get(worker_id) else {
+            return Ok(None);
+        };
+        if entry.ranks.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(ModelMetadataRecord {
+            source_id: source_id.to_string(),
+            worker_id: worker_id.to_string(),
+            model_name: source.model_name.clone(),
+            workers: entry.ranks.values().cloned().collect(),
+            published_at: 0,
+        }))
+    }
+
+    async fn list_workers(
+        &self,
+        source_id: Option<String>,
+        status_filter: Option<SourceStatus>,
+    ) -> MetadataResult<Vec<SourceInstanceInfo>> {
+        let sources = self.lock();
+        let mut result = Vec::new();
+        for (sid, source) in sources.iter() {
+            if let Some(filter) = &source_id
+                && sid != filter
+            {
+                continue;
+            }
+            for (worker_id, entry) in &source.workers {
+                if let Some(status) = status_filter
+                    && !entry.ranks.values().any(|r| r.status == status as i32)
+                {
+                    continue;
+                }
+                let reported = entry
+                    .ranks
+                    .get(&entry.index_rank)
+                    .or_else(|| entry.ranks.values().next());
+                let (status, updated_at) = reported.map_or((0, 0), |r| (r.status, r.updated_at));
+                result.push(SourceInstanceInfo {
+                    source_id: sid.clone(),
+                    worker_id: worker_id.clone(),
+                    model_name: source.model_name.clone(),
+                    worker_rank: entry.index_rank,
+                    status,
+                    updated_at,
+                });
+            }
+        }
+        Ok(result)
+    }
+
+    async fn remove_metadata(&self, source_id: &str) -> MetadataResult<()> {
+        self.lock().remove(source_id);
+        Ok(())
+    }
+
+    async fn remove_worker(&self, source_id: &str, worker_id: &str) -> MetadataResult<()> {
+        // drop the source once its last worker is gone, so empties don't pile up
+        let mut sources = self.lock();
+        if let Some(source) = sources.get_mut(source_id) {
+            source.workers.remove(worker_id);
+            if source.workers.is_empty() {
+                sources.remove(source_id);
+            }
+        }
+        Ok(())
+    }
+
+    async fn list_sources(&self) -> MetadataResult<Vec<(String, String)>> {
+        Ok(self
+            .lock()
+            .iter()
+            .map(|(sid, source)| (sid.clone(), source.model_name.clone()))
+            .collect())
+    }
+
+    async fn update_status(
+        &self,
+        source_id: &str,
+        worker_id: &str,
+        worker_rank: u32,
+        status: SourceStatus,
+        updated_at: i64,
+    ) -> MetadataResult<()> {
+        let mut sources = self.lock();
+        let record = sources
+            .get_mut(source_id)
+            .and_then(|source| source.workers.get_mut(worker_id))
+            .and_then(|entry| entry.ranks.get_mut(&worker_rank));
+        match record {
+            Some(record) => {
+                record.status = status as i32;
+                record.updated_at = updated_at;
+                Ok(())
+            }
+            None => Err(format!(
+                "update_status: rank {worker_rank} not found in source '{source_id}' worker '{worker_id}'"
+            )
+            .into()),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::p2p::source_identity::compute_mx_source_id;
+    use modelexpress_common::grpc::p2p::MxSourceType;
+
+    fn identity(model: &str) -> SourceIdentity {
+        SourceIdentity {
+            mx_version: "0.3.0".to_string(),
+            mx_source_type: MxSourceType::Weights as i32,
+            model_name: model.to_string(),
+            backend_framework: 1,
+            tensor_parallel_size: 1,
+            pipeline_parallel_size: 1,
+            expert_parallel_size: 0,
+            dtype: "bfloat16".to_string(),
+            quantization: String::new(),
+            extra_parameters: Default::default(),
+            revision: String::new(),
+        }
+    }
+
+    fn worker(rank: u32, status: SourceStatus) -> WorkerMetadata {
+        WorkerMetadata {
+            worker_rank: rank,
+            backend_metadata: None,
+            tensors: vec![],
+            status: status as i32,
+            updated_at: 0,
+            ..Default::default()
+        }
+    }
+
+    // store/fetch works, and the source goes away with its last worker
+    #[tokio::test]
+    async fn publish_get_remove_roundtrip() {
+        let backend = InMemoryMetadataBackend::new();
+        let id = identity("m");
+        let source_id = compute_mx_source_id(&id);
+
+        backend
+            .publish_metadata(&id, "w1", worker(0, SourceStatus::Ready))
+            .await
+            .expect("publish");
+        let record = backend
+            .get_metadata(&source_id, "w1")
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(record.model_name, "m");
+        assert_eq!(record.workers.len(), 1);
+
+        backend
+            .remove_worker(&source_id, "w1")
+            .await
+            .expect("remove");
+        assert!(
+            backend
+                .get_metadata(&source_id, "w1")
+                .await
+                .expect("get")
+                .is_none()
+        );
+        assert!(backend.list_sources().await.expect("list").is_empty());
+    }
+
+    // multiple ranks under one worker_id come back sorted by rank
+    #[tokio::test]
+    async fn get_metadata_returns_ranks_sorted() {
+        let backend = InMemoryMetadataBackend::new();
+        let id = identity("m");
+        let source_id = compute_mx_source_id(&id);
+
+        for rank in [2, 0, 1] {
+            backend
+                .publish_metadata(&id, "w1", worker(rank, SourceStatus::Ready))
+                .await
+                .expect("publish");
+        }
+
+        let record = backend
+            .get_metadata(&source_id, "w1")
+            .await
+            .expect("get")
+            .expect("present");
+        let ranks: Vec<u32> = record.workers.iter().map(|w| w.worker_rank).collect();
+        assert_eq!(ranks, [0, 1, 2], "ranks sorted ascending");
+    }
+
+    // a worker is listed when ANY of its ranks matches the status filter
+    #[tokio::test]
+    async fn list_workers_status_filter_matches_any_rank() {
+        let backend = InMemoryMetadataBackend::new();
+        let id = identity("m");
+
+        backend
+            .publish_metadata(&id, "w1", worker(0, SourceStatus::Initializing))
+            .await
+            .expect("publish r0");
+        backend
+            .publish_metadata(&id, "w1", worker(1, SourceStatus::Ready))
+            .await
+            .expect("publish r1");
+
+        assert_eq!(
+            backend
+                .list_workers(None, Some(SourceStatus::Ready))
+                .await
+                .expect("ready")
+                .len(),
+            1,
+            "Ready matches rank 1"
+        );
+        assert_eq!(
+            backend
+                .list_workers(None, Some(SourceStatus::Initializing))
+                .await
+                .expect("init")
+                .len(),
+            1,
+            "Initializing matches rank 0"
+        );
+        assert!(
+            backend
+                .list_workers(None, Some(SourceStatus::Stale))
+                .await
+                .expect("stale")
+                .is_empty(),
+            "no rank is Stale"
+        );
+    }
+
+    // list_workers reports the last-published (index) rank and its status
+    #[tokio::test]
+    async fn list_workers_reports_index_rank() {
+        let backend = InMemoryMetadataBackend::new();
+        let id = identity("m");
+        let source_id = compute_mx_source_id(&id);
+
+        backend
+            .publish_metadata(&id, "w1", worker(0, SourceStatus::Initializing))
+            .await
+            .expect("publish r0");
+        backend
+            .publish_metadata(&id, "w1", worker(3, SourceStatus::Ready))
+            .await
+            .expect("publish r3");
+
+        let listed = backend
+            .list_workers(Some(source_id), None)
+            .await
+            .expect("list");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].worker_rank, 3, "reports the last-published rank");
+        assert_eq!(listed[0].status, SourceStatus::Ready as i32);
+    }
+
+    // update_status patches an existing rank and errors on a missing rank or worker
+    #[tokio::test]
+    async fn update_status_patches_then_errors_on_missing() {
+        let backend = InMemoryMetadataBackend::new();
+        let id = identity("m");
+        let source_id = compute_mx_source_id(&id);
+
+        backend
+            .publish_metadata(&id, "w1", worker(0, SourceStatus::Initializing))
+            .await
+            .expect("publish");
+        backend
+            .update_status(&source_id, "w1", 0, SourceStatus::Ready, 123)
+            .await
+            .expect("patch existing rank");
+
+        let record = backend
+            .get_metadata(&source_id, "w1")
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(record.workers[0].status, SourceStatus::Ready as i32);
+        assert_eq!(record.workers[0].updated_at, 123);
+
+        assert!(
+            backend
+                .update_status(&source_id, "w1", 99, SourceStatus::Ready, 1)
+                .await
+                .is_err(),
+            "unknown rank errors"
+        );
+        assert!(
+            backend
+                .update_status(&source_id, "ghost", 0, SourceStatus::Ready, 1)
+                .await
+                .is_err(),
+            "unknown worker errors"
+        );
+    }
+
+    // a source survives while it has any worker, and is dropped with its last one
+    #[tokio::test]
+    async fn remove_worker_drops_source_only_when_empty() {
+        let backend = InMemoryMetadataBackend::new();
+        let id = identity("m");
+        let source_id = compute_mx_source_id(&id);
+
+        backend
+            .publish_metadata(&id, "w1", worker(0, SourceStatus::Ready))
+            .await
+            .expect("publish w1");
+        backend
+            .publish_metadata(&id, "w2", worker(0, SourceStatus::Ready))
+            .await
+            .expect("publish w2");
+
+        backend
+            .remove_worker(&source_id, "w1")
+            .await
+            .expect("remove w1");
+        assert_eq!(
+            backend.list_sources().await.expect("list").len(),
+            1,
+            "source stays while w2 remains"
+        );
+        assert!(
+            backend
+                .get_metadata(&source_id, "w2")
+                .await
+                .expect("get")
+                .is_some()
+        );
+
+        backend
+            .remove_worker(&source_id, "w2")
+            .await
+            .expect("remove w2");
+        assert!(
+            backend.list_sources().await.expect("list").is_empty(),
+            "source dropped with its last worker"
+        );
+    }
+}

--- a/modelexpress_server/src/registry.rs
+++ b/modelexpress_server/src/registry.rs
@@ -4,9 +4,10 @@
 //! Distributed model registry: model-download lifecycle (`DOWNLOADING` / `DOWNLOADED` /
 //! `ERROR`) and LRU cache-eviction timestamps.
 //!
-//! `backend` owns the `RegistryBackend` trait plus Redis and Kubernetes CRD
-//! implementations. `state` wraps the backend in a lazy-connect manager used by
-//! `ModelDownloadTracker` and `CacheEvictionService`.
+//! `backend` owns the `RegistryBackend` trait plus its Redis, Kubernetes CRD, and
+//! (behind the `memory-backend` feature) in-memory implementations. `state` wraps the
+//! backend in a lazy-connect manager used by `ModelDownloadTracker` and
+//! `CacheEvictionService`.
 
 pub mod backend;
 pub mod k8s_types;

--- a/modelexpress_server/src/registry/backend.rs
+++ b/modelexpress_server/src/registry/backend.rs
@@ -12,6 +12,8 @@ use modelexpress_common::models::{ModelProvider, ModelStatus};
 use std::sync::Arc;
 
 pub mod kubernetes;
+#[cfg(feature = "memory-backend")]
+pub mod memory;
 pub mod redis;
 
 /// Result type for registry operations. Errors are boxed so backend-specific error types
@@ -116,6 +118,12 @@ pub async fn create_registry_backend(
         }
         BackendConfig::Kubernetes { namespace } => {
             let backend = kubernetes::KubernetesRegistryBackend::new(&namespace).await?;
+            backend.connect().await?;
+            Ok(Arc::new(backend) as Arc<dyn RegistryBackend>)
+        }
+        #[cfg(feature = "memory-backend")]
+        BackendConfig::Memory => {
+            let backend = memory::InMemoryRegistryBackend::new();
             backend.connect().await?;
             Ok(Arc::new(backend) as Arc<dyn RegistryBackend>)
         }

--- a/modelexpress_server/src/registry/backend/memory.rs
+++ b/modelexpress_server/src/registry/backend/memory.rs
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory model-registry backend for tests and local dev. Not persistent, single
+//! process. Pairs with the in-memory P2P backend behind `MX_METADATA_BACKEND=memory`.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, PoisonError};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modelexpress_common::models::{ModelProvider, ModelStatus};
+
+use crate::registry::backend::{ClaimOutcome, ModelRecord, RegistryBackend, RegistryResult};
+
+#[derive(Default)]
+pub struct InMemoryRegistryBackend {
+    models: Mutex<HashMap<String, ModelRecord>>,
+}
+
+impl InMemoryRegistryBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, ModelRecord>> {
+        self.models.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[async_trait]
+impl RegistryBackend for InMemoryRegistryBackend {
+    async fn connect(&self) -> RegistryResult<()> {
+        Ok(())
+    }
+
+    async fn get_status(&self, model_name: &str) -> RegistryResult<Option<ModelStatus>> {
+        Ok(self.lock().get(model_name).map(|r| r.status))
+    }
+
+    async fn get_model_record(&self, model_name: &str) -> RegistryResult<Option<ModelRecord>> {
+        Ok(self.lock().get(model_name).cloned())
+    }
+
+    async fn set_status(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        status: ModelStatus,
+        message: Option<String>,
+    ) -> RegistryResult<()> {
+        let now = Utc::now();
+        let mut models = self.lock();
+        models
+            .entry(model_name.to_string())
+            .and_modify(|record| {
+                record.provider = provider;
+                record.status = status;
+                record.message = message.clone();
+                record.last_used_at = now;
+            })
+            .or_insert_with(|| ModelRecord {
+                model_name: model_name.to_string(),
+                provider,
+                status,
+                created_at: now,
+                last_used_at: now,
+                message,
+            });
+        Ok(())
+    }
+
+    async fn touch_model(&self, model_name: &str) -> RegistryResult<()> {
+        if let Some(record) = self.lock().get_mut(model_name) {
+            record.last_used_at = Utc::now();
+        }
+        Ok(())
+    }
+
+    async fn delete_model(&self, model_name: &str) -> RegistryResult<()> {
+        self.lock().remove(model_name);
+        Ok(())
+    }
+
+    async fn get_models_by_last_used(
+        &self,
+        limit: Option<u32>,
+    ) -> RegistryResult<Vec<ModelRecord>> {
+        let mut records: Vec<ModelRecord> = self.lock().values().cloned().collect();
+        records.sort_by_key(|r| r.last_used_at);
+        if let Some(limit) = limit {
+            records.truncate(limit as usize);
+        }
+        Ok(records)
+    }
+
+    async fn get_status_counts(&self) -> RegistryResult<(u32, u32, u32)> {
+        let models = self.lock();
+        let mut downloading = 0u32;
+        let mut downloaded = 0u32;
+        let mut error = 0u32;
+        for record in models.values() {
+            match record.status {
+                ModelStatus::DOWNLOADING => downloading = downloading.saturating_add(1),
+                ModelStatus::DOWNLOADED => downloaded = downloaded.saturating_add(1),
+                ModelStatus::ERROR => error = error.saturating_add(1),
+            }
+        }
+        Ok((downloading, downloaded, error))
+    }
+
+    async fn try_claim_for_download(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+    ) -> RegistryResult<ClaimOutcome> {
+        let now = Utc::now();
+        let mut models = self.lock();
+        match models.get(model_name) {
+            Some(existing) => Ok(ClaimOutcome::AlreadyExists(existing.status)),
+            None => {
+                models.insert(
+                    model_name.to_string(),
+                    ModelRecord {
+                        model_name: model_name.to_string(),
+                        provider,
+                        status: ModelStatus::DOWNLOADING,
+                        created_at: now,
+                        last_used_at: now,
+                        message: None,
+                    },
+                );
+                Ok(ClaimOutcome::Claimed)
+            }
+        }
+    }
+
+    async fn try_reset_error_for_retry(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+    ) -> RegistryResult<bool> {
+        let mut models = self.lock();
+        match models.get_mut(model_name) {
+            Some(record) if record.status == ModelStatus::ERROR => {
+                record.provider = provider;
+                record.status = ModelStatus::DOWNLOADING;
+                record.message = Some("Retrying download...".to_string());
+                record.last_used_at = Utc::now();
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // status round-trips, and a claim is exclusive
+    #[tokio::test]
+    async fn set_get_and_claim() {
+        let backend = InMemoryRegistryBackend::new();
+        backend
+            .set_status(
+                "m",
+                ModelProvider::HuggingFace,
+                ModelStatus::DOWNLOADED,
+                None,
+            )
+            .await
+            .expect("set");
+        assert_eq!(
+            backend.get_status("m").await.expect("get"),
+            Some(ModelStatus::DOWNLOADED)
+        );
+
+        assert_eq!(
+            backend
+                .try_claim_for_download("fresh", ModelProvider::HuggingFace)
+                .await
+                .expect("claim"),
+            ClaimOutcome::Claimed
+        );
+        assert_eq!(
+            backend
+                .try_claim_for_download("fresh", ModelProvider::HuggingFace)
+                .await
+                .expect("claim again"),
+            ClaimOutcome::AlreadyExists(ModelStatus::DOWNLOADING)
+        );
+    }
+
+    // created_at survives an update; status and message are overwritten
+    #[tokio::test]
+    async fn set_status_update_preserves_created_at() {
+        let backend = InMemoryRegistryBackend::new();
+        backend
+            .set_status(
+                "m",
+                ModelProvider::HuggingFace,
+                ModelStatus::DOWNLOADING,
+                None,
+            )
+            .await
+            .expect("first set");
+        let first = backend
+            .get_model_record("m")
+            .await
+            .expect("get")
+            .expect("present");
+
+        backend
+            .set_status(
+                "m",
+                ModelProvider::HuggingFace,
+                ModelStatus::DOWNLOADED,
+                Some("done".to_string()),
+            )
+            .await
+            .expect("second set");
+        let second = backend
+            .get_model_record("m")
+            .await
+            .expect("get")
+            .expect("present");
+
+        assert_eq!(
+            second.created_at, first.created_at,
+            "created_at must survive an update"
+        );
+        assert_eq!(second.status, ModelStatus::DOWNLOADED);
+        assert_eq!(second.message.as_deref(), Some("done"));
+    }
+
+    // oldest-first ordering, touch bumps to newest, and limit truncates
+    #[tokio::test]
+    async fn get_models_by_last_used_orders_oldest_first_and_limits() {
+        let backend = InMemoryRegistryBackend::new();
+        for name in ["a", "b", "c"] {
+            backend
+                .set_status(
+                    name,
+                    ModelProvider::HuggingFace,
+                    ModelStatus::DOWNLOADED,
+                    None,
+                )
+                .await
+                .expect("set");
+            // distinct last_used_at so the ordering assertion is deterministic
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+
+        let all = backend.get_models_by_last_used(None).await.expect("all");
+        let names: Vec<_> = all.iter().map(|r| r.model_name.as_str()).collect();
+        assert_eq!(names, ["a", "b", "c"], "oldest first");
+
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        backend.touch_model("a").await.expect("touch");
+        let reordered = backend.get_models_by_last_used(None).await.expect("all");
+        let names: Vec<_> = reordered.iter().map(|r| r.model_name.as_str()).collect();
+        assert_eq!(names, ["b", "c", "a"], "touched model moves to newest");
+
+        let limited = backend
+            .get_models_by_last_used(Some(2))
+            .await
+            .expect("limited");
+        assert_eq!(limited.len(), 2, "limit truncates");
+    }
+
+    // counts tally per status
+    #[tokio::test]
+    async fn get_status_counts_tallies_each_status() {
+        let backend = InMemoryRegistryBackend::new();
+        for (name, status) in [
+            ("dl", ModelStatus::DOWNLOADING),
+            ("done1", ModelStatus::DOWNLOADED),
+            ("done2", ModelStatus::DOWNLOADED),
+            ("err", ModelStatus::ERROR),
+        ] {
+            backend
+                .set_status(name, ModelProvider::HuggingFace, status, None)
+                .await
+                .expect("set");
+        }
+        assert_eq!(
+            backend.get_status_counts().await.expect("counts"),
+            (1, 2, 1)
+        );
+    }
+
+    // touch and delete on an unknown model are no-ops, not errors
+    #[tokio::test]
+    async fn touch_and_delete_unknown_are_noops() {
+        let backend = InMemoryRegistryBackend::new();
+        backend.touch_model("ghost").await.expect("touch unknown");
+        backend.delete_model("ghost").await.expect("delete unknown");
+        assert!(backend.get_status("ghost").await.expect("get").is_none());
+    }
+
+    // the error-retry CAS only fires when the model is currently in ERROR
+    #[tokio::test]
+    async fn try_reset_error_for_retry_only_from_error() {
+        let backend = InMemoryRegistryBackend::new();
+        assert!(
+            !backend
+                .try_reset_error_for_retry("m", ModelProvider::HuggingFace)
+                .await
+                .expect("reset unknown"),
+            "unknown model: nothing to reset"
+        );
+
+        backend
+            .set_status(
+                "m",
+                ModelProvider::HuggingFace,
+                ModelStatus::DOWNLOADED,
+                None,
+            )
+            .await
+            .expect("set downloaded");
+        assert!(
+            !backend
+                .try_reset_error_for_retry("m", ModelProvider::HuggingFace)
+                .await
+                .expect("reset non-error"),
+            "non-error status: no reset"
+        );
+
+        backend
+            .set_status(
+                "m",
+                ModelProvider::HuggingFace,
+                ModelStatus::ERROR,
+                Some("boom".to_string()),
+            )
+            .await
+            .expect("set error");
+        assert!(
+            backend
+                .try_reset_error_for_retry("m", ModelProvider::HuggingFace)
+                .await
+                .expect("reset from error"),
+            "ERROR flips to DOWNLOADING"
+        );
+        assert_eq!(
+            backend.get_status("m").await.expect("get"),
+            Some(ModelStatus::DOWNLOADING)
+        );
+    }
+}


### PR DESCRIPTION
Adds an in-memory implementation of the registry and P2P metadata backends, selected with `MX_METADATA_BACKEND=memory`. Behind a new `memory-backend` cargo feature that is off by default; Redis and k8s backends are unchanged and the new code only compiles under `--features memory-backend`.

Without this, the server requires an external backend (Redis or k8s) to boot, so it can't run standalone for local dev or in-process tests. The in-memory backend gives both a real backend with no external dependency.

Files:
- `memory-backend` feature flag: `modelexpress_server/Cargo.toml`
- `InMemoryRegistryBackend`: `registry/backend/memory.rs`
- in-memory P2P backend: `p2p/backend/memory.rs`
- backend selection: `backend_config.rs`, `registry.rs`, `p2p/backend.rs`

PR 1 of 2. PR 2 (#417) stacks an in-process integration test on top of this backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced in-memory backend implementations for P2P metadata and model registry operations, providing an alternative option for testing and local development environments.

* **Documentation**
  * Updated module documentation to reference the new in-memory backend capability.

* **Tests**
  * Extended CI pipeline to include feature-gated test coverage for the in-memory backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->