### PR TITLE
ci: skip GitLab mirror trigger for fork PRs

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -20,6 +20,9 @@ concurrency:
 
 jobs:
   trigger:
+    # Fork PRs do not receive repository secrets, so the GitLab mirror workflow
+    # would fail with empty TOKEN/MIRROR_URL/PIPELINE_* values.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ai-dynamo/.github/.github/workflows/mirror_and_trigger_ci.yml@main
     with:
       ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}


### PR DESCRIPTION
## What

- Skip the GitLab mirror/trigger workflow for pull requests opened from forked repositories.
- Keep the GitLab mirror/trigger workflow enabled for pushes and same-repository pull requests.
- Add an inline comment explaining why fork PRs are skipped.

## Why

External fork PRs do not receive repository secrets. The GitLab mirror workflow requires `TOKEN`, `MIRROR_URL`, `PIPELINE_TOKEN`, and `PIPELINE_URL`, so it fails on fork PRs with empty secret values before it can trigger the internal pipeline.

This keeps trusted paths unchanged while avoiding a guaranteed failure on external contributor PRs.

## Validation

- `pre-commit run --files .github/workflows/trigger_ci.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow stability by adding conditional checks to prevent unnecessary workflow runs on forked pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->