### PR TITLE
fix(docs): update RDMA retry semantics and stale README/CLI guidance (0.4.0 QA) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <p align="center">
   <a href="#features">Features</a> •
-  <a href="#dynamo-modelexpress-architecture">Architecture</a> •
+  <a href="#modelexpress-architecture">Architecture</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#deployment">Deployment</a> •
   <a href="#documentation">Docs</a> •
@@ -116,7 +116,8 @@ cd modelexpress
 docker run -d --name redis -p 6379:6379 redis:8-alpine
 
 cargo build
-MX_METADATA_BACKEND=redis cargo run --bin modelexpress-server
+# REDIS_URL is required; the server does not fall back to localhost:6379.
+REDIS_URL=redis://localhost:6379 MX_METADATA_BACKEND=redis cargo run --bin modelexpress-server
 ```
 
 Server listens on `0.0.0.0:8001`. In another terminal:
@@ -130,7 +131,7 @@ modelexpress-cli health
 ```
 
 **Without shared storage:** use `--no-shared-storage` for gRPC streaming.  
-**Air-gapped:** `HF_HUB_OFFLINE=1 modelexpress-cli model get <model-id>`.
+**Air-gapped:** with the model already in the local HF cache, `HF_HUB_OFFLINE=1 modelexpress-cli model download <model-id>` resolves it without network access.
 
 ---
 
@@ -177,7 +178,7 @@ docker compose -f docker/docker-compose.yml up --build
 | `MODEL_EXPRESS_SERVER_PORT` | `8001` | gRPC port |
 | `MODEL_EXPRESS_CACHE_DIRECTORY` | `./cache` | Cache root |
 | `MX_METADATA_BACKEND` | (required) | `redis` \| `kubernetes` |
-| `REDIS_URL` | `redis://localhost:6379` | Redis connection URL (`redis` backend only) |
+| `REDIS_URL` | (required for `redis`) | Redis connection URL. Alternatively set `MX_REDIS_HOST` + `MX_REDIS_PORT`. No localhost fallback. |
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Client-side gRPC server address (P2P). Recommended. |
 | `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -590,7 +590,7 @@ Auto-detects the best loading strategy with a prioritized chain. Each strategy i
 
 | Priority | Strategy | `is_available()` | Behavior |
 |---|---|---|---|
-| p0 | `RdmaStrategy` | NIXL available | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). On `SourceTransferError` or `ManifestMismatchError`, try next. |
+| p0 | `RdmaStrategy` | NIXL available | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). Candidate retry covers pre-transfer metadata misses only (no metadata found, fetch error). Once the RDMA receive starts, a `SourceTransferError` or `ManifestMismatchError` aborts RDMA and the chain falls through to the next strategy (GDS, then disk), not the next source. |
 | p1 | `ModelStreamerStrategy` | `MX_MODEL_URI` set + `runai_model_streamer` installed | Stream safetensors to GPU via CPU staging buffer. `MX_MODEL_URI` accepts remote URIs (`s3://`, `gs://`, `az://`), absolute local paths, or HF model IDs (resolved via `HF_HUB_CACHE`). All storage backends (S3, GCS, Azure) included by default. |
 | p2 | `GdsStrategy` | GDS hardware available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. |
 | p3 | `DefaultStrategy` | Engine native fallback loader available | Native loader fallback (for vLLM, `DefaultModelLoader`, CPU-staged, auto-downloads from HF Hub). |
@@ -603,7 +603,7 @@ Strategies handle the loading path and NIXL tensor registration. Adapter hooks h
 
 NVFP4 MoE models (known case: Kimi-K2.5-NVFP4) previously produced corrupted inference after RDMA transfer despite all registered tensor bytes matching. This is a specific instance of a broader class of bugs: post-processing stashes computed state on non-Module objects (e.g. `FusedMoEQuantConfig.a1_gscale = 1/activation_scale` on the quant method), which is invisible to `named_parameters()`/`named_buffers()`. On the target those values are computed from dummy weights before RDMA, and RDMA only overwrites the registered tensors, so the stashed values stay wrong. The fix (`adopt_hidden_tensors()`) recursively scans module attributes for orphaned CUDA tensors and registers them as non-persistent buffers so they are included in the RDMA manifest. Verified correct on vLLM v0.17.1 and v0.19.0 with Kimi-K2.5-NVFP4 and on DeepSeek-V3 (MLA + FP8).
 
-During transfer, `ManifestMismatchError` is raised if source and target tensor names or sizes don't match. This triggers trying the next source candidate rather than marking the source as stale, which is important during rolling updates where pods may run different image versions.
+During transfer, `ManifestMismatchError` is raised if source and target tensor names or sizes don't match (a likely symptom of a rolling update where pods run different image versions). The receive path converts it, like any receive failure, into a `SourceTransferError`, which the chain treats as a mutated RDMA failure: RDMA is abandoned and loading falls through to the next strategy (GDS, then disk) rather than retrying another source. Source-candidate retry happens only for pre-transfer metadata misses, before any target tensor is prepared.
 
 After loading by any strategy, the worker starts a `HeartbeatThread` that periodically sends `UpdateStatus(READY)` to keep `updated_at` fresh. On clean shutdown, the heartbeat sends `UpdateStatus(STALE)` via an `atexit` handler. Metadata publish failures are logged but do not crash the worker.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,7 +72,7 @@ modelexpress-cli --format json health
 ```
 Server Health Status
   Status: ok
-  Version: 0.1.0
+  Version: 0.4.0
   Uptime: 120 seconds
 ```
 
@@ -200,7 +200,7 @@ Colorized, structured output optimized for terminal viewing.
 Compact JSON output suitable for scripting:
 ```bash
 modelexpress-cli --format json health
-# Output: {"version":"0.1.0","status":"ok","uptime":120}
+# Output: {"version":"0.4.0","status":"ok","uptime":120}
 ```
 
 #### Pretty JSON
@@ -209,7 +209,7 @@ Formatted JSON with indentation:
 modelexpress-cli --format json-pretty health
 # Output:
 # {
-#   "version": "0.1.0",
+#   "version": "0.4.0",
 #   "status": "ok",
 #   "uptime": 120
 # }
@@ -390,7 +390,20 @@ modelexpress-cli model status
 
 ### Configuration File Support
 
-While the CLI doesn't currently support configuration files, you can create wrapper scripts:
+The CLI loads a YAML configuration file via `-c, --config <FILE>` (default
+`~/.model-express/config.yaml`). Values are merged in this order of precedence,
+highest first:
+
+1. Command line arguments
+2. Environment variables (`MODEL_EXPRESS_*`)
+3. Configuration file
+4. Built-in defaults
+
+```bash
+modelexpress-cli --config /etc/modelexpress/client.yaml health
+```
+
+Wrapper scripts remain a convenient option when you prefer fixed flags:
 
 ```bash
 #!/bin/bash
@@ -406,8 +419,10 @@ exec modelexpress-cli --endpoint "https://prod-server.com:8001" "$@"
 # Test with verbose output
 modelexpress-cli -vv health
 
-# Check network connectivity
-curl -v http://localhost:8001/health 2>&1 | grep -i connect
+# Check that the server's gRPC port is reachable. The server speaks gRPC,
+# not REST, so `curl http://localhost:8001/health` will not work; use a
+# TCP probe (or the CLI health command above).
+nc -vz localhost 8001
 ```
 
 ### Server Not Running
@@ -460,9 +475,9 @@ cargo test --bin modelexpress-cli
 
 The CLI is built using the `clap` crate with derive macros. To add new commands:
 
-1. Add the command to the `Commands` enum in `src/bin/cli.rs`
-2. Implement the handler function
-3. Add the handler to the main match statement
+1. Add the command to the `Commands` (or `ModelCommands`) enum in `modelexpress_client/src/bin/modules/args.rs`. Shared client arguments live in `ClientArgs` in `modelexpress_common/src/client_config.rs`.
+2. Implement the handler in `modelexpress_client/src/bin/modules/handlers.rs`
+3. Wire the handler into the dispatch `match cli.command` in `modelexpress_client/src/bin/cli.rs`
 
 ## License
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -341,14 +341,16 @@ sequenceDiagram
     MX-->>W: [SourceInstanceRef, ...]
     W->>W: Filter by worker_rank, shuffle for load balancing
     W->>W: Load dummy weights, initialize NIXL agent
-    loop For each candidate (max MAX_SOURCE_RETRIES)
+    loop For each candidate (max MAX_SOURCE_RETRIES) until metadata found
         W->>MX: GetMetadata(mx_source_id, worker_id)
         MX-->>W: WorkerMetadata (tensors, nixl_metadata)
-        W->>W: Add remote NIXL agent
-        W->>W: Execute RDMA transfers
-        alt Transfer fails (SourceTransferError)
+        alt Metadata missing or fetch error
             W->>W: Try next candidate
         end
+    end
+    W->>W: Add remote NIXL agent, execute RDMA transfers
+    alt Transfer fails (SourceTransferError / ManifestMismatchError)
+        W->>W: Abandon RDMA, fall through to next strategy (GDS, disk)
     end
     W->>W: process_weights_after_loading()
     W->>W: Register and publish own metadata (become a source)


### PR DESCRIPTION

  Backport of #418 (`main` commit fe7c479) to `release/0.4.0`. Clean cherry-pick,
  no conflicts. Doc-only; no code behavior changes. Resolves the two MX 0.4.0 doc
  QA bugs (nvbug 6262656, nvbug 6262411). Tracked in MX-364.

Fixes NVBug 6262656 and 6262411.

  ## RDMA candidate-retry semantics
  Docs claimed `RdmaStrategy` retries the next source on `SourceTransferError` or
  `ManifestMismatchError`. In reality the candidate loop only retries pre-transfer
  metadata misses; once the RDMA receive starts, both errors raise
  `StrategyFailed(mutated=True)` and the chain falls through to the next strategy
  (GDS, then disk), not the next source.
  - `docs/ARCHITECTURE.md`: strategy table row + ManifestMismatchError paragraph.
  - `docs/metadata.md`: target-path mermaid redrawn so only GetMetadata is inside
    the candidate loop.

  ## Stale README/CLI guidance
  - `README.md`: fixed the dead Architecture anchor; added the required
    `REDIS_URL` to the Quick Start command and the config table (no localhost
    fallback); replaced the invalid `model get` with `model download`.
  - `docs/CLI.md`: bumped the `0.1.0` health examples to `0.4.0`; documented the
    real `-c/--config <FILE>` support; replaced the gRPC-incompatible `curl /health`
    probe with a TCP check; corrected the Adding New Commands file locations.

