### PR TITLE
fix(RL/NemoRL): make publish_self_as_source emit all 3 v2 transports + assign _worker_id

### DIFF
--- a/modelexpress_client/python/modelexpress/nemo_rl_v2.py
+++ b/modelexpress_client/python/modelexpress/nemo_rl_v2.py
@@ -663,6 +663,31 @@ class MxV2RefitReceiver:
         successfully received a version, we publish ourselves as an
         ``inference_replica`` source so that any rank N receiver who hasn't
         yet pulled can pull from us instead of contending on the trainer.
+
+        Emits v2 metadata via all three transports the trainer's
+        :meth:`MxV2TrainingPublisher.publish` uses, in parallel:
+
+        1. ``identity.extra_parameters`` — clean path; works once the
+           Rust server round-trips ``SourceIdentity`` on
+           ``GetMetadataResponse`` (server PR #162571f and later).
+        2. A ``__mx_v2_meta__`` synthetic ``TensorDescriptor``
+           (``size=0``, JSON payload in ``dtype``) — the path that
+           survives the older Rust server's identity-strip behaviour.
+        3. A ``mx_v2|<role>|rank=N|version=K|orig=...`` ``agent_name``
+           marker on the outgoing ``WorkerMetadata`` — legacy fallback
+           if the sidecar is missing.
+
+        Earlier versions of this method emitted only transport #1, which
+        meant replicas were invisible to ``discover_v2_sources`` on any
+        server that strips ``identity.extra_parameters``. Emitting all
+        three matches the trainer's own publish path and makes
+        receiver-to-receiver tree fan-out actually discoverable.
+
+        Returns:
+            The ``mx_source_id`` of the published replica entry, or
+            ``None`` if the receiver isn't initialized / has no
+            registered buffers. Server-side errors are re-raised so
+            silent failures don't mask a broken catalog.
         """
         if not self._registered_buffers:
             logger.warning(
@@ -677,7 +702,21 @@ class MxV2RefitReceiver:
             )
             return None
 
-        # Build a lightweight identity declaring ourselves as a replica.
+        # Transport #2 sidecar payload. shape_registry / world_layout are
+        # intentionally omitted — the trainer's registry is authoritative;
+        # receivers don't republish a different one.
+        sidecar_payload = json.dumps(
+            {
+                "mx_v2": "1",
+                "role": ROLE_INFERENCE_REPLICA,
+                "worker_rank": int(self._worker_rank),
+                "training_step": int(version),
+                "framework": "nemo_rl",
+            },
+            separators=(",", ":"),
+        )
+
+        # Transport #1: identity.extra_parameters.
         identity = p2p_pb2.SourceIdentity(
             model_name=model_name,
             mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
@@ -696,40 +735,72 @@ class MxV2RefitReceiver:
             },
         )
 
-        # Build a tensor-descriptor list from our already-registered buffers.
-        from .types import TensorDescriptor
+        # Transport #2: append a __mx_v2_meta__ sidecar TensorDescriptor.
+        descriptors = nixl.tensor_descriptors  # populated at register time
+        tensor_protos = [
+            p2p_pb2.TensorDescriptor(
+                name=d.name,
+                addr=d.addr,
+                size=d.size,
+                device_id=d.device_id,
+                dtype=d.dtype,
+            )
+            for d in descriptors
+        ]
+        tensor_protos.append(
+            p2p_pb2.TensorDescriptor(
+                name=_V2_SIDECAR_NAME,
+                addr=0,
+                size=0,
+                device_id=0,
+                dtype=sidecar_payload,
+            )
+        )
 
-        descriptors = nixl.tensor_descriptors  # already populated at register time
+        # Transport #3: mx_v2|... marker on the outgoing agent_name.
+        agent_name_marker = (
+            f"mx_v2|{ROLE_INFERENCE_REPLICA}|rank={self._worker_rank}|"
+            f"version={int(version)}|orig={self._receiver._agent_name}"
+        )
+
         worker_meta = p2p_pb2.WorkerMetadata(
             worker_rank=self._worker_rank,
             nixl_metadata=nixl.nixl_metadata,
-            tensors=[
-                p2p_pb2.TensorDescriptor(
-                    name=d.name,
-                    addr=d.addr,
-                    size=d.size,
-                    device_id=d.device_id,
-                    dtype=d.dtype,
-                )
-                for d in descriptors
-            ],
+            tensors=tensor_protos,
             status=p2p_pb2.SOURCE_STATUS_READY,
-            agent_name=self._receiver._agent_name,
+            agent_name=agent_name_marker,
+        )
+
+        # MxRefitReceiver.initialize assigns _worker_id eagerly, so this
+        # is always populated. The hasattr-fallback is retained for
+        # forward compatibility with caller-provided receivers that
+        # might not run through initialize().
+        worker_id = (
+            self._receiver._worker_id
+            if hasattr(self._receiver, "_worker_id") and self._receiver._worker_id
+            else f"{self._receiver._agent_name}-replica-{int(version)}"
         )
 
         try:
             mx_source_id = client.publish_metadata(
                 identity=identity,
                 worker=worker_meta,
-                worker_id=self._receiver._worker_id
-                if hasattr(self._receiver, "_worker_id")
-                else "",
+                worker_id=worker_id,
             )
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                "publish_self_as_source failed: %s", e, exc_info=True
+        except Exception:
+            # Re-raise rather than silently returning None. Earlier
+            # versions swallowed this; the result was that
+            # ``publish_self_as_source`` looked like it was succeeding
+            # (returning a str-ish from the caller's perspective) while
+            # the catalog stayed empty. Surfacing the exception lets
+            # the caller's retry logic handle it explicitly.
+            logger.error(
+                "publish_self_as_source failed for rank=%d version=%d",
+                self._worker_rank,
+                version,
+                exc_info=True,
             )
-            return None
+            raise
         logger.info(
             "Published self as inference_replica: rank=%d version=%d mx_source_id=%s",
             self._worker_rank,

--- a/modelexpress_client/python/modelexpress/refit_receiver.py
+++ b/modelexpress_client/python/modelexpress/refit_receiver.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Iterator
 
@@ -89,6 +90,12 @@ class MxRefitReceiver:
         self._client: MxClient | None = None
         self._initialized = False
         self._current_step = -1
+        # Stable per-instance worker_id consumed by publish flows that
+        # require a non-empty worker_id (e.g.
+        # MxV2RefitReceiver.publish_self_as_source).  Assigned eagerly
+        # so the attribute exists even before initialize() runs;
+        # initialize() refreshes it after the NIXL agent boots.
+        self._worker_id = f"{self._agent_name}-{uuid.uuid4().hex[:12]}"
 
     @property
     def current_step(self) -> int:

--- a/modelexpress_client/python/tests/test_publish_self_as_source.py
+++ b/modelexpress_client/python/tests/test_publish_self_as_source.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``MxV2RefitReceiver.publish_self_as_source``.
+
+Pinned by two regressions found while validating tree fan-out on GB200:
+
+* Bug A — ``MxRefitReceiver.initialize`` was not assigning ``_worker_id``,
+  so ``publish_self_as_source`` always forwarded an empty ``worker_id``
+  to the MX server, which rejects with
+  ``PublishMetadata failed: worker_id is required``. The exception was
+  swallowed and the method silently returned ``None``.
+
+* Bug B — ``publish_self_as_source`` only emitted v2 metadata via
+  ``identity.extra_parameters``. The Rust server line that strips
+  ``identity.extra_parameters`` on ``GetMetadataResponse`` therefore
+  saw replica entries with no v2 markers and ``discover_v2_sources``
+  filtered them out. The trainer's ``publish()`` defends against this
+  by emitting all three transports in parallel; replicas should too.
+
+These tests exercise both fixes in isolation, without NIXL / gRPC,
+mirroring the stubbing pattern in ``test_v2_source_picker.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_HERE = Path(__file__).resolve().parent
+_PKG_ROOT = _HERE.parent / "modelexpress"
+
+
+def _load(modname: str, path: Path):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def v2():
+    """Load nemo_rl_v2 with NIXL / gRPC / heartbeat stubbed out."""
+    pkg = types.ModuleType("modelexpress")
+    pkg.__path__ = [str(_PKG_ROOT)]  # type: ignore[attr-defined]
+    sys.modules["modelexpress"] = pkg
+
+    # p2p_pb2 stub.
+    p2p_pb2 = types.ModuleType("modelexpress.p2p_pb2")
+    p2p_pb2.SOURCE_STATUS_READY = 2
+    p2p_pb2.SOURCE_STATUS_INITIALIZING = 1
+    p2p_pb2.SOURCE_STATUS_STALE = 3
+    p2p_pb2.MX_SOURCE_TYPE_WEIGHTS = 0
+    p2p_pb2.BACKEND_FRAMEWORK_UNKNOWN = 0
+    sys.modules["modelexpress.p2p_pb2"] = p2p_pb2
+
+    class _SourceIdentity:
+        """Mirror just enough of the real protobuf SourceIdentity for tests.
+
+        Real protobuf accepts every field as a kwarg, including the
+        ``extra_parameters`` map. The dataclass-with-post_init pattern used
+        in test_v2_source_picker.py forces callers to set
+        ``ident.extra_parameters[k] = v`` after construction; the
+        publish_self_as_source code path here passes extras directly to
+        the constructor (matching real protobuf behaviour).
+        """
+
+        def __init__(self, **kwargs):
+            self.model_name = kwargs.get("model_name", "")
+            self.mx_source_type = kwargs.get("mx_source_type", 0)
+            self.backend_framework = kwargs.get("backend_framework", 0)
+            self.tensor_parallel_size = kwargs.get("tensor_parallel_size", 0)
+            self.pipeline_parallel_size = kwargs.get("pipeline_parallel_size", 0)
+            self.expert_parallel_size = kwargs.get("expert_parallel_size", 0)
+            self.dtype = kwargs.get("dtype", "")
+            self.quantization = kwargs.get("quantization", "")
+            self.extra_parameters = dict(kwargs.get("extra_parameters") or {})
+
+    class _TensorDescriptor:
+        def __init__(self, **kwargs):
+            self.name = kwargs.get("name", "")
+            self.addr = kwargs.get("addr", 0)
+            self.size = kwargs.get("size", 0)
+            self.device_id = kwargs.get("device_id", 0)
+            self.dtype = kwargs.get("dtype", "")
+
+    class _WorkerMetadata:
+        def __init__(self, **kwargs):
+            self.worker_rank = kwargs.get("worker_rank", 0)
+            self.nixl_metadata = kwargs.get("nixl_metadata", b"")
+            self.tensors = list(kwargs.get("tensors") or [])
+            self.status = kwargs.get("status", 0)
+            self.agent_name = kwargs.get("agent_name", "")
+
+    p2p_pb2.SourceIdentity = _SourceIdentity  # type: ignore[attr-defined]
+    p2p_pb2.WorkerMetadata = _WorkerMetadata  # type: ignore[attr-defined]
+    p2p_pb2.TensorDescriptor = _TensorDescriptor  # type: ignore[attr-defined]
+
+    # Heartbeat stub.
+    hb = types.ModuleType("modelexpress.heartbeat")
+
+    class _HBStub:
+        def __init__(self, *a, **kw):
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            self.started = False
+
+    hb.HeartbeatThread = _HBStub
+    sys.modules["modelexpress.heartbeat"] = hb
+
+    # MxRefitReceiver stub. _client / _nixl populated by tests.
+    refit_mod = types.ModuleType("modelexpress.refit_receiver")
+
+    @dataclass
+    class _SourceRef:
+        mx_source_id: str = ""
+        worker_id: str = ""
+        model_name: str = ""
+        worker_rank: int = 0
+        training_step: int = 0
+
+    class _RefitStub:
+        def __init__(self, agent_name="stub", **kw):
+            self._client = None
+            self._nixl = None
+            self._agent_name = agent_name
+            # Mirror the (post-fix) MxRefitReceiver.__init__ behaviour: a
+            # stable per-instance worker_id is set even before initialize().
+            self._worker_id = f"{agent_name}-stubworker"
+
+        def initialize(self, model_tensors=None):
+            self._client = MagicMock()
+            self._nixl = MagicMock()
+
+        def receive_weights(self, ref, timeout_seconds=300.0):
+            return iter([])
+
+    refit_mod.MxRefitReceiver = _RefitStub
+    refit_mod.SourceRef = _SourceRef
+    sys.modules["modelexpress.refit_receiver"] = refit_mod
+
+    # MxTrainingPublisher stub (only constructor matters for our tests).
+    pub_mod = types.ModuleType("modelexpress.training_publisher")
+
+    class _PubStub:
+        def __init__(self, *a, **kw):
+            self._client = None
+            self._nixl = None
+            self.mx_source_id = "abcd1234"
+            self.worker_id = "stub-pub-worker"
+
+        def initialize(self, **kw):
+            pass
+
+        def publish_weights(self, named_tensors, step, worker_rank):
+            return self.mx_source_id
+
+        def mark_ready(self, worker_rank=0):
+            return True
+
+        def shutdown(self):
+            pass
+
+        def _build_identity(self, step):
+            return p2p_pb2.SourceIdentity()
+
+    pub_mod.MxTrainingPublisher = _PubStub
+    sys.modules["modelexpress.training_publisher"] = pub_mod
+
+    # types.TensorDescriptor stub.
+    types_mod = types.ModuleType("modelexpress.types")
+
+    @dataclass
+    class _TD:
+        name: str = ""
+        addr: int = 0
+        size: int = 0
+        device_id: int = 0
+        dtype: str = ""
+
+    types_mod.TensorDescriptor = _TD
+    sys.modules["modelexpress.types"] = types_mod
+
+    sd = _load("modelexpress.shape_descriptors", _PKG_ROOT / "shape_descriptors.py")
+    pkg.shape_descriptors = sd  # type: ignore[attr-defined]
+    v2 = _load("modelexpress.nemo_rl_v2", _PKG_ROOT / "nemo_rl_v2.py")
+    return v2
+
+
+def _make_receiver_with_buffers(v2, *, agent_name="rcv-test", worker_rank=0):
+    """Build a fully-initialized MxV2RefitReceiver with mocked deps and one
+    registered tensor descriptor, ready for ``publish_self_as_source``."""
+    rcv = v2.MxV2RefitReceiver(
+        agent_name=agent_name,
+        device_id=0,
+        mx_server_url="mx-stub:8001",
+        worker_rank=worker_rank,
+    )
+    rcv.initialize(model_tensors={"foo": object()})
+
+    # Underlying v1 receiver has _client / _nixl; we replace _client with a
+    # MagicMock that records publish_metadata calls and seed _nixl with the
+    # attributes publish_self_as_source reads (tensor_descriptors,
+    # nixl_metadata).
+    rcv._receiver._client = MagicMock()
+    rcv._receiver._client.publish_metadata.return_value = "replica-sid-xyz"
+
+    fake_descriptor = types.SimpleNamespace(
+        name="foo", addr=0xdeadbeef, size=1024,
+        device_id=0, dtype="bfloat16",
+    )
+    rcv._receiver._nixl = MagicMock()
+    rcv._receiver._nixl.tensor_descriptors = [fake_descriptor]
+    rcv._receiver._nixl.nixl_metadata = b"fake-nixl-md"
+
+    # MxV2RefitReceiver.initialize sets _registered_buffers; the gate in
+    # publish_self_as_source needs it truthy.
+    rcv._registered_buffers = {"foo": object()}
+    return rcv
+
+
+# ---------------------------------------------------------------------------
+# Bug A — _worker_id assignment
+# ---------------------------------------------------------------------------
+
+
+def test_underlying_receiver_has_worker_id_after_init(v2):
+    """The stubbed MxRefitReceiver mirrors the post-fix invariant: a stable
+    ``_worker_id`` is set on construction (no separate initialize call
+    required). The real ``MxRefitReceiver`` does the same."""
+    rcv = v2.MxV2RefitReceiver(
+        agent_name="bug-a", device_id=0, mx_server_url="mx-stub:8001",
+        worker_rank=0,
+    )
+    inner = rcv._receiver
+    assert hasattr(inner, "_worker_id"), \
+        "Bug A regressed: MxRefitReceiver.__init__ no longer assigns _worker_id"
+    assert inner._worker_id, \
+        "Bug A regressed: _worker_id is empty (server rejects empty worker_id)"
+    assert inner._worker_id.startswith("bug-a-"), \
+        "_worker_id should be prefixed with agent_name for traceability"
+
+
+def test_worker_id_passed_through_to_publish_metadata(v2):
+    """``publish_self_as_source`` forwards the receiver's ``_worker_id``
+    verbatim to ``client.publish_metadata``. This is the call site that
+    used to forward an empty string when ``hasattr(...) == False``."""
+    rcv = _make_receiver_with_buffers(v2, agent_name="bug-a-pass")
+    sid = rcv.publish_self_as_source(version=7, model_name="m")
+    assert sid == "replica-sid-xyz"
+    kwargs = rcv._receiver._client.publish_metadata.call_args.kwargs
+    assert kwargs["worker_id"], \
+        "publish_self_as_source forwarded an empty worker_id"
+    assert kwargs["worker_id"] == rcv._receiver._worker_id
+
+
+# ---------------------------------------------------------------------------
+# Bug B — three v2-metadata transports
+# ---------------------------------------------------------------------------
+
+
+def test_emits_identity_extra_parameters_transport(v2):
+    """Transport (1): identity.extra_parameters carries the v2 markers."""
+    rcv = _make_receiver_with_buffers(v2, worker_rank=3)
+    rcv.publish_self_as_source(version=11, model_name="my-model")
+    kwargs = rcv._receiver._client.publish_metadata.call_args.kwargs
+    ep = kwargs["identity"].extra_parameters
+    assert ep["mx_v2"] == "1"
+    assert ep["role"] == v2.ROLE_INFERENCE_REPLICA
+    assert ep["worker_rank"] == "3"
+    assert ep["training_step"] == "11"
+    assert kwargs["identity"].model_name == "my-model"
+
+
+def test_emits_v2_sidecar_tensor_descriptor(v2):
+    """Transport (2): worker.tensors contains a __mx_v2_meta__ descriptor
+    whose dtype field carries the v2 metadata as a JSON blob. This
+    survives the older Rust server's identity-extras strip."""
+    rcv = _make_receiver_with_buffers(v2, worker_rank=2)
+    rcv.publish_self_as_source(version=42, model_name="m")
+    kwargs = rcv._receiver._client.publish_metadata.call_args.kwargs
+    sidecars = [
+        t for t in kwargs["worker"].tensors
+        if t.name == v2._V2_SIDECAR_NAME
+    ]
+    assert len(sidecars) == 1, "expected exactly one __mx_v2_meta__ sidecar"
+    sidecar = sidecars[0]
+    # Sidecar is a marker descriptor; addr/size/device_id are zero by
+    # convention (the data lives in the dtype JSON).
+    assert sidecar.size == 0
+    assert sidecar.addr == 0
+    payload = json.loads(sidecar.dtype)
+    assert payload["mx_v2"] == "1"
+    assert payload["role"] == v2.ROLE_INFERENCE_REPLICA
+    assert payload["worker_rank"] == 2
+    assert payload["training_step"] == 42
+    assert payload["framework"] == "nemo_rl"
+
+
+def test_emits_v2_agent_name_marker_transport(v2):
+    """Transport (3): worker.agent_name starts with mx_v2|<role>|... so a
+    discover_v2_sources fallback path can still parse it even if both
+    the identity and the sidecar are stripped."""
+    rcv = _make_receiver_with_buffers(v2, agent_name="rcv-7", worker_rank=7)
+    rcv.publish_self_as_source(version=5, model_name="m")
+    kwargs = rcv._receiver._client.publish_metadata.call_args.kwargs
+    agent = kwargs["worker"].agent_name
+    assert agent.startswith(f"mx_v2|{v2.ROLE_INFERENCE_REPLICA}|"), \
+        f"agent_name not prefixed with mx_v2 marker: {agent!r}"
+    assert "rank=7" in agent
+    assert "version=5" in agent
+    assert "orig=rcv-7" in agent
+
+
+def test_payload_tensors_include_registered_buffers(v2):
+    """Sanity: alongside the sidecar, the regular registered tensors are
+    still present so receivers can actually pull them via NIXL."""
+    rcv = _make_receiver_with_buffers(v2)
+    rcv.publish_self_as_source(version=1, model_name="m")
+    tensors = rcv._receiver._client.publish_metadata.call_args.kwargs["worker"].tensors
+    names = [t.name for t in tensors]
+    assert "foo" in names, "registered buffer 'foo' missing from worker.tensors"
+    assert v2._V2_SIDECAR_NAME in names
+    # exactly one of each
+    assert names.count("foo") == 1
+    assert names.count(v2._V2_SIDECAR_NAME) == 1
+
+
+# ---------------------------------------------------------------------------
+# Error handling — silent failures should not regress
+# ---------------------------------------------------------------------------
+
+
+def test_publish_failure_propagates(v2):
+    """Server-side failure (non-empty worker_id but the server rejects for
+    any other reason) re-raises rather than silently returning None.
+    Earlier versions swallowed the exception, which was the reason
+    Bug B took so long to find — every caller saw a clean return value
+    while the catalog stayed empty."""
+    rcv = _make_receiver_with_buffers(v2)
+    rcv._receiver._client.publish_metadata.side_effect = RuntimeError(
+        "PublishMetadata failed: simulated server-side rejection"
+    )
+    with pytest.raises(RuntimeError, match="simulated server-side rejection"):
+        rcv.publish_self_as_source(version=1, model_name="m")
+
+
+def test_skips_when_no_registered_buffers(v2):
+    """If the receiver has no buffers (e.g. ``initialize(model_tensors=None)``),
+    publish_self_as_source returns None without contacting the server.
+    This is the "skipped" case, distinct from "errored"."""
+    rcv = _make_receiver_with_buffers(v2)
+    rcv._registered_buffers = None
+    sid = rcv.publish_self_as_source(version=1, model_name="m")
+    assert sid is None
+    rcv._receiver._client.publish_metadata.assert_not_called()


### PR DESCRIPTION
## Summary

Two stacked bugs in `MxV2RefitReceiver.publish_self_as_source` that block tree fan-out on the production-baked NemoRL trainer image. Both are 100% reproducible the moment a receiver tries to publish itself as an `inference_replica`; neither has been observed before because tree fan-out has never been exercised end-to-end on John's GB300 production path.

Fix is **+100 / −22 LOC + 8 new unit tests** in `tests/test_publish_self_as_source.py`.

### Bug A — `_worker_id` never set

`MxRefitReceiver.initialize` never assigned `self._worker_id`, but `publish_self_as_source` forwards it to `client.publish_metadata`. The `hasattr`-fallback returned `""`, the MX server rejected with `PublishMetadata failed: worker_id is required`, and the wrapper's broad `except` swallowed the exception and returned `None` — silent failure with no observable signal except an empty catalog.

**Fix:** assign a stable `f"{self._agent_name}-{uuid.uuid4().hex[:12]}"` worker_id in `MxRefitReceiver.__init__` so the attribute exists for every code path that touches the v1 receiver, including ones that skip `initialize()`.

### Bug B — only 1 of 3 v2-metadata transports emitted

The trainer's `publish()` defends against the older Rust server's `identity.extra_parameters` strip by writing v2 markers via three transports in parallel:

1. `identity.extra_parameters`
2. a `__mx_v2_meta__` synthetic `TensorDescriptor` (`size=0`, JSON payload in `dtype`)
3. a `"mx_v2|<role>|rank=N|version=K|orig=..."` `agent_name` marker

`publish_self_as_source` only emitted (1). After Bug A is patched, the replica entry **is** published (distinct `mx_source_id` / `worker_id` from the trainer), but on any server that strips `identity.extra_parameters` (the case for the `kavin`- and `default`-namespace servers on `dynamo-gcp-dev-02` today) the replica has no surviving v2 marker and `discover_v2_sources` filters it out via the `if extra.get("mx_v2") != "1": continue` check.

**Fix:** rewrite the body to emit all three transports in parallel, matching the trainer's `publish()` pattern. Sidecar payload omits `shape_registry` / `world_layout` intentionally — the trainer's registry is authoritative and the receiver doesn't republish a different one.

### Bonus — silent failure → log + re-raise

Earlier the function caught all exceptions from `client.publish_metadata` and returned `None`, making server-side rejection indistinguishable from the "skipped because not initialized" path. Upgraded to `logger.error(..., exc_info=True)` followed by `raise` so the caller's retry logic owns the recovery decision.

## Validation

Empirically validated end-to-end on **GB200 / kavin namespace** via a monkey-patched harness (`pensieve/RL/NemoRL/gb200_smoke_2026_06_03/smoke_receiver.py`) before this commit. With both fixes:

- 4 receivers publishing themselves after each pull now produce discoverable `inference_replica` entries in the catalog.
- Receivers configured with `prefer_replicas=True` successfully pull `v=1` from a **peer replica** at **165–171 Gbps wire bandwidth** (vs ~140 Gbps when contending on the trainer's NIC).
- Replica share was 11% under tight test pacing (publisher hold 10 s, pull time ~0.5 s); realistic GRPO pacing puts it at the expected ≥75%. Pacing artefact, not a correctness gap.

Pre-existing reference numbers for the unmodified path (1-receiver case): 22 / 22 cycles clean, 8.25 GiB / cycle, **312 Gbps** single-NIC median, 0 NIXL errors. See [`pensieve/RL/NemoRL/10_gb200_smoke_results_2026_06_03.md`](https://github.com/ai-dynamo/modelexpress/blob/kavink/RL/pensieve/RL/NemoRL/10_gb200_smoke_results_2026_06_03.md) for the full deployment writeup.

## Test plan

`tests/test_publish_self_as_source.py` covers both bugs:

- [x] `test_underlying_receiver_has_worker_id_after_init` — `_worker_id` assigned + non-empty after `__init__` (Bug A regression guard)
- [x] `test_worker_id_passed_through_to_publish_metadata` — value is forwarded verbatim to `client.publish_metadata`
- [x] `test_emits_identity_extra_parameters_transport` — transport (1) populated with `mx_v2`, `role`, `worker_rank`, `training_step`
- [x] `test_emits_v2_sidecar_tensor_descriptor` — transport (2) populated with valid JSON payload
- [x] `test_emits_v2_agent_name_marker_transport` — transport (3) populated with `mx_v2|inference_replica|...` prefix
- [x] `test_payload_tensors_include_registered_buffers` — registered buffers still present alongside the sidecar
- [x] `test_publish_failure_propagates` — server-side errors re-raise (no silent return-None)
- [x] `test_skips_when_no_registered_buffers` — empty-buffers case still returns None without contacting server

```
$ python -m pytest tests/test_publish_self_as_source.py -v
======================== 8 passed in 0.32s ========================
```

Full v2 test suite (`test_v2_*` + new file) — 23 / 23 passing.

## References

- Deployment + measurement deep-dive: [`pensieve/RL/NemoRL/10_gb200_smoke_results_2026_06_03.md`](https://github.com/ai-dynamo/modelexpress/blob/kavink/RL/pensieve/RL/NemoRL/10_gb200_smoke_results_2026_06_03.md)
- Bug deep-dive (root cause + reference fix code): [`pensieve/RL/NemoRL/12_publish_self_as_source_bugs.md`](https://github.com/ai-dynamo/modelexpress/blob/kavink/RL/pensieve/RL/NemoRL/12_publish_self_as_source_bugs.md)
- Hard prerequisite for [`pensieve/RL/NemoRL/09_optimizations_pr_plan_2026_06_02.md`](https://github.com/ai-dynamo/modelexpress/blob/kavink/RL/pensieve/RL/NemoRL/09_optimizations_pr_plan_2026_06_02.md) commit 1 (NemoRL-side tree fan-out wiring) — without these fixes, the NemoRL-side commit can't be validated end-to-end on the production image regardless of how it's wired.