### PR TITLE
fix(ci): avoid user-controlled data in run blocks for vCluster actions

### DIFF
--- a/.github/actions/check-vcluster-exists/action.yml
+++ b/.github/actions/check-vcluster-exists/action.yml
@@ -32,13 +32,14 @@ runs:
       env:
         VCLUSTER_NAME: ${{ inputs.vcluster_name }}
         NAMESPACE: ${{ inputs.vcluster_namespace }}
+        KUBECONFIG_BASE64: ${{ inputs.kubeconfig_base64 }}
       run: |
         # Use a unique temp file so concurrent runs on the same self-hosted
         # runner don't clobber each other's kubeconfig. Trap on EXIT to
         # remove the credential whether the step succeeds or fails.
         KUBECONFIG_FILE=$(mktemp)
         trap 'rm -f "${KUBECONFIG_FILE}"' EXIT
-        echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > "${KUBECONFIG_FILE}"
+        echo "${KUBECONFIG_BASE64}" | base64 -d > "${KUBECONFIG_FILE}"
         chmod 600 "${KUBECONFIG_FILE}"
         export KUBECONFIG="${KUBECONFIG_FILE}"
         RESULT=$(vcluster list --output json -n ${NAMESPACE})

--- a/.github/actions/install-vcluster-cli/action.yml
+++ b/.github/actions/install-vcluster-cli/action.yml
@@ -15,8 +15,10 @@ runs:
   steps:
     - name: Install vCluster CLI
       shell: bash
+      env:
+        VCLUSTER_VERSION: ${{ inputs.vcluster_version }}
       run: |
-        echo "::group::Install vCluster CLI ${{ inputs.vcluster_version }}"
+        echo "::group::Install vCluster CLI ${VCLUSTER_VERSION}"
         if command -v vcluster &>/dev/null; then
           echo "vCluster CLI already installed: $(vcluster version)"
         else
@@ -31,7 +33,7 @@ runs:
             --connect-timeout 10 --max-time 120 \
             --fail --show-error -sL \
             -o "${TMP_BIN}" \
-            "https://github.com/loft-sh/vcluster/releases/download/${{ inputs.vcluster_version }}/vcluster-linux-${VCLUSTER_ARCH}"
+            "https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/vcluster-linux-${VCLUSTER_ARCH}"
           sudo install -m 0755 "${TMP_BIN}" /usr/local/bin/vcluster
           rm -f "${TMP_BIN}"
           vcluster version

--- a/.github/actions/setup-mx-vcluster/action.yml
+++ b/.github/actions/setup-mx-vcluster/action.yml
@@ -61,10 +61,12 @@ runs:
   steps:
     - name: Setup host kubeconfig
       shell: bash
+      env:
+        KUBECONFIG_BASE64: ${{ inputs.kubeconfig_base64 }}
       run: |
-        echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig-host
-        chmod 600 ${{ github.workspace }}/.kubeconfig-host
-        echo "KUBECONFIG=${{ github.workspace }}/.kubeconfig-host" >> $GITHUB_ENV
+        echo "${KUBECONFIG_BASE64}" | base64 -d > "${GITHUB_WORKSPACE}/.kubeconfig-host"
+        chmod 600 "${GITHUB_WORKSPACE}/.kubeconfig-host"
+        echo "KUBECONFIG=${GITHUB_WORKSPACE}/.kubeconfig-host" >> $GITHUB_ENV
 
     - name: Install vCluster CLI
       uses: ./.github/actions/install-vcluster-cli
@@ -105,6 +107,7 @@ runs:
       env:
         VCLUSTER_NAME: ${{ inputs.vcluster_name }}
         NAMESPACE: ${{ inputs.vcluster_namespace }}
+        VCLUSTER_K8S_VERSION: ${{ inputs.vcluster_k8s_version }}
       run: |
         echo "::group::Create vCluster ${VCLUSTER_NAME} in ${NAMESPACE}"
         # GPU workloads require syncing host nodes into the vCluster so the GPU
@@ -114,7 +117,7 @@ runs:
           --connect=false \
           --upgrade \
           --set controlPlane.distro.k8s.enabled=true \
-          --set controlPlane.distro.k8s.version=${{ inputs.vcluster_k8s_version }} \
+          --set controlPlane.distro.k8s.version=${VCLUSTER_K8S_VERSION} \
           --set sync.fromHost.nodes.enabled=true \
           --set sync.fromHost.nodes.selector.all=true
         echo "::endgroup::"
@@ -146,7 +149,7 @@ runs:
         echo "::group::Apply ModelExpress CRD inside vCluster"
         # CRD is cluster-scoped — applied once here on bootstrap.
         # run-mx-p2p-test also applies it on every run for idempotency.
-        kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-vcluster apply \
+        kubectl --kubeconfig="${GITHUB_WORKSPACE}/.kubeconfig-vcluster" apply \
           -f ci/k8s/server/crd-modelmetadata.yaml
         echo "::endgroup::"
 
@@ -232,7 +235,7 @@ runs:
         echo "::group::Events (host namespace)"
         kubectl get events -n ${NAMESPACE} --sort-by='.lastTimestamp' 2>&1 || true
         echo "::endgroup::"
-        VC_KC=${{ github.workspace }}/.kubeconfig-vcluster
+        VC_KC="${GITHUB_WORKSPACE}/.kubeconfig-vcluster"
         if [ -f "${VC_KC}" ]; then
           echo "::group::Pod status (vCluster, all namespaces)"
           kubectl --kubeconfig=${VC_KC} get pods -A -o wide 2>&1 || true


### PR DESCRIPTION
SonarQube flagged three composite actions for interpolating action inputs
directly into shell `run:` blocks via `${{ }}`.

Fix: move each untrusted input into the step's `env:` block and reference it
as a normal shell variable, so the shell treats the value as literal data.

- `check-vcluster-exists`: `kubeconfig_base64` moved to an env var.
- `install-vcluster-cli`: `vcluster_version` moved to an env var (both the
  log-group echo and the release download URL).
- `setup-mx-vcluster`: `kubeconfig_base64` and `vcluster_k8s_version` moved to
  env vars; also replaced `${{ github.workspace }}` inside run blocks with the
  built-in `$GITHUB_WORKSPACE` so no run block expands a `${{ }}` expression.
  The `env:`-block `KUBECONFIG` value keeps `${{ github.workspace }}` since the
  runner must expand it there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow configuration for internal CI/CD processes, including refinements to kubeconfig handling, vCluster CLI installation, and environment variable management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->