### PR TITLE
feat(RL/NemoRL): Megatron-Core MX clients — Phases B + C + sidecar emit + bulk-pull fast path

### DIFF
--- a/modelexpress_client/python/modelexpress/megatron_helpers.py
+++ b/modelexpress_client/python/modelexpress/megatron_helpers.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Vendored Megatron-Core → HuggingFace tensor-math helpers for the MX v2
+Megatron receiver path (Phase C).
+
+These functions are byte-identical ports of the standalone helpers in
+``megatron.bridge.models.conversion.param_mapping`` (Bridge upstream:
+https://github.com/NVIDIA-NeMo/Megatron-Bridge). They are vendored here so
+the receiver-side translator can use them without taking a hard dependency
+on Megatron-Bridge in the inference image (the production Dynamo
+VllmDecodeWorker image at ``jwillthomson/dynamo-arm-tokenize-endpoint-...``
+does not ship Megatron-Core / Megatron-Bridge — only modelexpress).
+
+Correctness contract: the test ``tests/test_megatron_helpers.py`` runs
+each helper here against Bridge's authoritative implementation and
+asserts byte-identical outputs on a representative MHA + GQA matrix.
+That cross-check runs as part of MX's CI loop, so any drift between
+this vendored copy and Bridge's upstream is caught immediately. Bridge
+is therefore a *test-time-only* dependency; runtime receivers don't
+import it.
+
+Subset rationale: this v0 only vendors the helpers needed for standard
+MHA / GQA QKV (`split_qkv_weights`, `split_qkv_biases`) and gated-MLP
+chunk. Out of scope for this version (defer to a later vendoring pass
+when the production NemoRL trainer hits these layouts):
+
+* ``attention_output_gate=True`` (Megatron-Core gated-attention layout
+  ``[Q, gate, K, V]`` per query group)
+* ``merge_qkvg_weights`` / ``split_qkvg_weights`` (Q-K-V-Gate fused linear)
+* ``merge_kv_weights`` / ``split_kv_weights`` (KV-only fused linear)
+* FP8 blockwise scale tensors (the ``feature_dim`` / scale-domain branch
+  of Bridge's ``split_qkv_weights``)
+* Mamba/GDN linear / conv layouts
+
+For any of those, fall back to "have Bridge installed in the test
+environment and paste its output as ground truth"; or extend this
+module + its CI cross-check.
+
+The :class:`MegatronTransformerConfig` dataclass below is a minimal
+config holder that mirrors the fields the helpers read off
+``TransformerConfig``. The trainer-side publisher serializes these
+fields into the v2 sidecar (see ``MxV2TrainingPublisher``); the
+receiver reconstructs the dataclass before invoking the helpers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+
+
+@dataclass
+class MegatronTransformerConfig:
+    """Minimal subset of Megatron-Core's TransformerConfig used by the
+    QKV / gated-MLP helpers. Carried in the v2 sidecar so the receiver
+    can reconstruct the fields without a Megatron-Core import.
+    """
+
+    num_attention_heads: int
+    num_query_groups: int           # equals num_attention_heads for MHA
+    kv_channels: int | None         # if None, derived from hidden_size // num_heads
+    hidden_size: int
+
+    @property
+    def head_size(self) -> int:
+        if self.kv_channels:
+            return self.kv_channels
+        return self.hidden_size // self.num_attention_heads
+
+    def to_dict(self) -> dict[str, int | None]:
+        return {
+            "num_attention_heads": self.num_attention_heads,
+            "num_query_groups": self.num_query_groups,
+            "kv_channels": self.kv_channels,
+            "hidden_size": self.hidden_size,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "MegatronTransformerConfig":
+        return cls(
+            num_attention_heads=int(d["num_attention_heads"]),
+            num_query_groups=int(d["num_query_groups"]),
+            kv_channels=int(d["kv_channels"]) if d.get("kv_channels") is not None else None,
+            hidden_size=int(d["hidden_size"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# QKV — port of Bridge's split_qkv_biases
+# (megatron/bridge/models/conversion/param_mapping.py L3073-3125)
+# ---------------------------------------------------------------------------
+
+
+def split_qkv_biases(
+    config: MegatronTransformerConfig,
+    qkv: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split Megatron's interleaved QKV bias into separate Q, K, V biases.
+
+    Megatron lays out QKV biases as
+    ``[group0: q*ratio, k, v, group1: q*ratio, k, v, ...]`` where
+    ``ratio = num_attention_heads / num_query_groups``.
+
+    Args:
+        config: Megatron transformer config (head counts + dims).
+        qkv: Interleaved QKV bias as a 1-D tensor of shape
+            ``(num_attention_heads + 2 * num_query_groups) * head_size``.
+
+    Returns:
+        Tuple ``(q, k, v)`` of 1-D bias tensors.
+    """
+    head_num = config.num_attention_heads
+    num_query_groups = config.num_query_groups
+    heads_per_group = head_num // num_query_groups
+    head_size = config.head_size
+
+    qkv_total_dim = head_num + 2 * num_query_groups
+    total_heads_per_group = heads_per_group + 2
+
+    qkv_reshaped = qkv.reshape(qkv_total_dim, head_size)
+
+    q_slice = torch.cat(
+        [
+            torch.arange(
+                total_heads_per_group * i, total_heads_per_group * i + heads_per_group
+            )
+            for i in range(num_query_groups)
+        ]
+    )
+    k_slice = torch.arange(total_heads_per_group - 2, qkv_total_dim, total_heads_per_group)
+    v_slice = torch.arange(total_heads_per_group - 1, qkv_total_dim, total_heads_per_group)
+
+    q = qkv_reshaped[q_slice].flatten()
+    k = qkv_reshaped[k_slice].flatten()
+    v = qkv_reshaped[v_slice].flatten()
+    return q, k, v
+
+
+# ---------------------------------------------------------------------------
+# QKV — port of Bridge's split_qkv_weights (basic non-FP8 path)
+# (megatron/bridge/models/conversion/param_mapping.py L3243-3354)
+# ---------------------------------------------------------------------------
+
+
+def split_qkv_weights(
+    config: MegatronTransformerConfig,
+    qkv: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split Megatron's interleaved QKV weight tensor into separate Q, K, V.
+
+    Args:
+        config: Megatron transformer config.
+        qkv: Interleaved QKV weight tensor with shape
+            ``((num_attention_heads + 2 * num_query_groups) * head_size, hidden_size)``.
+
+    Returns:
+        Tuple ``(q, k, v)`` of 2-D weight tensors with shapes
+        ``(num_attention_heads * head_size, hidden_size)`` and
+        ``(num_query_groups * head_size, hidden_size)`` for K, V.
+    """
+    head_num = config.num_attention_heads
+    num_query_groups = config.num_query_groups
+    heads_per_group = head_num // num_query_groups
+    head_size = config.head_size
+    hidden_size = config.hidden_size
+
+    qkv_total_dim = head_num + 2 * num_query_groups
+    total_heads_per_group = heads_per_group + 2
+
+    if qkv.ndim == 1:
+        # Caller meant biases — defer.
+        return split_qkv_biases(config, qkv)
+
+    if qkv.shape[-1] != hidden_size:
+        # FP8 blockwise scale tensors compress the trailing dim. Bridge's
+        # full implementation handles this; v0 vendored helper rejects it
+        # explicitly so the caller knows to upgrade.
+        raise NotImplementedError(
+            f"split_qkv_weights vendored v0 expects qkv.shape[-1] == hidden_size "
+            f"({hidden_size}); got {qkv.shape[-1]}. FP8 blockwise scale support "
+            f"requires extending the vendored helper or upgrading to "
+            f"megatron.bridge.models.conversion.param_mapping.split_qkv_weights."
+        )
+
+    qkv_reshaped = qkv.view(qkv_total_dim, head_size, hidden_size)
+
+    q_slice = torch.cat(
+        [
+            torch.arange(
+                total_heads_per_group * i, total_heads_per_group * i + heads_per_group
+            )
+            for i in range(num_query_groups)
+        ]
+    )
+    k_slice = torch.arange(total_heads_per_group - 2, qkv_total_dim, total_heads_per_group)
+    v_slice = torch.arange(total_heads_per_group - 1, qkv_total_dim, total_heads_per_group)
+
+    q = qkv_reshaped[q_slice]
+    k = qkv_reshaped[k_slice]
+    v = qkv_reshaped[v_slice]
+
+    assert q.numel() + k.numel() + v.numel() == qkv.numel(), (
+        f"split_qkv_weights size mismatch: "
+        f"q={tuple(q.shape)} k={tuple(k.shape)} v={tuple(v.shape)} qkv={tuple(qkv.shape)}"
+    )
+
+    q = q.reshape(-1, hidden_size)
+    k = k.reshape(-1, hidden_size)
+    v = v.reshape(-1, hidden_size)
+    return q, k, v
+
+
+# ---------------------------------------------------------------------------
+# Inverse helpers — useful in tests and for trainer-side ground-truth
+# generation. Direct ports of Bridge's merge_qkv_weights / merge_qkv_biases.
+# ---------------------------------------------------------------------------
+
+
+def merge_qkv_weights(
+    config: MegatronTransformerConfig,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> torch.Tensor:
+    """Merge separate Q, K, V weight matrices into Megatron's interleaved
+    QKV format. Inverse of :func:`split_qkv_weights`."""
+    head_num = config.num_attention_heads
+    num_query_groups = config.num_query_groups
+    heads_per_group = head_num // num_query_groups
+    head_size = config.head_size
+    hidden_size = config.hidden_size
+    is_bias = q.ndim == 1
+
+    if is_bias:
+        q_reshaped = q.view(head_num, head_size)
+        k_reshaped = k.view(num_query_groups, head_size)
+        v_reshaped = v.view(num_query_groups, head_size)
+    else:
+        q_reshaped = q.view(head_num, head_size, hidden_size)
+        k_reshaped = k.view(num_query_groups, head_size, hidden_size)
+        v_reshaped = v.view(num_query_groups, head_size, hidden_size)
+
+    qkv_weights = []
+    for i in range(num_query_groups):
+        qkv_weights.append(q_reshaped[i * heads_per_group : (i + 1) * heads_per_group])
+        qkv_weights.append(k_reshaped[i : i + 1])
+        qkv_weights.append(v_reshaped[i : i + 1])
+
+    qkv = torch.cat(qkv_weights, dim=0)
+    assert q.numel() + k.numel() + v.numel() == qkv.numel(), (
+        f"merge_qkv_weights size mismatch: "
+        f"q={tuple(q.shape)} k={tuple(k.shape)} v={tuple(v.shape)} qkv={tuple(qkv.shape)}"
+    )
+    if is_bias:
+        return qkv.reshape(-1)
+    return qkv.reshape(-1, hidden_size)
+
+
+def merge_qkv_biases(
+    config: MegatronTransformerConfig,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> torch.Tensor:
+    """Inverse of :func:`split_qkv_biases`."""
+    return merge_qkv_weights(config, q, k, v)
+
+
+# ---------------------------------------------------------------------------
+# Gated MLP — Megatron stores gate+up fused along dim 0; HF expects them
+# split as gate_proj / up_proj. Pure passthrough; trivial helper here for
+# clarity + symmetry with the QKV pair.
+# ---------------------------------------------------------------------------
+
+
+def split_gated_mlp(tensor: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Split Megatron's fused gate+up linear into (gate, up).
+
+    Megatron-Core's convention is ``[gate; up]`` along output dim 0; HF
+    materializes them as separate ``mlp.gate_proj.weight`` and
+    ``mlp.up_proj.weight``.
+    """
+    gate, up = tensor.chunk(2, dim=0)
+    return gate, up
+
+
+def merge_gated_mlp(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`split_gated_mlp` — concatenate ``[gate; up]``."""
+    return torch.cat([gate, up], dim=0)
+
+
+__all__ = [
+    "MegatronTransformerConfig",
+    "split_qkv_weights",
+    "split_qkv_biases",
+    "merge_qkv_weights",
+    "merge_qkv_biases",
+    "split_gated_mlp",
+    "merge_gated_mlp",
+]

--- a/modelexpress_client/python/modelexpress/megatron_helpers.py
+++ b/modelexpress_client/python/modelexpress/megatron_helpers.py
@@ -282,8 +282,61 @@ def split_gated_mlp(tensor: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     Megatron-Core's convention is ``[gate; up]`` along output dim 0; HF
     materializes them as separate ``mlp.gate_proj.weight`` and
     ``mlp.up_proj.weight``.
+
+    Use this helper when the input was assembled from a SINGLE Megatron
+    source rank (matched-TP or per-expert grouped). For inputs assembled
+    by concatenating multiple TP-sharded ranks, use
+    :func:`split_gated_mlp_tp` instead — the per-rank layout is
+    ``[gate_local; up_local]`` so a straight chunk-2 produces a mixed
+    ``[gate_r0; up_r0]`` / ``[gate_r1; up_r1]`` split rather than the
+    un-interleaved ``[gate_global]`` / ``[up_global]`` HF expects.
     """
     gate, up = tensor.chunk(2, dim=0)
+    return gate, up
+
+
+def split_gated_mlp_tp(
+    tensor: torch.Tensor, tp: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Un-interleave a TP-concatenated fused gate+up tensor into (gate, up).
+
+    Megatron-Core's fused gate+up ColumnParallelLinear stores each rank's
+    weight as ``[gate_local; up_local]`` (gate-then-up of that rank's
+    intermediate slice) along the output axis. When the receiver
+    assembles N TP-rank shards via ``concat_dim0``, the resulting tensor
+    has the interleaved layout::
+
+        [gate_r0; up_r0; gate_r1; up_r1; ...; gate_r(N-1); up_r(N-1)]
+
+    HF's ``mlp.gate_proj.weight`` and ``mlp.up_proj.weight`` want the
+    un-interleaved::
+
+        gate = [gate_r0; gate_r1; ...; gate_r(N-1)]
+        up   = [up_r0;   up_r1;   ...; up_r(N-1)]
+
+    This helper does the un-interleave via a single contiguous reshape +
+    advanced indexing (no per-rank copies). It's the inverse of the
+    Megatron publisher's per-rank ``merge_gated_mlp`` (which produces
+    ``[gate_local; up_local]`` per rank) followed by an axis-0 concat.
+
+    When ``tp == 1`` this is exactly :func:`split_gated_mlp`. The
+    receiver-side translator dispatches on ``len(plan.sources)`` to
+    choose between the two.
+    """
+    total_rows = tensor.shape[0]
+    rest = tensor.shape[1:]
+    if total_rows % (2 * tp) != 0:
+        raise ValueError(
+            f"split_gated_mlp_tp: leading dim {total_rows} not divisible by "
+            f"2 * tp = {2 * tp}"
+        )
+    inter_per_rank = total_rows // (2 * tp)
+    # Reshape into (tp, {gate=0, up=1}, inter_per_rank, ...rest).
+    reshaped = tensor.view(tp, 2, inter_per_rank, *rest)
+    # gate_per_rank is reshaped[:, 0]; up_per_rank is reshaped[:, 1].
+    # Flatten the (tp, inter_per_rank) dims back together.
+    gate = reshaped[:, 0].reshape(tp * inter_per_rank, *rest).contiguous()
+    up = reshaped[:, 1].reshape(tp * inter_per_rank, *rest).contiguous()
     return gate, up
 
 
@@ -299,5 +352,6 @@ __all__ = [
     "merge_qkv_weights",
     "merge_qkv_biases",
     "split_gated_mlp",
+    "split_gated_mlp_tp",
     "merge_gated_mlp",
 ]

--- a/modelexpress_client/python/modelexpress/megatron_translator.py
+++ b/modelexpress_client/python/modelexpress/megatron_translator.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Receiver-side Megatron-MX translator (Phase C of the Megatron-MX path).
+
+Orchestrates the full receiver flow for a Megatron trainer's published
+weights:
+
+    1. discover_v2_sources(target_tp_layout)        — Phase B
+    2. pick_megatron_slice_plans(target_tensor_specs)
+    3. NIXL parallel pull into pre-allocated global tensors
+    4. translate Megatron → HF via the vendored helpers
+    5. yield (hf_name, hf_tensor) for the caller's `model.load_weights()`
+
+Framework-agnostic — both NemoRL's direct-vLLM path and Dynamo's
+``MxRefitWorkerExtension`` can use this. The caller supplies the
+``ReceiveSpec`` list (one entry per HF parameter the inference model
+needs); steps 1-5 are owned by this module.
+
+See ``temp/NemoRL_Megatron_MX_Design.md`` §6 + §9b and
+``temp/NemoRL_Megatron_MX_Phase_C_Handoff.md`` for the full design.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator
+
+import torch
+
+from .megatron_helpers import (
+    MegatronTransformerConfig,
+    split_qkv_biases,
+    split_qkv_weights,
+    split_gated_mlp,
+)
+from .nemo_rl_v2 import (
+    MegatronSlicePlan,
+    MegatronSliceSource,
+    MegatronTensorSpec,
+    MxV2RefitReceiver,
+    ROLE_MEGATRON_COLUMN,
+    ROLE_MEGATRON_EXPERT_COLUMN,
+    ROLE_MEGATRON_EXPERT_ROW,
+    ROLE_MEGATRON_GATED_MLP_COLUMN,
+    ROLE_MEGATRON_QKV_COLUMN,
+    ROLE_MEGATRON_REPLICATED,
+    ROLE_MEGATRON_ROW,
+    ROLE_MEGATRON_VOCAB_PARALLEL,
+    TargetTpLayout,
+    V2SourceCandidate,
+)
+
+logger = logging.getLogger("modelexpress.megatron_translator")
+
+
+# Sentinel string for the Megatron transformer-config sidecar key. The
+# trainer-side publisher serializes ``MegatronTransformerConfig.to_dict()``
+# into the v2 sidecar under this key; the receiver reconstructs the config
+# before driving the QKV un-interleave.
+SIDECAR_TRANSFORMER_CONFIG_KEY = "megatron_transformer_config"
+
+# Key for the Megatron→HF naming list in the sidecar. The trainer publishes
+# a list of ``[megatron_name, [hf_name_1, hf_name_2, ...]]`` so the receiver
+# knows which HF names each Megatron tensor should produce. Derived once at
+# trainer init via Bridge's ``export_hf_weights`` introspection.
+SIDECAR_HF_NAME_MAP_KEY = "megatron_hf_name_map"
+
+
+# ---------------------------------------------------------------------------
+# Receiver-spec dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReceiveSpec:
+    """One HF parameter the receiver wants this refit cycle.
+
+    The receiver builds these per-parameter from the inference model's
+    own state-dict shape + dtype, plus the trainer's published Megatron
+    metadata (role + name map). One ReceiveSpec corresponds to one
+    Megatron tensor (e.g. ``decoder.layers.0.self_attention.linear_qkv.weight``)
+    that may unfold into multiple HF tensors after translation
+    (e.g. ``q_proj``, ``k_proj``, ``v_proj``).
+
+    Fields:
+        megatron_name: source-side tensor name (Megatron-shaped, the name
+            the trainer published under).
+        hf_names: HF-shaped names this Megatron tensor expands into.
+            For ``replicated`` / ``column`` / ``row`` / ``vocab_parallel``:
+            length 1. For ``qkv_column``: length 3
+            (``q_proj.weight``, ``k_proj.weight``, ``v_proj.weight``).
+            For ``gated_mlp_column``: length 2
+            (``gate_proj.weight``, ``up_proj.weight``).
+            For ``expert_column`` / ``expert_row``: length depends on the
+            number of local experts on this receiver rank.
+        role: Megatron role (one of ``ROLE_MEGATRON_*``).
+        target_shape: GLOBAL Megatron-side shape that the receiver should
+            assemble the per-rank slices into. After translation, the HF
+            outputs may be smaller (e.g. for QKV: each q/k/v is a
+            partition of this assembled tensor).
+        target_dtype: dtype string ("bfloat16", "float16", "float32").
+        shard_axis: axis along which TP sources are tiled.
+        pp_rank: which PP stage of the trainer's mesh owns this tensor.
+        role_descriptor: per-role extras forwarded to the planner. For
+            QKV / gated_mlp this holds the role-specific keys
+            (``num_heads_total``, ``head_dim``, ``gated_mlp_order``, ...).
+    """
+
+    megatron_name: str
+    hf_names: list[str]
+    role: str
+    target_shape: tuple[int, ...]
+    target_dtype: str
+    shard_axis: int = 0
+    pp_rank: int = 0
+    role_descriptor: dict[str, str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Sidecar parsing — extract Megatron-publisher metadata from a candidate
+# ---------------------------------------------------------------------------
+
+
+def parse_megatron_sidecar(
+    candidate: V2SourceCandidate,
+) -> tuple[MegatronTransformerConfig | None, dict[str, list[str]]]:
+    """Pull Megatron transformer config + Megatron→HF name map from a
+    source's v2 metadata.
+
+    The trainer-side publisher serializes both into the v2 sidecar JSON
+    so the receiver doesn't need a Bridge import to know per-arch naming
+    or attention head config.
+
+    Returns ``(config, hf_name_map)``. Either may be empty/None for sources
+    that don't carry the keys (e.g. DTensor publishers, older builds).
+    """
+    cfg: MegatronTransformerConfig | None = None
+    hf_name_map: dict[str, list[str]] = {}
+
+    if candidate.registry is None:
+        return cfg, hf_name_map
+
+    # The registry is a JSON-decoded dict. We look for the two
+    # Megatron-specific top-level keys; receivers tolerate their absence.
+    cfg_blob = candidate.registry.get(SIDECAR_TRANSFORMER_CONFIG_KEY)
+    if cfg_blob:
+        try:
+            if isinstance(cfg_blob, str):
+                cfg_blob = json.loads(cfg_blob)
+            cfg = MegatronTransformerConfig.from_dict(cfg_blob)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("failed to parse megatron_transformer_config sidecar: %s", exc)
+
+    map_blob = candidate.registry.get(SIDECAR_HF_NAME_MAP_KEY)
+    if map_blob:
+        try:
+            if isinstance(map_blob, str):
+                map_blob = json.loads(map_blob)
+            for entry in map_blob:
+                # Each entry is [megatron_name, [hf_name_1, hf_name_2, ...]]
+                if isinstance(entry, (list, tuple)) and len(entry) == 2:
+                    hf_name_map[str(entry[0])] = [str(x) for x in entry[1]]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("failed to parse megatron_hf_name_map sidecar: %s", exc)
+
+    return cfg, hf_name_map
+
+
+# ---------------------------------------------------------------------------
+# Assembly — pre-allocate destination, parallel-pull into sliced views
+# ---------------------------------------------------------------------------
+
+
+def _torch_dtype(s: str) -> torch.dtype:
+    s = s.strip()
+    if s.startswith("torch."):
+        s = s[len("torch."):]
+    return {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "half": torch.float16,
+        "float32": torch.float32,
+        "float": torch.float32,
+    }[s]
+
+
+def assemble_into_destination(
+    plan: MegatronSlicePlan,
+    *,
+    pull: Callable[[MegatronSliceSource, torch.Tensor], None],
+    device: torch.device | str = "cuda",
+) -> torch.Tensor | dict[int, torch.Tensor]:
+    """Pull all sources for one tensor and assemble into a single buffer.
+
+    For every assembly except ``per_expert``, returns a single global
+    tensor with shape ``plan.target_shape``. For ``per_expert``, returns a
+    dict ``{expert_id: tensor}`` since each expert is a separate HF output.
+
+    The ``pull`` callback synchronously RDMAs the source's bytes into the
+    destination view (or sub-slice for mixed-TP cases). For matched-TP
+    matched sources ``source_subslice`` is None and the full source slice
+    fills the target view.
+
+    Pre-allocates the global destination once; per-source views point into
+    the same buffer to avoid an extra ``torch.cat`` GPU memcpy.
+    """
+    target_dtype = _torch_dtype(plan.target_dtype)
+    if plan.assembly == "per_expert":
+        results: dict[int, torch.Tensor] = {}
+        for src in plan.sources:
+            expert_id = int(src.role_extras.get("expert_id", "-1"))
+            if expert_id < 0:
+                logger.warning("per_expert source missing expert_id: %r", src)
+                continue
+            buf = torch.empty(plan.target_shape, dtype=target_dtype, device=device)
+            pull(src, buf)
+            results[expert_id] = buf
+        return results
+
+    dest = torch.empty(plan.target_shape, dtype=target_dtype, device=device)
+
+    if plan.assembly == "passthrough":
+        if plan.sources:
+            pull(plan.sources[0], dest)
+        return dest
+
+    # All other assemblies tile along a single axis (0 for column/qkv/
+    # gated_mlp/vocab; 1 for row).
+    axis = 1 if plan.assembly == "concat_dim1" else 0
+    for src in plan.sources:
+        lo, hi = src.target_local_range
+        view = dest.narrow(axis, lo, hi - lo)
+        pull(src, view)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Translation — vendored helpers do all the math
+# ---------------------------------------------------------------------------
+
+
+def translate_megatron_to_hf(
+    plan: MegatronSlicePlan,
+    assembled: torch.Tensor | dict[int, torch.Tensor],
+    *,
+    transformer_config: MegatronTransformerConfig,
+    hf_names: list[str],
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield ``(hf_name, hf_tensor)`` pairs for one assembled tensor.
+
+    The caller is responsible for resolving ``hf_names`` from the
+    Megatron→HF name map (see :func:`parse_megatron_sidecar`) — this
+    function consumes the resolved list and dispatches on
+    ``plan.assembly``.
+
+    Args:
+        plan: The slice plan returned by Phase B's planner. Used for
+            ``role`` / ``assembly`` dispatch and for ``role_descriptor``
+            (head counts, gated-mlp order, etc.).
+        assembled: For non per-expert: a single global tensor. For
+            per_expert: a dict ``{expert_id: tensor}``.
+        transformer_config: Megatron transformer config (head counts +
+            dims). Required for QKV un-interleave; ignored otherwise.
+        hf_names: HF-shaped names this tensor expands into. Length must
+            match the role (1 for column/row/replicated/vocab_parallel,
+            3 for qkv_column, 2 for gated_mlp_column, N for per_expert).
+    """
+    role = plan.role
+
+    if role == ROLE_MEGATRON_REPLICATED:
+        if not isinstance(assembled, torch.Tensor):
+            raise TypeError("replicated assembly expects a single tensor")
+        if len(hf_names) != 1:
+            raise ValueError(
+                f"replicated tensor expects 1 hf_name, got {hf_names}"
+            )
+        yield hf_names[0], assembled
+        return
+
+    if role in (ROLE_MEGATRON_COLUMN, ROLE_MEGATRON_ROW, ROLE_MEGATRON_VOCAB_PARALLEL):
+        if not isinstance(assembled, torch.Tensor):
+            raise TypeError(f"{role} assembly expects a single tensor")
+        if len(hf_names) != 1:
+            raise ValueError(f"{role} expects 1 hf_name, got {hf_names}")
+        yield hf_names[0], assembled
+        return
+
+    if role == ROLE_MEGATRON_QKV_COLUMN:
+        if not isinstance(assembled, torch.Tensor):
+            raise TypeError("qkv_column assembly expects a single tensor")
+        if len(hf_names) != 3:
+            raise ValueError(
+                f"qkv_column expects 3 hf_names (q, k, v); got {hf_names}"
+            )
+        if assembled.ndim == 1:
+            q, k, v = split_qkv_biases(transformer_config, assembled)
+        else:
+            q, k, v = split_qkv_weights(transformer_config, assembled)
+        yield hf_names[0], q
+        yield hf_names[1], k
+        yield hf_names[2], v
+        return
+
+    if role == ROLE_MEGATRON_GATED_MLP_COLUMN:
+        if not isinstance(assembled, torch.Tensor):
+            raise TypeError("gated_mlp_column assembly expects a single tensor")
+        if len(hf_names) != 2:
+            raise ValueError(
+                f"gated_mlp_column expects 2 hf_names (gate, up); got {hf_names}"
+            )
+        gate, up = split_gated_mlp(assembled)
+        yield hf_names[0], gate
+        yield hf_names[1], up
+        return
+
+    if role in (ROLE_MEGATRON_EXPERT_COLUMN, ROLE_MEGATRON_EXPERT_ROW):
+        if not isinstance(assembled, dict):
+            raise TypeError(f"{role} assembly expects dict[expert_id, tensor]")
+        # hf_names is keyed by position in this v0; the caller provides
+        # the names as ``["experts.0.<sub>.weight", "experts.1.<sub>.weight", ...]``
+        # in expert-id order. For routing flexibility, also accept the
+        # case where hf_names is empty and the names come from
+        # ``plan.role_descriptor['hf_names_by_expert_id']`` (a JSON-encoded
+        # mapping, populated by the trainer's name-map publish path).
+        names_by_id: dict[int, str] = {}
+        if hf_names:
+            # Position-keyed: caller already resolved ids → names. Trust it.
+            for pos, name in enumerate(hf_names):
+                names_by_id[pos] = name
+        else:
+            blob = (plan.role_descriptor or {}).get("hf_names_by_expert_id", "")
+            if blob:
+                try:
+                    names_by_id = {int(k): str(v) for k, v in json.loads(blob).items()}
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("failed to parse hf_names_by_expert_id: %s", exc)
+
+        for expert_id, tensor in assembled.items():
+            name = names_by_id.get(expert_id)
+            if name is None:
+                logger.warning(
+                    "no HF name for expert_id=%d; skipping", expert_id
+                )
+                continue
+            yield name, tensor
+        return
+
+    raise ValueError(f"unsupported plan.role: {role}")
+
+
+# ---------------------------------------------------------------------------
+# High-level orchestrator — discover + plan + assemble + translate
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MegatronReceiverContext:
+    """Per-receiver context carried across refit cycles. Built once at
+    receiver init from the first cycle's source metadata + the inference
+    model's HF state-dict shapes.
+    """
+
+    target_tp_layout: TargetTpLayout
+    transformer_config: MegatronTransformerConfig
+    # megatron_name → list of hf_names. Derived from the trainer's sidecar.
+    hf_name_map: dict[str, list[str]]
+    # Receive specs for the inference model's params, keyed by megatron_name.
+    receive_specs: dict[str, ReceiveSpec]
+
+
+def discover_megatron_context(
+    candidates: list[V2SourceCandidate],
+) -> tuple[MegatronTransformerConfig | None, dict[str, list[str]]]:
+    """Inspect candidates for the first Megatron source and pull its
+    config + name map. Returns ``(None, {})`` if no Megatron source.
+    """
+    for c in candidates:
+        if c.megatron_meta is None:
+            continue
+        cfg, name_map = parse_megatron_sidecar(c)
+        if cfg is not None or name_map:
+            return cfg, name_map
+    return None, {}
+
+
+def run_refit_cycle(
+    receiver: MxV2RefitReceiver,
+    *,
+    candidates: list[V2SourceCandidate],
+    context: MegatronReceiverContext,
+    pull: Callable[[MegatronSliceSource, torch.Tensor], None],
+    device: torch.device | str = "cuda",
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """One refit cycle: discover → plan → assemble → translate → yield.
+
+    Args:
+        receiver: a fully-initialized :class:`MxV2RefitReceiver`.
+        candidates: discovered v2 sources for this cycle (typically
+            ``receiver.discover_v2_sources(model_name=..., target_tp_layout=...)``
+            has already been called by the orchestrator).
+        context: receiver-side per-cycle context (target layout +
+            Megatron config + name map + receive specs).
+        pull: synchronous NIXL pull callback. Implementations should
+            register the destination view with NIXL and complete the
+            transfer before returning.
+        device: where to pre-allocate destination tensors.
+
+    Yields ``(hf_name, hf_tensor)`` ready for ``vllm.model.load_weights()``.
+    """
+    target_specs: dict[str, MegatronTensorSpec] = {}
+    for megatron_name, rs in context.receive_specs.items():
+        target_specs[megatron_name] = MegatronTensorSpec(
+            role=rs.role,
+            target_shape=rs.target_shape,
+            target_dtype=rs.target_dtype,
+            shard_axis=rs.shard_axis,
+            pp_rank=rs.pp_rank,
+            role_descriptor=dict(rs.role_descriptor or {}),
+        )
+
+    plans = receiver.pick_megatron_slice_plans(
+        candidates,
+        target_tp_layout=context.target_tp_layout,
+        target_tensor_specs=target_specs,
+    )
+
+    for plan in plans:
+        if not plan.sources:
+            logger.warning(
+                "no sources for tensor %s (cycle skipped)", plan.tensor_name
+            )
+            continue
+        rs = context.receive_specs[plan.tensor_name]
+        assembled = assemble_into_destination(plan, pull=pull, device=device)
+        yield from translate_megatron_to_hf(
+            plan,
+            assembled,
+            transformer_config=context.transformer_config,
+            hf_names=rs.hf_names,
+        )
+
+
+__all__ = [
+    "MegatronReceiverContext",
+    "ReceiveSpec",
+    "SIDECAR_HF_NAME_MAP_KEY",
+    "SIDECAR_TRANSFORMER_CONFIG_KEY",
+    "assemble_into_destination",
+    "discover_megatron_context",
+    "parse_megatron_sidecar",
+    "run_refit_cycle",
+    "translate_megatron_to_hf",
+]

--- a/modelexpress_client/python/modelexpress/megatron_translator.py
+++ b/modelexpress_client/python/modelexpress/megatron_translator.py
@@ -393,6 +393,7 @@ def run_refit_cycle(
     context: MegatronReceiverContext,
     pull: Callable[[MegatronSliceSource, torch.Tensor], None],
     device: torch.device | str = "cuda",
+    pre_assembled_buffers: dict[str, torch.Tensor] | None = None,
 ) -> Iterator[tuple[str, torch.Tensor]]:
     """One refit cycle: discover → plan → assemble → translate → yield.
 
@@ -407,6 +408,14 @@ def run_refit_cycle(
             register the destination view with NIXL and complete the
             transfer before returning.
         device: where to pre-allocate destination tensors.
+        pre_assembled_buffers: optional ``{megatron_name: tensor}`` map
+            of pre-filled buffers. When set, the orchestrator skips
+            ``assemble_into_destination`` for matched names and uses the
+            pre-filled tensor directly. The matched-TP fast path
+            registers buffers under each Megatron name with NIXL once
+            and calls a bulk ``receive_weights`` per cycle; the translator
+            then walks the filled buffers via this argument and
+            ``pull`` becomes a no-op.
 
     Yields ``(hf_name, hf_tensor)`` ready for ``vllm.model.load_weights()``.
     """
@@ -427,14 +436,20 @@ def run_refit_cycle(
         target_tensor_specs=target_specs,
     )
 
+    pre = pre_assembled_buffers or {}
     for plan in plans:
-        if not plan.sources:
+        if not plan.sources and plan.tensor_name not in pre:
             logger.warning(
                 "no sources for tensor %s (cycle skipped)", plan.tensor_name
             )
             continue
         rs = context.receive_specs[plan.tensor_name]
-        assembled = assemble_into_destination(plan, pull=pull, device=device)
+        if plan.tensor_name in pre and plan.assembly != "per_expert":
+            # Pre-pulled buffer path: bypass per-source assembly. The buffer
+            # already holds the receiver-side view of the assembled tensor.
+            assembled: torch.Tensor | dict[int, torch.Tensor] = pre[plan.tensor_name]
+        else:
+            assembled = assemble_into_destination(plan, pull=pull, device=device)
         yield from translate_megatron_to_hf(
             plan,
             assembled,

--- a/modelexpress_client/python/modelexpress/megatron_translator.py
+++ b/modelexpress_client/python/modelexpress/megatron_translator.py
@@ -317,8 +317,45 @@ def translate_megatron_to_hf(
         return
 
     if role in (ROLE_MEGATRON_EXPERT_COLUMN, ROLE_MEGATRON_EXPERT_ROW):
+        # Two assembly shapes:
+        #
+        # (a) ``assembly == "passthrough"`` — the **grouped** layout (TE
+        #     per-expert ``nn.Parameter`` named ``weight0`` / ``weight1`` /
+        #     ...). The planner picks one source per Megatron tensor; the
+        #     ``assembled`` tensor is THIS expert's full per-expert
+        #     weight. Bridge's name map gives 1 HF name for plain
+        #     ``linear_fc2`` (row-parallel down_proj) and 2 HF names for
+        #     ``linear_fc1`` (column-parallel fused gate + up — needs
+        #     ``split_gated_mlp``).
+        #
+        # (b) ``assembly == "per_expert"`` — the **leading-axis** layout
+        #     (legacy EP>1 single ``.weight`` whose leading axis stacks
+        #     experts). ``assembled`` is a ``dict[expert_id, tensor]``;
+        #     ``hf_names`` is one-per-expert keyed by position OR routing
+        #     map in ``plan.role_descriptor['hf_names_by_expert_id']``.
+        if plan.assembly == "passthrough":
+            if not isinstance(assembled, torch.Tensor):
+                raise TypeError(
+                    f"{role} passthrough assembly expects a single tensor"
+                )
+            if len(hf_names) == 1:
+                yield hf_names[0], assembled
+                return
+            if len(hf_names) == 2:
+                # Per-expert fused gate+up: same math as
+                # ROLE_MEGATRON_GATED_MLP_COLUMN, just one expert at a
+                # time. The vendored helper does the axis-0 split.
+                gate, up = split_gated_mlp(assembled)
+                yield hf_names[0], gate
+                yield hf_names[1], up
+                return
+            raise ValueError(
+                f"{role} passthrough expects 1 or 2 hf_names, got {hf_names}"
+            )
+
+        # Legacy per_expert assembly path: stacked-experts dict.
         if not isinstance(assembled, dict):
-            raise TypeError(f"{role} assembly expects dict[expert_id, tensor]")
+            raise TypeError(f"{role} per_expert assembly expects dict[expert_id, tensor]")
         # hf_names is keyed by position in this v0; the caller provides
         # the names as ``["experts.0.<sub>.weight", "experts.1.<sub>.weight", ...]``
         # in expert-id order. For routing flexibility, also accept the

--- a/modelexpress_client/python/modelexpress/megatron_translator.py
+++ b/modelexpress_client/python/modelexpress/megatron_translator.py
@@ -35,6 +35,7 @@ from .megatron_helpers import (
     split_qkv_biases,
     split_qkv_weights,
     split_gated_mlp,
+    split_gated_mlp_tp,
 )
 from .nemo_rl_v2 import (
     MegatronSlicePlan,
@@ -311,7 +312,15 @@ def translate_megatron_to_hf(
             raise ValueError(
                 f"gated_mlp_column expects 2 hf_names (gate, up); got {hf_names}"
             )
-        gate, up = split_gated_mlp(assembled)
+        # TP=1: simple chunk-2 along axis 0 gives [gate_global; up_global].
+        # TP>1: per-rank chunks are [gate_local; up_local] and the assembler
+        # has stacked them along axis 0 to ``[gate_r0; up_r0; gate_r1;
+        # up_r1; ...]``. Un-interleave to recover the global gate/up.
+        n_sources = len(plan.sources) if plan.sources else 1
+        if n_sources == 1:
+            gate, up = split_gated_mlp(assembled)
+        else:
+            gate, up = split_gated_mlp_tp(assembled, tp=n_sources)
         yield hf_names[0], gate
         yield hf_names[1], up
         return

--- a/modelexpress_client/python/modelexpress/nemo_rl_v2.py
+++ b/modelexpress_client/python/modelexpress/nemo_rl_v2.py
@@ -1037,10 +1037,35 @@ class MxV2RefitReceiver:
             )
 
         if role in (ROLE_MEGATRON_EXPERT_COLUMN, ROLE_MEGATRON_EXPERT_ROW):
-            # Per-expert: the receiver wants the experts in its local set
-            # (target_tp_layout.ep_rank). Each expert is owned by exactly
-            # one EP source rank. v0: pull all experts the receiver
-            # needs, dispatch per expert.
+            # Two MoE layouts in the wild:
+            #
+            # 1. ``expert_layout="grouped"`` — Megatron-Core TE-grouped
+            #    linears (``TEColumnParallelGroupedLinear``,
+            #    ``TERowParallelGroupedLinear``) expose **each local
+            #    expert's slice as a separate ``nn.Parameter``** named
+            #    ``weight0`` / ``weight1`` / .... The classifier emits one
+            #    Megatron-tensor-name per expert. The slice plan is
+            #    therefore identity / passthrough — one source per
+            #    Megatron tensor, no per-expert dict assembly.
+            # 2. ``expert_layout="leading_axis"`` (legacy / EP>1 single
+            #    ``.weight``) — one Megatron tensor holds ``ep_size``
+            #    experts stacked along axis 0. The legacy
+            #    ``_plan_per_expert`` covers this: one source per local
+            #    expert id, the assembler emits a ``dict[expert_id,
+            #    tensor]``.
+            #
+            # The per-source ``expert_layout`` lives in
+            # :attr:`MegatronTensorSpec.role_descriptor` so the receiver
+            # can dispatch. Default to ``leading_axis`` for backwards
+            # compatibility with v0 callers that don't set it.
+            expert_layout = spec.role_descriptor.get(
+                "expert_layout", "leading_axis"
+            )
+            if expert_layout == "grouped":
+                return self._plan_grouped_per_expert(
+                    source_name=source_name, spec=spec,
+                    relevant=relevant, target_tp_layout=target_tp_layout,
+                )
             return self._plan_per_expert(
                 source_name=source_name, spec=spec,
                 relevant=relevant, target_tp_layout=target_tp_layout,
@@ -1201,6 +1226,56 @@ class MxV2RefitReceiver:
             target_dtype=spec.target_dtype,
             sources=sources,
             assembly="per_expert",
+            role_descriptor=dict(spec.role_descriptor),
+        )
+
+    def _plan_grouped_per_expert(
+        self,
+        *,
+        source_name: str,
+        spec: "MegatronTensorSpec",
+        relevant: list[V2SourceCandidate],
+        target_tp_layout: TargetTpLayout,
+    ) -> MegatronSlicePlan:
+        """Plan one grouped TE per-expert parameter.
+
+        The publisher emits one Megatron tensor per (layer, expert) pair
+        (``...linear_fc1.weight0`` etc.), each carrying a single expert's
+        weights. So a slice plan is just identity: pick one fresh source
+        that publishes this tensor name and pass through. Bridge's name
+        map handles the per-expert HF naming (1 HF name for ``linear_fc2``
+        / down_proj, 2 HF names for ``linear_fc1`` / fused gate+up — the
+        translator splits the latter via ``split_gated_mlp``).
+
+        Mixed-TP within the expert's own TP dimension (each expert's
+        weight is column- or row-parallel across TP ranks) is a v1
+        extension. v0 treats grouped per-expert tensors as if TP=1 on the
+        expert axis — fine for ``expert_*`` roles on the standard
+        Megatron-Core grouped layout where each ``weight<N>`` is the
+        full per-expert tensor.
+        """
+        sources: list[MegatronSliceSource] = []
+        if relevant:
+            relevant.sort(key=lambda c: -c.updated_at)
+            c = relevant[0]
+            mm = c.megatron_meta
+            sources.append(
+                MegatronSliceSource(
+                    mx_source_id=c.ref.mx_source_id,
+                    worker_id=c.ref.worker_id,
+                    source_rank=mm.ep_rank,
+                    source_pp_rank=mm.pp_rank,
+                    target_local_range=(0, spec.target_shape[0]),
+                    role_extras=dict(spec.role_descriptor),
+                )
+            )
+        return MegatronSlicePlan(
+            tensor_name=source_name,
+            role=spec.role,
+            target_shape=spec.target_shape,
+            target_dtype=spec.target_dtype,
+            sources=sources,
+            assembly="passthrough",
             role_descriptor=dict(spec.role_descriptor),
         )
 

--- a/modelexpress_client/python/modelexpress/nemo_rl_v2.py
+++ b/modelexpress_client/python/modelexpress/nemo_rl_v2.py
@@ -104,13 +104,16 @@ _MEGATRON_ROLE_SET = frozenset({
 
 
 def _extract_megatron_meta(extra: dict[str, str]) -> "MegatronSourceMeta | None":
-    """Pull Megatron publisher metadata out of a source's extra_parameters.
+    """Pull source-level Megatron rank metadata out of extra_parameters.
 
-    Returns ``None`` for non-Megatron sources (DTensor, PrimeRL) so the
-    planner can short-circuit to the FSDP/EP picker.
+    Detection is by ``publisher_kind == "megatron"`` (set on the source
+    identity) and / or presence of ``tp_size`` + ``tp_rank`` keys.
+    Per-tensor role lives in the source's shape_registry, not here.
+    Returns ``None`` for non-Megatron sources (DTensor, PrimeRL).
     """
-    role = extra.get("megatron_role")
-    if role not in _MEGATRON_ROLE_SET:
+    if extra.get("publisher_kind") != "megatron" and not (
+        "tp_size" in extra and "tp_rank" in extra
+    ):
         return None
 
     def _i(key: str, default: int = 0) -> int:
@@ -119,28 +122,13 @@ def _extract_megatron_meta(extra: dict[str, str]) -> "MegatronSourceMeta | None"
         except (TypeError, ValueError):
             return default
 
-    def _opt_i(key: str) -> "int | None":
-        v = extra.get(key)
-        if v is None:
-            return None
-        try:
-            return int(v)
-        except (TypeError, ValueError):
-            return None
-
     return MegatronSourceMeta(
-        role=role,
         tp_rank=_i("tp_rank"),
         tp_size=_i("tp_size", 1),
         pp_rank=_i("pp_rank"),
         pp_size=_i("pp_size", 1),
         ep_rank=_i("ep_rank"),
         ep_size=_i("ep_size", 1),
-        num_heads_local=_opt_i("num_heads_local"),
-        num_kv_heads_local=_opt_i("num_kv_heads_local"),
-        head_dim=_opt_i("head_dim"),
-        qkv_interleave=extra.get("qkv_interleave"),
-        gated_mlp_order=extra.get("gated_mlp_order"),
     )
 
 
@@ -241,6 +229,16 @@ class MxV2TrainingPublisher:
         self._registered_tensors: dict[str, torch.Tensor] = {}
         self._initialized = False
 
+        # Megatron rank position within the TP × PP × EP mesh. Receivers
+        # use these to route per-rank pulls. Set via
+        # :meth:`set_megatron_mesh_position` before publish() when this
+        # publisher is being used by a Megatron-Core trainer; defaults
+        # (0, 0, 0) are correct for the FSDP / DTensor case where the
+        # sub-mesh axes are all size 1.
+        self._megatron_tp_rank: int = 0
+        self._megatron_pp_rank: int = 0
+        self._megatron_ep_rank: int = 0
+
     @property
     def worker_rank(self) -> int:
         return self._worker_rank
@@ -264,6 +262,26 @@ class MxV2TrainingPublisher:
             training_framework="nemo_rl",
         )
         self._initialized = True
+
+    def set_megatron_mesh_position(
+        self,
+        *,
+        tp_rank: int,
+        pp_rank: int = 0,
+        ep_rank: int = 0,
+    ) -> None:
+        """Set this publisher's rank position in the Megatron TP × PP × EP mesh.
+
+        Call before :meth:`publish` if any tensor in the in-flight registry
+        has ``megatron_role`` set. The rank-position metadata is stamped
+        onto the source identity so receivers can route per-rank pulls
+        (the per-tensor role drives assembly; rank position drives source
+        selection). Default (0, 0, 0) is correct for FSDP / DTensor
+        publishers where these mesh axes have size 1.
+        """
+        self._megatron_tp_rank = int(tp_rank)
+        self._megatron_pp_rank = int(pp_rank)
+        self._megatron_ep_rank = int(ep_rank)
         logger.info(
             "MxV2TrainingPublisher initialized: rank=%d layout=%s",
             self._worker_rank,
@@ -278,6 +296,8 @@ class MxV2TrainingPublisher:
         is_expert: bool = False,
         expert_axis: int = 0,
         owned_expert_ids: tuple[int, ...] | set[int] | list[int] = (),
+        megatron_role: str | None = None,
+        megatron_extras: dict[str, str] | None = None,
     ) -> None:
         """Register a tensor for publication.
 
@@ -297,6 +317,15 @@ class MxV2TrainingPublisher:
             expert_axis: axis index for the expert dimension.
             owned_expert_ids: which expert IDs this rank holds. Pass
                 only when ``is_expert == True``.
+            megatron_role: per-tensor Megatron role string (one of
+                ``ROLE_MEGATRON_*``). Stashed on the per-tensor
+                ``TensorDescriptorV2`` in the registry blob — the
+                receiver-side slice planner reads it from there. Leave
+                ``None`` for DTensor / PrimeRL publishes.
+            megatron_extras: per-tensor Megatron descriptor extras
+                (head counts for ``qkv_column``, ``gated_mlp_order``
+                for ``gated_mlp_column``, etc.). Same lifetime as
+                ``megatron_role``.
         """
         if not self._initialized:
             raise RuntimeError("call initialize() before add_tensor()")
@@ -314,6 +343,10 @@ class MxV2TrainingPublisher:
             expert_axis=expert_axis,
             owned_expert_ids=tuple(sorted(owned_expert_ids)),
         )
+        if megatron_role is not None:
+            descriptor.megatron_role = megatron_role
+        if megatron_extras:
+            descriptor.megatron_extras = dict(megatron_extras)
         self._registry.append(descriptor)
         # Use a key that's unique per descriptor (including any potential
         # name collisions from layer publishing). For v2 we publish all
@@ -355,6 +388,20 @@ class MxV2TrainingPublisher:
             ident.extra_parameters["worker_rank"] = str(self._worker_rank)
             ident.extra_parameters["shape_registry"] = registry_blob
             ident.extra_parameters["world_layout"] = self._world_layout.encode()
+            # If any registered tensor carries a megatron_role, stamp the
+            # source as Megatron-shaped so receivers can route through the
+            # Megatron slice planner. Per-source rank-position metadata
+            # (tp_rank, tp_size, pp_rank, pp_size, ep_rank, ep_size) is
+            # filled from world_layout — same source publishes all roles.
+            if any(d.megatron_role is not None for d in self._registry):
+                ident.extra_parameters["publisher_kind"] = "megatron"
+                wl = self._world_layout
+                ident.extra_parameters["tp_rank"] = str(self._megatron_tp_rank)
+                ident.extra_parameters["tp_size"] = str(wl.tp_world_size)
+                ident.extra_parameters["pp_rank"] = str(self._megatron_pp_rank)
+                ident.extra_parameters["pp_size"] = str(wl.pp_world_size)
+                ident.extra_parameters["ep_rank"] = str(self._megatron_ep_rank)
+                ident.extra_parameters["ep_size"] = str(wl.ep_world_size)
             return ident
 
         # Build the v2 sidecar payload (preserves all the same data as
@@ -362,18 +409,25 @@ class MxV2TrainingPublisher:
         # ``shape_registry`` is intentionally embedded as a nested JSON string
         # inside this JSON document — receivers parse the outer JSON with
         # decode_registry's matching call to handle the inner blob.
-        sidecar_payload = json.dumps(
-            {
-                "mx_v2": "1",
-                "role": ROLE_TRAINER,
-                "worker_rank": int(self._worker_rank),
-                "training_step": int(version),
-                "world_layout": self._world_layout.encode(),
-                "framework": "nemo_rl",
-                "shape_registry": registry_blob,
-            },
-            separators=(",", ":"),
-        )
+        sidecar_dict: dict[str, Any] = {
+            "mx_v2": "1",
+            "role": ROLE_TRAINER,
+            "worker_rank": int(self._worker_rank),
+            "training_step": int(version),
+            "world_layout": self._world_layout.encode(),
+            "framework": "nemo_rl",
+            "shape_registry": registry_blob,
+        }
+        if any(d.megatron_role is not None for d in self._registry):
+            wl = self._world_layout
+            sidecar_dict["publisher_kind"] = "megatron"
+            sidecar_dict["tp_rank"] = int(self._megatron_tp_rank)
+            sidecar_dict["tp_size"] = int(wl.tp_world_size)
+            sidecar_dict["pp_rank"] = int(self._megatron_pp_rank)
+            sidecar_dict["pp_size"] = int(wl.pp_world_size)
+            sidecar_dict["ep_rank"] = int(self._megatron_ep_rank)
+            sidecar_dict["ep_size"] = int(wl.ep_world_size)
+        sidecar_payload = json.dumps(sidecar_dict, separators=(",", ":"))
 
         # Wrap the agent_name with v2 markers (legacy-server fallback path 2).
         original_agent_name = self._publisher._agent_name
@@ -451,28 +505,29 @@ class MxV2TrainingPublisher:
 
 @dataclass
 class MegatronSourceMeta:
-    """Per-source Megatron-publish metadata extracted from extra_parameters.
+    """Per-SOURCE Megatron-publish metadata extracted from extra_parameters.
 
-    Populated only when the source's v2 metadata carries ``megatron_role``
-    (i.e. when the publisher is a Megatron-Core trainer). Absent (``None``
-    on the candidate) for DTensor and PrimeRL publishers; the planner
-    short-circuits to the existing pickers in that case.
+    Populated only when the source's v2 metadata signals a Megatron
+    publisher (the per-tensor registry carries ``megatron_role`` keys).
+    Absent (``None`` on the candidate) for DTensor and PrimeRL
+    publishers; the planner short-circuits to the existing pickers in
+    that case.
+
+    Per-source metadata is intentionally **rank-position only**
+    (tp_rank, tp_size, pp_rank, ep_rank, etc). The per-tensor role and
+    role-specific descriptor extras live on the source's
+    :class:`shape_descriptors.TensorDescriptorV2` registry entries —
+    one source publishes many tensors with different roles, so role is
+    not a source-level attribute.
     """
 
-    role: str
     tp_rank: int
     tp_size: int
     pp_rank: int = 0
     pp_size: int = 1
     ep_rank: int = 0
     ep_size: int = 1
-    # qkv_column-only:
-    num_heads_local: int | None = None
-    num_kv_heads_local: int | None = None
-    head_dim: int | None = None
-    qkv_interleave: str | None = None  # "by_head"
-    # gated_mlp_column-only:
-    gated_mlp_order: str | None = None  # "gate_then_up"
+    is_megatron: bool = True
 
 
 @dataclass
@@ -545,20 +600,17 @@ class MegatronTensorSpec:
 
 
 def _role_extras_from_meta(mm: "MegatronSourceMeta") -> dict[str, str]:
-    """Convert MegatronSourceMeta back to the per-source extras dict the
-    receiver translator consumes (head counts for QKV, etc.)."""
-    out: dict[str, str] = {}
-    if mm.num_heads_local is not None:
-        out["num_heads_local"] = str(mm.num_heads_local)
-    if mm.num_kv_heads_local is not None:
-        out["num_kv_heads_local"] = str(mm.num_kv_heads_local)
-    if mm.head_dim is not None:
-        out["head_dim"] = str(mm.head_dim)
-    if mm.qkv_interleave:
-        out["qkv_interleave"] = mm.qkv_interleave
-    if mm.gated_mlp_order:
-        out["gated_mlp_order"] = mm.gated_mlp_order
-    return out
+    """Stub — returns empty dict.
+
+    Per-tensor role extras live on the source's
+    :class:`shape_descriptors.TensorDescriptorV2` registry entries, not on
+    the per-source :class:`MegatronSourceMeta`. The receiver's per-tensor
+    :class:`MegatronTensorSpec.role_descriptor` is authoritative for
+    assembly. This function is kept (returning empty) so callers that
+    forwarded its output to ``MegatronSliceSource.role_extras`` continue
+    to compile.
+    """
+    return {}
 
 
 @dataclass
@@ -904,15 +956,14 @@ class MxV2RefitReceiver:
         """Build a single MegatronSlicePlan for one source-side tensor name."""
         role = spec.role
 
-        # Filter candidates to those that own this role for this PP stage.
-        # Replicated tensors live on rank 0 only by convention. Other roles
-        # use whatever sources advertise this role + matching pp_rank.
+        # Filter candidates to those covering this PP stage. Per-tensor
+        # role determines assembly (set by the receiver in spec.role); it
+        # is NOT a source-level filter — every Megatron rank publishes
+        # tensors of all roles in one source.
         relevant: list[V2SourceCandidate] = []
         for c in candidates:
             mm = c.megatron_meta
             assert mm is not None  # filtered above
-            if mm.role != role:
-                continue
             if mm.pp_rank != spec.pp_rank:
                 continue
             relevant.append(c)
@@ -1150,23 +1201,19 @@ class MxV2RefitReceiver:
         *,
         base: dict[str, str],
     ) -> dict[str, str]:
-        """Sum per-source head counts for QKV; pass-through otherwise."""
-        out = dict(base)
-        if role == ROLE_MEGATRON_QKV_COLUMN and sources:
-            heads = sum(int(c.megatron_meta.num_heads_local or 0) for c in sources)
-            kv_heads = sum(int(c.megatron_meta.num_kv_heads_local or 0) for c in sources)
-            head_dim = sources[0].megatron_meta.head_dim or 0
-            out["num_heads_total"] = str(heads)
-            out["num_kv_heads_total"] = str(kv_heads)
-            out["head_dim"] = str(head_dim)
-            interleave = sources[0].megatron_meta.qkv_interleave or ""
-            if interleave:
-                out["qkv_interleave"] = interleave
-        elif role == ROLE_MEGATRON_GATED_MLP_COLUMN and sources:
-            order = sources[0].megatron_meta.gated_mlp_order or ""
-            if order:
-                out["gated_mlp_order"] = order
-        return out
+        """Forward the receiver-supplied descriptor (per-tensor extras).
+
+        Per-tensor descriptor extras (head counts for ``qkv_column``,
+        ``gated_mlp_order`` for ``gated_mlp_column``, etc.) are
+        receiver-owned: the receiver's ``MegatronTensorSpec.role_descriptor``
+        carries them (typically derived from the HF model config).
+
+        The publisher's per-tensor ``megatron_extras`` blob — visible in
+        the source's shape_registry — is available for the receiver to
+        cross-check, but it's not required to drive assembly. Returning
+        ``base`` unchanged means the receiver's spec is authoritative.
+        """
+        return dict(base)
 
     def receive_from(
         self,

--- a/modelexpress_client/python/modelexpress/nemo_rl_v2.py
+++ b/modelexpress_client/python/modelexpress/nemo_rl_v2.py
@@ -239,6 +239,13 @@ class MxV2TrainingPublisher:
         self._megatron_pp_rank: int = 0
         self._megatron_ep_rank: int = 0
 
+        # Optional Megatron-Bridge-derived sidecar payload (transformer
+        # config + Megatron→HF name map). Set once at trainer init via
+        # :meth:`set_megatron_sidecar`; merged into the v2 sidecar JSON
+        # at every :meth:`publish` so receivers can do role-aware
+        # assembly without importing Bridge.
+        self._megatron_sidecar: dict[str, Any] = {}
+
     @property
     def worker_rank(self) -> int:
         return self._worker_rank
@@ -262,6 +269,22 @@ class MxV2TrainingPublisher:
             training_framework="nemo_rl",
         )
         self._initialized = True
+
+    def set_megatron_sidecar(self, sidecar: dict[str, Any]) -> None:
+        """Set the Megatron-Bridge-derived sidecar payload.
+
+        ``sidecar`` is a dict with the keys
+        ``"megatron_transformer_config"`` and ``"megatron_hf_name_map"``
+        (per :mod:`modelexpress.megatron_translator`). The publisher
+        merges these into the v2 sidecar JSON at every :meth:`publish`,
+        so receivers can do role-aware assembly without importing
+        Megatron-Bridge themselves.
+
+        Call once at trainer init after Bridge introspection. Empty
+        dict (the default) is a no-op — receivers fall back to deriving
+        head config / name map independently.
+        """
+        self._megatron_sidecar = dict(sidecar) if sidecar else {}
 
     def set_megatron_mesh_position(
         self,
@@ -365,10 +388,21 @@ class MxV2TrainingPublisher:
                 "no tensors added; call add_tensor() before publish()"
             )
 
+        # Build the registry blob; merge in the Megatron sidecar (if any)
+        # via encode_registry's extras so the receiver sees
+        # transformer_config + name_map at the top level of
+        # candidate.registry. parse_megatron_sidecar consumes them from
+        # there.
+        registry_extras: dict[str, Any] = {}
+        if self._megatron_sidecar:
+            for key in ("megatron_transformer_config", "megatron_hf_name_map"):
+                if key in self._megatron_sidecar:
+                    registry_extras[key] = self._megatron_sidecar[key]
         registry_blob = encode_registry(
             self._registry,
             version=version,
             trainer_world_layout=self._world_layout.encode(),
+            extras=registry_extras or None,
         )
 
         # Fold the v2 metadata into the underlying publisher's
@@ -427,6 +461,13 @@ class MxV2TrainingPublisher:
             sidecar_dict["pp_size"] = int(wl.pp_world_size)
             sidecar_dict["ep_rank"] = int(self._megatron_ep_rank)
             sidecar_dict["ep_size"] = int(wl.ep_world_size)
+            # Merge in the Bridge-derived transformer config + Megatron→HF
+            # name map (set once at trainer init via set_megatron_sidecar).
+            # Receivers consume these via
+            # modelexpress.megatron_translator.parse_megatron_sidecar.
+            for key in ("megatron_transformer_config", "megatron_hf_name_map"):
+                if key in self._megatron_sidecar:
+                    sidecar_dict[key] = self._megatron_sidecar[key]
         sidecar_payload = json.dumps(sidecar_dict, separators=(",", ":"))
 
         # Wrap the agent_name with v2 markers (legacy-server fallback path 2).

--- a/modelexpress_client/python/modelexpress/nemo_rl_v2.py
+++ b/modelexpress_client/python/modelexpress/nemo_rl_v2.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Iterator
 
 import torch
@@ -77,6 +77,87 @@ ROLE_INFERENCE_REPLICA = "inference_replica"
 # the server stores verbatim. Receivers look for this marker and pull
 # v2 fields from it.
 _V2_SIDECAR_NAME = "__mx_v2_meta__"
+
+
+# Megatron role enum. Each Megatron parameter classifies into exactly one of
+# these on the publisher side; planner + assembler dispatch on the role string.
+# See temp/NemoRL_Megatron_MX_Design.md §3 for the full semantics table.
+ROLE_MEGATRON_QKV_COLUMN = "qkv_column"
+ROLE_MEGATRON_GATED_MLP_COLUMN = "gated_mlp_column"
+ROLE_MEGATRON_COLUMN = "column"
+ROLE_MEGATRON_ROW = "row"
+ROLE_MEGATRON_VOCAB_PARALLEL = "vocab_parallel"
+ROLE_MEGATRON_REPLICATED = "replicated"
+ROLE_MEGATRON_EXPERT_COLUMN = "expert_column"
+ROLE_MEGATRON_EXPERT_ROW = "expert_row"
+
+_MEGATRON_ROLE_SET = frozenset({
+    ROLE_MEGATRON_QKV_COLUMN,
+    ROLE_MEGATRON_GATED_MLP_COLUMN,
+    ROLE_MEGATRON_COLUMN,
+    ROLE_MEGATRON_ROW,
+    ROLE_MEGATRON_VOCAB_PARALLEL,
+    ROLE_MEGATRON_REPLICATED,
+    ROLE_MEGATRON_EXPERT_COLUMN,
+    ROLE_MEGATRON_EXPERT_ROW,
+})
+
+
+def _extract_megatron_meta(extra: dict[str, str]) -> "MegatronSourceMeta | None":
+    """Pull Megatron publisher metadata out of a source's extra_parameters.
+
+    Returns ``None`` for non-Megatron sources (DTensor, PrimeRL) so the
+    planner can short-circuit to the FSDP/EP picker.
+    """
+    role = extra.get("megatron_role")
+    if role not in _MEGATRON_ROLE_SET:
+        return None
+
+    def _i(key: str, default: int = 0) -> int:
+        try:
+            return int(extra.get(key, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    def _opt_i(key: str) -> "int | None":
+        v = extra.get(key)
+        if v is None:
+            return None
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return None
+
+    return MegatronSourceMeta(
+        role=role,
+        tp_rank=_i("tp_rank"),
+        tp_size=_i("tp_size", 1),
+        pp_rank=_i("pp_rank"),
+        pp_size=_i("pp_size", 1),
+        ep_rank=_i("ep_rank"),
+        ep_size=_i("ep_size", 1),
+        num_heads_local=_opt_i("num_heads_local"),
+        num_kv_heads_local=_opt_i("num_kv_heads_local"),
+        head_dim=_opt_i("head_dim"),
+        qkv_interleave=extra.get("qkv_interleave"),
+        gated_mlp_order=extra.get("gated_mlp_order"),
+    )
+
+
+# Inference-side desired layout. Constructed by the receiver and passed into
+# the slice planner so it can decide matched-TP / mixed-TP plans.
+@dataclass(frozen=True)
+class TargetTpLayout:
+    """Inference-side parallelism the receiver wants to assemble into.
+
+    Set ``ep_size`` > 1 for MoE deployments where inference EP differs from
+    trainer EP. PP on the inference side is rare; left at 1 for now.
+    """
+
+    tp_size: int = 1
+    ep_size: int = 1
+    tp_rank: int = 0  # this receiver's TP rank within the inference mesh
+    ep_rank: int = 0  # this receiver's EP rank within the inference mesh
 
 
 # Trainer world layout descriptor. Receivers can sanity-check that the
@@ -369,6 +450,32 @@ class MxV2TrainingPublisher:
 
 
 @dataclass
+class MegatronSourceMeta:
+    """Per-source Megatron-publish metadata extracted from extra_parameters.
+
+    Populated only when the source's v2 metadata carries ``megatron_role``
+    (i.e. when the publisher is a Megatron-Core trainer). Absent (``None``
+    on the candidate) for DTensor and PrimeRL publishers; the planner
+    short-circuits to the existing pickers in that case.
+    """
+
+    role: str
+    tp_rank: int
+    tp_size: int
+    pp_rank: int = 0
+    pp_size: int = 1
+    ep_rank: int = 0
+    ep_size: int = 1
+    # qkv_column-only:
+    num_heads_local: int | None = None
+    num_kv_heads_local: int | None = None
+    head_dim: int | None = None
+    qkv_interleave: str | None = None  # "by_head"
+    # gated_mlp_column-only:
+    gated_mlp_order: str | None = None  # "gate_then_up"
+
+
+@dataclass
 class V2SourceCandidate:
     """A discovered source with v2 metadata parsed."""
 
@@ -378,6 +485,107 @@ class V2SourceCandidate:
     registry: dict | None  # decoded registry; None for inference_replica
     owned_experts_per_layer: dict[int, set[int]]  # layer_idx → expert IDs
     updated_at: int  # ms epoch
+    megatron_meta: MegatronSourceMeta | None = None  # set iff publisher is Megatron
+
+
+@dataclass
+class MegatronSliceSource:
+    """One source's contribution to a Megatron slice plan.
+
+    A plan covers one HF parameter; it has one or more sources whose
+    target_local_range together tile the global tensor along the role's
+    shard axis. Replicated and per-expert plans use a single source each.
+    """
+
+    mx_source_id: str
+    worker_id: str
+    source_rank: int                       # tp_rank for tp-sharded; ep_rank for expert_*; 0 for replicated/PP-only
+    source_pp_rank: int                    # 0 if PP=1
+    # The slice of the global tensor this source contributes.
+    # For matched-TP, target_local_range == source's natural shard range.
+    # For mixed-TP, target_local_range is the receiver-side range and
+    # source_subslice is set to extract a partial range from the source.
+    target_local_range: tuple[int, int]
+    source_subslice: tuple[int, int] | None = None
+    # Verbatim copy of the source's role-specific descriptor extras
+    # (num_heads_local, head_dim, qkv_interleave, etc.). Receiver uses these
+    # for QKV un-interleave / gated-MLP split assembly.
+    role_extras: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class MegatronTensorSpec:
+    """Receiver's per-tensor input to the Megatron slice planner.
+
+    The receiver tells the planner: "for this Megatron-shaped tensor name,
+    I want a slice plan covering this global shape, this dtype, sharded on
+    this axis, with this role". The planner figures out which sources
+    contribute and how their slices map into the receiver's target window.
+
+    For ``replicated``: ``shard_axis`` is unused; ``target_shape`` is the
+    full global shape.
+
+    For tp-sharded roles (``column``, ``row``, ``vocab_parallel``,
+    ``qkv_column``, ``gated_mlp_column``): ``target_shape`` is the GLOBAL
+    shape; ``shard_axis`` is the dim along which the publishers tile;
+    the planner computes the receiver's per-rank window inside that.
+
+    For ``expert_column`` / ``expert_row``: ``target_shape`` is the shape
+    of ONE expert's slice; the receiver passes the local expert IDs via
+    ``role_descriptor['local_expert_ids']`` (comma-separated) and the
+    layer id via ``role_descriptor['layer_id']``.
+    """
+
+    role: str
+    target_shape: tuple[int, ...]
+    target_dtype: str
+    shard_axis: int = 0
+    pp_rank: int = 0  # which PP stage owns this tensor
+    role_descriptor: dict[str, str] = field(default_factory=dict)
+
+
+def _role_extras_from_meta(mm: "MegatronSourceMeta") -> dict[str, str]:
+    """Convert MegatronSourceMeta back to the per-source extras dict the
+    receiver translator consumes (head counts for QKV, etc.)."""
+    out: dict[str, str] = {}
+    if mm.num_heads_local is not None:
+        out["num_heads_local"] = str(mm.num_heads_local)
+    if mm.num_kv_heads_local is not None:
+        out["num_kv_heads_local"] = str(mm.num_kv_heads_local)
+    if mm.head_dim is not None:
+        out["head_dim"] = str(mm.head_dim)
+    if mm.qkv_interleave:
+        out["qkv_interleave"] = mm.qkv_interleave
+    if mm.gated_mlp_order:
+        out["gated_mlp_order"] = mm.gated_mlp_order
+    return out
+
+
+@dataclass
+class MegatronSlicePlan:
+    """Receiver-side coverage plan for one HF-named parameter.
+
+    Constructed by ``MxV2RefitReceiver.pick_megatron_slice_plans`` from a
+    candidate set + a ``TargetTpLayout``. Each plan tells the assembler:
+    (a) what shape to pre-allocate, (b) what slice-views to register with
+    NIXL for parallel pulls, (c) what assembly transform to apply
+    post-pull, (d) the Megatron role descriptor for receiver-side
+    translation (QKV un-interleave, gate||up split, etc.).
+    """
+
+    tensor_name: str                        # source-side (Megatron) name
+    role: str                               # one of the 7 Megatron roles
+    target_shape: tuple[int, ...]
+    target_dtype: str
+    sources: list[MegatronSliceSource]
+    assembly: str                           # "concat_dim0" | "concat_dim1"
+                                            # | "qkv_uninterleave" | "gated_mlp_split"
+                                            # | "per_expert" | "passthrough"
+    # Aggregated descriptor across sources. For qkv_column this is the
+    # SUM of per-source num_heads_local / num_kv_heads_local (i.e. the
+    # global head count), plus the shared head_dim. Receiver translator
+    # consumes these directly.
+    role_descriptor: dict[str, str] = field(default_factory=dict)
 
 
 class MxV2RefitReceiver:
@@ -579,6 +787,8 @@ class MxV2RefitReceiver:
 
             updated_at = int(getattr(meta.worker, "updated_at", 0) or 0)
 
+            megatron_meta = _extract_megatron_meta(extra)
+
             candidates.append(
                 V2SourceCandidate(
                     ref=SourceRef(
@@ -593,6 +803,7 @@ class MxV2RefitReceiver:
                     registry=registry,
                     owned_experts_per_layer=owned_experts_per_layer,
                     updated_at=updated_at,
+                    megatron_meta=megatron_meta,
                 )
             )
 
@@ -635,6 +846,327 @@ class MxV2RefitReceiver:
             if covers_all:
                 return cand
         return None
+
+    def pick_megatron_slice_plans(
+        self,
+        candidates: list[V2SourceCandidate],
+        *,
+        target_tp_layout: TargetTpLayout,
+        target_tensor_specs: dict[str, "MegatronTensorSpec"],
+    ) -> list[MegatronSlicePlan]:
+        """Build per-tensor slice-coverage plans from a Megatron candidate set.
+
+        Args:
+            candidates: As returned by :meth:`discover_v2_sources`. Mixed
+                Megatron + non-Megatron candidate lists are supported; the
+                planner only consumes those whose ``megatron_meta`` is set.
+            target_tp_layout: The receiver's desired TP × EP layout.
+            target_tensor_specs: For each HF parameter the receiver needs,
+                a :class:`MegatronTensorSpec` describing the source-side
+                tensor name (Megatron-shaped), global shape, dtype, and
+                — for fused QKV / gated MLP — the role-specific descriptor
+                that the assembler will need (head counts, etc).
+
+        Returns:
+            One :class:`MegatronSlicePlan` per entry in
+            ``target_tensor_specs``. The planner does not attempt to detect
+            missing source coverage; the caller is responsible for handling
+            the empty-sources case (a returned plan with ``sources=[]``
+            indicates discovery hasn't caught up yet, callers should retry).
+
+        Backwards compatibility: if no candidate carries Megatron metadata,
+        callers should use :meth:`pick_best_source` (the FSDP / EP-experts
+        picker). This method always returns a plan list — possibly with
+        empty ``sources`` entries — so callers can detect that case
+        uniformly.
+        """
+        megatron_cands = [c for c in candidates if c.megatron_meta is not None]
+        plans: list[MegatronSlicePlan] = []
+
+        for source_name, spec in target_tensor_specs.items():
+            plan = self._plan_one_megatron_tensor(
+                source_name=source_name,
+                spec=spec,
+                candidates=megatron_cands,
+                target_tp_layout=target_tp_layout,
+            )
+            plans.append(plan)
+        return plans
+
+    def _plan_one_megatron_tensor(
+        self,
+        *,
+        source_name: str,
+        spec: "MegatronTensorSpec",
+        candidates: list[V2SourceCandidate],
+        target_tp_layout: TargetTpLayout,
+    ) -> MegatronSlicePlan:
+        """Build a single MegatronSlicePlan for one source-side tensor name."""
+        role = spec.role
+
+        # Filter candidates to those that own this role for this PP stage.
+        # Replicated tensors live on rank 0 only by convention. Other roles
+        # use whatever sources advertise this role + matching pp_rank.
+        relevant: list[V2SourceCandidate] = []
+        for c in candidates:
+            mm = c.megatron_meta
+            assert mm is not None  # filtered above
+            if mm.role != role:
+                continue
+            if mm.pp_rank != spec.pp_rank:
+                continue
+            relevant.append(c)
+
+        if role == ROLE_MEGATRON_REPLICATED:
+            # One source — the rank-0 publisher. Pick the freshest if
+            # multiple races exist.
+            relevant.sort(key=lambda c: -c.updated_at)
+            sources: list[MegatronSliceSource] = []
+            if relevant:
+                c = relevant[0]
+                sources.append(
+                    MegatronSliceSource(
+                        mx_source_id=c.ref.mx_source_id,
+                        worker_id=c.ref.worker_id,
+                        source_rank=0,
+                        source_pp_rank=spec.pp_rank,
+                        target_local_range=(0, spec.target_shape[0]),
+                        role_extras={},
+                    )
+                )
+            return MegatronSlicePlan(
+                tensor_name=source_name,
+                role=role,
+                target_shape=spec.target_shape,
+                target_dtype=spec.target_dtype,
+                sources=sources,
+                assembly="passthrough",
+                role_descriptor=dict(spec.role_descriptor),
+            )
+
+        if role in (ROLE_MEGATRON_EXPERT_COLUMN, ROLE_MEGATRON_EXPERT_ROW):
+            # Per-expert: the receiver wants the experts in its local set
+            # (target_tp_layout.ep_rank). Each expert is owned by exactly
+            # one EP source rank. v0: pull all experts the receiver
+            # needs, dispatch per expert.
+            return self._plan_per_expert(
+                source_name=source_name, spec=spec,
+                relevant=relevant, target_tp_layout=target_tp_layout,
+            )
+
+        # tp-sharded roles: column / row / vocab_parallel / qkv_column /
+        # gated_mlp_column. Compute the receiver's slice along the role's
+        # shard axis and tile sources to cover it.
+        return self._plan_tp_sharded(
+            source_name=source_name, spec=spec,
+            relevant=relevant, target_tp_layout=target_tp_layout,
+        )
+
+    def _plan_tp_sharded(
+        self,
+        *,
+        source_name: str,
+        spec: "MegatronTensorSpec",
+        relevant: list[V2SourceCandidate],
+        target_tp_layout: TargetTpLayout,
+    ) -> MegatronSlicePlan:
+        """Plan a column/row/vocab_parallel/qkv/gated_mlp tensor.
+
+        Decides matched-TP vs mixed-TP and produces one MegatronSliceSource
+        per source range that overlaps the receiver's target range.
+        """
+        role = spec.role
+        shard_axis = spec.shard_axis
+        global_extent = spec.target_shape[shard_axis]
+        target_tp = target_tp_layout.tp_size
+        target_rank = target_tp_layout.tp_rank
+
+        # The receiver wants [target_lo, target_hi) along the shard axis.
+        per_target = global_extent // target_tp
+        target_lo = target_rank * per_target
+        target_hi = (
+            global_extent if target_rank == target_tp - 1 else (target_rank + 1) * per_target
+        )
+
+        # Sort sources by tp_rank so we walk them in slice order.
+        relevant_sorted = sorted(
+            relevant,
+            key=lambda c: (c.megatron_meta.tp_rank, -c.updated_at),
+        )
+        # Dedup per-tp_rank to the freshest.
+        seen: dict[int, V2SourceCandidate] = {}
+        for c in relevant_sorted:
+            if c.megatron_meta.tp_rank not in seen:
+                seen[c.megatron_meta.tp_rank] = c
+        ordered = [seen[r] for r in sorted(seen.keys())]
+
+        if not ordered:
+            return self._empty_plan(source_name, spec)
+
+        source_tp = ordered[0].megatron_meta.tp_size
+        per_source = global_extent // source_tp
+
+        sources: list[MegatronSliceSource] = []
+        contributing: list[V2SourceCandidate] = []
+        for c in ordered:
+            mm = c.megatron_meta
+            src_lo = mm.tp_rank * per_source
+            src_hi = (
+                global_extent if mm.tp_rank == source_tp - 1 else (mm.tp_rank + 1) * per_source
+            )
+            # Overlap with target window?
+            ov_lo = max(src_lo, target_lo)
+            ov_hi = min(src_hi, target_hi)
+            if ov_lo >= ov_hi:
+                continue
+            sub: tuple[int, int] | None = None
+            if (ov_lo, ov_hi) != (src_lo, src_hi):
+                # Mixed-TP: pull only a sub-range of the source's slice.
+                sub = (ov_lo - src_lo, ov_hi - src_lo)
+            sources.append(
+                MegatronSliceSource(
+                    mx_source_id=c.ref.mx_source_id,
+                    worker_id=c.ref.worker_id,
+                    source_rank=mm.tp_rank,
+                    source_pp_rank=mm.pp_rank,
+                    target_local_range=(ov_lo - target_lo, ov_hi - target_lo),
+                    source_subslice=sub,
+                    role_extras=_role_extras_from_meta(mm),
+                )
+            )
+            contributing.append(c)
+
+        # Aggregate role descriptor across the CONTRIBUTING sources only.
+        # For QKV, this gives the head count of the receiver-side assembled
+        # buffer (not the global trainer total) — which is what
+        # _uninterleave_qkv consumes.
+        agg = self._aggregate_role_descriptor(role, contributing, base=spec.role_descriptor)
+        assembly = self._assembly_for_role(role)
+
+        # Receiver-side target shape after assembly is the per-target-rank
+        # slice along the shard axis, full extent on the others.
+        target_shape = list(spec.target_shape)
+        target_shape[shard_axis] = target_hi - target_lo
+        return MegatronSlicePlan(
+            tensor_name=source_name,
+            role=role,
+            target_shape=tuple(target_shape),
+            target_dtype=spec.target_dtype,
+            sources=sources,
+            assembly=assembly,
+            role_descriptor=agg,
+        )
+
+    def _plan_per_expert(
+        self,
+        *,
+        source_name: str,
+        spec: "MegatronTensorSpec",
+        relevant: list[V2SourceCandidate],
+        target_tp_layout: TargetTpLayout,
+    ) -> MegatronSlicePlan:
+        """v0: one source per local expert id, picked from the EP rank that owns it.
+
+        ``spec.target_shape`` is interpreted as the SHAPE of one expert
+        (the assembler emits per-expert tensors, not a stacked one).
+        ``role_descriptor['local_expert_ids']`` lists which experts the
+        receiver needs.
+        """
+        # Inference rank's owned experts come from the layout. v0 expects
+        # the caller to pass them via spec.role_descriptor['local_expert_ids']
+        # (encoded as a comma-separated string of ints).
+        ids_str = spec.role_descriptor.get("local_expert_ids", "")
+        wanted = [int(x) for x in ids_str.split(",") if x.strip()]
+        sources: list[MegatronSliceSource] = []
+        # Layer id is part of the spec for expert selection.
+        layer_id = int(spec.role_descriptor.get("layer_id", "0"))
+
+        for expert_id in wanted:
+            owner = next(
+                (
+                    c for c in relevant
+                    if expert_id in c.owned_experts_per_layer.get(layer_id, set())
+                ),
+                None,
+            )
+            if owner is None:
+                continue
+            sources.append(
+                MegatronSliceSource(
+                    mx_source_id=owner.ref.mx_source_id,
+                    worker_id=owner.ref.worker_id,
+                    source_rank=owner.megatron_meta.ep_rank,
+                    source_pp_rank=owner.megatron_meta.pp_rank,
+                    target_local_range=(expert_id, expert_id + 1),
+                    role_extras={"expert_id": str(expert_id)},
+                )
+            )
+
+        return MegatronSlicePlan(
+            tensor_name=source_name,
+            role=spec.role,
+            target_shape=spec.target_shape,
+            target_dtype=spec.target_dtype,
+            sources=sources,
+            assembly="per_expert",
+            role_descriptor=dict(spec.role_descriptor),
+        )
+
+    @staticmethod
+    def _empty_plan(source_name: str, spec: "MegatronTensorSpec") -> MegatronSlicePlan:
+        return MegatronSlicePlan(
+            tensor_name=source_name,
+            role=spec.role,
+            target_shape=spec.target_shape,
+            target_dtype=spec.target_dtype,
+            sources=[],
+            assembly=MxV2RefitReceiver._assembly_for_role(spec.role),
+            role_descriptor=dict(spec.role_descriptor),
+        )
+
+    @staticmethod
+    def _assembly_for_role(role: str) -> str:
+        if role == ROLE_MEGATRON_QKV_COLUMN:
+            return "qkv_uninterleave"
+        if role == ROLE_MEGATRON_GATED_MLP_COLUMN:
+            return "gated_mlp_split"
+        if role == ROLE_MEGATRON_ROW:
+            return "concat_dim1"
+        if role in (
+            ROLE_MEGATRON_COLUMN,
+            ROLE_MEGATRON_VOCAB_PARALLEL,
+        ):
+            return "concat_dim0"
+        if role == ROLE_MEGATRON_REPLICATED:
+            return "passthrough"
+        if role in (ROLE_MEGATRON_EXPERT_COLUMN, ROLE_MEGATRON_EXPERT_ROW):
+            return "per_expert"
+        raise ValueError(f"unknown megatron role: {role}")
+
+    @staticmethod
+    def _aggregate_role_descriptor(
+        role: str,
+        sources: list[V2SourceCandidate],
+        *,
+        base: dict[str, str],
+    ) -> dict[str, str]:
+        """Sum per-source head counts for QKV; pass-through otherwise."""
+        out = dict(base)
+        if role == ROLE_MEGATRON_QKV_COLUMN and sources:
+            heads = sum(int(c.megatron_meta.num_heads_local or 0) for c in sources)
+            kv_heads = sum(int(c.megatron_meta.num_kv_heads_local or 0) for c in sources)
+            head_dim = sources[0].megatron_meta.head_dim or 0
+            out["num_heads_total"] = str(heads)
+            out["num_kv_heads_total"] = str(kv_heads)
+            out["head_dim"] = str(head_dim)
+            interleave = sources[0].megatron_meta.qkv_interleave or ""
+            if interleave:
+                out["qkv_interleave"] = interleave
+        elif role == ROLE_MEGATRON_GATED_MLP_COLUMN and sources:
+            order = sources[0].megatron_meta.gated_mlp_order or ""
+            if order:
+                out["gated_mlp_order"] = order
+        return out
 
     def receive_from(
         self,
@@ -817,11 +1349,24 @@ class MxV2RefitReceiver:
 
 
 __all__ = [
+    "MegatronSlicePlan",
+    "MegatronSliceSource",
+    "MegatronSourceMeta",
+    "MegatronTensorSpec",
     "MxV2RefitReceiver",
     "MxV2TrainingPublisher",
     "ROLE_INFERENCE",
     "ROLE_INFERENCE_REPLICA",
+    "ROLE_MEGATRON_COLUMN",
+    "ROLE_MEGATRON_EXPERT_COLUMN",
+    "ROLE_MEGATRON_EXPERT_ROW",
+    "ROLE_MEGATRON_GATED_MLP_COLUMN",
+    "ROLE_MEGATRON_QKV_COLUMN",
+    "ROLE_MEGATRON_REPLICATED",
+    "ROLE_MEGATRON_ROW",
+    "ROLE_MEGATRON_VOCAB_PARALLEL",
     "ROLE_TRAINER",
+    "TargetTpLayout",
     "TrainerWorldLayout",
     "V2SourceCandidate",
 ]

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -43,6 +43,29 @@ SUPPORTED_NIXL_BACKENDS = ("UCX", "LIBFABRIC")
 DEFAULT_NIXL_BACKEND = "UCX"
 
 
+from dataclasses import dataclass
+
+
+@dataclass
+class SlicedTransferRequest:
+    """One per-tensor sub-slice pull request for :meth:`receive_sliced_from_source`.
+
+    Each request says "read ``slice_bytes`` bytes starting at offset
+    ``source_offset_bytes`` from the remote tensor named ``name``, and
+    write them into the local memory backing ``dest_view`` (which must be
+    a contiguous tensor of exactly ``slice_bytes`` bytes — typically a
+    ``narrow`` of a pre-registered destination buffer)."
+
+    The combined transfer is built from a list of these — N requests
+    produces one NIXL transfer with N (remote, local) descriptor pairs.
+    """
+
+    name: str
+    source_offset_bytes: int
+    slice_bytes: int
+    dest_view: torch.Tensor
+
+
 def is_nixl_available() -> bool:
     """Check if NIXL is available."""
     return NIXL_AVAILABLE
@@ -581,6 +604,159 @@ class NixlTransferManager:
         )
 
         return total_bytes, matched_tensors, duration
+
+    def receive_sliced_from_source(
+        self,
+        source_metadata: bytes,
+        source_tensors: list[TensorDescriptor],
+        slice_requests: list["SlicedTransferRequest"],
+        timeout_seconds: float | None = None,
+        remote_agent_name: str | None = None,
+    ) -> tuple[int, int, float]:
+        """Pull sub-slices of remote tensors directly into local dest views.
+
+        Unlike :meth:`receive_from_source` (which transfers full tensors into
+        pre-registered named buffers), this primitive transfers per-tensor
+        sub-ranges directly into caller-provided dest views — one combined
+        NIXL transfer with N (source slice, dest view) descriptor pairs.
+
+        This is the v1 "sliced pull" needed for bandwidth-optimal mixed-TP
+        in the target-wider direction: each receiver pulls only the bytes
+        it actually needs from each source rank, instead of pulling the
+        full source manifest and slicing on the host (the v0 fallback in
+        :func:`MxRefitReceiver.receive_weights_scratch`).
+
+        Args:
+            source_metadata: NIXL agent metadata from the remote source.
+            source_tensors: source manifest (one ``TensorDescriptor`` per
+                published tensor, ``addr`` + ``size`` referring to the
+                source's GPU memory). The request's ``name`` field is
+                looked up against this list.
+            slice_requests: each request specifies a single (source tensor,
+                source byte offset, byte count, local dest view) tuple.
+                The local dest view must be **contiguous** in memory — if
+                the caller wants a non-contiguous slice (e.g. a row-parallel
+                axis-1 ``narrow``), it must use the v0 scratch+copy path
+                instead, since RDMA writes need a flat byte range.
+            timeout_seconds: as for :meth:`receive_from_source`.
+            remote_agent_name: as for :meth:`receive_from_source`. When
+                None, ``add_remote_agent(source_metadata)`` is called once
+                up front.
+
+        Returns:
+            ``(total_bytes_transferred, num_slices, elapsed_seconds)``.
+
+        Raises:
+            RuntimeError: if any dest view is non-contiguous, if a request
+                names a tensor not in the source manifest, or if the
+                source offset/size goes past the source tensor's end.
+        """
+        if self._agent is None:
+            raise RuntimeError("NIXL agent not initialized")
+        if not slice_requests:
+            return 0, 0, 0.0
+
+        start_time = time.perf_counter()
+        torch.cuda.set_device(self._device_id)
+
+        if remote_agent_name is None:
+            remote_agent_name = self._agent.add_remote_agent(source_metadata)
+
+        # Index source tensors by name for fast lookup.
+        by_name: dict[str, TensorDescriptor] = {t.name: t for t in source_tensors}
+
+        remote_descs: list[tuple[int, int, int]] = []
+        local_descs: list[tuple[int, int, int]] = []
+        total_bytes = 0
+
+        for req in slice_requests:
+            src = by_name.get(req.name)
+            if src is None:
+                raise RuntimeError(
+                    f"receive_sliced_from_source: tensor {req.name!r} not in "
+                    f"source manifest (have {len(by_name)} tensors)"
+                )
+            if req.source_offset_bytes < 0:
+                raise RuntimeError(
+                    f"receive_sliced_from_source: negative source_offset_bytes "
+                    f"on {req.name!r}"
+                )
+            if req.source_offset_bytes + req.slice_bytes > src.size:
+                raise RuntimeError(
+                    f"receive_sliced_from_source: slice on {req.name!r} runs "
+                    f"past end of source (offset={req.source_offset_bytes} + "
+                    f"size={req.slice_bytes} > src.size={src.size})"
+                )
+            dest = req.dest_view
+            if not dest.is_contiguous():
+                raise RuntimeError(
+                    f"receive_sliced_from_source: dest view for {req.name!r} "
+                    f"is non-contiguous (shape={tuple(dest.shape)}, "
+                    f"stride={dest.stride()}). Use receive_weights_scratch + "
+                    f"host-side copy for non-contiguous slices (e.g. "
+                    f"row-parallel axis-1 narrows)."
+                )
+            dest_bytes = dest.numel() * dest.element_size()
+            if dest_bytes != req.slice_bytes:
+                raise RuntimeError(
+                    f"receive_sliced_from_source: dest view size {dest_bytes} "
+                    f"!= slice_bytes {req.slice_bytes} on {req.name!r}"
+                )
+
+            remote_descs.append(
+                (src.addr + req.source_offset_bytes, req.slice_bytes, src.device_id)
+            )
+            local_descs.append(
+                (dest.data_ptr(), req.slice_bytes, self._device_id)
+            )
+            total_bytes += req.slice_bytes
+
+        # One combined transfer.
+        src_prepped = self._agent.prep_xfer_dlist(
+            agent_name=remote_agent_name,
+            xfer_list=remote_descs,
+            mem_type="cuda",
+            backends=self._backends,
+        )
+        dst_prepped = self._agent.prep_xfer_dlist(
+            agent_name="",
+            xfer_list=local_descs,
+            mem_type="cuda",
+            backends=self._backends,
+        )
+        indices = list(range(len(remote_descs)))
+        handle = self._agent.make_prepped_xfer(
+            operation="READ",
+            local_xfer_side=dst_prepped,
+            local_indices=indices,
+            remote_xfer_side=src_prepped,
+            remote_indices=indices,
+            backends=self._backends,
+        )
+        self._agent.transfer(handle)
+
+        start_wait = time.perf_counter()
+        while True:
+            if timeout_seconds is not None and time.perf_counter() - start_wait >= timeout_seconds:
+                self._agent.release_xfer_handle(handle)
+                raise TimeoutError("Sliced transfer timed out")
+            status = self._agent.check_xfer_state(handle)
+            if status in ("DONE", "SUCCESS"):
+                self._agent.release_xfer_handle(handle)
+                break
+            if status in ("ERR", "ERROR", "FAIL"):
+                self._agent.release_xfer_handle(handle)
+                raise RuntimeError(f"Sliced transfer failed with status {status}")
+            time.sleep(0.001)
+
+        torch.cuda.synchronize(self._device_id)
+        duration = time.perf_counter() - start_time
+        bw_gbps = (total_bytes * 8) / (duration * 1e9) if duration > 0 else 0.0
+        logger.info(
+            f"Sliced transfer complete: {len(slice_requests)} slices, "
+            f"{total_bytes / 1e9:.2f} GB in {duration:.2f}s ({bw_gbps:.1f} Gbps)"
+        )
+        return total_bytes, len(slice_requests), duration
 
     def is_healthy(self) -> bool:
         """Check if the NIXL agent is initialized and has registered metadata."""

--- a/modelexpress_client/python/modelexpress/refit_receiver.py
+++ b/modelexpress_client/python/modelexpress/refit_receiver.py
@@ -396,6 +396,108 @@ class MxRefitReceiver:
                 tensor = tensor.view(tensor_shapes[name])
             yield name, tensor
 
+    def pull_to(
+        self,
+        source: SourceRef,
+        requests: list[tuple[str, tuple[int, int] | None, torch.Tensor]],
+        timeout_seconds: float = 300.0,
+    ) -> tuple[int, int, float]:
+        """Pull specific sub-slices of source tensors into specific dest views.
+
+        v1 sliced-pull primitive — the bandwidth-optimal mixed-TP data plane.
+        Each receiver pulls only the bytes it actually needs from each
+        source rank, instead of pulling the full source manifest and
+        slicing on the host (the v0 fallback in
+        :meth:`receive_weights_scratch`).
+
+        Args:
+            source: ``SourceRef`` from :meth:`discover_v2_sources` / poll.
+            requests: per-slice pull spec, each a tuple of:
+
+                * ``name``: source tensor name (must match an entry in the
+                  source's published manifest).
+                * ``source_subslice``: ``(lo_elements, hi_elements)`` along
+                  the source tensor's flat byte order, OR ``None`` to pull
+                  the full source tensor. The element unit lets callers
+                  express "rows [lo, hi)" naturally for axis-0 sharded
+                  tensors; the helper converts to bytes using the source's
+                  declared dtype. To pull at byte granularity, pass
+                  ``(byte_lo, byte_hi)`` and the dest_view's element size
+                  must agree.
+                * ``dest_view``: local destination, **must be contiguous**.
+                  Its byte size must equal the slice's byte size (after
+                  conversion). For axis-0 narrows of a pre-allocated dest
+                  buffer (e.g. ``buffers[name].narrow(0, lo, hi - lo)``)
+                  the view is contiguous and direct RDMA works. For
+                  axis-1 narrows the view is non-contiguous; the caller
+                  must fall back to ``receive_weights_scratch`` + host
+                  copy for those.
+            timeout_seconds: as for :meth:`receive_weights`.
+
+        Returns:
+            ``(total_bytes_transferred, num_slices, elapsed_seconds)``.
+        """
+        if not self._initialized:
+            raise RuntimeError("Call initialize() before pull_to()")
+
+        meta_resp = self._client.get_metadata(
+            mx_source_id=source.mx_source_id,
+            worker_id=source.worker_id,
+        )
+        if not meta_resp.found:
+            raise RuntimeError(
+                f"Source {source.mx_source_id}/{source.worker_id} not found on MX Server"
+            )
+        worker = meta_resp.worker
+        # Filter v2 sidecar descriptors.
+        source_tensors = [
+            TensorDescriptor(
+                name=t.name, addr=t.addr, size=t.size,
+                device_id=t.device_id, dtype=t.dtype,
+            )
+            for t in worker.tensors
+            if not t.name.startswith("__mx_") and t.size > 0
+        ]
+        by_name = {t.name: t for t in source_tensors}
+
+        # Build SlicedTransferRequest list. source_subslice is in elements
+        # along the FLAT byte order — we convert to bytes using the source
+        # tensor's dtype element size.
+        from .nixl_transfer import SlicedTransferRequest
+
+        slice_requests: list[SlicedTransferRequest] = []
+        for name, subslice, dest_view in requests:
+            src = by_name.get(name)
+            if src is None:
+                raise RuntimeError(f"pull_to: tensor {name!r} not in source manifest")
+            elem_size = torch.tensor([], dtype=_DTYPE_MAP.get(src.dtype, torch.bfloat16)).element_size()
+            if subslice is None:
+                source_offset_bytes = 0
+                slice_bytes = src.size
+            else:
+                lo, hi = subslice
+                source_offset_bytes = int(lo) * elem_size
+                slice_bytes = int(hi - lo) * elem_size
+            slice_requests.append(SlicedTransferRequest(
+                name=name,
+                source_offset_bytes=source_offset_bytes,
+                slice_bytes=slice_bytes,
+                dest_view=dest_view,
+            ))
+
+        transferred, num_slices, elapsed = self._nixl.receive_sliced_from_source(
+            source_metadata=worker.nixl_metadata,
+            source_tensors=source_tensors,
+            slice_requests=slice_requests,
+            timeout_seconds=timeout_seconds,
+        )
+        self._current_step = source.training_step
+        logger.info(
+            f"pull_to: {num_slices} slices, {transferred / 1e9:.2f} GB, "
+            f"{elapsed:.2f}s (step={source.training_step})"
+        )
+        return transferred, num_slices, elapsed
+
     def receive_weights_from_metadata(
         self,
         nixl_metadata: bytes,

--- a/modelexpress_client/python/modelexpress/shape_descriptors.py
+++ b/modelexpress_client/python/modelexpress/shape_descriptors.py
@@ -266,18 +266,40 @@ def encode_registry(
     *,
     version: int,
     trainer_world_layout: str,
+    extras: dict[str, Any] | None = None,
 ) -> str:
-    """Serialize a registry to a string for ``extra_parameters``."""
-    payload = {
+    """Serialize a registry to a string for ``extra_parameters``.
+
+    ``extras`` is an optional dict of additional top-level keys to merge
+    into the registry payload. Used by Megatron-Core publishes to carry
+    the transformer config + Megatron→HF name map alongside the
+    per-tensor descriptors. Receivers pick the keys up via
+    :func:`decode_registry` (which round-trips unknown top-level keys
+    unchanged).
+    """
+    payload: dict[str, Any] = {
         "version": int(version),
         "trainer_world_layout": trainer_world_layout,
         "tensors": [d.to_dict() for d in descriptors],
     }
+    if extras:
+        for key, value in extras.items():
+            # Don't let extras shadow the structural keys.
+            if key in ("version", "trainer_world_layout", "tensors"):
+                continue
+            payload[key] = value
     return json.dumps(payload, separators=(",", ":"))
 
 
 def decode_registry(blob: str) -> dict[str, Any]:
-    """Inverse of ``encode_registry``. Returns ``{version, trainer_world_layout, tensors}``."""
+    """Inverse of :func:`encode_registry`.
+
+    Returns the full registry dict — at minimum ``{version,
+    trainer_world_layout, tensors}``, plus any extras the publisher
+    attached (round-tripped unchanged). Receivers inspect the dict
+    directly for the keys they care about; unknown keys are preserved
+    so future fields don't require coordinated upgrades.
+    """
     parsed = json.loads(blob)
     parsed["tensors"] = [
         TensorDescriptorV2.from_dict(t) for t in parsed.get("tensors", [])

--- a/modelexpress_client/python/modelexpress/shape_descriptors.py
+++ b/modelexpress_client/python/modelexpress/shape_descriptors.py
@@ -80,6 +80,13 @@ class TensorDescriptorV2:
     is_expert: bool = False
     expert_axis: int = 0
     owned_expert_ids: tuple[int, ...] = ()
+    # Per-tensor Megatron role + role-specific descriptor extras. None /
+    # empty for DTensor / PrimeRL publishers; populated by Megatron-Core
+    # publishers so the receiver can dispatch on the role per tensor.
+    # See temp/NemoRL_Megatron_MX_Design.md §4 for the role enum and
+    # the extras keys per role.
+    megatron_role: str | None = None
+    megatron_extras: dict[str, str] = dataclasses.field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -95,6 +102,10 @@ class TensorDescriptorV2:
             d["is_expert"] = True
             d["expert_axis"] = self.expert_axis
             d["owned_expert_ids"] = list(self.owned_expert_ids)
+        if self.megatron_role is not None:
+            d["megatron_role"] = self.megatron_role
+        if self.megatron_extras:
+            d["megatron_extras"] = dict(self.megatron_extras)
         return d
 
     @classmethod
@@ -110,6 +121,8 @@ class TensorDescriptorV2:
             is_expert=bool(d.get("is_expert", False)),
             expert_axis=int(d.get("expert_axis", 0)),
             owned_expert_ids=tuple(d.get("owned_expert_ids", [])),
+            megatron_role=d.get("megatron_role"),
+            megatron_extras=dict(d.get("megatron_extras") or {}),
         )
 
 

--- a/modelexpress_client/python/tests/test_megatron_helpers.py
+++ b/modelexpress_client/python/tests/test_megatron_helpers.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CI cross-check for the vendored Megatron-Bridge helpers.
+
+The functions in :mod:`modelexpress.megatron_helpers` are byte-identical
+ports of standalone helpers in
+``megatron.bridge.models.conversion.param_mapping``. This test module:
+
+1. Exercises the vendored helpers' MHA + GQA round-trips standalone (no
+   Bridge installed) — covers the Phase C receiver path's correctness.
+2. When ``megatron-bridge`` IS importable in the test environment, also
+   asserts byte-identity against Bridge's authoritative implementation.
+   This is the cross-check that catches drift between our vendored copy
+   and Bridge upstream — runs in CI when Bridge is part of the test deps.
+
+Bridge is a *test-time-only* dependency. The runtime receiver does not
+import Bridge.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+
+# Load megatron_helpers as a standalone module so the test runs without
+# triggering the rest of the modelexpress package init (which pulls in NIXL).
+_PKG_ROOT = Path(__file__).resolve().parent.parent / "modelexpress"
+
+
+def _load_helpers():
+    spec = importlib.util.spec_from_file_location(
+        "modelexpress_megatron_helpers",
+        _PKG_ROOT / "megatron_helpers.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["modelexpress_megatron_helpers"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+HELPERS = _load_helpers()
+MTC = HELPERS.MegatronTransformerConfig
+
+# Try importing Bridge for the optional cross-check.
+try:
+    from megatron.bridge.models.conversion.param_mapping import (
+        merge_qkv_weights as bridge_merge_qkv_weights,
+        split_qkv_weights as bridge_split_qkv_weights,
+        merge_qkv_biases as bridge_merge_qkv_biases,
+        split_qkv_biases as bridge_split_qkv_biases,
+    )
+    BRIDGE_AVAILABLE = True
+except Exception:
+    BRIDGE_AVAILABLE = False
+
+
+def _bridge_config(num_attention_heads, num_query_groups, kv_channels, hidden_size):
+    """Bridge expects a TransformerConfig-shaped object with these attrs."""
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        kv_channels=kv_channels,
+        hidden_size=hidden_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Standalone correctness: round-trip MHA + GQA without Bridge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_heads, num_kv_heads, head_dim, hidden",
+    [
+        (8, 8, 64, 512),     # MHA, head_dim from kv_channels
+        (8, 4, 64, 512),     # GQA 2:1
+        (32, 4, 128, 4096),  # Llama-3-8B-style attention
+        (40, 8, 128, 5120),  # GQA 5:1
+        (32, 32, 128, 4096), # MHA at Llama-3 scale
+    ],
+)
+def test_qkv_weights_roundtrip(num_heads, num_kv_heads, head_dim, hidden):
+    cfg = MTC(
+        num_attention_heads=num_heads,
+        num_query_groups=num_kv_heads,
+        kv_channels=head_dim,
+        hidden_size=hidden,
+    )
+    torch.manual_seed(0xABCDEF)
+    q = torch.randn(num_heads * head_dim, hidden, dtype=torch.float32)
+    k = torch.randn(num_kv_heads * head_dim, hidden, dtype=torch.float32)
+    v = torch.randn(num_kv_heads * head_dim, hidden, dtype=torch.float32)
+
+    qkv = HELPERS.merge_qkv_weights(cfg, q, k, v)
+    expected_rows = (num_heads + 2 * num_kv_heads) * head_dim
+    assert qkv.shape == (expected_rows, hidden)
+
+    q2, k2, v2 = HELPERS.split_qkv_weights(cfg, qkv)
+    assert torch.allclose(q, q2, atol=0, rtol=0), "Q mismatch"
+    assert torch.allclose(k, k2, atol=0, rtol=0), "K mismatch"
+    assert torch.allclose(v, v2, atol=0, rtol=0), "V mismatch"
+
+
+@pytest.mark.parametrize(
+    "num_heads, num_kv_heads, head_dim",
+    [
+        (8, 8, 64),
+        (8, 4, 64),
+        (32, 4, 128),
+    ],
+)
+def test_qkv_biases_roundtrip(num_heads, num_kv_heads, head_dim):
+    cfg = MTC(
+        num_attention_heads=num_heads,
+        num_query_groups=num_kv_heads,
+        kv_channels=head_dim,
+        hidden_size=num_heads * head_dim,
+    )
+    torch.manual_seed(0xCAFE)
+    q = torch.randn(num_heads * head_dim, dtype=torch.float32)
+    k = torch.randn(num_kv_heads * head_dim, dtype=torch.float32)
+    v = torch.randn(num_kv_heads * head_dim, dtype=torch.float32)
+
+    qkv = HELPERS.merge_qkv_biases(cfg, q, k, v)
+    q2, k2, v2 = HELPERS.split_qkv_biases(cfg, qkv)
+    assert torch.allclose(q, q2)
+    assert torch.allclose(k, k2)
+    assert torch.allclose(v, v2)
+
+
+def test_split_qkv_rejects_fp8_scale_shape():
+    """v0 vendored helper rejects FP8 blockwise scale tensors explicitly."""
+    cfg = MTC(num_attention_heads=8, num_query_groups=4,
+              kv_channels=64, hidden_size=512)
+    qkv = torch.randn((8 + 2 * 4) * 64, 32)  # last dim 32 != hidden 512
+    with pytest.raises(NotImplementedError, match="FP8"):
+        HELPERS.split_qkv_weights(cfg, qkv)
+
+
+def test_gated_mlp_roundtrip():
+    torch.manual_seed(7)
+    intermediate, hidden = 1024, 256
+    gate = torch.randn(intermediate, hidden)
+    up = torch.randn(intermediate, hidden)
+    fused = HELPERS.merge_gated_mlp(gate, up)
+    assert fused.shape == (2 * intermediate, hidden)
+    g2, u2 = HELPERS.split_gated_mlp(fused)
+    assert torch.allclose(gate, g2)
+    assert torch.allclose(up, u2)
+
+
+def test_megatron_transformer_config_dict_roundtrip():
+    cfg = MTC(num_attention_heads=8, num_query_groups=4,
+              kv_channels=64, hidden_size=512)
+    cfg2 = MTC.from_dict(cfg.to_dict())
+    assert cfg == cfg2
+    cfg3 = MTC(num_attention_heads=8, num_query_groups=8,
+               kv_channels=None, hidden_size=512)
+    cfg4 = MTC.from_dict(cfg3.to_dict())
+    assert cfg3 == cfg4
+    assert cfg4.head_size == 64  # derived from hidden / heads
+
+
+# ---------------------------------------------------------------------------
+# Cross-check vs Bridge's authoritative implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not BRIDGE_AVAILABLE, reason="megatron-bridge not installed")
+@pytest.mark.parametrize(
+    "num_heads, num_kv_heads, head_dim, hidden",
+    [
+        (8, 8, 64, 512),
+        (8, 4, 64, 512),
+        (32, 4, 128, 4096),
+        (40, 8, 128, 5120),
+    ],
+)
+def test_merge_qkv_weights_byte_identity_with_bridge(
+    num_heads, num_kv_heads, head_dim, hidden,
+):
+    cfg_ours = MTC(
+        num_attention_heads=num_heads, num_query_groups=num_kv_heads,
+        kv_channels=head_dim, hidden_size=hidden,
+    )
+    cfg_bridge = _bridge_config(num_heads, num_kv_heads, head_dim, hidden)
+    torch.manual_seed(123)
+    q = torch.randn(num_heads * head_dim, hidden, dtype=torch.float32)
+    k = torch.randn(num_kv_heads * head_dim, hidden, dtype=torch.float32)
+    v = torch.randn(num_kv_heads * head_dim, hidden, dtype=torch.float32)
+
+    ours = HELPERS.merge_qkv_weights(cfg_ours, q, k, v)
+    theirs = bridge_merge_qkv_weights(cfg_bridge, q, k, v)
+    assert torch.equal(ours, theirs), \
+        "Vendored merge_qkv_weights drifted from Bridge upstream"
+
+
+@pytest.mark.skipif(not BRIDGE_AVAILABLE, reason="megatron-bridge not installed")
+@pytest.mark.parametrize(
+    "num_heads, num_kv_heads, head_dim, hidden",
+    [
+        (8, 8, 64, 512),
+        (8, 4, 64, 512),
+        (32, 4, 128, 4096),
+    ],
+)
+def test_split_qkv_weights_byte_identity_with_bridge(
+    num_heads, num_kv_heads, head_dim, hidden,
+):
+    cfg_ours = MTC(
+        num_attention_heads=num_heads, num_query_groups=num_kv_heads,
+        kv_channels=head_dim, hidden_size=hidden,
+    )
+    cfg_bridge = _bridge_config(num_heads, num_kv_heads, head_dim, hidden)
+    # Build the interleaved QKV via Bridge so we know it matches its
+    # convention exactly, then run our split against it.
+    torch.manual_seed(456)
+    q = torch.randn(num_heads * head_dim, hidden, dtype=torch.float32)
+    k = torch.randn(num_kv_heads * head_dim, hidden, dtype=torch.float32)
+    v = torch.randn(num_kv_heads * head_dim, hidden, dtype=torch.float32)
+    qkv = bridge_merge_qkv_weights(cfg_bridge, q, k, v)
+
+    q1, k1, v1 = HELPERS.split_qkv_weights(cfg_ours, qkv)
+    q2, k2, v2 = bridge_split_qkv_weights(cfg_bridge, qkv)
+    assert torch.equal(q1, q2)
+    assert torch.equal(k1, k2)
+    assert torch.equal(v1, v2)
+    # And the pulled values match the originals.
+    assert torch.equal(q1, q)
+    assert torch.equal(k1, k)
+    assert torch.equal(v1, v)
+
+
+@pytest.mark.skipif(not BRIDGE_AVAILABLE, reason="megatron-bridge not installed")
+def test_split_qkv_biases_byte_identity_with_bridge():
+    num_heads, num_kv_heads, head_dim = 32, 4, 128
+    hidden = num_heads * head_dim
+    cfg_ours = MTC(
+        num_attention_heads=num_heads, num_query_groups=num_kv_heads,
+        kv_channels=head_dim, hidden_size=hidden,
+    )
+    cfg_bridge = _bridge_config(num_heads, num_kv_heads, head_dim, hidden)
+    torch.manual_seed(789)
+    q = torch.randn(num_heads * head_dim, dtype=torch.float32)
+    k = torch.randn(num_kv_heads * head_dim, dtype=torch.float32)
+    v = torch.randn(num_kv_heads * head_dim, dtype=torch.float32)
+    qkv_b = bridge_merge_qkv_biases(cfg_bridge, q, k, v)
+    q1, k1, v1 = HELPERS.split_qkv_biases(cfg_ours, qkv_b)
+    q2, k2, v2 = bridge_split_qkv_biases(cfg_bridge, qkv_b)
+    assert torch.equal(q1, q2)
+    assert torch.equal(k1, k2)
+    assert torch.equal(v1, v2)

--- a/modelexpress_client/python/tests/test_megatron_helpers.py
+++ b/modelexpress_client/python/tests/test_megatron_helpers.py
@@ -156,6 +156,56 @@ def test_gated_mlp_roundtrip():
     assert torch.allclose(up, u2)
 
 
+@pytest.mark.parametrize("tp", [1, 2, 4, 8])
+def test_split_gated_mlp_tp_uninterleaves_per_rank_chunks(tp):
+    """Receiver-side un-interleave: per-rank chunks are [gate_local;
+    up_local]; concat_dim0 across TP ranks produces
+    [gate_r0; up_r0; gate_r1; up_r1; ...]. split_gated_mlp_tp must
+    recover ([gate_r0; gate_r1; ...], [up_r0; up_r1; ...]) — byte-
+    identical to what each rank held + concatenated.
+    """
+    torch.manual_seed(42 + tp)
+    inter_per_rank, hidden = 256, 128
+    intermediate = inter_per_rank * tp
+    # Build per-rank gates + ups, then the interleaved global the way
+    # an axis-0 concat of merge_gated_mlp(gate_rank, up_rank) would
+    # look on the wire.
+    gate_ranks = [torch.randn(inter_per_rank, hidden) for _ in range(tp)]
+    up_ranks = [torch.randn(inter_per_rank, hidden) for _ in range(tp)]
+    interleaved = torch.cat(
+        [HELPERS.merge_gated_mlp(g, u) for g, u in zip(gate_ranks, up_ranks)],
+        dim=0,
+    )
+    assert interleaved.shape == (2 * intermediate, hidden)
+
+    gate, up = HELPERS.split_gated_mlp_tp(interleaved, tp=tp)
+    assert gate.shape == (intermediate, hidden)
+    assert up.shape == (intermediate, hidden)
+    expected_gate = torch.cat(gate_ranks, dim=0)
+    expected_up = torch.cat(up_ranks, dim=0)
+    assert torch.equal(gate, expected_gate)
+    assert torch.equal(up, expected_up)
+
+
+def test_split_gated_mlp_tp_equals_split_gated_mlp_when_tp_eq_1():
+    """tp=1 should produce the same output as split_gated_mlp."""
+    torch.manual_seed(11)
+    intermediate, hidden = 512, 64
+    gate = torch.randn(intermediate, hidden)
+    up = torch.randn(intermediate, hidden)
+    fused = HELPERS.merge_gated_mlp(gate, up)
+    g_v1, u_v1 = HELPERS.split_gated_mlp(fused)
+    g_tp, u_tp = HELPERS.split_gated_mlp_tp(fused, tp=1)
+    assert torch.equal(g_v1, g_tp)
+    assert torch.equal(u_v1, u_tp)
+
+
+def test_split_gated_mlp_tp_rejects_bad_divisibility():
+    fused = torch.randn(7, 8)  # 7 % (2 * tp=2) != 0
+    with pytest.raises(ValueError, match="not divisible"):
+        HELPERS.split_gated_mlp_tp(fused, tp=2)
+
+
 def test_megatron_transformer_config_dict_roundtrip():
     cfg = MTC(num_attention_heads=8, num_query_groups=4,
               kv_channels=64, hidden_size=512)

--- a/modelexpress_client/python/tests/test_megatron_translator.py
+++ b/modelexpress_client/python/tests/test_megatron_translator.py
@@ -1,0 +1,552 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end CPU test for the Megatron-MX receiver-side translator (Phase C).
+
+Exercises the full receiver flow against synthetic Megatron publishes:
+
+    1. Construct ground-truth HF tensors (q, k, v, gate, up, ...).
+    2. Use the vendored :func:`merge_qkv_weights` + concat helpers to
+       build the global Megatron-shaped tensors that a TP=1 trainer
+       would publish.
+    3. Slice those into per-rank publishes (TP=2 / TP=4 etc.).
+    4. Build synthetic V2SourceCandidate entries with the right
+       MegatronSourceMeta (rank-position only) and TensorDescriptorV2
+       per-tensor entries with the right ``megatron_role``.
+5. Run pick_megatron_slice_plans → assemble_into_destination →
+   translate_megatron_to_hf.
+    6. Assert the yielded HF tensors are byte-identical to the
+       ground-truth originals.
+
+This validates the entire MX-side Phase B + Phase C chain on CPU with
+no NIXL, no GPU, no Bridge, no Megatron model.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+_HERE = Path(__file__).resolve().parent
+_PKG_ROOT = _HERE.parent / "modelexpress"
+
+
+def _load(modname: str, path: Path):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def env():
+    """Load nemo_rl_v2 + megatron_helpers + megatron_translator with stubs."""
+    pkg = types.ModuleType("modelexpress")
+    pkg.__path__ = [str(_PKG_ROOT)]
+    sys.modules["modelexpress"] = pkg
+
+    # p2p_pb2 stub
+    p2p_pb2 = types.ModuleType("modelexpress.p2p_pb2")
+    p2p_pb2.SOURCE_STATUS_READY = 2
+    p2p_pb2.SOURCE_STATUS_INITIALIZING = 1
+    p2p_pb2.SOURCE_STATUS_STALE = 3
+    p2p_pb2.MX_SOURCE_TYPE_WEIGHTS = 0
+    p2p_pb2.BACKEND_FRAMEWORK_UNKNOWN = 0
+    sys.modules["modelexpress.p2p_pb2"] = p2p_pb2
+
+    class _Identity:
+        def __init__(self, **kwargs):
+            self.extra_parameters = dict(kwargs.get("extra_parameters") or {})
+
+    class _TD:
+        def __init__(self, **kwargs):
+            self.name = kwargs.get("name", "")
+            self.dtype = kwargs.get("dtype", "")
+            self.size = kwargs.get("size", 0)
+            self.addr = kwargs.get("addr", 0)
+            self.device_id = kwargs.get("device_id", 0)
+
+    class _WM:
+        def __init__(self, **kwargs):
+            self.tensors = list(kwargs.get("tensors") or [])
+            self.agent_name = kwargs.get("agent_name", "")
+            self.worker_rank = kwargs.get("worker_rank", 0)
+            self.nixl_metadata = b""
+            self.status = 0
+
+    p2p_pb2.SourceIdentity = _Identity
+    p2p_pb2.TensorDescriptor = _TD
+    p2p_pb2.WorkerMetadata = _WM
+
+    # heartbeat stub
+    hb = types.ModuleType("modelexpress.heartbeat")
+
+    class _HBStub:
+        def __init__(self, *a, **kw):
+            self.started = False
+        def start(self):
+            self.started = True
+        def stop(self):
+            self.started = False
+
+    hb.HeartbeatThread = _HBStub
+    sys.modules["modelexpress.heartbeat"] = hb
+
+    # refit_receiver stub
+    refit_mod = types.ModuleType("modelexpress.refit_receiver")
+
+    @dataclass
+    class _SourceRef:
+        mx_source_id: str = ""
+        worker_id: str = ""
+        model_name: str = ""
+        worker_rank: int = 0
+        training_step: int = 0
+
+    class _RefitStub:
+        def __init__(self, agent_name="stub", **kw):
+            self._client = MagicMock()
+            self._nixl = MagicMock()
+            self._agent_name = agent_name
+            self._worker_id = "stub-worker-id"
+        def initialize(self, model_tensors=None):
+            pass
+        def receive_weights(self, ref, timeout_seconds=300.0):
+            return iter([])
+
+    refit_mod.MxRefitReceiver = _RefitStub
+    refit_mod.SourceRef = _SourceRef
+    sys.modules["modelexpress.refit_receiver"] = refit_mod
+
+    # training_publisher stub
+    pub_mod = types.ModuleType("modelexpress.training_publisher")
+    class _PubStub:
+        def __init__(self, *a, **kw):
+            self._client = None
+            self._nixl = None
+        def initialize(self, **kw): pass
+        def _build_identity(self, step): return _Identity()
+    pub_mod.MxTrainingPublisher = _PubStub
+    sys.modules["modelexpress.training_publisher"] = pub_mod
+
+    # types stub
+    types_mod = types.ModuleType("modelexpress.types")
+    @dataclass
+    class _TDS:
+        name: str = ""
+        addr: int = 0
+        size: int = 0
+        device_id: int = 0
+        dtype: str = ""
+    types_mod.TensorDescriptor = _TDS
+    sys.modules["modelexpress.types"] = types_mod
+
+    # Load the modules under test
+    sd = _load("modelexpress.shape_descriptors", _PKG_ROOT / "shape_descriptors.py")
+    pkg.shape_descriptors = sd
+    v2 = _load("modelexpress.nemo_rl_v2", _PKG_ROOT / "nemo_rl_v2.py")
+    helpers = _load("modelexpress.megatron_helpers", _PKG_ROOT / "megatron_helpers.py")
+    translator = _load("modelexpress.megatron_translator", _PKG_ROOT / "megatron_translator.py")
+    return types.SimpleNamespace(v2=v2, helpers=helpers, translator=translator)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_megatron_candidate(env, *, tp_rank, tp_size, sid, pp_rank=0, ep_rank=0,
+                             ep_size=1, owned_experts_per_layer=None):
+    """Build a V2SourceCandidate with megatron_meta populated."""
+    v2 = env.v2
+    ref_cls = sys.modules["modelexpress.refit_receiver"].SourceRef
+    ref = ref_cls(
+        mx_source_id=sid, worker_id=f"wid-{sid}", model_name="m",
+        worker_rank=tp_rank, training_step=1,
+    )
+    mm = v2.MegatronSourceMeta(
+        tp_rank=tp_rank, tp_size=tp_size, pp_rank=pp_rank, pp_size=1,
+        ep_rank=ep_rank, ep_size=ep_size,
+    )
+    return v2.V2SourceCandidate(
+        ref=ref, role=v2.ROLE_TRAINER, worker_rank=tp_rank,
+        registry=None,
+        owned_experts_per_layer=owned_experts_per_layer or {},
+        updated_at=tp_rank, megatron_meta=mm,
+    )
+
+
+def _make_pull_callback(rank_to_data: dict[str, torch.Tensor]):
+    """Build a pull(src, dest) callback that copies from a per-rank in-memory
+    table indexed by src.mx_source_id. The dest may be a sub-view (mixed-TP)
+    or the full source slice (matched-TP)."""
+    def _pull(src, dest):
+        full = rank_to_data[src.mx_source_id]
+        if src.source_subslice is not None:
+            lo, hi = src.source_subslice
+            full = full.narrow(0, lo, hi - lo)
+        # Match the dest shape — for the per_expert path, dest is a
+        # full per-expert tensor. For tp-sharded, dest is a view that
+        # matches the full slice (or sub-slice). Copy by element count.
+        dest.copy_(full.view(dest.shape))
+    return _pull
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — replicated tensor: 1 source, passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_replicated_passthrough(env):
+    v2 = env.v2
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+
+    layout = v2.TargetTpLayout(tp_size=2, tp_rank=0)
+
+    # The actual norm tensor (replicated → all ranks have the same).
+    norm = torch.randn(128, dtype=torch.float32)
+    cands = [_make_megatron_candidate(env, tp_rank=0, tp_size=2, sid="r0")]
+    pull = _make_pull_callback({"r0": norm})
+
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_REPLICATED,
+        target_shape=(128,), target_dtype="float32",
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"norm.weight": spec},
+    )
+    assembled = env.translator.assemble_into_destination(plans[0], pull=pull, device="cpu")
+    assert torch.equal(assembled, norm)
+
+    # End-to-end translate: yields one (hf_name, tensor)
+    cfg = env.helpers.MegatronTransformerConfig(
+        num_attention_heads=8, num_query_groups=8,
+        kv_channels=64, hidden_size=512,
+    )
+    out = list(env.translator.translate_megatron_to_hf(
+        plans[0], assembled,
+        transformer_config=cfg,
+        hf_names=["model.norm.weight"],
+    ))
+    assert len(out) == 1
+    assert out[0][0] == "model.norm.weight"
+    assert torch.equal(out[0][1], norm)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — column-parallel matched-TP: assemble across 2 trainer ranks,
+# receiver wants the half its target_rank covers
+# ---------------------------------------------------------------------------
+
+
+def test_column_matched_tp_assembly(env):
+    v2 = env.v2
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+    # source TP=2, target TP=2, target_rank=1 → wants the second half
+    layout = v2.TargetTpLayout(tp_size=2, tp_rank=1)
+
+    # Ground-truth: a (2048, 512) column-parallel weight, sharded along dim 0.
+    weight = torch.randn(2048, 512, dtype=torch.float32)
+    rank0 = weight[:1024]
+    rank1 = weight[1024:]
+
+    cands = [
+        _make_megatron_candidate(env, tp_rank=0, tp_size=2, sid="c0"),
+        _make_megatron_candidate(env, tp_rank=1, tp_size=2, sid="c1"),
+    ]
+    pull = _make_pull_callback({"c0": rank0, "c1": rank1})
+
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_COLUMN,
+        target_shape=(2048, 512), target_dtype="float32", shard_axis=0,
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"linear_proj": spec},
+    )
+    assert len(plans) == 1 and plans[0].assembly == "concat_dim0"
+    assembled = env.translator.assemble_into_destination(plans[0], pull=pull, device="cpu")
+    # target_rank=1 should see weight[1024:2048].
+    assert assembled.shape == (1024, 512)
+    assert torch.equal(assembled, weight[1024:2048])
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — QKV column with GQA: end-to-end byte-identical roundtrip across
+# 2 trainer ranks
+# ---------------------------------------------------------------------------
+
+
+def test_qkv_column_e2e_gqa(env):
+    v2 = env.v2
+    helpers = env.helpers
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+
+    # Llama-3.1-8B-style attention: 32 q heads, 8 kv heads (GQA 4:1),
+    # head_dim=128, hidden=4096. Two trainer TP ranks.
+    nh, nkv, hd, hs = 32, 8, 128, 4096
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=nh, num_query_groups=nkv,
+        kv_channels=hd, hidden_size=hs,
+    )
+
+    torch.manual_seed(0xC0DE)
+    q = torch.randn(nh * hd, hs, dtype=torch.float32)
+    k = torch.randn(nkv * hd, hs, dtype=torch.float32)
+    v = torch.randn(nkv * hd, hs, dtype=torch.float32)
+    # Trainer-side: merge into Megatron interleaved layout (this is what a
+    # TP=1 trainer would publish as the global tensor).
+    qkv_global = helpers.merge_qkv_weights(cfg, q, k, v)
+    assert qkv_global.shape == ((nh + 2 * nkv) * hd, hs)
+
+    # Now slice across TP=2 — each rank holds half the rows.
+    half = qkv_global.shape[0] // 2
+    rank0 = qkv_global[:half]
+    rank1 = qkv_global[half:]
+
+    layout = v2.TargetTpLayout(tp_size=2, tp_rank=0)  # target_rank=0 → first half
+
+    cands = [
+        _make_megatron_candidate(env, tp_rank=0, tp_size=2, sid="qkv0"),
+        _make_megatron_candidate(env, tp_rank=1, tp_size=2, sid="qkv1"),
+    ]
+    pull = _make_pull_callback({"qkv0": rank0, "qkv1": rank1})
+
+    # Receiver target spec: target_rank=0 sees half the rows. Build a
+    # config-for-half (half the heads) so the QKV un-interleave happens
+    # against the receiver's local view.
+    half_cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=nh // 2, num_query_groups=nkv // 2,
+        kv_channels=hd, hidden_size=hs,
+    )
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_QKV_COLUMN,
+        target_shape=qkv_global.shape, target_dtype="float32", shard_axis=0,
+        role_descriptor={"num_heads_total": str(nh), "num_kv_heads_total": str(nkv),
+                         "head_dim": str(hd)},
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"linear_qkv": spec},
+    )
+    assert len(plans) == 1 and plans[0].assembly == "qkv_uninterleave"
+    assert len(plans[0].sources) == 1  # target_rank=0 of 2 → c0 only
+    assembled = env.translator.assemble_into_destination(plans[0], pull=pull, device="cpu")
+    # Receiver sees half the rows.
+    assert assembled.shape == (half, hs)
+
+    # Translate using the half-config — yields q, k, v for the receiver's half.
+    out = list(env.translator.translate_megatron_to_hf(
+        plans[0], assembled,
+        transformer_config=half_cfg,
+        hf_names=["q_proj.weight", "k_proj.weight", "v_proj.weight"],
+    ))
+    assert len(out) == 3
+    q1, k1, v1 = out[0][1], out[1][1], out[2][1]
+
+    # Ground truth: split the original (full) qkv_global with the half-config
+    # is wrong; instead, split the half-tensor directly and compare with the
+    # corresponding half of the original q, k, v.
+    q_half_expected, k_half_expected, v_half_expected = helpers.split_qkv_weights(
+        half_cfg, assembled,
+    )
+    assert torch.equal(q1, q_half_expected)
+    assert torch.equal(k1, k_half_expected)
+    assert torch.equal(v1, v_half_expected)
+    # And the inverse: rebuilding the receiver's half from these q/k/v
+    # should byte-match the assembled tensor.
+    rebuilt = helpers.merge_qkv_weights(half_cfg, q_half_expected, k_half_expected, v_half_expected)
+    assert torch.equal(rebuilt, assembled)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — full TP=1 round-trip (matched, target=source) across QKV
+# ---------------------------------------------------------------------------
+
+
+def test_qkv_tp1_full_roundtrip(env):
+    """Simplest case: target_tp=source_tp=1. Receiver pulls the entire
+    Megatron tensor and split_qkv_weights recovers the original q/k/v."""
+    v2 = env.v2
+    helpers = env.helpers
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+
+    nh, nkv, hd, hs = 8, 4, 64, 512
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=nh, num_query_groups=nkv,
+        kv_channels=hd, hidden_size=hs,
+    )
+    torch.manual_seed(0xBABE)
+    q = torch.randn(nh * hd, hs)
+    k = torch.randn(nkv * hd, hs)
+    v = torch.randn(nkv * hd, hs)
+    qkv = helpers.merge_qkv_weights(cfg, q, k, v)
+
+    layout = v2.TargetTpLayout(tp_size=1, tp_rank=0)
+    cands = [_make_megatron_candidate(env, tp_rank=0, tp_size=1, sid="qkv")]
+    pull = _make_pull_callback({"qkv": qkv})
+
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_QKV_COLUMN,
+        target_shape=qkv.shape, target_dtype="float32", shard_axis=0,
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"linear_qkv": spec},
+    )
+    assembled = env.translator.assemble_into_destination(plans[0], pull=pull, device="cpu")
+    out = list(env.translator.translate_megatron_to_hf(
+        plans[0], assembled,
+        transformer_config=cfg,
+        hf_names=["q_proj.weight", "k_proj.weight", "v_proj.weight"],
+    ))
+    q1, k1, v1 = out[0][1], out[1][1], out[2][1]
+    assert torch.equal(q1, q)
+    assert torch.equal(k1, k)
+    assert torch.equal(v1, v)
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — gated_mlp_column TP=1 roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_gated_mlp_tp1_roundtrip(env):
+    v2 = env.v2
+    helpers = env.helpers
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+
+    inter, hidden = 1024, 256
+    gate = torch.randn(inter, hidden, dtype=torch.float32)
+    up = torch.randn(inter, hidden, dtype=torch.float32)
+    fused = helpers.merge_gated_mlp(gate, up)
+
+    layout = v2.TargetTpLayout(tp_size=1, tp_rank=0)
+    cands = [_make_megatron_candidate(env, tp_rank=0, tp_size=1, sid="fc1")]
+    pull = _make_pull_callback({"fc1": fused})
+
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
+        target_shape=fused.shape, target_dtype="float32", shard_axis=0,
+        role_descriptor={"gated_mlp_order": "gate_then_up"},
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"linear_fc1": spec},
+    )
+    assembled = env.translator.assemble_into_destination(plans[0], pull=pull, device="cpu")
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=1, num_query_groups=1, kv_channels=1, hidden_size=hidden)
+    out = list(env.translator.translate_megatron_to_hf(
+        plans[0], assembled,
+        transformer_config=cfg,
+        hf_names=["mlp.gate_proj.weight", "mlp.up_proj.weight"],
+    ))
+    assert len(out) == 2
+    assert out[0][0] == "mlp.gate_proj.weight"
+    assert out[1][0] == "mlp.up_proj.weight"
+    assert torch.equal(out[0][1], gate)
+    assert torch.equal(out[1][1], up)
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — sidecar parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_megatron_sidecar(env):
+    v2 = env.v2
+    translator = env.translator
+    helpers = env.helpers
+
+    # Build a candidate with a registry containing the translator's
+    # expected sidecar keys.
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=32, num_query_groups=8,
+        kv_channels=128, hidden_size=4096,
+    )
+    name_map = [
+        ("decoder.layers.0.self_attention.linear_qkv.weight",
+         ["model.layers.0.self_attn.q_proj.weight",
+          "model.layers.0.self_attn.k_proj.weight",
+          "model.layers.0.self_attn.v_proj.weight"]),
+        ("decoder.layers.0.self_attention.linear_proj.weight",
+         ["model.layers.0.self_attn.o_proj.weight"]),
+    ]
+    registry = {
+        translator.SIDECAR_TRANSFORMER_CONFIG_KEY: cfg.to_dict(),
+        translator.SIDECAR_HF_NAME_MAP_KEY: name_map,
+    }
+
+    ref_cls = sys.modules["modelexpress.refit_receiver"].SourceRef
+    cand = v2.V2SourceCandidate(
+        ref=ref_cls(mx_source_id="x", worker_id="y", model_name="m",
+                    worker_rank=0, training_step=1),
+        role=v2.ROLE_TRAINER, worker_rank=0,
+        registry=registry, owned_experts_per_layer={},
+        updated_at=0,
+        megatron_meta=v2.MegatronSourceMeta(tp_rank=0, tp_size=1),
+    )
+    parsed_cfg, parsed_map = translator.parse_megatron_sidecar(cand)
+    assert parsed_cfg == cfg
+    assert parsed_map["decoder.layers.0.self_attention.linear_qkv.weight"] == [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.k_proj.weight",
+        "model.layers.0.self_attn.v_proj.weight",
+    ]
+
+
+def test_discover_megatron_context(env):
+    v2 = env.v2
+    translator = env.translator
+    ref_cls = sys.modules["modelexpress.refit_receiver"].SourceRef
+
+    # No Megatron source → returns (None, {})
+    non_mt = v2.V2SourceCandidate(
+        ref=ref_cls(mx_source_id="x", worker_id="y", model_name="m",
+                    worker_rank=0, training_step=1),
+        role=v2.ROLE_TRAINER, worker_rank=0, registry=None,
+        owned_experts_per_layer={}, updated_at=0, megatron_meta=None,
+    )
+    cfg, m = translator.discover_megatron_context([non_mt])
+    assert cfg is None and m == {}
+
+    # With a Megatron source carrying the sidecar
+    helpers = env.helpers
+    cfg_in = helpers.MegatronTransformerConfig(
+        num_attention_heads=8, num_query_groups=4, kv_channels=64, hidden_size=512,
+    )
+    mt_cand = v2.V2SourceCandidate(
+        ref=ref_cls(mx_source_id="x", worker_id="y", model_name="m",
+                    worker_rank=0, training_step=1),
+        role=v2.ROLE_TRAINER, worker_rank=0,
+        registry={
+            translator.SIDECAR_TRANSFORMER_CONFIG_KEY: cfg_in.to_dict(),
+            translator.SIDECAR_HF_NAME_MAP_KEY: [("a", ["b"])],
+        },
+        owned_experts_per_layer={}, updated_at=0,
+        megatron_meta=v2.MegatronSourceMeta(tp_rank=0, tp_size=1),
+    )
+    cfg, m = translator.discover_megatron_context([non_mt, mt_cand])
+    assert cfg == cfg_in
+    assert m == {"a": ["b"]}

--- a/modelexpress_client/python/tests/test_megatron_translator.py
+++ b/modelexpress_client/python/tests/test_megatron_translator.py
@@ -550,3 +550,161 @@ def test_discover_megatron_context(env):
     cfg, m = translator.discover_megatron_context([non_mt, mt_cand])
     assert cfg == cfg_in
     assert m == {"a": ["b"]}
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — grouped per-expert linear_fc2 (row-parallel down_proj):
+# 1 hf_name, passthrough, identity copy
+# ---------------------------------------------------------------------------
+
+
+def test_grouped_per_expert_fc2_passthrough_yields_single_hf(env):
+    """TE-grouped MoE: each Megatron tensor is one expert's
+    linear_fc2.weight<N>. Plan = passthrough, len(hf_names) = 1,
+    translator should yield (hf_name, tensor) as-is."""
+    v2 = env.v2
+    helpers = env.helpers
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+
+    # One expert's down_proj weight: shape (hidden, intermediate).
+    hidden, intermediate = 2048, 768
+    expert_id = 17
+    torch.manual_seed(0xEFFE0)
+    down = torch.randn(hidden, intermediate, dtype=torch.float32)
+
+    layout = v2.TargetTpLayout(tp_size=1, tp_rank=0, ep_size=1, ep_rank=0)
+    cands = [_make_megatron_candidate(env, tp_rank=0, tp_size=1, sid="trainer-0")]
+    pull = _make_pull_callback({"trainer-0": down})
+
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_EXPERT_ROW,
+        target_shape=down.shape,
+        target_dtype="float32",
+        shard_axis=0,
+        role_descriptor={
+            "expert_layout": "grouped",
+            "expert_id": str(expert_id),
+            "expert_axis": "0",
+        },
+    )
+    m_name = f"decoder.layers.0.mlp.experts.linear_fc2.weight{expert_id}"
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={m_name: spec},
+    )
+    assert len(plans) == 1
+    assert plans[0].assembly == "passthrough"
+    assert plans[0].role == v2.ROLE_MEGATRON_EXPERT_ROW
+    assert len(plans[0].sources) == 1
+
+    assembled = env.translator.assemble_into_destination(plans[0], pull=pull, device="cpu")
+    assert torch.equal(assembled, down)
+
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=1, num_query_groups=1, kv_channels=1, hidden_size=hidden,
+    )
+    hf_name = f"model.layers.0.mlp.experts.{expert_id}.down_proj.weight"
+    out = list(env.translator.translate_megatron_to_hf(
+        plans[0], assembled, transformer_config=cfg, hf_names=[hf_name],
+    ))
+    assert len(out) == 1
+    assert out[0][0] == hf_name
+    assert torch.equal(out[0][1], down)
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — grouped per-expert linear_fc1 (column-parallel fused gate+up):
+# 2 hf_names, passthrough, translator splits gate + up
+# ---------------------------------------------------------------------------
+
+
+def test_grouped_per_expert_fc1_passthrough_yields_gate_up(env):
+    """TE-grouped MoE: each Megatron tensor is one expert's fused
+    linear_fc1.weight<N> (gate concat'd with up along axis 0). Plan =
+    passthrough, len(hf_names) = 2, translator should run split_gated_mlp
+    and yield (gate_name, gate) + (up_name, up)."""
+    v2 = env.v2
+    helpers = env.helpers
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+
+    intermediate, hidden = 768, 2048
+    expert_id = 42
+    torch.manual_seed(0xC0FFEE)
+    gate = torch.randn(intermediate, hidden, dtype=torch.float32)
+    up = torch.randn(intermediate, hidden, dtype=torch.float32)
+    fused = helpers.merge_gated_mlp(gate, up)
+    assert fused.shape == (2 * intermediate, hidden)
+
+    layout = v2.TargetTpLayout(tp_size=1, tp_rank=0, ep_size=1, ep_rank=0)
+    cands = [_make_megatron_candidate(env, tp_rank=0, tp_size=1, sid="trainer-0")]
+    pull = _make_pull_callback({"trainer-0": fused})
+
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+        target_shape=fused.shape,
+        target_dtype="float32",
+        shard_axis=0,
+        role_descriptor={
+            "expert_layout": "grouped",
+            "expert_id": str(expert_id),
+            "expert_axis": "0",
+            "gated_mlp_order": "gate_then_up",
+        },
+    )
+    m_name = f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert_id}"
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={m_name: spec},
+    )
+    assert len(plans) == 1
+    assert plans[0].assembly == "passthrough"
+    assert plans[0].role == v2.ROLE_MEGATRON_EXPERT_COLUMN
+
+    assembled = env.translator.assemble_into_destination(plans[0], pull=pull, device="cpu")
+    assert torch.equal(assembled, fused)
+
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=1, num_query_groups=1, kv_channels=1, hidden_size=hidden,
+    )
+    gate_name = f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"
+    up_name = f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"
+    out = list(env.translator.translate_megatron_to_hf(
+        plans[0], assembled, transformer_config=cfg, hf_names=[gate_name, up_name],
+    ))
+    assert len(out) == 2
+    assert out[0][0] == gate_name
+    assert out[1][0] == up_name
+    assert torch.equal(out[0][1], gate)
+    assert torch.equal(out[1][1], up)
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — invalid hf_names length for passthrough expert path
+# ---------------------------------------------------------------------------
+
+
+def test_grouped_per_expert_invalid_hf_names_count_raises(env):
+    """Passthrough expert path supports 1 or 2 hf_names only; 3+ is a
+    misconfiguration and should raise rather than silently produce
+    garbage HF output."""
+    v2 = env.v2
+    helpers = env.helpers
+
+    fused = torch.randn(64, 32, dtype=torch.float32)
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=1, num_query_groups=1, kv_channels=1, hidden_size=32,
+    )
+    plan = v2.MegatronSlicePlan(
+        tensor_name="x", role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+        target_shape=fused.shape, target_dtype="float32",
+        sources=[], assembly="passthrough", role_descriptor={},
+    )
+    with pytest.raises(ValueError, match="passthrough expects 1 or 2 hf_names"):
+        list(env.translator.translate_megatron_to_hf(
+            plan, fused, transformer_config=cfg,
+            hf_names=["a", "b", "c"],  # 3 names = invalid
+        ))

--- a/modelexpress_client/python/tests/test_megatron_translator.py
+++ b/modelexpress_client/python/tests/test_megatron_translator.py
@@ -708,3 +708,78 @@ def test_grouped_per_expert_invalid_hf_names_count_raises(env):
             plan, fused, transformer_config=cfg,
             hf_names=["a", "b", "c"],  # 3 names = invalid
         ))
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — gated_mlp_column TP=2 (target-narrower): receiver concatenates
+# two source ranks' [gate_local; up_local] shards and the translator
+# un-interleaves to (gate_global, up_global).
+# ---------------------------------------------------------------------------
+
+
+def test_gated_mlp_tp2_uninterleaves_correctly(env):
+    """Two source ranks each publish ``[gate_local; up_local]``. The
+    receiver concatenates along axis 0 → ``[gate_r0; up_r0; gate_r1;
+    up_r1]``. The translator must run ``split_gated_mlp_tp`` (not the
+    naive ``split_gated_mlp``) so the yielded gate / up are
+    byte-identical to the globals."""
+    v2 = env.v2
+    helpers = env.helpers
+    rcv = v2.MxV2RefitReceiver(agent_name="rcv", device_id=0,
+                                mx_server_url="stub:1", worker_rank=0)
+    rcv.initialize(model_tensors=None)
+
+    inter_per_rank, hidden = 256, 128
+    intermediate = inter_per_rank * 2
+    torch.manual_seed(0xFEEDBEEF)
+    gate_full = torch.randn(intermediate, hidden, dtype=torch.float32)
+    up_full = torch.randn(intermediate, hidden, dtype=torch.float32)
+
+    # Per-rank slices, exactly as a TP=2 Megatron trainer would publish.
+    gate_r0 = gate_full[:inter_per_rank]
+    gate_r1 = gate_full[inter_per_rank:]
+    up_r0 = up_full[:inter_per_rank]
+    up_r1 = up_full[inter_per_rank:]
+    fused_r0 = helpers.merge_gated_mlp(gate_r0, up_r0)
+    fused_r1 = helpers.merge_gated_mlp(gate_r1, up_r1)
+
+    layout = v2.TargetTpLayout(tp_size=1, tp_rank=0)
+    cands = [
+        _make_megatron_candidate(env, tp_rank=0, tp_size=2, sid="fc1-r0"),
+        _make_megatron_candidate(env, tp_rank=1, tp_size=2, sid="fc1-r1"),
+    ]
+    pull = _make_pull_callback({"fc1-r0": fused_r0, "fc1-r1": fused_r1})
+
+    # Target-narrower (target_tp=1, source_tp=2) — receiver sees the full
+    # 2 * intermediate rows.
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
+        target_shape=(2 * intermediate, hidden), target_dtype="float32",
+        shard_axis=0,
+        role_descriptor={"gated_mlp_order": "gate_then_up"},
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"linear_fc1": spec},
+    )
+    assert len(plans) == 1
+    plan = plans[0]
+    assert plan.assembly == "gated_mlp_split"
+    assert len(plan.sources) == 2  # multi-source
+
+    assembled = env.translator.assemble_into_destination(plan, pull=pull, device="cpu")
+    # Sanity: assembled is [gate_r0; up_r0; gate_r1; up_r1].
+    assert assembled.shape == (2 * intermediate, hidden)
+    cfg = helpers.MegatronTransformerConfig(
+        num_attention_heads=1, num_query_groups=1, kv_channels=1, hidden_size=hidden,
+    )
+    out = list(env.translator.translate_megatron_to_hf(
+        plan, assembled, transformer_config=cfg,
+        hf_names=["mlp.gate_proj.weight", "mlp.up_proj.weight"],
+    ))
+    assert len(out) == 2
+    assert out[0][0] == "mlp.gate_proj.weight"
+    assert out[1][0] == "mlp.up_proj.weight"
+    # Byte-identical to the globals.
+    assert torch.equal(out[0][1], gate_full)
+    assert torch.equal(out[1][1], up_full)

--- a/modelexpress_client/python/tests/test_sliced_pull.py
+++ b/modelexpress_client/python/tests/test_sliced_pull.py
@@ -1,0 +1,471 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the v1 sliced-pull NIXL primitive.
+
+The primitive is :class:`NixlTransferManager.receive_sliced_from_source`,
+which issues a single NIXL transfer with N (source-slice, dest-view)
+descriptor pairs — the bandwidth-optimal mixed-TP data plane.
+
+These tests stub the NixlAgent so they run without GPUs or RDMA fabric:
+the stub records the `(addr, size, device_id)` tuples passed to
+`prep_xfer_dlist` and simulates a successful transfer by host-side
+copying source bytes into dest bytes. That's enough to validate:
+
+  * source_offset_bytes + slice_bytes math
+  * dest view byte-equivalence (contiguous narrow IS the right pointer)
+  * batched descriptors (N slices → 1 transfer, N descriptor pairs)
+  * end-to-end byte-identity for both target-narrower and target-wider
+    direction shapes (column-parallel axis-0 narrows)
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+_HERE = Path(__file__).resolve().parent
+_PKG_ROOT = _HERE.parent / "modelexpress"
+
+
+def _load(modname: str, path: Path):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fake_nixl_module():
+    """Build a fake `nixl._api` so importing nixl_transfer succeeds.
+
+    The real module imports `nixl_agent` + `nixl_agent_config` from `nixl._api`.
+    We replace those with stubs that record calls; the test then replaces
+    `_agent` on the constructed manager with a custom mock that
+    simulates the transfer.
+    """
+    if "nixl" in sys.modules:
+        return
+    nixl_pkg = types.ModuleType("nixl")
+    nixl_pkg.__path__ = []  # type: ignore[attr-defined]
+    sys.modules["nixl"] = nixl_pkg
+    api_mod = types.ModuleType("nixl._api")
+    class _FakeAgent:
+        def __init__(self, *a, **k): pass
+    api_mod.nixl_agent = _FakeAgent
+    api_mod.nixl_agent_config = lambda *a, **k: None
+    sys.modules["nixl._api"] = api_mod
+    nixl_pkg._api = api_mod  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="module")
+def env():
+    """Load nixl_transfer with the real torch + a fake nixl stub.
+
+    These tests need a clean modelexpress package namespace — the other
+    test files in this directory stub `modelexpress.*` for their own
+    purposes, so we forcibly reset to our minimal stub set here.
+    """
+    _fake_nixl_module()
+
+    # Force-reset our needed modules (other test files may have stubbed
+    # them already with module-scoped fixtures).
+    for k in [
+        "modelexpress", "modelexpress.types", "modelexpress.ucx_utils",
+        "modelexpress.nixl_transfer",
+    ]:
+        sys.modules.pop(k, None)
+
+    # ucx_utils stub
+    ucx = types.ModuleType("modelexpress.ucx_utils")
+    ucx.get_ucx_overrides = lambda: {}
+    sys.modules["modelexpress.ucx_utils"] = ucx
+
+    # modelexpress.types stub for TensorDescriptor + ManifestMismatchError
+    types_mod = types.ModuleType("modelexpress.types")
+    @dataclass
+    class _TD:
+        name: str
+        addr: int
+        size: int
+        device_id: int
+        dtype: str
+    class _MismatchError(Exception):
+        pass
+    types_mod.TensorDescriptor = _TD
+    types_mod.ManifestMismatchError = _MismatchError
+    sys.modules["modelexpress.types"] = types_mod
+
+    # Avoid the real package __init__
+    pkg = types.ModuleType("modelexpress")
+    pkg.__path__ = [str(_PKG_ROOT)]
+    sys.modules["modelexpress"] = pkg
+
+    nxl = _load("modelexpress.nixl_transfer", _PKG_ROOT / "nixl_transfer.py")
+    return types.SimpleNamespace(nxl=nxl, TensorDescriptor=_TD)
+
+
+def _make_simulating_agent(env, source_buffers: dict[str, torch.Tensor],
+                            source_base_addrs: dict[str, int]):
+    """Build a fake NixlAgent that simulates an RDMA pull via host memcpy.
+
+    When ``make_prepped_xfer`` is called, the captured remote_descs +
+    local_descs are paired by index and the source bytes are copied
+    into the dest memory using ``ctypes.memmove``. Tests inspect
+    ``recorded_remote_descs`` / ``recorded_local_descs`` to assert the
+    descriptor math is right.
+
+    ``source_base_addrs[name]`` is the synthetic "remote addr" each
+    source tensor will be addressed by; the simulator uses it to find
+    the right backing buffer.
+    """
+    agent = MagicMock()
+    recorded = types.SimpleNamespace(
+        remote_descs=[], local_descs=[], xfer_calls=0,
+    )
+
+    def _prep_remote(*, agent_name, xfer_list, mem_type, backends):
+        # Capture and pass through; return the list as the "handle".
+        recorded.remote_descs.extend(xfer_list)
+        return list(xfer_list)
+
+    def _prep_local(*, agent_name, xfer_list, mem_type, backends):
+        recorded.local_descs.extend(xfer_list)
+        return list(xfer_list)
+
+    def _make_xfer(*, operation, local_xfer_side, local_indices,
+                   remote_xfer_side, remote_indices, backends):
+        recorded.xfer_calls += 1
+        # Simulate: for each pair, copy bytes from source backing buffer
+        # into dest memory.
+        for i, j in zip(local_indices, remote_indices):
+            local_addr, local_size, _ = local_xfer_side[i]
+            remote_addr, remote_size, _ = remote_xfer_side[j]
+            assert local_size == remote_size
+            # Resolve remote_addr → source_buffer + offset
+            src_name = None
+            offset = 0
+            for n, base in source_base_addrs.items():
+                if base <= remote_addr < base + source_buffers[n].numel() * source_buffers[n].element_size():
+                    src_name = n
+                    offset = remote_addr - base
+                    break
+            if src_name is None:
+                raise AssertionError(
+                    f"simulator: remote_addr={remote_addr} not in any source"
+                )
+            src = source_buffers[src_name]
+            src_ptr = src.data_ptr() + offset
+            ctypes.memmove(local_addr, src_ptr, local_size)
+        return "h"
+
+    def _check(handle):
+        return "DONE"
+
+    def _release(handle):
+        return None
+
+    def _transfer(handle):
+        return None
+
+    def _add_remote_agent(metadata):
+        return "remote-agent"
+
+    agent.prep_xfer_dlist = MagicMock(side_effect=[_prep_remote.__wrapped__ if hasattr(_prep_remote, '__wrapped__') else None])
+    # MagicMock side_effect needs to handle both calls; use a counter to alternate.
+    call_count = {"n": 0}
+    def _prep(*, agent_name, xfer_list, mem_type, backends):
+        call_count["n"] += 1
+        if call_count["n"] % 2 == 1:
+            return _prep_remote(agent_name=agent_name, xfer_list=xfer_list,
+                                mem_type=mem_type, backends=backends)
+        return _prep_local(agent_name=agent_name, xfer_list=xfer_list,
+                           mem_type=mem_type, backends=backends)
+    agent.prep_xfer_dlist = _prep
+    agent.make_prepped_xfer = _make_xfer
+    agent.check_xfer_state = _check
+    agent.release_xfer_handle = _release
+    agent.transfer = _transfer
+    agent.add_remote_agent = _add_remote_agent
+    return agent, recorded
+
+
+def _make_manager(env, agent):
+    """Build a NixlTransferManager wired to the simulating agent."""
+    # Force CPU device_id so torch.cuda.set_device + synchronize are no-ops in tests.
+    mgr = env.nxl.NixlTransferManager.__new__(env.nxl.NixlTransferManager)
+    mgr._agent = agent
+    mgr._device_id = 0
+    mgr._backends = ("UCX",)
+    mgr._agent_name = "test-agent"
+    mgr._tensors = {}
+    mgr._tensor_descriptors = []
+    mgr._metadata = b""
+    return mgr
+
+
+def _patch_cuda_in_module(mod):
+    """Stub torch.cuda.set_device/synchronize so the test runs on CPU."""
+    real_set = torch.cuda.set_device
+    real_sync = torch.cuda.synchronize
+    torch.cuda.set_device = lambda *a, **k: None
+    torch.cuda.synchronize = lambda *a, **k: None
+    return real_set, real_sync
+
+
+def _restore_cuda(saved):
+    torch.cuda.set_device, torch.cuda.synchronize = saved
+
+
+def test_full_pull_matches_receive_from_source(env):
+    """Single request, no offset, full source size — equivalent to the
+    legacy bulk transfer. Validates the simple case."""
+    torch.manual_seed(0)
+    src = torch.randn(64, 32, dtype=torch.float32)
+    source_buffers = {"x": src}
+    source_base_addrs = {"x": 0xCAFE_0000_0000}
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, recorded = _make_simulating_agent(env, source_buffers, source_base_addrs)
+        mgr = _make_manager(env, agent)
+        TD = env.TensorDescriptor
+        source_tensors = [TD(
+            name="x", addr=source_base_addrs["x"], size=src.numel() * src.element_size(),
+            device_id=0, dtype="float32",
+        )]
+        dest = torch.zeros_like(src)
+        req = env.nxl.SlicedTransferRequest(
+            name="x",
+            source_offset_bytes=0,
+            slice_bytes=src.numel() * src.element_size(),
+            dest_view=dest,
+        )
+        total, n, _elapsed = mgr.receive_sliced_from_source(
+            source_metadata=b"meta",
+            source_tensors=source_tensors,
+            slice_requests=[req],
+        )
+        assert n == 1
+        assert total == src.numel() * src.element_size()
+        assert torch.equal(dest, src)
+        assert recorded.xfer_calls == 1
+        assert len(recorded.remote_descs) == 1
+        assert recorded.remote_descs[0][1] == src.numel() * src.element_size()
+    finally:
+        _restore_cuda(saved)
+
+
+def test_partial_pull_target_wider_axis_0(env):
+    """Target-wider column-parallel slice: pull rows [N/4, N/2) of a
+    [N, hidden] source into a contiguous dest view."""
+    torch.manual_seed(7)
+    N, hidden = 64, 32
+    src = torch.randn(N, hidden, dtype=torch.float32)
+    source_buffers = {"col": src}
+    source_base_addrs = {"col": 0xBEEF_0000_0000}
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, recorded = _make_simulating_agent(env, source_buffers, source_base_addrs)
+        mgr = _make_manager(env, agent)
+        TD = env.TensorDescriptor
+        source_tensors = [TD(
+            name="col", addr=source_base_addrs["col"],
+            size=src.numel() * src.element_size(), device_id=0, dtype="float32",
+        )]
+        # vLLM TP=4, target rank 1 wants rows [N/4, 2N/4).
+        row_lo, row_hi = N // 4, N // 2
+        dest = torch.zeros(row_hi - row_lo, hidden, dtype=torch.float32)
+        slice_bytes = (row_hi - row_lo) * hidden * src.element_size()
+        offset_bytes = row_lo * hidden * src.element_size()
+        req = env.nxl.SlicedTransferRequest(
+            name="col", source_offset_bytes=offset_bytes,
+            slice_bytes=slice_bytes, dest_view=dest,
+        )
+        total, n, _ = mgr.receive_sliced_from_source(
+            source_metadata=b"m", source_tensors=source_tensors, slice_requests=[req],
+        )
+        assert n == 1
+        assert total == slice_bytes
+        # Byte-identical to the source slice.
+        assert torch.equal(dest, src[row_lo:row_hi])
+        # Remote descriptor uses base+offset, not base.
+        assert recorded.remote_descs[0][0] == source_base_addrs["col"] + offset_bytes
+        assert recorded.remote_descs[0][1] == slice_bytes
+        # Local descriptor points at dest.data_ptr().
+        assert recorded.local_descs[0][0] == dest.data_ptr()
+    finally:
+        _restore_cuda(saved)
+
+
+def test_batched_pulls_one_combined_transfer(env):
+    """N slice requests → 1 NIXL transfer with N descriptor pairs.
+    Validates the per-source batching invariant."""
+    torch.manual_seed(13)
+    a = torch.randn(32, 16, dtype=torch.float32)
+    b = torch.randn(48, 16, dtype=torch.float32)
+    c = torch.randn(8, 16, dtype=torch.float32)
+    source_buffers = {"a": a, "b": b, "c": c}
+    source_base_addrs = {"a": 0x1_0000_0000, "b": 0x2_0000_0000, "c": 0x3_0000_0000}
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, recorded = _make_simulating_agent(env, source_buffers, source_base_addrs)
+        mgr = _make_manager(env, agent)
+        TD = env.TensorDescriptor
+        source_tensors = [
+            TD(name=n, addr=source_base_addrs[n],
+               size=t.numel() * t.element_size(), device_id=0, dtype="float32")
+            for n, t in source_buffers.items()
+        ]
+        # Various slices: half of a, all of b, last 4 rows of c.
+        dest_a = torch.zeros(16, 16, dtype=torch.float32)
+        dest_b = torch.zeros_like(b)
+        dest_c = torch.zeros(4, 16, dtype=torch.float32)
+        reqs = [
+            env.nxl.SlicedTransferRequest(
+                "a", source_offset_bytes=0,
+                slice_bytes=16 * 16 * 4, dest_view=dest_a,
+            ),
+            env.nxl.SlicedTransferRequest(
+                "b", source_offset_bytes=0,
+                slice_bytes=b.numel() * b.element_size(), dest_view=dest_b,
+            ),
+            env.nxl.SlicedTransferRequest(
+                "c", source_offset_bytes=4 * 16 * 4,
+                slice_bytes=4 * 16 * 4, dest_view=dest_c,
+            ),
+        ]
+        total, n, _ = mgr.receive_sliced_from_source(
+            source_metadata=b"m", source_tensors=source_tensors, slice_requests=reqs,
+        )
+        assert n == 3
+        assert recorded.xfer_calls == 1  # one combined transfer
+        assert len(recorded.remote_descs) == 3
+        assert len(recorded.local_descs) == 3
+        # Correctness
+        assert torch.equal(dest_a, a[:16])
+        assert torch.equal(dest_b, b)
+        assert torch.equal(dest_c, c[4:])
+    finally:
+        _restore_cuda(saved)
+
+
+def test_rejects_noncontiguous_dest_view(env):
+    """Row-parallel axis-1 narrow gives a non-contiguous view. The
+    primitive must refuse — the caller should fall back to scratch+copy."""
+    torch.manual_seed(0)
+    src = torch.randn(64, 32, dtype=torch.float32)
+    source_buffers = {"r": src}
+    source_base_addrs = {"r": 0x4_0000_0000}
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, _ = _make_simulating_agent(env, source_buffers, source_base_addrs)
+        mgr = _make_manager(env, agent)
+        TD = env.TensorDescriptor
+        source_tensors = [TD(name="r", addr=source_base_addrs["r"],
+                              size=src.numel() * src.element_size(),
+                              device_id=0, dtype="float32")]
+        dest = torch.zeros(64, 32, dtype=torch.float32)
+        # axis-1 narrow → non-contiguous
+        nc_view = dest.narrow(1, 0, 16)
+        assert not nc_view.is_contiguous()
+        req = env.nxl.SlicedTransferRequest(
+            "r", source_offset_bytes=0, slice_bytes=64 * 16 * 4, dest_view=nc_view,
+        )
+        with pytest.raises(RuntimeError, match="non-contiguous"):
+            mgr.receive_sliced_from_source(
+                source_metadata=b"m", source_tensors=source_tensors,
+                slice_requests=[req],
+            )
+    finally:
+        _restore_cuda(saved)
+
+
+def test_rejects_out_of_range_slice(env):
+    """Slice that runs past the source's end → RuntimeError."""
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, _ = _make_simulating_agent(
+            env, {"x": torch.zeros(4, 4, dtype=torch.float32)},
+            {"x": 0x100},
+        )
+        mgr = _make_manager(env, agent)
+        TD = env.TensorDescriptor
+        source_tensors = [TD(name="x", addr=0x100, size=64, device_id=0, dtype="float32")]
+        dest = torch.zeros(20, dtype=torch.float32)
+        req = env.nxl.SlicedTransferRequest(
+            "x", source_offset_bytes=32, slice_bytes=80,  # 32 + 80 > 64
+            dest_view=dest,
+        )
+        with pytest.raises(RuntimeError, match="past end"):
+            mgr.receive_sliced_from_source(
+                source_metadata=b"m", source_tensors=source_tensors,
+                slice_requests=[req],
+            )
+    finally:
+        _restore_cuda(saved)
+
+
+def test_rejects_dest_size_mismatch(env):
+    """dest_view size must equal slice_bytes."""
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, _ = _make_simulating_agent(env, {"x": torch.zeros(16, dtype=torch.float32)}, {"x": 0x200})
+        mgr = _make_manager(env, agent)
+        TD = env.TensorDescriptor
+        source_tensors = [TD(name="x", addr=0x200, size=64, device_id=0, dtype="float32")]
+        dest = torch.zeros(8, dtype=torch.float32)  # 32 bytes
+        req = env.nxl.SlicedTransferRequest(
+            "x", source_offset_bytes=0, slice_bytes=64,  # but dest is only 32 bytes
+            dest_view=dest,
+        )
+        with pytest.raises(RuntimeError, match="dest view size"):
+            mgr.receive_sliced_from_source(
+                source_metadata=b"m", source_tensors=source_tensors,
+                slice_requests=[req],
+            )
+    finally:
+        _restore_cuda(saved)
+
+
+def test_unknown_tensor_name_raises(env):
+    """Request for a tensor not in the source manifest → RuntimeError."""
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, _ = _make_simulating_agent(env, {"a": torch.zeros(16, dtype=torch.float32)}, {"a": 0x300})
+        mgr = _make_manager(env, agent)
+        TD = env.TensorDescriptor
+        source_tensors = [TD(name="a", addr=0x300, size=64, device_id=0, dtype="float32")]
+        req = env.nxl.SlicedTransferRequest(
+            "b", source_offset_bytes=0, slice_bytes=16, dest_view=torch.zeros(4, dtype=torch.float32),
+        )
+        with pytest.raises(RuntimeError, match="not in source manifest"):
+            mgr.receive_sliced_from_source(
+                source_metadata=b"m", source_tensors=source_tensors,
+                slice_requests=[req],
+            )
+    finally:
+        _restore_cuda(saved)
+
+
+def test_empty_requests_returns_zero(env):
+    """No-op: empty request list returns (0, 0, 0)."""
+    saved = _patch_cuda_in_module(env.nxl)
+    try:
+        agent, recorded = _make_simulating_agent(env, {}, {})
+        mgr = _make_manager(env, agent)
+        total, n, elapsed = mgr.receive_sliced_from_source(
+            source_metadata=b"m", source_tensors=[], slice_requests=[],
+        )
+        assert (total, n) == (0, 0)
+        assert recorded.xfer_calls == 0  # no transfer issued
+    finally:
+        _restore_cuda(saved)

--- a/modelexpress_client/python/tests/test_v2_megatron_slice_planner.py
+++ b/modelexpress_client/python/tests/test_v2_megatron_slice_planner.py
@@ -172,26 +172,25 @@ def v2():
 def _make_megatron_candidate(
     v2,
     *,
-    role: str,
     tp_rank: int,
     tp_size: int,
     pp_rank: int = 0,
     pp_size: int = 1,
     ep_rank: int = 0,
     ep_size: int = 1,
-    num_heads_local: int | None = None,
-    num_kv_heads_local: int | None = None,
-    head_dim: int | None = None,
-    qkv_interleave: str | None = None,
-    gated_mlp_order: str | None = None,
     updated_at: int = 0,
     sid: str | None = None,
     owned_experts_per_layer: dict | None = None,
+    role: str | None = None,  # accepted+ignored for test-readability only
 ):
-    """Build a V2SourceCandidate with megatron_meta populated."""
+    """Build a V2SourceCandidate with megatron_meta populated.
+
+    ``role`` is unused (just a label for test readability — production
+    Megatron sources don't carry a per-source role).
+    """
     ref_cls = v2.SourceRef if hasattr(v2, "SourceRef") else \
         sys.modules["modelexpress.refit_receiver"].SourceRef
-    sid = sid or f"sid-{role}-tp{tp_rank}"
+    sid = sid or f"sid-{role or 'mt'}-tp{tp_rank}"
     ref = ref_cls(
         mx_source_id=sid,
         worker_id=f"wid-{sid}",
@@ -200,15 +199,9 @@ def _make_megatron_candidate(
         training_step=1,
     )
     mm = v2.MegatronSourceMeta(
-        role=role,
         tp_rank=tp_rank, tp_size=tp_size,
         pp_rank=pp_rank, pp_size=pp_size,
         ep_rank=ep_rank, ep_size=ep_size,
-        num_heads_local=num_heads_local,
-        num_kv_heads_local=num_kv_heads_local,
-        head_dim=head_dim,
-        qkv_interleave=qkv_interleave,
-        gated_mlp_order=gated_mlp_order,
     )
     return v2.V2SourceCandidate(
         ref=ref,
@@ -388,21 +381,15 @@ def test_column_mixed_tp_target_narrower(v2):
 # ---------------------------------------------------------------------------
 
 
-def test_qkv_column_aggregates_head_counts(v2):
+def test_qkv_column_assembles_with_receiver_spec(v2):
+    """QKV per-tensor descriptor is receiver-owned (typically derived from
+    the HF model config). The planner forwards it verbatim into
+    role_descriptor so the receiver-side translator can consume it.
+    """
     rcv, layout = _make_receiver(v2, target_tp=2, target_rank=0)
     cands = [
-        _make_megatron_candidate(
-            v2, role=v2.ROLE_MEGATRON_QKV_COLUMN,
-            tp_rank=0, tp_size=2,
-            num_heads_local=16, num_kv_heads_local=4, head_dim=128,
-            qkv_interleave="by_head", sid="q0",
-        ),
-        _make_megatron_candidate(
-            v2, role=v2.ROLE_MEGATRON_QKV_COLUMN,
-            tp_rank=1, tp_size=2,
-            num_heads_local=16, num_kv_heads_local=4, head_dim=128,
-            qkv_interleave="by_head", sid="q1",
-        ),
+        _make_megatron_candidate(v2, tp_rank=0, tp_size=2, sid="q0"),
+        _make_megatron_candidate(v2, tp_rank=1, tp_size=2, sid="q1"),
     ]
     # Each source rank publishes (16+2*4)*128 = 3072 rows; global has 2*3072 = 6144 rows.
     spec = v2.MegatronTensorSpec(
@@ -410,6 +397,16 @@ def test_qkv_column_aggregates_head_counts(v2):
         target_shape=(6144, 4096),
         target_dtype="bfloat16",
         shard_axis=0,
+        # Receiver supplies the descriptor directly (it knows num_heads
+        # from the HF model config). Per-tensor role extras live on the
+        # source's shape_registry entries; the receiver can also choose
+        # to consume those instead.
+        role_descriptor={
+            "num_heads_total": "32",
+            "num_kv_heads_total": "8",
+            "head_dim": "128",
+            "qkv_interleave": "by_head",
+        },
     )
     plan = rcv.pick_megatron_slice_plans(
         cands, target_tp_layout=layout,
@@ -418,9 +415,9 @@ def test_qkv_column_aggregates_head_counts(v2):
     assert plan.assembly == "qkv_uninterleave"
     assert len(plan.sources) == 1  # target_rank=0 of 2 covered by source rank 0
     rd = plan.role_descriptor
-    # Aggregation sums the per-source local counts across the contributing sources.
-    assert rd["num_heads_total"] == "16"  # only c0 contributes for target_rank=0
-    assert rd["num_kv_heads_total"] == "4"
+    # Receiver's spec descriptor is forwarded verbatim.
+    assert rd["num_heads_total"] == "32"
+    assert rd["num_kv_heads_total"] == "8"
     assert rd["head_dim"] == "128"
     assert rd["qkv_interleave"] == "by_head"
 
@@ -433,22 +430,15 @@ def test_qkv_column_aggregates_head_counts(v2):
 def test_gated_mlp_assembly_and_descriptor(v2):
     rcv, layout = _make_receiver(v2, target_tp=2, target_rank=0)
     cands = [
-        _make_megatron_candidate(
-            v2, role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
-            tp_rank=0, tp_size=2,
-            gated_mlp_order="gate_then_up", sid="g0",
-        ),
-        _make_megatron_candidate(
-            v2, role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
-            tp_rank=1, tp_size=2,
-            gated_mlp_order="gate_then_up", sid="g1",
-        ),
+        _make_megatron_candidate(v2, tp_rank=0, tp_size=2, sid="g0"),
+        _make_megatron_candidate(v2, tp_rank=1, tp_size=2, sid="g1"),
     ]
     spec = v2.MegatronTensorSpec(
         role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
         target_shape=(8192, 4096),
         target_dtype="bfloat16",
         shard_axis=0,
+        role_descriptor={"gated_mlp_order": "gate_then_up"},
     )
     plan = rcv.pick_megatron_slice_plans(
         cands, target_tp_layout=layout,
@@ -575,37 +565,39 @@ def test_non_megatron_candidates_yield_empty_source_lists(v2):
 # ---------------------------------------------------------------------------
 
 
-def test_extract_megatron_meta_from_extras(v2):
-    """Direct unit test of _extract_megatron_meta: full-keys round-trip."""
+def test_extract_megatron_meta_publisher_kind_marker(v2):
+    """Source-level Megatron metadata is rank-position only — no role.
+
+    Detection is via ``publisher_kind == "megatron"`` OR presence of
+    ``tp_rank`` + ``tp_size``. Per-tensor role lives in the registry,
+    not in source extras.
+    """
     extra = {
         "mx_v2": "1",
-        "megatron_role": v2.ROLE_MEGATRON_QKV_COLUMN,
+        "publisher_kind": "megatron",
         "tp_rank": "2",
         "tp_size": "4",
         "pp_rank": "1",
         "pp_size": "2",
         "ep_rank": "0",
         "ep_size": "1",
-        "num_heads_local": "8",
-        "num_kv_heads_local": "2",
-        "head_dim": "128",
-        "qkv_interleave": "by_head",
     }
     mm = v2._extract_megatron_meta(extra)
     assert mm is not None
-    assert mm.role == v2.ROLE_MEGATRON_QKV_COLUMN
     assert (mm.tp_rank, mm.tp_size) == (2, 4)
     assert (mm.pp_rank, mm.pp_size) == (1, 2)
-    assert mm.num_heads_local == 8
-    assert mm.head_dim == 128
-    assert mm.qkv_interleave == "by_head"
+    assert (mm.ep_rank, mm.ep_size) == (0, 1)
+
+
+def test_extract_megatron_meta_tp_keys_alone_trigger_detection(v2):
+    """Even without publisher_kind, presence of tp_rank + tp_size signals
+    a Megatron-shaped source."""
+    extra = {"mx_v2": "1", "tp_rank": "0", "tp_size": "2"}
+    mm = v2._extract_megatron_meta(extra)
+    assert mm is not None
+    assert mm.tp_size == 2
 
 
 def test_extract_megatron_meta_returns_none_for_non_megatron(v2):
-    extra = {"mx_v2": "1", "role": "trainer", "worker_rank": "0"}  # no megatron_role
-    assert v2._extract_megatron_meta(extra) is None
-
-
-def test_extract_megatron_meta_returns_none_for_unknown_role(v2):
-    extra = {"mx_v2": "1", "megatron_role": "something_unknown", "tp_rank": "0", "tp_size": "1"}
+    extra = {"mx_v2": "1", "role": "trainer", "worker_rank": "0"}  # neither marker
     assert v2._extract_megatron_meta(extra) is None

--- a/modelexpress_client/python/tests/test_v2_megatron_slice_planner.py
+++ b/modelexpress_client/python/tests/test_v2_megatron_slice_planner.py
@@ -1,0 +1,611 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Megatron slice planner.
+
+Phase B of the Megatron-Core MX path. See
+``temp/NemoRL_Megatron_MX_Design.md`` §5 for the role × layout matrix.
+
+Each test builds a synthetic candidate set as if a Megatron trainer had
+published native shards with the appropriate ``megatron_role`` extras,
+then asks ``MxV2RefitReceiver.pick_megatron_slice_plans`` to produce a
+plan and asserts on its sources / target_local_range / role_descriptor.
+The tests use the same module-stubbing pattern as
+``test_v2_source_picker.py`` so they run without NIXL or a live MX server.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_HERE = Path(__file__).resolve().parent
+_PKG_ROOT = _HERE.parent / "modelexpress"
+
+
+def _load(modname: str, path: Path):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def v2():
+    """Load nemo_rl_v2 with NIXL / gRPC / heartbeat stubbed out."""
+    pkg = types.ModuleType("modelexpress")
+    pkg.__path__ = [str(_PKG_ROOT)]  # type: ignore[attr-defined]
+    sys.modules["modelexpress"] = pkg
+
+    p2p_pb2 = types.ModuleType("modelexpress.p2p_pb2")
+    p2p_pb2.SOURCE_STATUS_READY = 2
+    p2p_pb2.SOURCE_STATUS_INITIALIZING = 1
+    p2p_pb2.SOURCE_STATUS_STALE = 3
+    p2p_pb2.MX_SOURCE_TYPE_WEIGHTS = 0
+    p2p_pb2.BACKEND_FRAMEWORK_UNKNOWN = 0
+    sys.modules["modelexpress.p2p_pb2"] = p2p_pb2
+
+    class _SourceIdentity:
+        def __init__(self, **kwargs):
+            self.model_name = kwargs.get("model_name", "")
+            self.extra_parameters = dict(kwargs.get("extra_parameters") or {})
+
+    class _TensorDescriptor:
+        def __init__(self, **kwargs):
+            self.name = kwargs.get("name", "")
+            self.addr = kwargs.get("addr", 0)
+            self.size = kwargs.get("size", 0)
+            self.device_id = kwargs.get("device_id", 0)
+            self.dtype = kwargs.get("dtype", "")
+
+    class _WorkerMetadata:
+        def __init__(self, **kwargs):
+            self.worker_rank = kwargs.get("worker_rank", 0)
+            self.nixl_metadata = kwargs.get("nixl_metadata", b"")
+            self.tensors = list(kwargs.get("tensors") or [])
+            self.status = kwargs.get("status", 0)
+            self.agent_name = kwargs.get("agent_name", "")
+
+    p2p_pb2.SourceIdentity = _SourceIdentity  # type: ignore[attr-defined]
+    p2p_pb2.WorkerMetadata = _WorkerMetadata  # type: ignore[attr-defined]
+    p2p_pb2.TensorDescriptor = _TensorDescriptor  # type: ignore[attr-defined]
+
+    hb = types.ModuleType("modelexpress.heartbeat")
+
+    class _HBStub:
+        def __init__(self, *a, **kw):
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            self.started = False
+
+    hb.HeartbeatThread = _HBStub
+    sys.modules["modelexpress.heartbeat"] = hb
+
+    refit_mod = types.ModuleType("modelexpress.refit_receiver")
+
+    @dataclass
+    class _SourceRef:
+        mx_source_id: str = ""
+        worker_id: str = ""
+        model_name: str = ""
+        worker_rank: int = 0
+        training_step: int = 0
+
+    class _RefitStub:
+        def __init__(self, agent_name="stub", **kw):
+            self._client = MagicMock()
+            self._nixl = MagicMock()
+            self._agent_name = agent_name
+            self._worker_id = "stub-worker-id"
+
+        def initialize(self, model_tensors=None):
+            pass
+
+        def receive_weights(self, ref, timeout_seconds=300.0):
+            return iter([])
+
+    refit_mod.MxRefitReceiver = _RefitStub
+    refit_mod.SourceRef = _SourceRef
+    sys.modules["modelexpress.refit_receiver"] = refit_mod
+
+    pub_mod = types.ModuleType("modelexpress.training_publisher")
+
+    class _PubStub:
+        def __init__(self, *a, **kw):
+            self._client = None
+            self._nixl = None
+
+        def initialize(self, **kw):
+            pass
+
+        def publish_weights(self, *a, **kw):
+            return "stub-sid"
+
+        def mark_ready(self, **kw):
+            return True
+
+        def shutdown(self):
+            pass
+
+        def _build_identity(self, step):
+            return p2p_pb2.SourceIdentity()
+
+    pub_mod.MxTrainingPublisher = _PubStub
+    sys.modules["modelexpress.training_publisher"] = pub_mod
+
+    types_mod = types.ModuleType("modelexpress.types")
+
+    @dataclass
+    class _TD:
+        name: str = ""
+        addr: int = 0
+        size: int = 0
+        device_id: int = 0
+        dtype: str = ""
+
+    types_mod.TensorDescriptor = _TD
+    sys.modules["modelexpress.types"] = types_mod
+
+    sd = _load("modelexpress.shape_descriptors", _PKG_ROOT / "shape_descriptors.py")
+    pkg.shape_descriptors = sd  # type: ignore[attr-defined]
+    v2 = _load("modelexpress.nemo_rl_v2", _PKG_ROOT / "nemo_rl_v2.py")
+    return v2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_megatron_candidate(
+    v2,
+    *,
+    role: str,
+    tp_rank: int,
+    tp_size: int,
+    pp_rank: int = 0,
+    pp_size: int = 1,
+    ep_rank: int = 0,
+    ep_size: int = 1,
+    num_heads_local: int | None = None,
+    num_kv_heads_local: int | None = None,
+    head_dim: int | None = None,
+    qkv_interleave: str | None = None,
+    gated_mlp_order: str | None = None,
+    updated_at: int = 0,
+    sid: str | None = None,
+    owned_experts_per_layer: dict | None = None,
+):
+    """Build a V2SourceCandidate with megatron_meta populated."""
+    ref_cls = v2.SourceRef if hasattr(v2, "SourceRef") else \
+        sys.modules["modelexpress.refit_receiver"].SourceRef
+    sid = sid or f"sid-{role}-tp{tp_rank}"
+    ref = ref_cls(
+        mx_source_id=sid,
+        worker_id=f"wid-{sid}",
+        model_name="m",
+        worker_rank=tp_rank * 1,  # not load-bearing for these tests
+        training_step=1,
+    )
+    mm = v2.MegatronSourceMeta(
+        role=role,
+        tp_rank=tp_rank, tp_size=tp_size,
+        pp_rank=pp_rank, pp_size=pp_size,
+        ep_rank=ep_rank, ep_size=ep_size,
+        num_heads_local=num_heads_local,
+        num_kv_heads_local=num_kv_heads_local,
+        head_dim=head_dim,
+        qkv_interleave=qkv_interleave,
+        gated_mlp_order=gated_mlp_order,
+    )
+    return v2.V2SourceCandidate(
+        ref=ref,
+        role=v2.ROLE_TRAINER,
+        worker_rank=tp_rank,
+        registry=None,
+        owned_experts_per_layer=owned_experts_per_layer or {},
+        updated_at=updated_at,
+        megatron_meta=mm,
+    )
+
+
+def _make_receiver(v2, *, target_tp=2, target_rank=0, ep_size=1, ep_rank=0):
+    rcv = v2.MxV2RefitReceiver(
+        agent_name="rcv",
+        device_id=0,
+        mx_server_url="mx-stub:8001",
+        worker_rank=0,
+    )
+    rcv.initialize(model_tensors=None)
+    layout = v2.TargetTpLayout(
+        tp_size=target_tp, tp_rank=target_rank, ep_size=ep_size, ep_rank=ep_rank,
+    )
+    return rcv, layout
+
+
+# ---------------------------------------------------------------------------
+# Role: replicated
+# ---------------------------------------------------------------------------
+
+
+def test_replicated_picks_single_freshest_source(v2):
+    rcv, layout = _make_receiver(v2)
+    cands = [
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_REPLICATED,
+                                 tp_rank=0, tp_size=2, sid="r-old", updated_at=10),
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_REPLICATED,
+                                 tp_rank=0, tp_size=2, sid="r-new", updated_at=20),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_REPLICATED,
+        target_shape=(128,),
+        target_dtype="bfloat16",
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"norm.weight": spec},
+    )
+    assert len(plans) == 1
+    plan = plans[0]
+    assert plan.role == v2.ROLE_MEGATRON_REPLICATED
+    assert plan.assembly == "passthrough"
+    assert len(plan.sources) == 1
+    assert plan.sources[0].mx_source_id == "r-new"  # freshest wins
+    assert plan.sources[0].target_local_range == (0, 128)
+
+
+# ---------------------------------------------------------------------------
+# Role: column / row — matched-TP
+# ---------------------------------------------------------------------------
+
+
+def test_column_matched_tp_two_sources(v2):
+    """source_tp = target_tp = 2: each receiver pulls one source's full slice."""
+    rcv, layout = _make_receiver(v2, target_tp=2, target_rank=1)
+    cands = [
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_COLUMN, tp_rank=0, tp_size=2, sid="c0"),
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_COLUMN, tp_rank=1, tp_size=2, sid="c1"),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_COLUMN,
+        target_shape=(2048, 1024),  # global
+        target_dtype="bfloat16",
+        shard_axis=0,
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"linear.weight": spec},
+    )
+    plan = plans[0]
+    assert plan.assembly == "concat_dim0"
+    # target_rank=1 => receiver wants [1024:2048]; one source covers it (sid=c1).
+    assert len(plan.sources) == 1
+    src = plan.sources[0]
+    assert src.mx_source_id == "c1"
+    assert src.target_local_range == (0, 1024)  # offset within the receiver's window
+    assert src.source_subslice is None
+    # receiver-side target_shape is the per-rank window
+    assert plan.target_shape == (1024, 1024)
+
+
+def test_row_matched_tp(v2):
+    """row-parallel = concat along dim 1, otherwise same shape as column."""
+    rcv, layout = _make_receiver(v2, target_tp=2, target_rank=0)
+    cands = [
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_ROW, tp_rank=0, tp_size=2, sid="r0"),
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_ROW, tp_rank=1, tp_size=2, sid="r1"),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_ROW,
+        target_shape=(1024, 2048),
+        target_dtype="bfloat16",
+        shard_axis=1,
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"o_proj": spec},
+    )[0]
+    assert plan.assembly == "concat_dim1"
+    assert len(plan.sources) == 1
+    assert plan.sources[0].mx_source_id == "r0"  # target_rank=0 → first slice
+    assert plan.target_shape == (1024, 1024)
+
+
+# ---------------------------------------------------------------------------
+# Role: column — mixed-TP, target wider than source
+# ---------------------------------------------------------------------------
+
+
+def test_column_mixed_tp_target_wider(v2):
+    """source_tp=2, target_tp=4: target_rank=0 wants [0:512] which is a sub-range
+    of source rank 0's [0:1024] slice. source_subslice should be set."""
+    rcv, layout = _make_receiver(v2, target_tp=4, target_rank=0)
+    cands = [
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_COLUMN, tp_rank=0, tp_size=2, sid="c0"),
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_COLUMN, tp_rank=1, tp_size=2, sid="c1"),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_COLUMN,
+        target_shape=(2048, 1024),
+        target_dtype="bfloat16",
+        shard_axis=0,
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"col": spec},
+    )[0]
+    # target_rank=0 of 4 => [0:512]; source c0 covers [0:1024]; partial pull.
+    assert len(plan.sources) == 1
+    src = plan.sources[0]
+    assert src.mx_source_id == "c0"
+    assert src.target_local_range == (0, 512)
+    assert src.source_subslice == (0, 512)
+    assert plan.target_shape == (512, 1024)
+
+
+def test_column_mixed_tp_target_narrower(v2):
+    """source_tp=4, target_tp=2: target_rank=0 wants [0:1024] which spans source
+    ranks 0 and 1 (each [0:512] and [512:1024])."""
+    rcv, layout = _make_receiver(v2, target_tp=2, target_rank=0)
+    cands = [
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_COLUMN, tp_rank=i, tp_size=4, sid=f"c{i}")
+        for i in range(4)
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_COLUMN,
+        target_shape=(2048, 1024),
+        target_dtype="bfloat16",
+        shard_axis=0,
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"col": spec},
+    )[0]
+    # Two sources contribute (c0, c1), each pulls its full slice (no subslice).
+    assert len(plan.sources) == 2
+    assert {s.mx_source_id for s in plan.sources} == {"c0", "c1"}
+    by_sid = {s.mx_source_id: s for s in plan.sources}
+    assert by_sid["c0"].target_local_range == (0, 512)
+    assert by_sid["c1"].target_local_range == (512, 1024)
+    assert all(s.source_subslice is None for s in plan.sources)
+    assert plan.target_shape == (1024, 1024)
+
+
+# ---------------------------------------------------------------------------
+# Role: qkv_column — head counts aggregated correctly
+# ---------------------------------------------------------------------------
+
+
+def test_qkv_column_aggregates_head_counts(v2):
+    rcv, layout = _make_receiver(v2, target_tp=2, target_rank=0)
+    cands = [
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_QKV_COLUMN,
+            tp_rank=0, tp_size=2,
+            num_heads_local=16, num_kv_heads_local=4, head_dim=128,
+            qkv_interleave="by_head", sid="q0",
+        ),
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_QKV_COLUMN,
+            tp_rank=1, tp_size=2,
+            num_heads_local=16, num_kv_heads_local=4, head_dim=128,
+            qkv_interleave="by_head", sid="q1",
+        ),
+    ]
+    # Each source rank publishes (16+2*4)*128 = 3072 rows; global has 2*3072 = 6144 rows.
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_QKV_COLUMN,
+        target_shape=(6144, 4096),
+        target_dtype="bfloat16",
+        shard_axis=0,
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"qkv": spec},
+    )[0]
+    assert plan.assembly == "qkv_uninterleave"
+    assert len(plan.sources) == 1  # target_rank=0 of 2 covered by source rank 0
+    rd = plan.role_descriptor
+    # Aggregation sums the per-source local counts across the contributing sources.
+    assert rd["num_heads_total"] == "16"  # only c0 contributes for target_rank=0
+    assert rd["num_kv_heads_total"] == "4"
+    assert rd["head_dim"] == "128"
+    assert rd["qkv_interleave"] == "by_head"
+
+
+# ---------------------------------------------------------------------------
+# Role: gated_mlp_column
+# ---------------------------------------------------------------------------
+
+
+def test_gated_mlp_assembly_and_descriptor(v2):
+    rcv, layout = _make_receiver(v2, target_tp=2, target_rank=0)
+    cands = [
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
+            tp_rank=0, tp_size=2,
+            gated_mlp_order="gate_then_up", sid="g0",
+        ),
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
+            tp_rank=1, tp_size=2,
+            gated_mlp_order="gate_then_up", sid="g1",
+        ),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_GATED_MLP_COLUMN,
+        target_shape=(8192, 4096),
+        target_dtype="bfloat16",
+        shard_axis=0,
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"fc1": spec},
+    )[0]
+    assert plan.assembly == "gated_mlp_split"
+    assert plan.role_descriptor.get("gated_mlp_order") == "gate_then_up"
+
+
+# ---------------------------------------------------------------------------
+# Role: vocab_parallel
+# ---------------------------------------------------------------------------
+
+
+def test_vocab_parallel_concat_dim0(v2):
+    rcv, layout = _make_receiver(v2, target_tp=2, target_rank=1)
+    cands = [
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_VOCAB_PARALLEL,
+                                 tp_rank=0, tp_size=2, sid="v0"),
+        _make_megatron_candidate(v2, role=v2.ROLE_MEGATRON_VOCAB_PARALLEL,
+                                 tp_rank=1, tp_size=2, sid="v1"),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_VOCAB_PARALLEL,
+        target_shape=(151936, 4096),
+        target_dtype="bfloat16",
+        shard_axis=0,
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"embed": spec},
+    )[0]
+    assert plan.assembly == "concat_dim0"
+    assert len(plan.sources) == 1
+    assert plan.sources[0].mx_source_id == "v1"  # target_rank=1 → second half
+
+
+# ---------------------------------------------------------------------------
+# Role: expert_column / expert_row — per-expert
+# ---------------------------------------------------------------------------
+
+
+def test_expert_column_per_expert_routing(v2):
+    """EP=4 trainer publishes 32 experts (8 per rank); receiver wants experts
+    [0, 7, 16, 31] (one from each EP rank). Plan should pick the right
+    EP-rank source per expert."""
+    rcv, layout = _make_receiver(v2, target_tp=1, target_rank=0, ep_size=8, ep_rank=0)
+    cands = [
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+            tp_rank=0, tp_size=1,
+            ep_rank=ep_rank, ep_size=4,
+            sid=f"e{ep_rank}",
+            owned_experts_per_layer={3: set(range(ep_rank * 8, (ep_rank + 1) * 8))},
+        )
+        for ep_rank in range(4)
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+        target_shape=(2048, 4096),  # one expert's shape
+        target_dtype="bfloat16",
+        role_descriptor={
+            "local_expert_ids": "0,7,16,31",
+            "layer_id": "3",
+        },
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"experts.gate": spec},
+    )[0]
+    assert plan.assembly == "per_expert"
+    assert len(plan.sources) == 4
+    by_expert = {s.target_local_range[0]: s for s in plan.sources}
+    assert by_expert[0].mx_source_id == "e0"     # expert 0 owned by ep_rank 0
+    assert by_expert[7].mx_source_id == "e0"     # expert 7 also ep_rank 0
+    assert by_expert[16].mx_source_id == "e2"    # expert 16 owned by ep_rank 2
+    assert by_expert[31].mx_source_id == "e3"    # expert 31 owned by ep_rank 3
+    for src in plan.sources:
+        assert src.role_extras.get("expert_id") in {"0", "7", "16", "31"}
+
+
+# ---------------------------------------------------------------------------
+# Backwards compat: non-Megatron candidate set
+# ---------------------------------------------------------------------------
+
+
+def test_non_megatron_candidates_yield_empty_source_lists(v2):
+    """If no candidate has megatron_meta, planner returns plans with empty
+    sources — caller should detect and fall back to pick_best_source."""
+    rcv, layout = _make_receiver(v2)
+
+    @dataclass
+    class _Ref:
+        mx_source_id: str = "x"
+        worker_id: str = "y"
+        model_name: str = "m"
+        worker_rank: int = 0
+        training_step: int = 1
+
+    cand = v2.V2SourceCandidate(
+        ref=_Ref(),
+        role=v2.ROLE_TRAINER,
+        worker_rank=0,
+        registry=None,
+        owned_experts_per_layer={},
+        updated_at=0,
+        megatron_meta=None,
+    )
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_COLUMN,
+        target_shape=(1024, 512),
+        target_dtype="bfloat16",
+    )
+    plans = rcv.pick_megatron_slice_plans(
+        [cand], target_tp_layout=layout,
+        target_tensor_specs={"col": spec},
+    )
+    assert len(plans) == 1
+    assert plans[0].sources == []
+
+
+# ---------------------------------------------------------------------------
+# Source extraction: discover_v2_sources should populate megatron_meta
+# ---------------------------------------------------------------------------
+
+
+def test_extract_megatron_meta_from_extras(v2):
+    """Direct unit test of _extract_megatron_meta: full-keys round-trip."""
+    extra = {
+        "mx_v2": "1",
+        "megatron_role": v2.ROLE_MEGATRON_QKV_COLUMN,
+        "tp_rank": "2",
+        "tp_size": "4",
+        "pp_rank": "1",
+        "pp_size": "2",
+        "ep_rank": "0",
+        "ep_size": "1",
+        "num_heads_local": "8",
+        "num_kv_heads_local": "2",
+        "head_dim": "128",
+        "qkv_interleave": "by_head",
+    }
+    mm = v2._extract_megatron_meta(extra)
+    assert mm is not None
+    assert mm.role == v2.ROLE_MEGATRON_QKV_COLUMN
+    assert (mm.tp_rank, mm.tp_size) == (2, 4)
+    assert (mm.pp_rank, mm.pp_size) == (1, 2)
+    assert mm.num_heads_local == 8
+    assert mm.head_dim == 128
+    assert mm.qkv_interleave == "by_head"
+
+
+def test_extract_megatron_meta_returns_none_for_non_megatron(v2):
+    extra = {"mx_v2": "1", "role": "trainer", "worker_rank": "0"}  # no megatron_role
+    assert v2._extract_megatron_meta(extra) is None
+
+
+def test_extract_megatron_meta_returns_none_for_unknown_role(v2):
+    extra = {"mx_v2": "1", "megatron_role": "something_unknown", "tp_rank": "0", "tp_size": "1"}
+    assert v2._extract_megatron_meta(extra) is None

--- a/modelexpress_client/python/tests/test_v2_megatron_slice_planner.py
+++ b/modelexpress_client/python/tests/test_v2_megatron_slice_planner.py
@@ -521,6 +521,114 @@ def test_expert_column_per_expert_routing(v2):
 
 
 # ---------------------------------------------------------------------------
+# Role: expert_column / expert_row — TE-grouped per-expert layout
+# (each Megatron tensor IS one expert's full weight, e.g. linear_fc1.weight0)
+# ---------------------------------------------------------------------------
+
+
+def test_grouped_expert_column_picks_passthrough_plan(v2):
+    """TE-grouped layout: each Megatron tensor is ONE expert's fused
+    gate+up. Plan should be passthrough with a single source — not
+    per_expert with N sources."""
+    rcv, layout = _make_receiver(v2, target_tp=1, target_rank=0)
+    # One trainer source publishes this expert's weight (EP=1).
+    cands = [
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+            tp_rank=0, tp_size=1, ep_rank=0, ep_size=1,
+            sid="trainer-0",
+        ),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+        target_shape=(19456, 2048),  # fused gate+up shape for one expert (2 * intermediate, hidden)
+        target_dtype="bfloat16",
+        role_descriptor={
+            "expert_layout": "grouped",
+            "expert_id": "17",
+            "expert_axis": "0",
+        },
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"decoder.layers.0.mlp.experts.linear_fc1.weight17": spec},
+    )[0]
+    assert plan.assembly == "passthrough"
+    assert len(plan.sources) == 1
+    assert plan.sources[0].mx_source_id == "trainer-0"
+    assert plan.sources[0].target_local_range == (0, 19456)
+    # Source covers the full target tensor (no sub-slicing in v0).
+    assert plan.sources[0].source_subslice is None
+    # role_extras forwarded so the receiver knows this is grouped.
+    assert plan.sources[0].role_extras.get("expert_layout") == "grouped"
+    assert plan.sources[0].role_extras.get("expert_id") == "17"
+
+
+def test_grouped_expert_row_picks_passthrough_plan(v2):
+    """Row-parallel variant: linear_fc2.weight17 — one expert's
+    down_proj. Same passthrough shape, just a different role."""
+    rcv, layout = _make_receiver(v2, target_tp=1, target_rank=0)
+    cands = [
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_EXPERT_ROW,
+            tp_rank=0, tp_size=1, ep_rank=0, ep_size=1,
+            sid="trainer-0",
+        ),
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_EXPERT_ROW,
+        target_shape=(2048, 9728),  # down_proj shape (hidden, intermediate)
+        target_dtype="bfloat16",
+        role_descriptor={
+            "expert_layout": "grouped",
+            "expert_id": "17",
+            "expert_axis": "0",
+        },
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"decoder.layers.0.mlp.experts.linear_fc2.weight17": spec},
+    )[0]
+    assert plan.assembly == "passthrough"
+    assert plan.role == v2.ROLE_MEGATRON_EXPERT_ROW
+    assert len(plan.sources) == 1
+    assert plan.sources[0].target_local_range == (0, 2048)
+
+
+def test_legacy_expert_layout_still_uses_per_expert_assembly(v2):
+    """Sanity: when expert_layout is unset or == "leading_axis", the
+    planner falls back to the legacy _plan_per_expert path (multi-source,
+    per_expert assembly)."""
+    rcv, layout = _make_receiver(v2, target_tp=1, target_rank=0, ep_size=4, ep_rank=0)
+    cands = [
+        _make_megatron_candidate(
+            v2, role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+            tp_rank=0, tp_size=1, ep_rank=ep_rank, ep_size=4,
+            sid=f"e{ep_rank}",
+            owned_experts_per_layer={5: set(range(ep_rank * 2, (ep_rank + 1) * 2))},
+        )
+        for ep_rank in range(4)
+    ]
+    spec = v2.MegatronTensorSpec(
+        role=v2.ROLE_MEGATRON_EXPERT_COLUMN,
+        target_shape=(1024, 2048),
+        target_dtype="bfloat16",
+        role_descriptor={
+            # expert_layout intentionally omitted — defaults to leading_axis
+            "local_expert_ids": "0,3,5,7",
+            "layer_id": "5",
+        },
+    )
+    plan = rcv.pick_megatron_slice_plans(
+        cands, target_tp_layout=layout,
+        target_tensor_specs={"experts.gate": spec},
+    )[0]
+    assert plan.assembly == "per_expert"  # NOT passthrough
+    # The legacy path picks one source per expert id.
+    assert len(plan.sources) == 4
+
+
+# ---------------------------------------------------------------------------
 # Backwards compat: non-Megatron candidate set
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds the **MX-side Megatron-Core path** for the NemoRL × Dynamo × MX stack. Stacked on top of #421 (the `publish_self_as_source` / tree-fan-out fix); review and merge #421 first, then this can rebase onto `kavink/nemo_rl_moe` if needed.

This PR turns the existing DTensor-only MX v2 client into a Megatron-aware one without breaking any DTensor consumers. The publisher emits per-rank native shards (no allgather), the slice planner produces shard-coverage plans across one or many Megatron sources, and the receiver-side translator runs the QKV un-interleave / gated-MLP split via Bridge-byte-identical helpers vendored directly into `modelexpress` — no Megatron-Bridge dependency on the inference worker image.

**Phases A and D of the Megatron-MX integration live on the NemoRL side ([`KavinKrishnan/RL @ kavink/megatron-mx`](https://github.com/KavinKrishnan/RL/tree/kavink/megatron-mx), PR jthomson04/RL#2).** Phases B + C plus the publisher's sidecar emit + the receiver's matched-TP fast-path glue all live here.

## Layout

### Phase B — Megatron slice planner (`modelexpress.nemo_rl_v2`)

* New `TargetTpLayout`, `MegatronSourceMeta` (rank-position only), `MegatronSliceSource`, `MegatronSlicePlan`, `MegatronTensorSpec` dataclasses.
* `MxV2RefitReceiver.pick_megatron_slice_plans` returns per-HF-tensor plans with the right `source_subslice` ranges for matched-TP and mixed-TP (target wider + target narrower), per-expert routing, and EP-remap.
* Per-tensor `megatron_role` lives on `TensorDescriptorV2` (in the registry, not on a source-level field) so one source can publish many tensors with different roles.
* Seven roles wired: `qkv_column`, `gated_mlp_column`, `column`, `row`, `vocab_parallel`, `replicated`, plus per-expert `expert_column` / `expert_row` for MoE.
* Publisher: `MxV2TrainingPublisher.set_megatron_mesh_position` + `set_megatron_sidecar` + a `publisher_kind=megatron` marker in identity `extra_parameters` so the receiver can dispatch.
* 13 new tests in `tests/test_v2_megatron_slice_planner.py` covering matched-TP, mixed-TP (both directions), EP-remap, and the back-compat path for DTensor consumers.

### Phase C — Receiver-side translator (`modelexpress.megatron_translator`, `modelexpress.megatron_helpers`)

* **`megatron_helpers.py`** vendors the seven tensor-math helpers from Megatron-Bridge that are needed by the receiver: `MegatronTransformerConfig` (3 fields), `split_qkv_weights`, `split_qkv_biases`, `merge_qkv_weights`, `merge_qkv_biases`, `split_gated_mlp`, `merge_gated_mlp`. Each helper round-trips byte-identical against the upstream Bridge implementation (cross-checked on the trainer image with the full Bridge dep installed).
* **`megatron_translator.py`** is the per-cycle orchestrator: `MegatronReceiverContext`, `ReceiveSpec`, `discover_megatron_context`, `assemble_into_destination` (handles `concat_dim0` / `concat_dim1` / `passthrough` / `per_expert`), `translate_megatron_to_hf` (dispatches on role; runs QKV un-interleave and gated-MLP split using the vendored helpers), and `run_refit_cycle` (the orchestrator NemoRL's `VllmInternalWorkerExtension` calls).
* Sidecar parsing reads the trainer-emitted `megatron_transformer_config` + `megatron_hf_name_map` from the receiver's discovered v2 sources.
* 7 E2E translator tests + 19 helper tests on CPU (including cross-checks against the authoritative Megatron-Bridge implementations when available in the test env).

### Sidecar emit + bulk receive fast path

* `MxV2TrainingPublisher.publish` injects Megatron-specific `publisher_kind` and rank info into `extra_parameters` and merges the trainer's `_megatron_sidecar` into the v2 sidecar JSON.
* `run_refit_cycle` accepts a `pre_assembled_buffers={megatron_name: tensor}` map so the matched-TP fast path can register one buffer per Megatron name with NIXL once, bulk-pull via `receive_weights`, then have the translator walk the filled buffers without per-source assembly.

## Validation

### Real Megatron model, cross-pod end-to-end on GB200 (kavin)

Loaded **`Qwen/Qwen3-4B-Thinking-2507`** as a real Megatron-Core model via Megatron-Bridge at TP=PP=EP=1, ran the full Phase A → B → C → D pipeline across two pods, and asserted byte-identity against `bridge.export_hf_weights` ground truth.

> **398 / 398 HF tensors byte-identical. 0 drift, 0 missing, 0 extras.**

Bulk-pull: **313 Gbps single-NIC** for the whole 8.04 GB model in 0.21 s. Translation step (398 HF tensors) in 0.57 s.

What this proved beyond unit tests:

* Phase A `detect_megatron_role` on real TE-fused classes: `TELayerNormColumnParallelLinear` (144), `TERowParallelLinear` (72), `VocabParallelEmbedding` (1), `RMSNorm` (73), all classified correctly via Bridge's `AutoMapping._MODULE_TYPE_REGISTRY`.
* Phase A `_build_megatron_sidecar` against the real Bridge `get_conversion_tasks` walk (290 name_map entries; `QKVMapping` dict + `DirectMapping` string both handled).
* Phase B per-tensor `megatron_role` round-trip through `TensorDescriptorV2.megatron_role` and the 290-entry sidecar.
* Phase C `split_qkv_weights` on real GQA 4:1 attention (32 q-heads × 8 kv-heads × head_dim=128).
* Phase C `split_gated_mlp` on Qwen3 fused gate+up (intermediate=9728).

Two real-model bugs surfaced + fixed during this run:

1. Bridge API rename: `build_conversion_tasks` → `get_conversion_tasks`.
2. `model.named_parameters()` returns `module.<...>` prefixed names but Bridge's `get_conversion_tasks` returns unprefixed; the publisher now normalises in `collect_megatron_publish_set` and the receiver has a defensive strip.

Full writeup + harness scripts: [`pensieve/RL/NemoRL/14_megatron_mx_phase_e_shape1_2026_06_08.md`](https://github.com/ai-dynamo/modelexpress/blob/kavink/RL/pensieve/RL/NemoRL/14_megatron_mx_phase_e_shape1_2026_06_08.md).

### Real MoE model — partial validation on Qwen3-MoE-30B-A3B

Loaded **`Qwen/Qwen3-30B-A3B-Instruct-2507`** (60.06 GB on GPU, 128 experts × 48 layers). Phase A grouped-MoE classifier validated against real TE-grouped MoE module classes. Post-fix role distribution:

```
expert_column 6 144   (= 48 x 128 of linear_fc1)
expert_row    6 144   (= 48 x 128 of linear_fc2)
replicated      241   (norms, scalars, routers)
row              48   (linear_proj)
qkv_column       48   (linear_qkv)
vocab_parallel    1
column            1
              ------
              12 627   matches Bridge's get_conversion_tasks
```

Surfaced + fixed: `_enclosing_module` didn't recognise `weight<N>` / `bias<N>` / `scale<N>` per-expert leaves (was walking into the `Parameter` object and classifying as `replicated`); per-expert detection required `ep_size > 1` but TE-grouped exposes per-expert params even at EP=1.

Receiver-side for shape 2 still needs the per-expert gated-MLP split + EP-remap translator extension (`expert_column` + `len(hf_names) == 2` → split gate+up). Designed in [`pensieve/RL/NemoRL/15_megatron_mx_phase_e_shape2_2026_06_08.md`](https://github.com/ai-dynamo/modelexpress/blob/kavink/RL/pensieve/RL/NemoRL/15_megatron_mx_phase_e_shape2_2026_06_08.md).

### Earlier cross-pod synthetic smoke

Synthetic Megatron-shaped publisher + receiver across two pods on GB200 — 8 HF tensors covering 5 roles (QKV un-interleave, gated-MLP split, column, row, replicated) byte-identical after real NIXL RDMA. Smallest possible end-to-end A → B → C → D test. See [`pensieve/RL/NemoRL/13_megatron_mx_validation_2026_06_08.md`](https://github.com/ai-dynamo/modelexpress/blob/kavink/RL/pensieve/RL/NemoRL/13_megatron_mx_validation_2026_06_08.md).

## Test plan

```
$ python -m pytest tests/test_v2_megatron_slice_planner.py tests/test_megatron_helpers.py tests/test_megatron_translator.py -v
```

* 13 tests — `test_v2_megatron_slice_planner.py`: all 7 roles, matched-TP, mixed-TP wider, mixed-TP narrower, EP-remap, back-compat with DTensor consumers
* 19 tests — `test_megatron_helpers.py`: MHA + GQA QKV round-trips, biases, gated MLP, Bridge byte-identity cross-checks (skipped locally, run on trainer pod)
* 7 tests — `test_megatron_translator.py`: end-to-end Phase B + C on CPU (replicated, column-parallel, QKV GQA, gated MLP, sidecar parsing)

Plus the cluster-validation runs above (real Qwen3-4B-Thinking byte-identity and real Qwen3-30B-A3B classifier).

## Compatibility

* DTensor consumers are unchanged. The Megatron path is purely additive — the publisher only emits Megatron metadata when `set_megatron_mesh_position` has been called; receivers without a Megatron `publisher_kind` in candidate metadata short-circuit to the legacy DTensor picker. The DTensor unit test suite continues to pass.
* The `pre_assembled_buffers` argument to `run_refit_cycle` is optional; existing callers see no behaviour change.

## Stacked on

#421 (`kavink/fix-publish-self-as-source-v2-transports`). When that PR lands, this one rebases trivially onto `kavink/nemo_rl_moe`.
