### PR TITLE
feat: add AcceleratorBackend boundary and CUDA capability gates

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -527,6 +527,7 @@ Loading precedence: CLI args > environment variables > config file > defaults.
 |--------|---------|
 | `__init__.py` | Package init, exports `register_modelexpress_loaders()` for callers to register the `modelexpress` and `mx` loaders with vLLM |
 | `client.py` | `MxClient` - gRPC client wrapping `PublishMetadata`, `ListSources`, `GetMetadata`, and `UpdateStatus` RPCs |
+| `accelerator_backend.py` | `AcceleratorBackend` boundary for accelerator-specific torch device control and fast-path capability gates. CUDA is the implemented backend; non-CUDA backends can be added behind the same interface |
 | `nixl_transfer.py` | `NixlTransferManager` - NIXL agent lifecycle, tensor registration, RDMA transfers |
 | `gds_transfer.py` | GPUDirect Storage availability check and transfer utilities |
 | `gds_loader.py` | `MxGdsLoader` - GDS-based model loader (direct file-to-GPU) |
@@ -560,9 +561,9 @@ Manages a NIXL agent and RDMA transfers for a single GPU worker:
 
 | Method | Purpose |
 |--------|---------|
-| `__init__(agent_name, device_id, listen_port)` | Create NIXL agent with UCX backend; `listen_port` enables P2P listen thread |
-| `register_tensors(tensors)` | Register GPU tensors for RDMA, return serialized metadata. With `MX_POOL_REG=1`, registers each unique cudaMalloc allocation backing the tensors instead of registering each tensor individually |
-| `register_arena(arena, tensors)` | Register the used VMM arena range once through dmabuf, then publish every tensor descriptor against that single MR |
+| `__init__(agent_name, device_id, listen_port, accelerator_backend)` | Create NIXL agent with UCX backend; `listen_port` enables P2P listen thread; `accelerator_backend` owns torch device operations and accelerator capability gates |
+| `register_tensors(tensors)` | Register GPU tensors for RDMA, return serialized metadata. With `MX_POOL_REG=1` on a backend that supports pool registration, registers each unique cudaMalloc allocation backing the tensors instead of registering each tensor individually |
+| `register_arena(arena, tensors)` | Register the used VMM arena range once through dmabuf when the active accelerator backend supports the VMM arena fast path, then publish every tensor descriptor against that single MR |
 | `fetch_remote_and_wait(agent_name, ip, port)` | P2P: fetch remote NIXL metadata via listen thread (polls until loaded) |
 | `receive_from_source(source_metadata, source_tensors, ..., remote_agent_name)` | Execute RDMA read transfer; `remote_agent_name` skips `add_remote_agent` (P2P) |
 | `shutdown()` | Clean up NIXL agent and resources |
@@ -600,10 +601,10 @@ Auto-detects the best loading strategy with a prioritized chain. Each strategy i
 |---|---|---|---|
 | p0 | `RdmaStrategy` | NIXL available | `ListSources(READY)`, filter by `worker_rank`, shuffle, try candidates (max 3). Candidate retry covers pre-transfer metadata misses only (no metadata found, fetch error). Once the RDMA receive starts, a `SourceTransferError` or `ManifestMismatchError` aborts RDMA and the chain falls through to the next strategy (GDS, then disk), not the next source. |
 | p1 | `ModelStreamerStrategy` | `MX_MODEL_URI` set + `runai_model_streamer` installed | Stream safetensors to GPU via CPU staging buffer. `MX_MODEL_URI` accepts remote URIs (`s3://`, `gs://`, `az://`), absolute local paths, or HF model IDs (resolved via `HF_HUB_CACHE`). All storage backends (S3, GCS, Azure) included by default. |
-| p2 | `GdsStrategy` | GDS hardware available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. Reads full checkpoint tensors and slices for TP downstream — see [GDS Reads Full Checkpoint Tensors Under TP](#gds-reads-full-checkpoint-tensors-under-tp). |
+| p2 | `GdsStrategy` | Active accelerator backend supports GDS and GDS hardware is available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. Reads full checkpoint tensors and slices for TP downstream — see [GDS Reads Full Checkpoint Tensors Under TP](#gds-reads-full-checkpoint-tensors-under-tp). |
 | p3 | `DefaultStrategy` | Engine native fallback loader available | Native loader fallback (for vLLM, `DefaultModelLoader`, CPU-staged, auto-downloads from HF Hub). |
 
-Strategies handle the loading path and NIXL tensor registration. Adapter hooks handle engine lifecycle such as vLLM `process_weights_after_loading`, and the chain performs best-effort metadata publication after a successful strategy. New strategies can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
+Strategies handle the loading path and NIXL tensor registration. `LoadContext.accelerator_backend` centralizes accelerator-specific torch operations and capability gates for CUDA-only fast paths such as pool registration, VMM arena registration, and GDS. Adapter hooks handle engine lifecycle such as vLLM `process_weights_after_loading`, and the chain performs best-effort metadata publication after a successful strategy. New strategies can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
 
 ### Transfer Safety
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -527,7 +527,7 @@ Loading precedence: CLI args > environment variables > config file > defaults.
 |--------|---------|
 | `__init__.py` | Package init, exports `register_modelexpress_loaders()` for callers to register the `modelexpress` and `mx` loaders with vLLM |
 | `client.py` | `MxClient` - gRPC client wrapping `PublishMetadata`, `ListSources`, `GetMetadata`, and `UpdateStatus` RPCs |
-| `accelerator_backend.py` | `AcceleratorBackend` boundary for accelerator-specific torch device control and fast-path capability gates. CUDA is the implemented backend; non-CUDA backends can be added behind the same interface |
+| `accelerators/` | `AcceleratorBackend` boundary for accelerator-specific torch device control and fast-path capability gates, split into `base.py` (protocol) and `cuda.py` (`CudaAcceleratorBackend`). CUDA is the implemented backend; non-CUDA backends can be added behind the same interface |
 | `nixl_transfer.py` | `NixlTransferManager` - NIXL agent lifecycle, tensor registration, RDMA transfers |
 | `gds_transfer.py` | GPUDirect Storage availability check and transfer utilities |
 | `gds_loader.py` | `MxGdsLoader` - GDS-based model loader (direct file-to-GPU) |

--- a/modelexpress_client/python/modelexpress/accelerator_backend.py
+++ b/modelexpress_client/python/modelexpress/accelerator_backend.py
@@ -64,7 +64,7 @@ class AcceleratorBackend(Protocol):
         """Return whether allocation-level NIXL pool registration is supported."""
         ...
 
-    def supports_vmm_arena(self) -> bool:
+    def supports_vmm(self) -> bool:
         """Return whether the CUDA VMM arena fast path is supported."""
         ...
 
@@ -116,7 +116,7 @@ class CudaAcceleratorBackend:
     def supports_pool_reg(self) -> bool:
         return True
 
-    def supports_vmm_arena(self) -> bool:
+    def supports_vmm(self) -> bool:
         return True
 
     def supports_gds(self) -> bool:

--- a/modelexpress_client/python/modelexpress/accelerator_backend.py
+++ b/modelexpress_client/python/modelexpress/accelerator_backend.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Accelerator backend abstraction for device-specific operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+
+NIXL_ACCELERATOR_MEM_TYPE = "VRAM"
+
+
+class AcceleratorBackend(Protocol):
+    """Boundary for torch device control and accelerator capabilities."""
+
+    @property
+    def name(self) -> str:
+        """Backend family name for logs and capability policy, for example ``cuda``."""
+        ...
+
+    @property
+    def torch_device_type(self) -> str:
+        """Torch device type used to construct tensors, which may differ from ``name``."""
+        ...
+
+    @property
+    def nixl_mem_type(self) -> str:
+        """NIXL memory segment for accelerator memory."""
+        ...
+
+    def set_device(self, device_id: int) -> None:
+        """Make ``device_id`` current for this backend."""
+        ...
+
+    def current_device(self) -> int:
+        """Return the current local device ordinal."""
+        ...
+
+    def synchronize(self, device_id: int | None = None) -> None:
+        """Synchronize backend work on ``device_id`` or the current device."""
+        ...
+
+    def empty_cache(self) -> None:
+        """Release backend allocator cache where supported."""
+        ...
+
+    def torch_device(self, device_id: int) -> torch.device:
+        """Return a torch device object for ``device_id``."""
+        ...
+
+    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
+        """Return whether ``tensor`` lives on this backend's accelerator memory."""
+        ...
+
+    def supports_pool_reg(self) -> bool:
+        """Return whether allocation-level NIXL pool registration is supported."""
+        ...
+
+    def supports_vmm_arena(self) -> bool:
+        """Return whether the CUDA VMM arena fast path is supported."""
+        ...
+
+    def supports_gds(self) -> bool:
+        """Return whether GPUDirect Storage loading is supported."""
+        ...
+
+
+@dataclass(frozen=True)
+class CudaAcceleratorBackend:
+    """CUDA implementation of the accelerator backend boundary."""
+
+    @property
+    def name(self) -> str:
+        return "cuda"
+
+    @property
+    def torch_device_type(self) -> str:
+        return "cuda"
+
+    @property
+    def nixl_mem_type(self) -> str:
+        return NIXL_ACCELERATOR_MEM_TYPE
+
+    def set_device(self, device_id: int) -> None:
+        torch.cuda.set_device(device_id)
+
+    def current_device(self) -> int:
+        return int(torch.cuda.current_device())
+
+    def synchronize(self, device_id: int | None = None) -> None:
+        if device_id is None:
+            torch.cuda.synchronize()
+        else:
+            torch.cuda.synchronize(device_id)
+
+    def empty_cache(self) -> None:
+        torch.cuda.empty_cache()
+
+    def torch_device(self, device_id: int) -> torch.device:
+        return torch.device(self.torch_device_type, device_id)
+
+    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
+        return bool(tensor.is_cuda)
+
+    def supports_pool_reg(self) -> bool:
+        return True
+
+    def supports_vmm_arena(self) -> bool:
+        return True
+
+    def supports_gds(self) -> bool:
+        return True
+
+
+def accelerator_backend_for(device: torch.device | str) -> AcceleratorBackend:
+    """Return the backend implementation for ``device``.
+
+    Only CUDA devices are currently supported by this factory.
+    """
+    torch_device = torch.device(device)
+    if torch_device.type == "cuda":
+        return CudaAcceleratorBackend()
+    raise ValueError(f"Unsupported accelerator backend for torch device {torch_device!s}")

--- a/modelexpress_client/python/modelexpress/accelerator_backend.py
+++ b/modelexpress_client/python/modelexpress/accelerator_backend.py
@@ -56,6 +56,10 @@ class AcceleratorBackend(Protocol):
         """Return whether ``tensor`` lives on this backend's accelerator memory."""
         ...
 
+    def supports_rdma_p2p(self) -> bool:
+        """Return whether this backend supports NIXL RDMA P2P transfers."""
+        ...
+
     def supports_pool_reg(self) -> bool:
         """Return whether allocation-level NIXL pool registration is supported."""
         ...
@@ -105,6 +109,9 @@ class CudaAcceleratorBackend:
 
     def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
         return bool(tensor.is_cuda)
+
+    def supports_rdma_p2p(self) -> bool:
+        return True
 
     def supports_pool_reg(self) -> bool:
         return True

--- a/modelexpress_client/python/modelexpress/accelerators/__init__.py
+++ b/modelexpress_client/python/modelexpress/accelerators/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Accelerator backend abstraction for device-specific operations."""
+
+from __future__ import annotations
+
+import torch
+
+from .base import NIXL_ACCELERATOR_MEM_TYPE, AcceleratorBackend
+from .cuda import CudaAcceleratorBackend
+
+__all__ = [
+    "NIXL_ACCELERATOR_MEM_TYPE",
+    "AcceleratorBackend",
+    "CudaAcceleratorBackend",
+    "accelerator_backend_for",
+]
+
+
+def accelerator_backend_for(device: torch.device | str) -> AcceleratorBackend:
+    """Return the backend implementation for ``device``.
+
+    Only CUDA devices are currently supported by this factory.
+    """
+    torch_device = torch.device(device)
+    if torch_device.type == "cuda":
+        return CudaAcceleratorBackend()
+    raise ValueError(f"Unsupported accelerator backend for torch device {torch_device!s}")

--- a/modelexpress_client/python/modelexpress/accelerators/base.py
+++ b/modelexpress_client/python/modelexpress/accelerators/base.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Accelerator backend abstraction for device-specific operations."""
+"""Accelerator backend boundary for device-specific operations."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Protocol
 
 import torch
@@ -71,64 +70,3 @@ class AcceleratorBackend(Protocol):
     def supports_gds(self) -> bool:
         """Return whether GPUDirect Storage loading is supported."""
         ...
-
-
-@dataclass(frozen=True)
-class CudaAcceleratorBackend:
-    """CUDA implementation of the accelerator backend boundary."""
-
-    @property
-    def name(self) -> str:
-        return "cuda"
-
-    @property
-    def torch_device_type(self) -> str:
-        return "cuda"
-
-    @property
-    def nixl_mem_type(self) -> str:
-        return NIXL_ACCELERATOR_MEM_TYPE
-
-    def set_device(self, device_id: int) -> None:
-        torch.cuda.set_device(device_id)
-
-    def current_device(self) -> int:
-        return int(torch.cuda.current_device())
-
-    def synchronize(self, device_id: int | None = None) -> None:
-        if device_id is None:
-            torch.cuda.synchronize()
-        else:
-            torch.cuda.synchronize(device_id)
-
-    def empty_cache(self) -> None:
-        torch.cuda.empty_cache()
-
-    def torch_device(self, device_id: int) -> torch.device:
-        return torch.device(self.torch_device_type, device_id)
-
-    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
-        return bool(tensor.is_cuda)
-
-    def supports_rdma_p2p(self) -> bool:
-        return True
-
-    def supports_pool_reg(self) -> bool:
-        return True
-
-    def supports_vmm(self) -> bool:
-        return True
-
-    def supports_gds(self) -> bool:
-        return True
-
-
-def accelerator_backend_for(device: torch.device | str) -> AcceleratorBackend:
-    """Return the backend implementation for ``device``.
-
-    Only CUDA devices are currently supported by this factory.
-    """
-    torch_device = torch.device(device)
-    if torch_device.type == "cuda":
-        return CudaAcceleratorBackend()
-    raise ValueError(f"Unsupported accelerator backend for torch device {torch_device!s}")

--- a/modelexpress_client/python/modelexpress/accelerators/cuda.py
+++ b/modelexpress_client/python/modelexpress/accelerators/cuda.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA implementation of the accelerator backend boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from .base import NIXL_ACCELERATOR_MEM_TYPE
+
+
+@dataclass(frozen=True)
+class CudaAcceleratorBackend:
+    """CUDA implementation of the accelerator backend boundary."""
+
+    @property
+    def name(self) -> str:
+        return "cuda"
+
+    @property
+    def torch_device_type(self) -> str:
+        return "cuda"
+
+    @property
+    def nixl_mem_type(self) -> str:
+        return NIXL_ACCELERATOR_MEM_TYPE
+
+    def set_device(self, device_id: int) -> None:
+        torch.cuda.set_device(device_id)
+
+    def current_device(self) -> int:
+        return int(torch.cuda.current_device())
+
+    def synchronize(self, device_id: int | None = None) -> None:
+        if device_id is None:
+            torch.cuda.synchronize()
+        else:
+            torch.cuda.synchronize(device_id)
+
+    def empty_cache(self) -> None:
+        torch.cuda.empty_cache()
+
+    def torch_device(self, device_id: int) -> torch.device:
+        return torch.device(self.torch_device_type, device_id)
+
+    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
+        return bool(tensor.is_cuda)
+
+    def supports_rdma_p2p(self) -> bool:
+        return True
+
+    def supports_pool_reg(self) -> bool:
+        return True
+
+    def supports_vmm(self) -> bool:
+        return True
+
+    def supports_gds(self) -> bool:
+        return True

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -16,7 +16,7 @@ import torch
 
 from ... import p2p_pb2
 from ...adapter import EngineAdapter
-from ...accelerator_backend import accelerator_backend_for
+from ...accelerators import accelerator_backend_for
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -16,6 +16,7 @@ import torch
 
 from ... import p2p_pb2
 from ...adapter import EngineAdapter
+from ...accelerator_backend import accelerator_backend_for
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 
@@ -40,6 +41,7 @@ class SglangAdapter(EngineAdapter):
         self.model_config = model_config
         self.device_config = device_config
         self.target_device = torch.device(device_config.device)
+        self.accelerator_backend = accelerator_backend_for(self.target_device)
 
     def build_identity(self) -> p2p_pb2.SourceIdentity:
         return build_sglang_source_identity(
@@ -147,8 +149,7 @@ class SglangAdapter(EngineAdapter):
         result.value = None
         result.model = None
         del old_value
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        self.accelerator_backend.empty_cache()
 
         logger.info(
             "[Worker %s] Re-initializing SGLang model after failed strategy",
@@ -341,4 +342,5 @@ def build_sglang_load_context(
         ),
         worker_id=uuid.uuid4().hex[:8],
         adapter=adapter,
+        accelerator_backend=adapter.accelerator_backend,
     )

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Iterator
 import torch
 
 from ...adapter import EngineAdapter
-from ...accelerator_backend import accelerator_backend_for
+from ...accelerators import accelerator_backend_for
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 from ...metadata.publish import build_source_identity

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Iterator
 import torch
 
 from ...adapter import EngineAdapter
+from ...accelerator_backend import accelerator_backend_for
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 from ...metadata.publish import build_source_identity
@@ -41,6 +42,7 @@ class VllmAdapter(EngineAdapter):
         self.model_config = model_config
         self.load_config = vllm_config.load_config
         self.target_device = self._resolve_target_device()
+        self.accelerator_backend = accelerator_backend_for(self.target_device)
 
     def build_identity(self):
         return build_source_identity(self.vllm_config, self.model_config)
@@ -147,7 +149,7 @@ class VllmAdapter(EngineAdapter):
         result.value = None
         result.model = None
         del old_value
-        torch.cuda.empty_cache()
+        self.accelerator_backend.empty_cache()
         self._reset_compilation_state()
         logger.info(
             "[Worker %s] Re-initializing vLLM model after failed strategy",
@@ -306,4 +308,5 @@ def build_vllm_load_context(vllm_config, model_config) -> LoadContext:
         mx_client=create_metadata_client(worker_rank=worker_rank),
         worker_id=uuid.uuid4().hex[:8],
         adapter=adapter,
+        accelerator_backend=adapter.accelerator_backend,
     )

--- a/modelexpress_client/python/modelexpress/gds_loader.py
+++ b/modelexpress_client/python/modelexpress/gds_loader.py
@@ -26,7 +26,7 @@ from typing import Iterator
 
 import torch
 
-from .accelerator_backend import AcceleratorBackend, CudaAcceleratorBackend
+from .accelerators import AcceleratorBackend, CudaAcceleratorBackend
 from .gds_transfer import GdsTransferManager, is_gds_available
 
 logger = logging.getLogger("modelexpress.gds_loader")

--- a/modelexpress_client/python/modelexpress/gds_loader.py
+++ b/modelexpress_client/python/modelexpress/gds_loader.py
@@ -26,7 +26,7 @@ from typing import Iterator
 
 import torch
 
-from .accelerators import AcceleratorBackend, CudaAcceleratorBackend
+from .accelerators import AcceleratorBackend
 from .gds_transfer import GdsTransferManager, is_gds_available
 
 logger = logging.getLogger("modelexpress.gds_loader")
@@ -57,7 +57,7 @@ class MxGdsLoader:
 
     Usage::
 
-        loader = MxGdsLoader()
+        loader = MxGdsLoader(accelerator_backend)
         tensors = loader.load("/path/to/model")
 
         # Or stream per-file:
@@ -65,10 +65,10 @@ class MxGdsLoader:
             process(name, tensor)
     """
 
-    def __init__(self, accelerator_backend: AcceleratorBackend | None = None):
+    def __init__(self, accelerator_backend: AcceleratorBackend):
         self._gds_manager: GdsTransferManager | None = None
         self._device_id: int | None = None
-        self._accelerator_backend = accelerator_backend or CudaAcceleratorBackend()
+        self._accelerator_backend = accelerator_backend
 
     # ------------------------------------------------------------------
     # Public API

--- a/modelexpress_client/python/modelexpress/gds_loader.py
+++ b/modelexpress_client/python/modelexpress/gds_loader.py
@@ -7,8 +7,8 @@ Framework-agnostic GDS model loader.
 Loads model weights from safetensors files directly to GPU memory via NIXL's
 GDS (GPUDirect Storage) backend, bypassing CPU bounce buffers entirely.
 
-The target GPU is determined from torch.cuda.current_device(), matching
-the behavior of vLLM/sglang default loaders.
+The target GPU is determined from the active accelerator backend, matching the
+behavior of vLLM/sglang default loaders on CUDA.
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ from typing import Iterator
 
 import torch
 
+from .accelerator_backend import AcceleratorBackend, CudaAcceleratorBackend
 from .gds_transfer import GdsTransferManager, is_gds_available
 
 logger = logging.getLogger("modelexpress.gds_loader")
@@ -64,9 +65,10 @@ class MxGdsLoader:
             process(name, tensor)
     """
 
-    def __init__(self):
+    def __init__(self, accelerator_backend: AcceleratorBackend | None = None):
         self._gds_manager: GdsTransferManager | None = None
         self._device_id: int | None = None
+        self._accelerator_backend = accelerator_backend or CudaAcceleratorBackend()
 
     # ------------------------------------------------------------------
     # Public API
@@ -100,7 +102,7 @@ class MxGdsLoader:
                 "GDS is not available. Check nvidia_fs module and libcufile."
             )
 
-        self._device_id = torch.cuda.current_device()
+        self._device_id = self._accelerator_backend.current_device()
         self._ensure_gds_manager()
 
         file_tensor_map = self._resolve_safetensors_files(model_path)
@@ -177,7 +179,10 @@ class MxGdsLoader:
             return
 
         agent_name = f"mx-gds-{self._device_id}-{uuid.uuid4().hex[:8]}"
-        self._gds_manager = GdsTransferManager(agent_name=agent_name)
+        self._gds_manager = GdsTransferManager(
+            agent_name=agent_name,
+            accelerator_backend=self._accelerator_backend,
+        )
         self._gds_manager.initialize()
         logger.info("GDS manager initialized for device %d", self._device_id)
 
@@ -287,7 +292,7 @@ class MxGdsLoader:
         All tensors are submitted in a single batch so GDS_MT threads
         work in parallel. Reads go directly into result tensors.
         """
-        device = torch.device("cuda", self._device_id)
+        device = self._accelerator_backend.torch_device(self._device_id)
 
         sorted_names = sorted(
             tensor_infos.keys(),

--- a/modelexpress_client/python/modelexpress/gds_transfer.py
+++ b/modelexpress_client/python/modelexpress/gds_transfer.py
@@ -22,6 +22,8 @@ from typing import Any
 
 import torch
 
+from .accelerator_backend import AcceleratorBackend, CudaAcceleratorBackend
+
 logger = logging.getLogger("modelexpress.gds_transfer")
 
 NIXL_AVAILABLE = False
@@ -96,10 +98,11 @@ class GdsTransferManager:
             gds.batch_load_file(fd, file_size, tensor_list, device)
     """
 
-    def __init__(self, agent_name: str):
+    def __init__(self, agent_name: str, accelerator_backend: AcceleratorBackend | None = None):
         self._agent_name = agent_name
         self._device_id: int | None = None
         self._agent: Any = None
+        self._accelerator_backend = accelerator_backend or CudaAcceleratorBackend()
         override = os.environ.get("MX_GDS_MAX_CHUNK_KB")
         self._max_chunk_size = int(override) * 1024 if override else _DEFAULT_MAX_CHUNK
 
@@ -124,7 +127,7 @@ class GdsTransferManager:
         if self._agent is not None:
             return
 
-        self._device_id = torch.cuda.current_device()
+        self._device_id = self._accelerator_backend.current_device()
 
         thread_count = int(os.environ.get("MX_GDS_THREADS", "8"))
         config = NixlAgentConfig(backends=["GDS_MT"], num_threads=thread_count)

--- a/modelexpress_client/python/modelexpress/gds_transfer.py
+++ b/modelexpress_client/python/modelexpress/gds_transfer.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import torch
 
-from .accelerators import AcceleratorBackend, CudaAcceleratorBackend
+from .accelerators import AcceleratorBackend
 
 logger = logging.getLogger("modelexpress.gds_transfer")
 
@@ -94,15 +94,15 @@ class GdsTransferManager:
     a single NIXL transfer so GDS_MT threads work in parallel.
 
     Usage as context manager:
-        with GdsTransferManager(agent_name="mx-gds-0") as gds:
+        with GdsTransferManager(agent_name="mx-gds-0", accelerator_backend=backend) as gds:
             gds.batch_load_file(fd, file_size, tensor_list, device)
     """
 
-    def __init__(self, agent_name: str, accelerator_backend: AcceleratorBackend | None = None):
+    def __init__(self, agent_name: str, accelerator_backend: AcceleratorBackend):
         self._agent_name = agent_name
         self._device_id: int | None = None
         self._agent: Any = None
-        self._accelerator_backend = accelerator_backend or CudaAcceleratorBackend()
+        self._accelerator_backend = accelerator_backend
         override = os.environ.get("MX_GDS_MAX_CHUNK_KB")
         self._max_chunk_size = int(override) * 1024 if override else _DEFAULT_MAX_CHUNK
 

--- a/modelexpress_client/python/modelexpress/gds_transfer.py
+++ b/modelexpress_client/python/modelexpress/gds_transfer.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import torch
 
-from .accelerator_backend import AcceleratorBackend, CudaAcceleratorBackend
+from .accelerators import AcceleratorBackend, CudaAcceleratorBackend
 
 logger = logging.getLogger("modelexpress.gds_transfer")
 

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -11,7 +11,6 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
-import torch
 import torch.nn as nn
 
 from ..nixl_transfer import is_nixl_available
@@ -20,6 +19,7 @@ from ..metadata.publish import publish_metadata_and_ready
 from .context import LoadContext, LoadResult
 
 if TYPE_CHECKING:
+    from ..accelerator_backend import AcceleratorBackend
     from ..nixl_transfer import NixlTransferManager
 
 logger = logging.getLogger("modelexpress.load_strategy")
@@ -82,7 +82,11 @@ class LoadStrategy(ABC):
 
 
 def _init_nixl_manager(
-    global_rank: int, device_id: int, role: str, listen_port: int = 0,
+    global_rank: int,
+    device_id: int,
+    role: str,
+    listen_port: int = 0,
+    accelerator_backend: AcceleratorBackend | None = None,
 ) -> NixlTransferManager:
     """Create and initialize a NIXL transfer manager."""
     from ..nixl_transfer import NixlTransferManager
@@ -93,6 +97,7 @@ def _init_nixl_manager(
         agent_name=agent_name,
         device_id=device_id,
         listen_port=listen_port,
+        accelerator_backend=accelerator_backend,
     )
     manager.initialize()
     logger.debug(f"[Worker {global_rank}] NIXL manager initialized")
@@ -181,7 +186,11 @@ def register_tensors(
             base_port = int(os.environ.get("MX_METADATA_PORT", "5555"))
             listen_port = base_port + ctx.device_id
             ctx.nixl_manager = _init_nixl_manager(
-                ctx.global_rank, ctx.device_id, "auto", listen_port
+                ctx.global_rank,
+                ctx.device_id,
+                "auto",
+                listen_port,
+                ctx.accelerator_backend,
             )
 
         if not ctx.nixl_manager.tensor_descriptors:

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -19,7 +19,7 @@ from ..metadata.publish import publish_metadata_and_ready
 from .context import LoadContext, LoadResult
 
 if TYPE_CHECKING:
-    from ..accelerator_backend import AcceleratorBackend
+    from ..accelerators import AcceleratorBackend
     from ..nixl_transfer import NixlTransferManager
 
 logger = logging.getLogger("modelexpress.load_strategy")

--- a/modelexpress_client/python/modelexpress/load_strategy/context.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/context.py
@@ -13,7 +13,7 @@ import torch.nn as nn
 
 from .. import p2p_pb2
 from ..client import MxClientBase
-from ..accelerator_backend import AcceleratorBackend, CudaAcceleratorBackend
+from ..accelerators import AcceleratorBackend, CudaAcceleratorBackend
 
 if TYPE_CHECKING:
     from ..adapter import EngineAdapter

--- a/modelexpress_client/python/modelexpress/load_strategy/context.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/context.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 
 from .. import p2p_pb2
 from ..client import MxClientBase
+from ..accelerator_backend import AcceleratorBackend, CudaAcceleratorBackend
 
 if TYPE_CHECKING:
     from ..adapter import EngineAdapter
@@ -61,6 +62,7 @@ class LoadContext:
     mx_client: MxClientBase
     worker_id: str
     adapter: EngineAdapter | None = None
+    accelerator_backend: AcceleratorBackend = field(default_factory=CudaAcceleratorBackend)
     nixl_manager: NixlTransferManager | None = None
     tensors: dict[str, torch.Tensor] = field(default_factory=dict)
     # When MX_VMM_ARENA=1, maybe_enter_vmm_arena populates this with the

--- a/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/gds_strategy.py
@@ -23,6 +23,12 @@ class GdsStrategy(LoadStrategy):
     def is_available(self, ctx: LoadContext) -> bool:
         if not super().is_available(ctx):
             return False
+        if not ctx.accelerator_backend.supports_gds():
+            logger.info(
+                f"[Worker {ctx.global_rank}] GDS not supported on "
+                f"{ctx.accelerator_backend.name}, skipping"
+            )
+            return False
         from ..gds_transfer import is_gds_available
         available = is_gds_available()
         if not available:
@@ -34,7 +40,7 @@ class GdsStrategy(LoadStrategy):
         from ..gds_loader import MxGdsLoader
 
         logger.info(f"[Worker {ctx.global_rank}] Attempting GDS loading...")
-        gds_loader = MxGdsLoader()
+        gds_loader = MxGdsLoader(accelerator_backend=ctx.accelerator_backend)
         try:
             try:
                 use_tqdm = getattr(ctx.load_config, "use_tqdm_on_load", True)

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -58,6 +58,13 @@ class RdmaStrategy(LoadStrategy):
         if not is_nixl_available():
             return False
 
+        if not ctx.accelerator_backend.supports_rdma_p2p():
+            logger.info(
+                f"[Worker {ctx.global_rank}] Backend "
+                f"{ctx.accelerator_backend.name} does not support RDMA P2P, skipping"
+            )
+            return False
+
         # Decentralized backends (k8s-service) serve their own
         # metadata; skip the central-server precondition for them.
         # Strict `is True` check so MagicMock's auto-attribute doesn't

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -10,8 +10,6 @@ import os
 import random
 import time
 
-import torch
-
 from ..adapter import EngineAdapter, StrategyFailed
 from .base import (
     LoadContext,
@@ -302,7 +300,7 @@ class RdmaStrategy(LoadStrategy):
             f"{transfer_time:.3f}s, {bandwidth_gbps:.1f} Gbps"
         )
 
-        torch.cuda.synchronize()
+        ctx.accelerator_backend.synchronize()
 
         total_time = time.perf_counter() - receive_start
         logger.info(f"[Worker {ctx.global_rank}] [TIMING] Total receive time: {total_time:.2f}s")

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -22,6 +22,10 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from . import ucx_utils
+from .accelerator_backend import (
+    AcceleratorBackend,
+    CudaAcceleratorBackend,
+)
 from .types import ManifestMismatchError, TensorDescriptor
 
 if TYPE_CHECKING:
@@ -42,7 +46,6 @@ except ImportError:
 
 SUPPORTED_NIXL_BACKENDS = ("UCX", "LIBFABRIC")
 DEFAULT_NIXL_BACKEND = "UCX"
-NIXL_ACCELERATOR_MEM_TYPE = "VRAM"
 NIXL_DRAM_MEM_TYPE = "DRAM"
 
 
@@ -89,10 +92,17 @@ class NixlTransferManager:
         device_id: GPU device ID for this worker
     """
 
-    def __init__(self, agent_name: str, device_id: int, listen_port: int | None = None):
+    def __init__(
+        self,
+        agent_name: str,
+        device_id: int,
+        listen_port: int | None = None,
+        accelerator_backend: AcceleratorBackend | None = None,
+    ):
         self._agent_name = agent_name
         self._device_id = device_id
         self._listen_port = listen_port
+        self._accelerator_backend = accelerator_backend or CudaAcceleratorBackend()
 
         self._backend = _resolve_nixl_backend()
         self._backends = [self._backend]
@@ -135,7 +145,7 @@ class NixlTransferManager:
         if self._agent is not None:
             return
 
-        torch.cuda.set_device(self._device_id)
+        self._accelerator_backend.set_device(self._device_id)
 
         # Let UCX auto-detect transports (RoCE, TCP, etc).
         # OMPI_MCA_pml=ob1 keeps MPI on TCP independently.
@@ -256,7 +266,15 @@ class NixlTransferManager:
         # Phase 1: Discover CUDA allocation boundaries (if pool reg enabled)
         alloc_discovery_start = time.perf_counter()
         if _pool_reg_enabled():
-            allocations = self._find_cuda_allocations(tensor_descriptors)
+            if self._accelerator_backend.supports_pool_reg():
+                allocations = self._find_cuda_allocations(tensor_descriptors)
+            else:
+                allocations = None
+                logger.warning(
+                    "MX_POOL_REG=1 set but %s does not support pool "
+                    "registration; using per-tensor registration",
+                    self._accelerator_backend.name,
+                )
         else:
             allocations = None
             logger.info("Pool registration disabled (MX_POOL_REG != '1'), using per-tensor registration")
@@ -271,7 +289,7 @@ class NixlTransferManager:
             ]
             self._agent.register_memory(
                 alloc_tuples,
-                mem_type=NIXL_ACCELERATOR_MEM_TYPE,
+                mem_type=self._accelerator_backend.nixl_mem_type,
                 backends=self._backends,
             )
             reg_count = len(allocations)
@@ -343,10 +361,18 @@ class NixlTransferManager:
             )
             return self.register_tensors(tensors)
 
+        if not self._accelerator_backend.supports_vmm_arena():
+            logger.warning(
+                "%s does not support VMM arena registration; falling back "
+                "to per-tensor registration",
+                self._accelerator_backend.name,
+            )
+            return self.register_tensors(tensors)
+
         nixl_reg_start = time.perf_counter()
         self._agent.register_memory(
             [(base, used, self._device_id, "")],
-            mem_type=NIXL_ACCELERATOR_MEM_TYPE,
+            mem_type=self._accelerator_backend.nixl_mem_type,
             backends=self._backends,
         )
         nixl_reg_time = time.perf_counter() - nixl_reg_start
@@ -491,7 +517,7 @@ class NixlTransferManager:
             raise RuntimeError("NIXL agent not initialized")
 
         start_time = time.perf_counter()
-        torch.cuda.set_device(self._device_id)
+        self._accelerator_backend.set_device(self._device_id)
 
         if remote_agent_name is None:
             add_start = time.perf_counter()
@@ -556,13 +582,13 @@ class NixlTransferManager:
         src_prepped = self._agent.prep_xfer_dlist(
             agent_name=remote_agent_name,
             xfer_list=remote_descs,
-            mem_type=NIXL_ACCELERATOR_MEM_TYPE,
+            mem_type=self._accelerator_backend.nixl_mem_type,
             backends=self._backends,
         )
         dst_prepped = self._agent.prep_xfer_dlist(
             agent_name="",
             xfer_list=local_descs,
-            mem_type=NIXL_ACCELERATOR_MEM_TYPE,
+            mem_type=self._accelerator_backend.nixl_mem_type,
             backends=self._backends,
         )
         prep_time = time.perf_counter() - prep_start
@@ -597,9 +623,9 @@ class NixlTransferManager:
                 raise RuntimeError(f"Transfer failed with status {status}")
             time.sleep(0.001)
 
-        # CRITICAL: Synchronize CUDA to ensure RDMA writes are visible.
-        # GPUDirect RDMA writes bypass CUDA streams, so we must sync.
-        torch.cuda.synchronize(self._device_id)
+        # CRITICAL: Synchronize the device to ensure RDMA writes are visible.
+        # GPUDirect RDMA writes bypass torch streams, so we must sync.
+        self._accelerator_backend.synchronize(self._device_id)
 
         duration = time.perf_counter() - start_time
         bandwidth_gbps = (total_bytes * 8) / (duration * 1e9) if duration > 0 else 0.0

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -361,7 +361,7 @@ class NixlTransferManager:
             )
             return self.register_tensors(tensors)
 
-        if not self._accelerator_backend.supports_vmm_arena():
+        if not self._accelerator_backend.supports_vmm():
             logger.warning(
                 "%s does not support VMM arena registration; falling back "
                 "to per-tensor registration",

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from . import ucx_utils
-from .accelerator_backend import (
+from .accelerators import (
     AcceleratorBackend,
     CudaAcceleratorBackend,
 )

--- a/modelexpress_client/python/modelexpress/vmm/runtime.py
+++ b/modelexpress_client/python/modelexpress/vmm/runtime.py
@@ -107,7 +107,7 @@ def maybe_enter_vmm_arena(ctx: "LoadContext") -> Iterator[None]:
         yield
         return
 
-    if not ctx.accelerator_backend.supports_vmm_arena():
+    if not ctx.accelerator_backend.supports_vmm():
         logger.warning(
             "[Worker %d] MX_VMM_ARENA=1 set but %s does not support VMM "
             "arena; falling back to the non-arena load path.",

--- a/modelexpress_client/python/modelexpress/vmm/runtime.py
+++ b/modelexpress_client/python/modelexpress/vmm/runtime.py
@@ -107,6 +107,17 @@ def maybe_enter_vmm_arena(ctx: "LoadContext") -> Iterator[None]:
         yield
         return
 
+    accelerator_backend = getattr(ctx, "accelerator_backend", None)
+    if accelerator_backend is not None and not accelerator_backend.supports_vmm_arena():
+        logger.warning(
+            "[Worker %d] MX_VMM_ARENA=1 set but %s does not support VMM "
+            "arena; falling back to the non-arena load path.",
+            ctx.global_rank,
+            accelerator_backend.name,
+        )
+        yield
+        return
+
     # The previous chunked-arena design accepted MX_VMM_ARENA_BYTES and
     # MX_VMM_ARENA_CHUNK_BYTES env vars. The current design ignores
     # both (16 TiB VA reserve is unconditional, no chunked

--- a/modelexpress_client/python/modelexpress/vmm/runtime.py
+++ b/modelexpress_client/python/modelexpress/vmm/runtime.py
@@ -107,13 +107,12 @@ def maybe_enter_vmm_arena(ctx: "LoadContext") -> Iterator[None]:
         yield
         return
 
-    accelerator_backend = getattr(ctx, "accelerator_backend", None)
-    if accelerator_backend is not None and not accelerator_backend.supports_vmm_arena():
+    if not ctx.accelerator_backend.supports_vmm_arena():
         logger.warning(
             "[Worker %d] MX_VMM_ARENA=1 set but %s does not support VMM "
             "arena; falling back to the non-arena load path.",
             ctx.global_rank,
-            accelerator_backend.name,
+            ctx.accelerator_backend.name,
         )
         yield
         return

--- a/modelexpress_client/python/tests/conftest.py
+++ b/modelexpress_client/python/tests/conftest.py
@@ -57,7 +57,7 @@ class MockAcceleratorBackend:
     def supports_pool_reg(self) -> bool:
         return self.pool_reg
 
-    def supports_vmm_arena(self) -> bool:
+    def supports_vmm(self) -> bool:
         return self.vmm_arena
 
     def supports_gds(self) -> bool:

--- a/modelexpress_client/python/tests/conftest.py
+++ b/modelexpress_client/python/tests/conftest.py
@@ -27,7 +27,7 @@ class MockAcceleratorBackend:
     nixl_mem_type: str = "VRAM"
     rdma_p2p: bool = False
     pool_reg: bool = False
-    vmm_arena: bool = False
+    vmm: bool = False
     gds: bool = False
     set_device_calls: list[int] = field(default_factory=list)
     synchronize_calls: list[int | None] = field(default_factory=list)
@@ -58,7 +58,7 @@ class MockAcceleratorBackend:
         return self.pool_reg
 
     def supports_vmm(self) -> bool:
-        return self.vmm_arena
+        return self.vmm
 
     def supports_gds(self) -> bool:
         return self.gds

--- a/modelexpress_client/python/tests/conftest.py
+++ b/modelexpress_client/python/tests/conftest.py
@@ -25,6 +25,7 @@ class MockAcceleratorBackend:
     name: str = "mock"
     torch_device_type: str = "mock"
     nixl_mem_type: str = "VRAM"
+    rdma_p2p: bool = False
     pool_reg: bool = False
     vmm_arena: bool = False
     gds: bool = False
@@ -49,6 +50,9 @@ class MockAcceleratorBackend:
 
     def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
         return tensor.device.type == self.torch_device_type
+
+    def supports_rdma_p2p(self) -> bool:
+        return self.rdma_p2p
 
     def supports_pool_reg(self) -> bool:
         return self.pool_reg

--- a/modelexpress_client/python/tests/conftest.py
+++ b/modelexpress_client/python/tests/conftest.py
@@ -12,9 +12,57 @@ validation works correctly.
 
 import sys
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from unittest.mock import MagicMock
 
+import pytest
+import torch
 import torch.nn as nn
+
+
+@dataclass
+class MockAcceleratorBackend:
+    name: str = "mock"
+    torch_device_type: str = "mock"
+    nixl_mem_type: str = "VRAM"
+    pool_reg: bool = False
+    vmm_arena: bool = False
+    gds: bool = False
+    set_device_calls: list[int] = field(default_factory=list)
+    synchronize_calls: list[int | None] = field(default_factory=list)
+    empty_cache_calls: int = 0
+
+    def set_device(self, device_id: int) -> None:
+        self.set_device_calls.append(device_id)
+
+    def current_device(self) -> int:
+        return 0
+
+    def synchronize(self, device_id: int | None = None) -> None:
+        self.synchronize_calls.append(device_id)
+
+    def empty_cache(self) -> None:
+        self.empty_cache_calls += 1
+
+    def torch_device(self, device_id: int) -> torch.device:
+        return torch.device("cpu")
+
+    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
+        return tensor.device.type == self.torch_device_type
+
+    def supports_pool_reg(self) -> bool:
+        return self.pool_reg
+
+    def supports_vmm_arena(self) -> bool:
+        return self.vmm_arena
+
+    def supports_gds(self) -> bool:
+        return self.gds
+
+
+@pytest.fixture
+def mock_accelerator_backend_cls():
+    return MockAcceleratorBackend
 
 
 def _maybe_mock_vllm():

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -128,7 +128,7 @@ class TestAcceleratorCapabilityGates:
             def registered_range(self):
                 return 0x1000, 0x2000
 
-        backend = mock_accelerator_backend_cls(vmm_arena=False)
+        backend = mock_accelerator_backend_cls(vmm=False)
         mgr = self._make_manager(backend)
         tensor = torch.zeros(1)
 
@@ -216,7 +216,7 @@ class TestAcceleratorCapabilityGates:
             target_device = nullcontext()
 
         ctx = Ctx()
-        ctx.accelerator_backend = mock_accelerator_backend_cls(vmm_arena=False)
+        ctx.accelerator_backend = mock_accelerator_backend_cls(vmm=False)
 
         entered = False
         with vmm_runtime.maybe_enter_vmm_arena(ctx):

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -30,7 +30,7 @@ class TestCudaAcceleratorBackend:
         assert backend.nixl_mem_type == "VRAM"
         assert backend.supports_rdma_p2p() is True
         assert backend.supports_pool_reg() is True
-        assert backend.supports_vmm_arena() is True
+        assert backend.supports_vmm() is True
         assert backend.supports_gds() is True
 
     def test_cuda_backend_delegates_torch_calls(self, monkeypatch):

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -28,6 +28,7 @@ class TestCudaAcceleratorBackend:
         assert backend.name == "cuda"
         assert backend.torch_device_type == "cuda"
         assert backend.nixl_mem_type == "VRAM"
+        assert backend.supports_rdma_p2p() is True
         assert backend.supports_pool_reg() is True
         assert backend.supports_vmm_arena() is True
         assert backend.supports_gds() is True

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for accelerator backend abstractions and capability gates."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from modelexpress.accelerator_backend import (
+    CudaAcceleratorBackend,
+    accelerator_backend_for,
+)
+from modelexpress.adapter import EngineAdapter
+from modelexpress.load_strategy.context import LoadResult
+from modelexpress.nixl_transfer import NixlTransferManager
+from modelexpress.types import TensorDescriptor
+
+
+class TestCudaAcceleratorBackend:
+    def test_cuda_backend_uses_nixl_vram_segment(self):
+        backend = CudaAcceleratorBackend()
+
+        assert backend.name == "cuda"
+        assert backend.torch_device_type == "cuda"
+        assert backend.nixl_mem_type == "VRAM"
+        assert backend.supports_pool_reg() is True
+        assert backend.supports_vmm_arena() is True
+        assert backend.supports_gds() is True
+
+    def test_cuda_backend_delegates_torch_calls(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            torch.cuda,
+            "set_device",
+            lambda device_id: calls.append(("set", device_id)),
+        )
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: 3)
+        monkeypatch.setattr(
+            torch.cuda,
+            "synchronize",
+            lambda device_id=None: calls.append(("sync", device_id)),
+        )
+        monkeypatch.setattr(
+            torch.cuda,
+            "empty_cache",
+            lambda: calls.append(("empty", None)),
+        )
+
+        backend = CudaAcceleratorBackend()
+        backend.set_device(2)
+        assert backend.current_device() == 3
+        backend.synchronize(2)
+        backend.synchronize()
+        backend.empty_cache()
+
+        assert calls == [
+            ("set", 2),
+            ("sync", 2),
+            ("sync", None),
+            ("empty", None),
+        ]
+
+    def test_cuda_backend_is_accel_tensor_uses_tensor_cuda_flag(self):
+        backend = CudaAcceleratorBackend()
+
+        assert backend.is_accel_tensor(torch.zeros(1)) is False
+
+        class FakeCudaTensor:
+            is_cuda = True
+
+        assert backend.is_accel_tensor(FakeCudaTensor()) is True
+
+    def test_accelerator_backend_for_cuda(self):
+        assert isinstance(
+            accelerator_backend_for(torch.device("cuda:0")),
+            CudaAcceleratorBackend,
+        )
+
+    def test_accelerator_backend_for_rejects_unsupported_device(self):
+        with pytest.raises(ValueError, match="Unsupported accelerator backend"):
+            accelerator_backend_for(torch.device("cpu"))
+
+
+class TestAcceleratorCapabilityGates:
+    def _make_manager(self, backend) -> NixlTransferManager:
+        mgr = NixlTransferManager(
+            agent_name="test",
+            device_id=0,
+            accelerator_backend=backend,
+        )
+        mgr._agent = MagicMock()
+        mgr._agent.get_agent_metadata.return_value = b"metadata"
+        return mgr
+
+    def test_pool_reg_unsupported_falls_back_to_tensor_registration(
+        self,
+        monkeypatch,
+        mock_accelerator_backend_cls,
+    ):
+        backend = mock_accelerator_backend_cls(pool_reg=False)
+        mgr = self._make_manager(backend)
+        tensor = torch.zeros(4, dtype=torch.float32)
+        monkeypatch.setenv("MX_POOL_REG", "1")
+
+        with patch.object(
+            NixlTransferManager,
+            "_find_cuda_allocations",
+            side_effect=AssertionError("pool discovery should not run"),
+        ):
+            assert mgr.register_tensors({"w": tensor}) == b"metadata"
+
+        mgr._agent.register_memory.assert_called_once_with(
+            [tensor],
+            backends=["UCX"],
+        )
+
+    def test_vmm_arena_unsupported_falls_back_to_tensor_registration(
+        self,
+        mock_accelerator_backend_cls,
+    ):
+        class FakeArena:
+            def registered_range(self):
+                return 0x1000, 0x2000
+
+        backend = mock_accelerator_backend_cls(vmm_arena=False)
+        mgr = self._make_manager(backend)
+        tensor = torch.zeros(1)
+
+        assert mgr.register_arena(FakeArena(), {"w": tensor}) == b"metadata"
+
+        mgr._agent.register_memory.assert_called_once_with(
+            [tensor],
+            backends=["UCX"],
+        )
+
+    def test_receive_uses_backend_device_ops_and_mem_type(
+        self,
+        mock_accelerator_backend_cls,
+    ):
+        backend = mock_accelerator_backend_cls(nixl_mem_type="VRAM")
+        mgr = self._make_manager(backend)
+        local = torch.zeros(4, dtype=torch.float32)
+        mgr._tensors = {"w": local}
+        mgr._agent.prep_xfer_dlist.side_effect = ["src", "dst"]
+        mgr._agent.make_prepped_xfer.return_value = "handle"
+        mgr._agent.check_xfer_state.return_value = "DONE"
+
+        bytes_transferred, tensor_count, _ = mgr.receive_from_source(
+            source_metadata=b"",
+            source_tensors=[
+                TensorDescriptor(
+                    name="w",
+                    addr=0x1000,
+                    size=local.numel() * local.element_size(),
+                    device_id=0,
+                    dtype=str(local.dtype),
+                )
+            ],
+            remote_agent_name="source",
+        )
+
+        assert bytes_transferred == local.numel() * local.element_size()
+        assert tensor_count == 1
+        assert backend.set_device_calls == [0]
+        assert backend.synchronize_calls == [0]
+
+    def test_gds_strategy_unavailable_when_backend_does_not_support_gds(
+        self,
+        mock_accelerator_backend_cls,
+    ):
+        from modelexpress.load_strategy.context import LoadContext
+        from modelexpress.load_strategy.gds_strategy import GdsStrategy
+
+        class Adapter(EngineAdapter):
+            def apply_weight_iter(self, result: LoadResult, weights_iter):
+                return result
+
+        ctx = LoadContext(
+            model_config=MagicMock(),
+            load_config=MagicMock(),
+            target_device=torch.device("cpu"),
+            global_rank=0,
+            worker_rank=0,
+            device_id=0,
+            identity=MagicMock(),
+            mx_client=MagicMock(),
+            worker_id="test-worker",
+            adapter=Adapter(),
+            accelerator_backend=mock_accelerator_backend_cls(gds=False),
+        )
+
+        with patch(
+            "modelexpress.gds_transfer.is_gds_available",
+            side_effect=AssertionError("system GDS probe should not run"),
+        ):
+            assert GdsStrategy().is_available(ctx) is False
+
+    def test_vmm_runtime_noops_when_backend_does_not_support_arena(
+        self,
+        monkeypatch,
+        mock_accelerator_backend_cls,
+    ):
+        from modelexpress.vmm import runtime as vmm_runtime
+
+        monkeypatch.setenv("MX_VMM_ARENA", "1")
+
+        class Ctx:
+            global_rank = 0
+            device_id = 0
+            target_device = nullcontext()
+
+        ctx = Ctx()
+        ctx.accelerator_backend = mock_accelerator_backend_cls(vmm_arena=False)
+
+        entered = False
+        with vmm_runtime.maybe_enter_vmm_arena(ctx):
+            entered = True
+
+        assert entered is True

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from modelexpress.accelerator_backend import (
+from modelexpress.accelerators import (
     CudaAcceleratorBackend,
     accelerator_backend_for,
 )

--- a/modelexpress_client/python/tests/test_gds_loader.py
+++ b/modelexpress_client/python/tests/test_gds_loader.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 import torch
 
+from modelexpress.accelerators import CudaAcceleratorBackend
 from modelexpress.adapter import EngineAdapter, StrategyFailed
 from modelexpress.load_strategy.context import LoadResult
 
@@ -98,14 +99,18 @@ class TestGdsTransferManager:
     def test_not_available_raises(self):
         with patch("modelexpress.gds_transfer.NIXL_AVAILABLE", False):
             from modelexpress.gds_transfer import GdsTransferManager
-            mgr = GdsTransferManager(agent_name="test")
+            mgr = GdsTransferManager(
+                agent_name="test", accelerator_backend=CudaAcceleratorBackend()
+            )
             with pytest.raises(RuntimeError, match="not available"):
                 mgr.initialize()
 
     def test_batch_load_requires_init(self):
         with patch("modelexpress.gds_transfer.NIXL_AVAILABLE", True):
             from modelexpress.gds_transfer import GdsTransferManager
-            mgr = GdsTransferManager(agent_name="test")
+            mgr = GdsTransferManager(
+                agent_name="test", accelerator_backend=CudaAcceleratorBackend()
+            )
             with pytest.raises(RuntimeError, match="not initialized"):
                 mgr.batch_load_file(0, 100, [], torch.device("cpu"))
 
@@ -135,7 +140,7 @@ class TestParseSafetensorsHeader:
             f.write(header_bytes)
             f.write(b"\x00" * 32)
 
-        loader = MxGdsLoader()
+        loader = MxGdsLoader(CudaAcceleratorBackend())
         parsed = loader._parse_safetensors_header(str(file_path))
         assert "weight" in parsed
         assert parsed["weight"]["dtype"] == "F32"
@@ -186,13 +191,13 @@ class TestResolveSafetensorsFiles:
         }
         (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
 
-        loader = MxGdsLoader()
+        loader = MxGdsLoader(CudaAcceleratorBackend())
         result = loader._resolve_safetensors_files(str(tmp_path))
         assert len(result) == 2
 
     def test_no_files_raises(self, tmp_path):
         from modelexpress.gds_loader import MxGdsLoader
-        loader = MxGdsLoader()
+        loader = MxGdsLoader(CudaAcceleratorBackend())
         with pytest.raises(FileNotFoundError, match=r"No \.safetensors"):
             loader._resolve_safetensors_files(str(tmp_path))
 

--- a/modelexpress_client/python/tests/test_nixl_backend.py
+++ b/modelexpress_client/python/tests/test_nixl_backend.py
@@ -5,9 +5,9 @@
 
 import pytest
 
+from modelexpress.accelerator_backend import NIXL_ACCELERATOR_MEM_TYPE
 from modelexpress.nixl_transfer import (
     DEFAULT_NIXL_BACKEND,
-    NIXL_ACCELERATOR_MEM_TYPE,
     NixlTransferManager,
     SUPPORTED_NIXL_BACKENDS,
     _resolve_nixl_backend,

--- a/modelexpress_client/python/tests/test_nixl_backend.py
+++ b/modelexpress_client/python/tests/test_nixl_backend.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from modelexpress.accelerator_backend import NIXL_ACCELERATOR_MEM_TYPE
+from modelexpress.accelerators import NIXL_ACCELERATOR_MEM_TYPE
 from modelexpress.nixl_transfer import (
     DEFAULT_NIXL_BACKEND,
     NixlTransferManager,

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, call
 import pytest
 import torch
 
-from modelexpress.accelerator_backend import NIXL_ACCELERATOR_MEM_TYPE
+from modelexpress.accelerators import NIXL_ACCELERATOR_MEM_TYPE
 from modelexpress.nixl_transfer import (
     NixlTransferManager,
     _pool_reg_enabled,

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -11,8 +11,8 @@ from unittest.mock import MagicMock, call
 import pytest
 import torch
 
+from modelexpress.accelerator_backend import NIXL_ACCELERATOR_MEM_TYPE
 from modelexpress.nixl_transfer import (
-    NIXL_ACCELERATOR_MEM_TYPE,
     NixlTransferManager,
     _pool_reg_enabled,
 )

--- a/modelexpress_client/python/tests/test_sglang_loader.py
+++ b/modelexpress_client/python/tests/test_sglang_loader.py
@@ -8,6 +8,7 @@ from types import ModuleType
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -44,6 +45,14 @@ def _device_config(**overrides):
     defaults = dict(device="cpu", gpu_id=0)
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _stub_accelerator_backend_selection(monkeypatch, mock_accelerator_backend_cls):
+    monkeypatch.setattr(
+        "modelexpress.engines.sglang.adapter.accelerator_backend_for",
+        lambda device: mock_accelerator_backend_cls(),
+    )
 
 
 def test_sglang_adapter_builds_identity_from_sglang_configs():

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -79,13 +79,20 @@ def test_vllm_device_id_uses_current_platform_device(monkeypatch):
     assert _get_vllm_device_id(torch.device("cuda")) == 2
 
 
-def test_vllm_is_cuda_alike_uses_current_platform(monkeypatch):
+def test_vllm_is_cuda_alike_uses_current_platform(
+    monkeypatch,
+    mock_accelerator_backend_cls,
+):
     fake_platforms = SimpleNamespace(
         current_platform=SimpleNamespace(
             is_cuda_alike=lambda: True,
         ),
     )
     monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
+    monkeypatch.setattr(
+        "modelexpress.engines.vllm.adapter.accelerator_backend_for",
+        lambda device: mock_accelerator_backend_cls(),
+    )
     adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
 
     assert adapter.is_cuda_alike() is True

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -29,6 +29,14 @@ def _vllm_config(*, rank: int, tp_size: int, pp_size: int):
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_accelerator_backend_selection(monkeypatch, mock_accelerator_backend_cls):
+    monkeypatch.setattr(
+        "modelexpress.engines.vllm.adapter.accelerator_backend_for",
+        lambda device: mock_accelerator_backend_cls(),
+    )
+
+
 def test_worker_rank_uses_torch_distributed_global_rank():
     config = _vllm_config(rank=2, tp_size=4, pp_size=2)
     device = torch.device("cuda", 0)

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -877,6 +877,28 @@ class TestRdmaStrategyAvailability:
         assert strategy.is_available(ctx) is False
 
     @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True)
+    def test_unavailable_when_backend_lacks_rdma_p2p(
+        self, _mock, mock_accelerator_backend_cls
+    ):
+        strategy = self._make_strategy()
+        ctx = _make_load_context(
+            accelerator_backend=mock_accelerator_backend_cls(rdma_p2p=False)
+        )
+        with patch.dict("os.environ", {"MX_SERVER_ADDRESS": "server:8001"}):
+            assert strategy.is_available(ctx) is False
+
+    @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True)
+    def test_available_when_backend_supports_rdma_p2p(
+        self, _mock, mock_accelerator_backend_cls
+    ):
+        strategy = self._make_strategy()
+        ctx = _make_load_context(
+            accelerator_backend=mock_accelerator_backend_cls(rdma_p2p=True)
+        )
+        with patch.dict("os.environ", {"MX_SERVER_ADDRESS": "server:8001"}):
+            assert strategy.is_available(ctx) is True
+
+    @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True)
     def test_available_when_decentralized_backend_and_no_server_address(self, _mock):
         # Decentralized backends (REQUIRES_P2P_METADATA=True) don't need
         # a central server, so the "no server configured" gate shouldn't

--- a/modelexpress_client/python/tests/test_vmm_hook.py
+++ b/modelexpress_client/python/tests/test_vmm_hook.py
@@ -13,6 +13,20 @@ from __future__ import annotations
 import pytest
 
 
+class _StubBackend:
+    """Minimal accelerator backend for VMM hook tests.
+
+    maybe_enter_vmm_arena only reads name + supports_vmm_arena(); these
+    tests exercise the path past the capability gate, so the gate returns
+    True.
+    """
+
+    name = "stub"
+
+    def supports_vmm_arena(self) -> bool:
+        return True
+
+
 # ---------------------------------------------------------------------------
 # C extension loadable on any host where it built
 # ---------------------------------------------------------------------------
@@ -273,6 +287,7 @@ class TestOptionalExtension:
         class _Ctx:
             global_rank = 0
             device_id = 0
+            accelerator_backend = _StubBackend()
 
         with caplog.at_level("WARNING", logger=vmm_runtime.logger.name):
             # Entering the context manager must not raise; the body must
@@ -302,6 +317,7 @@ class TestOptionalExtension:
         class _Ctx:
             global_rank = 0
             device_id = 0
+            accelerator_backend = _StubBackend()
 
         entered = False
         with vmm_runtime.maybe_enter_vmm_arena(_Ctx()):
@@ -329,6 +345,7 @@ class _StubCtx:
     device_id = 0
     target_device = _StubTargetDevice()
     vmm_arena = None
+    accelerator_backend = _StubBackend()
 
 
 class _StubCudaVmmBackend:

--- a/modelexpress_client/python/tests/test_vmm_hook.py
+++ b/modelexpress_client/python/tests/test_vmm_hook.py
@@ -16,14 +16,14 @@ import pytest
 class _StubBackend:
     """Minimal accelerator backend for VMM hook tests.
 
-    maybe_enter_vmm_arena only reads name + supports_vmm_arena(); these
+    maybe_enter_vmm_arena only reads name + supports_vmm(); these
     tests exercise the path past the capability gate, so the gate returns
     True.
     """
 
     name = "stub"
 
-    def supports_vmm_arena(self) -> bool:
+    def supports_vmm(self) -> bool:
         return True
 
 


### PR DESCRIPTION
## Summary

Introduce an `AcceleratorBackend` boundary to centralize accelerator-specific torch device operations and capability checks.

- Replace direct `torch.cuda.*` usage with a backend abstraction  
- Introduce capability gating for CUDA-only fast paths:
  - pool registration
  - VMM arena
  - GDS loading  
- Wire the backend through:
  - engine adapters
  - NIXL registration
  - RDMA receive synchronization
  - load strategies  

NIXL memory registration remains the canonical `VRAM` segment; the backend is used strictly for local runtime operations and policy decisions.

CUDA behavior is unchanged:
- CUDA remains the default backend  
- All capability gates return `true`  
- Non-CUDA paths remain inactive until additional backends are implemented  

Mock backend tests are added to validate fallback behavior without requiring a GPU.

---

## Why

`NixlTransferManager`, load strategies, and engine adapters previously called `torch.cuda.*` directly, creating scattered CUDA dependencies.

`AcceleratorBackend` introduces a clear abstraction boundary by:
- centralizing device-specific operations  
- consolidating policy for accelerator-specific optimizations  

Capability checks are enforced consistently at:
- the arena lifecycle boundary  
- the NIXL registration boundary  

`supports_vmm_arena()` acts as the single source of truth for VMM enablement.

This design removes CUDA-specific assumptions at the call sites and enables future support for non-CUDA accelerators by modifying only backend implementations.

**No functional change is expected on CUDA.**

---

## Scope

This PR is strictly scoped to introducing the backend abstraction and capability gating.

- ✅ Adds `AcceleratorBackend`  
- ✅ Replaces direct CUDA calls with backend interface  
- ✅ Introduces capability gates for CUDA-specific fast paths  

---

## Testing

```bash
python -m pytest \
  modelexpress_client/python/tests/test_accelerator_backend.py \
  modelexpress_client/python/tests/test_vllm_adapter.py \
  modelexpress_client/python/tests/test_sglang_loader.py -v
# 36 passed

python -m pytest \
  modelexpress_client/python/tests/test_nixl_backend.py \
  modelexpress_client/python/tests/test_pool_registration.py \
  modelexpress_client/python/tests/test_gds_loader.py \
  modelexpress_client/python/tests/test_vmm_hook.py -v
# 67 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced accelerator backend abstraction layer enabling flexible device-specific operation handling.
  * Standardized memory segment naming to use VRAM across all transfer operations.
  * Enhanced feature capability detection for GDS and VMM arena support through the accelerator backend.

* **Bug Fixes**
  * Improved fallback behavior when optional accelerator features are unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->