### PR TITLE
docs: Refresh getting started docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+---
+name: modelexpress
+description: Work on the public ModelExpress repository, including Rust server/client code, Python engine integrations, docs, Helm charts, examples, CI, and release/version alignment.
+license: Apache-2.0
+compatibility: Applies to the public ai-dynamo/modelexpress repository.
+metadata:
+  author: ModelExpress maintainers
+  version: "1.0"
+---
+
+# ModelExpress guide for agents
+
+ModelExpress is a Rust-based model weight management service with Python
+engine integrations for LLM inference. It handles model acquisition, cache
+coordination, metadata, and GPU-to-GPU weight transfer.
+
+## Non-negotiables
+
+- **Do not guess flags, defaults, release versions, image tags, or support
+  status.** Verify against source files, examples, CI, or published release
+  artifacts before documenting them.
+- **Keep public docs public.** Do not add internal runner names, internal
+  registries, private repo details, secrets, or company-only release mechanics
+  to public documentation.
+- **Do not bump public image references ahead of a published container.** If a
+  doc or example references `nvcr.io/nvidia/ai-dynamo/modelexpress-server:<tag>`,
+  verify that tag is the intended public image tag for the branch/release.
+- **Protect user work.** Check `git status --short --branch` before editing,
+  stage explicit paths, and never revert unrelated changes.
+
+## Source of truth hierarchy
+
+1. **This repository**
+   - `Cargo.toml` and `Cargo.lock` for Rust workspace versions.
+   - `modelexpress_client/python/pyproject.toml` and `uv.lock` for Python
+     client versions and dependencies.
+   - `helm/Chart.yaml`, `helm/values*.yaml`, and `helm/README.md` for chart
+     and server-image defaults.
+   - `ci/`, `.github/workflows/`, and integration Dockerfiles for tested
+     runtime combinations.
+   - `examples/` for user-facing deployment patterns.
+2. **Public release artifacts**
+   - GitHub release tags and public container images for release/image claims.
+3. **Upstream integrations**
+   - vLLM, SGLang, Dynamo, TensorRT-LLM, NIXL, Kubernetes, and cloud-provider
+     docs when documenting behavior owned by those projects.
+
+## Before you edit
+
+- Fetch current main for docs or release work: `git fetch origin main`.
+- Read the nearby file(s) before changing structure or tone.
+- Search before adding new docs; prefer updating an existing page or adding a
+  link over duplicating content.
+- Keep README focused on orientation. Put detailed support/status/version
+  information in `docs/COMPATIBILITY.md`.
+
+## Documentation standards
+
+- Position ModelExpress as usable standalone and with integrations such as
+  vLLM, SGLang, Dynamo, llm-d, Prime-RL, and similar systems. Dynamo is an
+  integration path, not a requirement.
+- Clearly label experimental or beta paths, especially TensorRT-LLM P2P,
+  GPUDirect Storage, SGLang ModelStreamer, and evolving RL/live-refit flows.
+- Keep commands copy/pasteable. Use consistent placeholders such as
+  `<namespace>`, `<your-registry>`, `<tag>`, and `<your-token>`.
+- For compatibility/version docs, derive pins from CI, Dockerfiles, Helm, and
+  examples. Do not invent untested combinations.
+- Use Mermaid for diagrams rather than ASCII art.
+
+## Version and compatibility checks
+
+When changing release docs, compatibility docs, Helm, or examples, check for
+drift across:
+
+- Rust workspace version in `Cargo.toml`.
+- Python package version in `modelexpress_client/python/pyproject.toml`.
+- Helm chart/app version in `helm/Chart.yaml`.
+- Helm image tags in `helm/values*.yaml` and `helm/README.md`.
+- Public server image references in `examples/**/*.yaml`.
+- Runtime pins in `ci/k8s/client/**/Dockerfile*`,
+  `examples/**/Dockerfile*`, and `.github/workflows/*.yml`.
+- Support coverage in `ci/TEST_PLAN.md` and `docs/COMPATIBILITY.md`.
+
+For detailed version-bump mechanics, read `CLAUDE.md` before editing release
+metadata or source-id fixtures.
+
+## Validation commands
+
+Run the narrowest relevant checks for the change. For docs/release metadata,
+prefer:
+
+```bash
+git diff --check
+find README.md docs CONTRIBUTING.md helm/README.md examples -name '*.md' -print0 \
+  | xargs -0 awk 'BEGIN{bad=0} /^```/{count[FILENAME]++} END{for (f in count) if (count[f] % 2) {print f ": odd fence count " count[f]; bad=1} exit bad}'
+OLD_TAG="REPLACE_WITH_OLD_TAG"
+rg -n "modelexpress-server:${OLD_TAG}|image\\.tag.*${OLD_TAG}|${OLD_TAG}" \
+  README.md docs helm examples .github ci -g '*.md' -g '*.yaml' -g '*.yml'
+helm lint helm
+```
+
+For Rust/Python code changes, use the build and test commands in `CLAUDE.md`
+and `CONTRIBUTING.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ---
-name: modelexpress
-description: Work on the public ModelExpress repository, including Rust server/client code, Python engine integrations, docs, Helm charts, examples, CI, and release/version alignment.
+name: modelexpress-user-guide
+description: Help users understand, deploy, operate, and debug public ModelExpress. Use for questions about MX concepts, quick starts, Kubernetes, Helm, metadata backends, engine integrations, ModelStreamer, P2P transfer, and troubleshooting.
 license: Apache-2.0
 compatibility: Applies to the public ai-dynamo/modelexpress repository.
 metadata:
@@ -8,96 +8,172 @@ metadata:
   version: "1.0"
 ---
 
-# ModelExpress guide for agents
+# ModelExpress guide for user-facing agents
 
-ModelExpress is a Rust-based model weight management service with Python
-engine integrations for LLM inference. It handles model acquisition, cache
-coordination, metadata, and GPU-to-GPU weight transfer.
+Use this file when helping a user get ModelExpress running or debug a
+deployment. Prefer clear operational guidance over internal implementation
+details.
 
-## Non-negotiables
+## What ModelExpress does
 
-- **Do not guess flags, defaults, release versions, image tags, or support
-  status.** Verify against source files, examples, CI, or published release
-  artifacts before documenting them.
-- **Keep public docs public.** Do not add internal runner names, internal
-  registries, private repo details, secrets, or company-only release mechanics
-  to public documentation.
-- **Do not bump public image references ahead of a published container.** If a
-  doc or example references `nvcr.io/nvidia/ai-dynamo/modelexpress-server:<tag>`,
-  verify that tag is the intended public image tag for the branch/release.
-- **Protect user work.** Check `git status --short --branch` before editing,
-  stage explicit paths, and never revert unrelated changes.
+ModelExpress manages model weights for LLM inference:
 
-## Source of truth hierarchy
+- downloads or resolves model artifacts from Hugging Face, object storage, or
+  local/PVC-backed paths
+- tracks model lifecycle and worker metadata with Redis or Kubernetes CRDs
+- lets new inference replicas receive weights from an already-loaded replica
+  through GPU-to-GPU P2P transfer
+- can also run ModelStreamer paths that stream from object storage without an
+  MX coordination server
 
-1. **This repository**
-   - `Cargo.toml` and `Cargo.lock` for Rust workspace versions.
-   - `modelexpress_client/python/pyproject.toml` and `uv.lock` for Python
-     client versions and dependencies.
-   - `helm/Chart.yaml`, `helm/values*.yaml`, and `helm/README.md` for chart
-     and server-image defaults.
-   - `ci/`, `.github/workflows/`, and integration Dockerfiles for tested
-     runtime combinations.
-   - `examples/` for user-facing deployment patterns.
-2. **Public release artifacts**
-   - GitHub release tags and public container images for release/image claims.
-3. **Upstream integrations**
-   - vLLM, SGLang, Dynamo, TensorRT-LLM, NIXL, Kubernetes, and cloud-provider
-     docs when documenting behavior owned by those projects.
+ModelExpress can run standalone. Dynamo is one integration path, not a
+requirement. vLLM uses `--load-format modelexpress`; SGLang uses
+`remote_instance` with the `modelexpress` backend; TensorRT-LLM P2P is a beta
+path using the documented patch/runtime flow.
 
-## Before you edit
+## Route users by goal
 
-- Fetch current main for docs or release work: `git fetch origin main`.
-- Read the nearby file(s) before changing structure or tone.
-- Search before adding new docs; prefer updating an existing page or adding a
-  link over duplicating content.
-- Keep README focused on orientation. Put detailed support/status/version
-  information in `docs/COMPATIBILITY.md`.
+| User goal | Send them to | Notes |
+|-----------|--------------|-------|
+| Try MX locally | [`README.md#quick-start`](README.md#quick-start), [`docs/CLI.md`](docs/CLI.md) | Good first path; basic health/cache commands do not require GPUs. |
+| Deploy MX server on Kubernetes | [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md), [`helm/README.md`](helm/README.md) | Choose Redis or Kubernetes CRD metadata before deploying. |
+| Speed up vLLM scale-out with P2P | [`examples/p2p_transfer_k8s/README.md`](examples/p2p_transfer_k8s/README.md) | Requires MX server, metadata backend, GPU workers, and RDMA-capable networking for the fast path. |
+| Use SGLang | [`docs/SGLANG.md`](docs/SGLANG.md) | Use an SGLang image with the ModelExpress delegation hook; install MX with `--no-deps`. |
+| Evaluate TensorRT-LLM P2P | [`examples/p2p_transfer_k8s/client/trtllm/`](examples/p2p_transfer_k8s/client/trtllm/) | Treat as beta and keep the TRT-LLM/Dynamo runtime requirements visible. |
+| Stream from object storage | [`examples/model_streamer_k8s/README.md`](examples/model_streamer_k8s/README.md) | ModelStreamer does not require MX server or RDMA by itself. |
+| Use Dynamo | [`examples/dynamo_model_cache_k8s/README.md`](examples/dynamo_model_cache_k8s/README.md), [`examples/dynamo_p2p_transfer_k8s/README.md`](examples/dynamo_p2p_transfer_k8s/README.md) | Explain Dynamo as optional orchestration around MX. |
+| Check support and tested versions | [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md), [`ci/TEST_PLAN.md`](ci/TEST_PLAN.md) | Do not invent version pins; derive them from these files and Dockerfiles. |
 
-## Documentation standards
+## Deployment questions to answer first
 
-- Position ModelExpress as usable standalone and with integrations such as
-  vLLM, SGLang, Dynamo, llm-d, Prime-RL, and similar systems. Dynamo is an
-  integration path, not a requirement.
-- Clearly label experimental or beta paths, especially TensorRT-LLM P2P,
-  GPUDirect Storage, SGLang ModelStreamer, and evolving RL/live-refit flows.
-- Keep commands copy/pasteable. Use consistent placeholders such as
-  `<namespace>`, `<your-registry>`, `<tag>`, and `<your-token>`.
-- For compatibility/version docs, derive pins from CI, Dockerfiles, Helm, and
-  examples. Do not invent untested combinations.
-- Use Mermaid for diagrams rather than ASCII art.
+Before recommending a deployment, identify:
 
-## Version and compatibility checks
+- runtime: vLLM, SGLang, TensorRT-LLM, Dynamo, or standalone CLI/server
+- environment: local Docker, Kubernetes, Helm, DynamoGraphDeployment, or cloud
+  managed Kubernetes
+- weight source: Hugging Face, S3, GCS, Azure Blob Storage, local disk, or PVC
+- metadata backend: Redis, Kubernetes CRD, or `k8s-service`
+- networking: InfiniBand/RoCE, AWS EFA, or no RDMA
+- scaling shape: single replica, replica scale-out, tensor parallelism,
+  live-refit/RL, or stable-weight serving
 
-When changing release docs, compatibility docs, Helm, or examples, check for
-drift across:
+### Metadata backend guidance
 
-- Rust workspace version in `Cargo.toml`.
-- Python package version in `modelexpress_client/python/pyproject.toml`.
-- Helm chart/app version in `helm/Chart.yaml`.
-- Helm image tags in `helm/values*.yaml` and `helm/README.md`.
-- Public server image references in `examples/**/*.yaml`.
-- Runtime pins in `ci/k8s/client/**/Dockerfile*`,
-  `examples/**/Dockerfile*`, and `.github/workflows/*.yml`.
-- Support coverage in `ci/TEST_PLAN.md` and `docs/COMPATIBILITY.md`.
+- Use `redis` or `kubernetes` for coordinated fleets, live refits, RL loops,
+  mixed revisions, or heterogeneous workers.
+- Use `k8s-service` only for stable-weight inference where all pods behind a
+  Service serve the same checkpoint and avoiding a central MX server is the
+  main simplification.
+- For Redis, set `MX_METADATA_BACKEND=redis` and `REDIS_URL`.
+- For Kubernetes CRD, apply `examples/crds.yaml`, configure RBAC, and set
+  `MX_METADATA_BACKEND=kubernetes` plus namespace wiring.
 
-For detailed version-bump mechanics, read `CLAUDE.md` before editing release
-metadata or source-id fixtures.
+See [`docs/DEPLOYMENT.md#choosing-a-metadata-backend`](docs/DEPLOYMENT.md#choosing-a-metadata-backend).
 
-## Validation commands
+## Important environment variables
 
-Run the narrowest relevant checks for the change. For docs/release metadata,
-prefer:
+| Variable | When to mention |
+|----------|-----------------|
+| `MX_METADATA_BACKEND` | Required server-side for Redis/Kubernetes metadata. |
+| `REDIS_URL` | Required when the metadata backend is Redis. |
+| `MX_METADATA_NAMESPACE` | Kubernetes CRD namespace override. |
+| `MX_SERVER_ADDRESS` | Recommended client gRPC endpoint for central-server P2P paths. |
+| `MODEL_EXPRESS_URL` | Deprecated, but still needed by some legacy/client paths; set both during transition when docs say so. |
+| `VLLM_PLUGINS=modelexpress` | vLLM plugin registration when needed by the launch path. |
+| `MX_MODEL_URI` | Enables ModelStreamer storage loading. |
+| `MX_NIXL_BACKEND` | Use `UCX` for InfiniBand/RoCE; use `LIBFABRIC` on AWS EFA examples. |
+| `MX_RDMA_NIC_PIN` | Use for NIC pinning or `auto` topology selection on multi-NIC RDMA hosts. |
+| `MODEL_EXPRESS_LOG_LEVEL` | Set to `DEBUG` for more detailed MX Python logs. |
+
+## Debugging playbook
+
+Start with the failure surface: server unreachable, model cache issue, metadata
+issue, image/config issue, or P2P/RDMA issue.
+
+### Local CLI and server
+
+```bash
+modelexpress-cli -vv health
+nc -vz localhost 8001
+modelexpress-cli model status
+modelexpress-cli model validate
+modelexpress-cli model stats --detailed
+```
+
+The MX server speaks gRPC, not REST; `curl http://localhost:8001/health` is not
+a valid health check.
+
+### Kubernetes server and metadata
+
+```bash
+kubectl -n $NAMESPACE logs -f deploy/modelexpress-server
+kubectl -n $NAMESPACE describe pod -l app=modelexpress-server
+
+# Redis backend
+kubectl -n $NAMESPACE exec deploy/modelexpress-server -c redis -- redis-cli KEYS 'mx:source:*'
+kubectl -n $NAMESPACE exec deploy/modelexpress-server -c redis -- redis-cli HGETALL 'mx:source:<source_id>'
+
+# Kubernetes CRD backend
+kubectl -n $NAMESPACE get modelmetadatas
+kubectl -n $NAMESPACE get modelcacheentries
+```
+
+If stale Redis metadata is suspected after redeploy, flushing Redis is a valid
+debug step, but call out that it clears MX metadata:
+
+```bash
+kubectl -n $NAMESPACE exec deploy/modelexpress-server -c redis -- redis-cli FLUSHALL
+```
+
+### Inference worker and P2P
+
+```bash
+kubectl -n $NAMESPACE logs -f deploy/mx-vllm
+kubectl -n $NAMESPACE exec deploy/mx-vllm -- curl -s http://localhost:8000/v1/models
+kubectl -n $NAMESPACE exec deploy/mx-vllm -c vllm -- ibstat
+kubectl -n $NAMESPACE exec deploy/mx-vllm -c vllm -- ucx_info -d
+```
+
+Look for logs that indicate loader registration, native source load, metadata
+publish, source discovery, transfer start, and transfer completion. If a target
+falls back to storage, check whether a READY source exists, whether the
+`mx_source_id` identity matches, and whether source metadata is stale.
+
+### Storage and ModelStreamer
+
+For ModelStreamer, confirm `MX_MODEL_URI` is set and the pod has the right
+cloud identity or secret. Expected vLLM logs include the ModelExpress loader
+registration, `Trying strategy: model_streamer`, and a storage streaming
+completion message. See [`examples/model_streamer_k8s/README.md`](examples/model_streamer_k8s/README.md).
+
+## Answering standards
+
+- Give the shortest viable path first, then link to deeper docs.
+- Include prerequisites before commands: GPU/RDMA requirements, secrets, CRDs,
+  RBAC, image build/push, or cloud credentials.
+- Be explicit about status: supported, beta, experimental, example-only, or
+  not in CI.
+- Keep public answers free of private repositories, internal registries,
+  internal runner names, and secrets.
+- When editing docs, keep README for orientation and put detailed support,
+  compatibility, and version pins in `docs/COMPATIBILITY.md`.
+
+## Sources to verify before changing docs
+
+- [`README.md`](README.md) for overview and first-run paths.
+- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for server, Kubernetes, metadata,
+  P2P, ModelStreamer, and debugging details.
+- [`docs/CLI.md`](docs/CLI.md) for CLI commands and troubleshooting.
+- [`docs/SGLANG.md`](docs/SGLANG.md) for SGLang-specific launch guidance.
+- [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) and
+  [`ci/TEST_PLAN.md`](ci/TEST_PLAN.md) for support status and tested versions.
+- [`examples/`](examples/) for copy/paste deployment manifests.
+
+For docs-only edits, run:
 
 ```bash
 git diff --check
-find README.md docs CONTRIBUTING.md helm/README.md examples -name '*.md' -print0 \
+find AGENTS.md README.md docs CONTRIBUTING.md helm/README.md examples -name '*.md' -print0 \
   | xargs -0 awk 'BEGIN{bad=0} /^```/{count[FILENAME]++} END{for (f in count) if (count[f] % 2) {print f ": odd fence count " count[f]; bad=1} exit bad}'
-OLD_TAG="REPLACE_WITH_OLD_TAG"
-rg -n "modelexpress-server:${OLD_TAG}|image\\.tag.*${OLD_TAG}|${OLD_TAG}" \
-  README.md docs helm examples .github ci -g '*.md' -g '*.yaml' -g '*.yml'
 helm lint helm
 ```
-
-For Rust/Python code changes, use the build and test commands in `CLAUDE.md`
-and `CONTRIBUTING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,4 +221,5 @@ Signed-off-by: Jane Smith <jane.smith@email.com>
 
 You can use `-s` or `--signoff` to add the `Signed-off-by` line automatically.
 
-If your pull request fails the DCO check, see the [DCO Troubleshooting Guide](DCO.md).
+If your pull request fails the DCO check, confirm each commit includes a valid
+`Signed-off-by` line and review the [Developer Certificate of Origin](https://developercertificate.org/).

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Overview
 
-ModelExpress is a Rust-based service that manages the complete model weight lifecycle in the cluster—from acquisition to GPU memory. It accelerates LLM inference by caching, routing, and transferring weights through the fastest available path.
+ModelExpress (MX) is a Rust-based service that manages the complete model weight lifecycle in a GPU cluster — from acquisition to GPU memory. It accelerates the startup times of new LLM inference deployments by caching, routing, and transferring model weights through the fastest available path(s). 
 
-ModelExpress is not tied to NVIDIA Dynamo. You can run it standalone as a model-weight service, integrate it directly with stock inference runtimes such as vLLM and recent SGLang releases through their loader/plugin hooks, or let higher-level systems such as Dynamo, llm-d, Prime-RL, and similar orchestration layers use it as the weight lifecycle and transfer substrate.
+ModelExpress works beyond NVIDIA Dynamo. You can run it standalone as a model-weight service, integrate it directly with stock inference runtimes such as vLLM and  SGLang, or let higher-level systems such as Dynamo, llm-d, Prime-RL, and similar orchestration layers use MX as the weight lifecycle and transfer substrate.
 
 | LLM serving problem | How ModelExpress helps |
 |---------------------|------------------------|
@@ -47,7 +47,7 @@ ModelExpress is not tied to NVIDIA Dynamo. You can run it standalone as a model-
 
 ModelExpress orchestrates the full flow—from download to GPU memory. It ensures only one node downloads a model from external sources (e.g., HuggingFace); other nodes receive weights via P2P or shared storage—eliminating duplicate downloads and reducing cluster ingress.
 
-1. **Download from HuggingFace** — One node pulls the model; ModelExpress coordinates so no other node duplicates this download, reducing external ingress. In air-gapped mode, serve from cache only (`HF_HUB_OFFLINE=1`).
+1. **Download from HuggingFace/S3** — One node pulls the model; ModelExpress coordinates so no other node duplicates this download, reducing external ingress. In air-gapped mode, serve from cache only (`HF_HUB_OFFLINE=1`).
 2. **Persist to disk** — Store in a cache backed by disk:
    - **Host-attached disk** — Local disk on the node (single-node or per-node cache).
    - **PVC** — RWO (ReadWriteOnce) for single-node; RWX (ReadWriteMany) for shared access across nodes.
@@ -62,9 +62,9 @@ ModelExpress orchestrates the full flow—from download to GPU memory. It ensure
 |------|------------|-------|
 | Try the server and CLI locally | [Quick Start](#quick-start) and [CLI reference](docs/CLI.md) | No GPUs required for basic server health and model-cache commands. |
 | Speed up vLLM replica startup | [Kubernetes P2P examples](examples/p2p_transfer_k8s/README.md) | Uses `--load-format modelexpress` with Redis or Kubernetes CRD metadata. |
-| Use ModelExpress with Dynamo | [Dynamo model cache](examples/dynamo_model_cache_k8s/README.md) or [Dynamo P2P](examples/dynamo_p2p_transfer_k8s/README.md) | Dynamo is an integration target, not a requirement. |
+| Use ModelExpress with Dynamo | [Dynamo model cache](examples/dynamo_model_cache_k8s/README.md) or [Dynamo P2P](examples/dynamo_p2p_transfer_k8s/README.md) | Dynamo is an integration path, not a requirement. |
 | Use ModelExpress with SGLang | [SGLang guide](docs/SGLANG.md) | Uses SGLang `remote_instance` with the `modelexpress` backend. |
-| Evaluate TRT-LLM P2P | [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) | Beta path; requires the TRT-LLM/Dynamo image and patch flow described in the example. |
+| Evaluate TRT-LLM P2P | [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) | Beta path; requires a TRT-LLM/Dynamo image and patch flow described in the example. |
 | Stream from object storage | [ModelStreamer examples](examples/model_streamer_k8s/README.md) | Storage-loading path for S3, Azure Blob, GCS, or local/PVC sources. |
 | Choose a metadata backend | [Deployment backend guide](docs/DEPLOYMENT.md#choosing-a-metadata-backend) | Redis/Kubernetes for coordinated fleets; `k8s-service` for stable-weight inference only. |
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 </p>
 
 <p align="center">
+  <a href="#start-here">Start Here</a> •
+  <a href="#support-matrix">Support Matrix</a> •
+  <a href="docs/COMPATIBILITY.md">Compatibility</a> •
   <a href="#features">Features</a> •
   <a href="#modelexpress-architecture">Architecture</a> •
   <a href="#quick-start">Quick Start</a> •
@@ -31,7 +34,9 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Overview
 
-ModelExpress is a Rust-based service that manages the complete model weight lifecycle in the cluster—from acquisition to GPU memory. It accelerates LLM inference by caching, routing, and transferring weights through the fastest available path. Deploy standalone or as a sidecar alongside vLLM, NVIDIA Dynamo, and other inference runtimes.
+ModelExpress is a Rust-based service that manages the complete model weight lifecycle in the cluster—from acquisition to GPU memory. It accelerates LLM inference by caching, routing, and transferring weights through the fastest available path.
+
+ModelExpress is not tied to NVIDIA Dynamo. You can run it standalone as a model-weight service, integrate it directly with stock inference runtimes such as vLLM and recent SGLang releases through their loader/plugin hooks, or let higher-level systems such as Dynamo, llm-d, Prime-RL, and similar orchestration layers use it as the weight lifecycle and transfer substrate.
 
 | LLM serving problem | How ModelExpress helps |
 |---------------------|------------------------|
@@ -51,17 +56,53 @@ ModelExpress orchestrates the full flow—from download to GPU memory. It ensure
 
 ---
 
+## Start Here
+
+| Goal | Start here | Notes |
+|------|------------|-------|
+| Try the server and CLI locally | [Quick Start](#quick-start) and [CLI reference](docs/CLI.md) | No GPUs required for basic server health and model-cache commands. |
+| Speed up vLLM replica startup | [Kubernetes P2P examples](examples/p2p_transfer_k8s/README.md) | Uses `--load-format modelexpress` with Redis or Kubernetes CRD metadata. |
+| Use ModelExpress with Dynamo | [Dynamo model cache](examples/dynamo_model_cache_k8s/README.md) or [Dynamo P2P](examples/dynamo_p2p_transfer_k8s/README.md) | Dynamo is an integration target, not a requirement. |
+| Use ModelExpress with SGLang | [SGLang guide](docs/SGLANG.md) | Uses SGLang `remote_instance` with the `modelexpress` backend. |
+| Evaluate TRT-LLM P2P | [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) | Beta path; requires the TRT-LLM/Dynamo image and patch flow described in the example. |
+| Stream from object storage | [ModelStreamer examples](examples/model_streamer_k8s/README.md) | Storage-loading path for S3, Azure Blob, GCS, or local/PVC sources. |
+| Choose a metadata backend | [Deployment backend guide](docs/DEPLOYMENT.md#choosing-a-metadata-backend) | Redis/Kubernetes for coordinated fleets; `k8s-service` for stable-weight inference only. |
+
+## Support Matrix
+
+| Capability | Engine / mode | Status | Validation |
+|------------|---------------|--------|------------|
+| Server + CLI model-cache management | Standalone | Supported | Rust integration tests and CLI docs |
+| P2P weight transfer | vLLM | Supported | In CI |
+| Multi-node tensor parallel P2P | vLLM | Supported | In CI for TP=2 |
+| Dynamo integration | Dynamo + vLLM | Supported | In CI for aggregated and disaggregated vLLM paths |
+| P2P weight transfer | SGLang + NIXL | Supported | In CI with a known-good SGLang release image |
+| P2P weight transfer | SGLang + Mooncake TransferEngine | Supported | In CI |
+| P2P weight transfer | TensorRT-LLM | Beta | In CI, requires TRT-LLM/Dynamo-specific image and patches |
+| ModelStreamer storage loading | vLLM | Supported | In CI for S3; examples cover S3, Azure Blob, and local/PVC |
+| ModelStreamer storage loading | SGLang | Experimental | Adapter and launch coverage still gated |
+| Metadata backend | Redis or Kubernetes CRD | Supported | Used by P2P and model-cache examples |
+| Metadata backend | `k8s-service` | Specialized | Stable-weight inference only; no central MX server |
+| Metadata backend | In-memory | Dev/test only | Feature-gated; not for production deployments |
+| GPUDirect Storage | vLLM/TRT-LLM/SGLang | Experimental | Hardware-dependent; CI coverage pending |
+| RL/live refit workflows | Framework integrations | Emerging | Use Redis or Kubernetes CRD; APIs and examples are still evolving |
+
+See [Compatibility](docs/COMPATIBILITY.md) for tested runtime pins and
+[CI Test Plan](ci/TEST_PLAN.md) for the detailed coverage matrix and open gaps.
+
+---
+
 ## Features
 
 - **Cold start reduction** — GPU-to-GPU P2P transfer over InfiniBand instead of disk load
 - **HuggingFace caching** — PVC-backed cache, `HF_HUB_OFFLINE`, `ignore_weights`, `get_model_path` for Dynamo
-- **P2P GPU transfer** — vLLM `modelexpress` loader (`mx` alias) and TRT-LLM `PRESHARDED` loader with NVIDIA NIXL over RDMA
-- **Metadata backends** — In-memory, Redis, or Kubernetes CRD (layered write-through for HA)
+- **P2P GPU transfer** — vLLM `modelexpress` loader (`mx` alias), SGLang `remote_instance` backend, and TRT-LLM `PRESHARDED` beta path
+- **Metadata backends** — Redis or Kubernetes CRD for coordinated deployments; feature-gated in-memory backend for local development and tests
 - **Kubernetes** — Helm chart, CRDs/Redis for P2P, no-shared-storage support
 - **CLI** — Health, download, list, validate, clear; init-container support for pre-warming
-- **ModelStreamer integration**: stream weights from object storage (AWS S3, Azure Blob, GCS) with multi-engine support
+- **ModelStreamer integration**: stream weights from object storage (AWS S3, Azure Blob, GCS), with vLLM support today and additional engine coverage evolving
 - **Expanded model pull providers**: NGC catalog and Google Cloud Storage in addition to Hugging Face
-- **GDS (GPUDirect Storage)**: load model weights directly from NVMe into GPU memory, bypassing the CPU/DRAM copy path
+- **GDS (GPUDirect Storage)**: hardware-dependent path for loading model weights directly from NVMe into GPU memory
 
 ### Integrations
 
@@ -225,6 +266,7 @@ cargo bench
 | Doc | Description |
 |-----|-------------|
 | [Deployment](docs/DEPLOYMENT.md) | Server/client config, Docker, K8s, P2P |
+| [Compatibility](docs/COMPATIBILITY.md) | Tested runtime and platform pins |
 | [Architecture](docs/ARCHITECTURE.md) | Components, gRPC, NIXL, FP8 |
 | [CLI](docs/CLI.md) | Full CLI reference |
 | [Metadata](docs/metadata.md) | Redis keys, K8s CRD schema |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ SPDX-License-Identifier: Apache-2.0
 
 <p align="center">
   <a href="#start-here">Start Here</a> •
-  <a href="#support-matrix">Support Matrix</a> •
   <a href="docs/COMPATIBILITY.md">Compatibility</a> •
   <a href="#features">Features</a> •
   <a href="#modelexpress-architecture">Architecture</a> •
@@ -67,28 +66,7 @@ ModelExpress orchestrates the full flow—from download to GPU memory. It ensure
 | Evaluate TRT-LLM P2P | [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) | Beta path; requires a TRT-LLM/Dynamo image and patch flow described in the example. |
 | Stream from object storage | [ModelStreamer examples](examples/model_streamer_k8s/README.md) | Storage-loading path for S3, Azure Blob, GCS, or local/PVC sources. |
 | Choose a metadata backend | [Deployment backend guide](docs/DEPLOYMENT.md#choosing-a-metadata-backend) | Redis/Kubernetes for coordinated fleets; `k8s-service` for stable-weight inference only. |
-
-## Support Matrix
-
-| Capability | Engine / mode | Status | Validation |
-|------------|---------------|--------|------------|
-| Server + CLI model-cache management | Standalone | Supported | Rust integration tests and CLI docs |
-| P2P weight transfer | vLLM | Supported | In CI |
-| Multi-node tensor parallel P2P | vLLM | Supported | In CI for TP=2 |
-| Dynamo integration | Dynamo + vLLM | Supported | In CI for aggregated and disaggregated vLLM paths |
-| P2P weight transfer | SGLang + NIXL | Supported | In CI with a known-good SGLang release image |
-| P2P weight transfer | SGLang + Mooncake TransferEngine | Supported | In CI |
-| P2P weight transfer | TensorRT-LLM | Beta | In CI, requires TRT-LLM/Dynamo-specific image and patches |
-| ModelStreamer storage loading | vLLM | Supported | In CI for S3; examples cover S3, Azure Blob, and local/PVC |
-| ModelStreamer storage loading | SGLang | Experimental | Adapter and launch coverage still gated |
-| Metadata backend | Redis or Kubernetes CRD | Supported | Used by P2P and model-cache examples |
-| Metadata backend | `k8s-service` | Specialized | Stable-weight inference only; no central MX server |
-| Metadata backend | In-memory | Dev/test only | Feature-gated; not for production deployments |
-| GPUDirect Storage | vLLM/TRT-LLM/SGLang | Experimental | Hardware-dependent; CI coverage pending |
-| RL/live refit workflows | Framework integrations | Emerging | Use Redis or Kubernetes CRD; APIs and examples are still evolving |
-
-See [Compatibility](docs/COMPATIBILITY.md) for tested runtime pins and
-[CI Test Plan](ci/TEST_PLAN.md) for the detailed coverage matrix and open gaps.
+| Check support and tested versions | [Compatibility](docs/COMPATIBILITY.md) | Support status, runtime pins, and platform pins. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,16 +57,21 @@ ModelExpress orchestrates the full flow—from download to GPU memory. It ensure
 
 ## Start Here
 
-| Goal | Start here | Notes |
-|------|------------|-------|
-| Try the server and CLI locally | [Quick Start](#quick-start) and [CLI reference](docs/CLI.md) | No GPUs required for basic server health and model-cache commands. |
-| Speed up vLLM replica startup | [Kubernetes P2P examples](examples/p2p_transfer_k8s/README.md) | Uses `--load-format modelexpress` with Redis or Kubernetes CRD metadata. |
-| Use ModelExpress with Dynamo | [Dynamo model cache](examples/dynamo_model_cache_k8s/README.md) or [Dynamo P2P](examples/dynamo_p2p_transfer_k8s/README.md) | Dynamo is an integration path, not a requirement. |
-| Use ModelExpress with SGLang | [SGLang guide](docs/SGLANG.md) | Uses SGLang `remote_instance` with the `modelexpress` backend. |
-| Evaluate TRT-LLM P2P | [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) | Beta path; requires a TRT-LLM/Dynamo image and patch flow described in the example. |
-| Stream from object storage | [ModelStreamer examples](examples/model_streamer_k8s/README.md) | Storage-loading path for S3, Azure Blob, GCS, or local/PVC sources. |
-| Choose a metadata backend | [Deployment backend guide](docs/DEPLOYMENT.md#choosing-a-metadata-backend) | Redis/Kubernetes for coordinated fleets; `k8s-service` for stable-weight inference only. |
-| Check support and tested versions | [Compatibility](docs/COMPATIBILITY.md) | Support status, runtime pins, and platform pins. |
+New to ModelExpress? Follow this path:
+
+1. **Run the server and CLI locally:** [Quick Start](#quick-start) gets a local server running and verifies it with `modelexpress-cli health`. No GPU required.
+2. **Check what is supported:** [Compatibility](docs/COMPATIBILITY.md) lists tested engines, image pins, and beta/experimental paths.
+3. **Pick one deployment path:**
+
+| If your goal is... | Start here |
+|--------------------|------------|
+| Faster vLLM replica startup with P2P RDMA | [Kubernetes P2P examples](examples/p2p_transfer_k8s/README.md) |
+| Loading weights directly from S3, Azure Blob, GCS, or PVC | [ModelStreamer examples](examples/model_streamer_k8s/README.md) |
+| Using ModelExpress inside Dynamo | [Dynamo model cache](examples/dynamo_model_cache_k8s/README.md) or [Dynamo P2P](examples/dynamo_p2p_transfer_k8s/README.md) |
+| Using SGLang | [SGLang guide](docs/SGLANG.md) |
+| Evaluating TensorRT-LLM P2P | [TRT-LLM examples](examples/p2p_transfer_k8s/client/trtllm/) |
+
+For Kubernetes deployments, choose a metadata backend before rollout: see the [deployment backend guide](docs/DEPLOYMENT.md#choosing-a-metadata-backend).
 
 ---
 

--- a/ci/k8s/client/vllm/dynamo/manifest-azure-aggregated.yaml
+++ b/ci/k8s/client/vllm/dynamo/manifest-azure-aggregated.yaml
@@ -40,7 +40,7 @@
 #   WORKER_IMAGE       — image built from ci/k8s/client/vllm/dynamo/Dockerfile
 #                        (dynamo vllm-runtime + modelexpress client)
 #   MX_SERVER_IMAGE    — image built from ci/k8s/server/Dockerfile.server
-#                        (our own MX server, not the public nvcr.io/0.3.0)
+#                        (our own MX server, not a published release image)
 
 ---
 # apiVersion: nvidia.com/v1alpha1 is deprecated in favor of v1beta1, but the

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -12,6 +12,25 @@ see [`ci/TEST_PLAN.md`](../ci/TEST_PLAN.md).
 Use the documentation from the release tag you deploy. The values below track
 the current `main` branch.
 
+## Support Matrix
+
+| Capability | Engine / mode | Status | Validation |
+|------------|---------------|--------|------------|
+| Server + CLI model-cache management | Standalone | Supported | Rust integration tests and CLI docs |
+| P2P weight transfer | vLLM | Supported | In CI |
+| Multi-node tensor parallel P2P | vLLM | Supported | In CI for TP=2 |
+| Dynamo integration | Dynamo + vLLM | Supported | In CI for aggregated and disaggregated vLLM paths |
+| P2P weight transfer | SGLang + NIXL | Supported | In CI with a known-good SGLang release image |
+| P2P weight transfer | SGLang + Mooncake TransferEngine | Supported | In CI |
+| P2P weight transfer | TensorRT-LLM | Beta | In CI, requires TRT-LLM/Dynamo-specific image and patches |
+| ModelStreamer storage loading | vLLM | Supported | In CI for S3; examples cover S3, Azure Blob, and local/PVC |
+| ModelStreamer storage loading | SGLang | Experimental | Adapter and launch coverage still gated |
+| Metadata backend | Redis or Kubernetes CRD | Supported | Used by P2P and model-cache examples |
+| Metadata backend | `k8s-service` | Specialized | Stable-weight inference only; no central MX server |
+| Metadata backend | In-memory | Dev/test only | Feature-gated; not for production deployments |
+| GPUDirect Storage | vLLM/TRT-LLM/SGLang | Experimental | Hardware-dependent; CI coverage pending |
+| RL/live refit workflows | Framework integrations | Emerging | Use Redis or Kubernetes CRD; APIs and examples are still evolving |
+
 ## ModelExpress Artifacts
 
 | Artifact | Current pin | Source |

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,53 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Compatibility
+
+This page summarizes the runtime combinations currently exercised by CI or
+maintained as public examples. For detailed scenario coverage and open gaps,
+see [`ci/TEST_PLAN.md`](../ci/TEST_PLAN.md).
+
+Use the documentation from the release tag you deploy. The values below track
+the current `main` branch.
+
+## ModelExpress Artifacts
+
+| Artifact | Current pin | Source |
+|----------|-------------|--------|
+| Rust workspace crates | `0.5.0` | [`Cargo.toml`](../Cargo.toml) |
+| Python client package | `0.5.0` | [`modelexpress_client/python/pyproject.toml`](../modelexpress_client/python/pyproject.toml) |
+| Helm chart | `0.5.0` | [`helm/Chart.yaml`](../helm/Chart.yaml) |
+| Helm app version | `0.5.0` | [`helm/Chart.yaml`](../helm/Chart.yaml) |
+| Server image used by examples | `nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0` | [`helm/values.yaml`](../helm/values.yaml) and Kubernetes examples |
+
+## Engine Integrations
+
+| Integration | Tested or documented runtime | Status | Notes |
+|-------------|------------------------------|--------|-------|
+| vLLM P2P | `vllm/vllm-openai:v0.17.1` | In CI | Uses `--load-format modelexpress`; CI covers single-replica P2P plus TP=2 single-node and multi-node vLLM paths. |
+| Dynamo + vLLM | `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1`; Dynamo operator image tag `1.0.2` | In CI | CI covers aggregated and disaggregated DynamoGraphDeployment paths with vLLM. |
+| SGLang P2P with NIXL | `lmsysorg/sglang:v0.5.13.post1` | In CI | This image includes the upstream ModelExpress delegation hook from `sgl-project/sglang#24723`. Install ModelExpress with `--no-deps` inside SGLang images. |
+| SGLang P2P with Mooncake TransferEngine | `lmsysorg/sglang:v0.5.13.post1` plus `mooncake-transfer-engine-cuda13` | In CI | Uses the same SGLang `remote_instance` path with `modelexpress-config` selecting `{"transport": "transfer_engine"}`. |
+| TensorRT-LLM P2P | `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.1` | Beta, in CI | Runtime includes TRT-LLM `1.3.0rc13`, NIXL `0.10.1`, and `nixl-cu12` `0.10.1`; ModelExpress applies the PRESHARDED patch flow during image build. |
+| ModelStreamer with vLLM | `vllm/vllm-openai:v0.17.1` | In CI for S3 | Examples also cover Azure Blob Storage and local/PVC sources. |
+| ModelStreamer with SGLang | `lmsysorg/sglang:v0.5.13.post1` | Experimental | The CI matrix is gated until the SGLang adapter and framework-aware launch path are completed. |
+| vLLM on AWS EFA | `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0-efa-amd64` | Example only | Set `MX_NIXL_BACKEND=LIBFABRIC`; this path is documented but not part of the default PR CI matrix. |
+
+## Platform Pins
+
+| Area | Pin or requirement | Notes |
+|------|--------------------|-------|
+| Python | `>=3.10` | Python package classifiers cover Python 3.10, 3.11, and 3.12. |
+| Rust | `1.90.0` | See [`rust-toolchain.toml`](../rust-toolchain.toml). |
+| Kubernetes | Helm docs require Kubernetes 1.19+; CI vCluster uses `v1.32.13` | Kubernetes CRD code is built with the `k8s-openapi` `v1_31` feature. |
+| vCluster CLI | `v0.33.0` | Used by the Kubernetes CI bootstrap action. |
+| NIXL | Normal Python installs depend on `nixl[cu12]` on Linux | Engine images often own the CUDA/NIXL stack. For SGLang, install ModelExpress with `--no-deps`; for TRT-LLM, use the Dynamo TRT-LLM runtime pin above. |
+| CUDA | Runtime-owned | Dynamo source-build examples use CUDA `12.9`; SGLang source-build examples use CUDA `13.0.1`; TRT-LLM CI uses the CUDA 12 NIXL stack from the runtime image. |
+
+## Update Rule
+
+When bumping a runtime image, ModelExpress release version, or CI platform pin,
+update this file in the same change as the Dockerfile, workflow, Helm chart,
+or example manifest that introduced the bump.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -238,26 +238,7 @@ Without buildx (single arch, matches the host):
 ```bash
 docker build -f docker/Dockerfile.client-wheel --target builder -t mx-wheel-builder .
 docker run --rm -v "$PWD/dist:/out" mx-wheel-builder bash -lc 'cp -r /dist/. /out/'
-
-#### CI uploads to Artifactory
-
-`.github/workflows/build-wheels.yml` runs this Dockerfile on every PR
-(via `copy-pr-bot` mirroring into `pull-request/<pr_id>` branches) and
-every push to `main` / `release/**`, building both archs in parallel on
-velonix self-hosted runners and uploading the artifacts to NV Artifactory.
-
-Destination layout under `${ARTIFACTORY_PYPI_REPO_NAME}`:
-
-| Event | Subpath |
-|---|---|
-| `push` to `pull-request/<pr_id>` (copy-pr-bot mirror) | `pr/<pr_id>/<commit_sha>/<run_id>/<run_attempt>/<arch>/` |
-| `push` to `main`, `release/**` | `post-merge/<commit_sha>/<run_id>/<run_attempt>/<arch>/` |
-
-Each path contains the 6 artifacts from one arch: 4 manylinux wheels
-(cp310-cp313), 1 `py3-none-any` wheel, and 1 sdist. The upload step is
-gated on the `automated-release` GitHub environment, which holds three
-secrets: `ARTIFACTORY_URL`, `ARTIFACTORY_TOKEN` (JFrog identity token),
-and `ARTIFACTORY_PYPI_REPO_NAME`.
+```
 
 ### Custom Client Image (P2P Transfers)
 

--- a/examples/dynamo_model_cache_k8s/agg.yaml
+++ b/examples/dynamo_model_cache_k8s/agg.yaml
@@ -97,7 +97,7 @@ spec:
           runAsGroup: 1000
           fsGroup: 1000
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0
           imagePullPolicy: IfNotPresent
           env:
             - name: MODEL_EXPRESS_SERVER_PORT

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -49,7 +49,7 @@ spec:
       extraPodSpec:
         serviceAccountName: modelexpress
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0
           command:
             - /bin/sh
             - -c

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -43,7 +43,7 @@ spec:
       extraPodSpec:
         serviceAccountName: modelexpress
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0
           command:
             - /bin/sh
             - -c

--- a/examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml
+++ b/examples/p2p_transfer_k8s/client/trtllm/mx-infra-decode.yaml
@@ -77,7 +77,7 @@ spec:
           effect: NoExecute
       containers:
         - name: server
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0
           ports:
             - containerPort: 8001
           env:

--- a/examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml
+++ b/examples/p2p_transfer_k8s/server/kubernetes_backend/modelexpress-server-kubernetes.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: modelexpress
       containers:
         - name: modelexpress-server
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8001

--- a/examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml
+++ b/examples/p2p_transfer_k8s/server/redis_backend/modelexpress-server-redis.yaml
@@ -75,7 +75,7 @@ spec:
 
       containers:
         - name: modelexpress-server
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8001

--- a/helm/README.md
+++ b/helm/README.md
@@ -54,12 +54,11 @@ imagePullSecrets:
 
 If you're using a custom values file, ensure it includes this configuration or the deployment will fail with image pull errors.
 
-### 3. Add the Helm repository (if using a repository)
+### 3. Use the local chart
 
-```bash
-helm repo add modelexpress https://your-repo-url
-helm repo update
-```
+The public repository includes the chart under `helm/`. If your organization mirrors
+it to a Helm repository, add that repository according to your environment's
+instructions before installing.
 
 ### 4. Install the chart
 
@@ -101,7 +100,7 @@ The following table lists the configurable parameters of the ModelExpress chart 
 | `replicaCount`                               | Number of ModelExpress replicas                | `1`     |
 | `image.repository`                           | ModelExpress image repository                  | `nvcr.io/nvidia/ai-dynamo/modelexpress-server` |
 | `image.pullPolicy`                           | Image pull policy                              | `IfNotPresent` |
-| `image.tag`                                  | ModelExpress image tag                         | `0.3.0` |
+| `image.tag`                                  | ModelExpress image tag                         | `0.5.0` |
 | `imagePullSecrets`                           | Image pull secrets for nvcr.io access          | `[]`     |
 | `nameOverride`                               | Override the chart name                        | `""`     |
 | `fullnameOverride`                           | Override the full app name                     | `""`     |
@@ -295,7 +294,7 @@ The Helm chart uses the official NVIDIA ModelExpress image from the NVIDIA Conta
 docker login nvcr.io -u '$oauthtoken' -p 'YOUR_NVCR_API_KEY'
 
 # Pull the image
-docker pull nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+docker pull nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0
 ```
 
 **Note:** The default image requires authentication. See the [Installation](#installation) section for creating the required Kubernetes secret.

--- a/helm/test-values.yaml
+++ b/helm/test-values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  tag: "0.5.0"
 
 serviceAccount:
   create: true

--- a/helm/values-development.yaml
+++ b/helm/values-development.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  tag: "0.5.0"
 
 serviceAccount:
   create: true

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -7,7 +7,7 @@ replicaCount: 3
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: Always
-  tag: "0.3.0"
+  tag: "0.5.0"
 
 serviceAccount:
   create: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  tag: "0.5.0"
 
 imagePullSecrets:
   - name: nvcr-secret


### PR DESCRIPTION
## Summary

- Adds clearer README entry points with a crisp Start Here path for new users and links out to deeper docs.
- Adds `docs/COMPATIBILITY.md` for support status and tested/runtime pins across ModelExpress, vLLM, Dynamo, SGLang, TRT-LLM, and platform dependencies.
- Adds root `AGENTS.md` in a SGLang-style structure, focused on user-facing MX help: what MX does, how to route users by goal, deployment questions, metadata backend guidance, key env vars, and debugging playbooks.
- Aligns Helm values, Helm docs, and public example manifests to the current `0.5.0` ModelExpress server image.
- Fixes public-doc correctness issues: closes a broken deployment Markdown fence, removes internal Artifactory/runner details from deployment docs, replaces the broken DCO troubleshooting link, and removes a placeholder Helm repo URL.

## Validation

- `git diff --check`
- Markdown fence scan across AGENTS/README/docs/examples/Helm docs
- stale `0.3.0` reference scan across AGENTS, README, docs, helm, examples, `.github`, and `ci`
- `helm lint helm`