### PR TITLE
fix: run vLLM finalizers before RDMA receive

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -22,6 +22,13 @@ from ...tensor_utils import adopt_hidden_tensors, capture_tensor_attrs, collect_
 
 logger = logging.getLogger("modelexpress.engines.vllm.adapter")
 
+_VLLM_POST_LOAD_FINALIZER_NAMES = (
+    # DeepSeek V4 finalizes MegaMoE expert layouts from load_weights().
+    # The RDMA target path uses vLLM's dummy loader, which bypasses the
+    # model load_weights() method, so mirror the model-level hook here.
+    "finalize_mega_moe_weights",
+)
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
@@ -76,6 +83,11 @@ class VllmAdapter(EngineAdapter):
         return result
 
     def before_rdma_receive(self, result: LoadResult) -> LoadResult:
+        # Native vLLM load_weights() runs model-specific finalizers before
+        # post-load processing. RDMA targets use the dummy loader, so run
+        # those hooks before receiving tensors to expose the same target
+        # tensor layout and hidden buffers that the source published.
+        result = self._finalize_model_specific_weights(result)
         return self._process_weights_after_loading(result)
 
     def apply_weight_iter(
@@ -148,7 +160,10 @@ class VllmAdapter(EngineAdapter):
             )
         return LoadResult(value=model, model=model, publishable=result.publishable)
 
-    def _process_weights_after_loading(self, result: LoadResult) -> LoadResult:
+    def _process_weights_after_loading(
+        self,
+        result: LoadResult,
+    ) -> LoadResult:
         if result.model is None:
             raise RuntimeError("vLLM post-load processing requires result.model")
 
@@ -156,8 +171,49 @@ class VllmAdapter(EngineAdapter):
 
         with capture_tensor_attrs():
             process_weights_after_loading(
-                result.model, self.model_config, self.target_device,
+                result.model,
+                self.model_config,
+                self.target_device,
             )
+        return result
+
+    def _finalize_model_specific_weights(
+        self,
+        result: LoadResult,
+    ) -> LoadResult:
+        """Run model finalizers that vLLM normally calls in load_weights()."""
+
+        if result.model is None:
+            raise RuntimeError("vLLM RDMA post-load processing requires result.model")
+
+        finalized_prefixes: list[str] = []
+        with capture_tensor_attrs():
+            for name, module in result.model.named_modules():
+                # Some vLLM finalizers are model-level hooks that recursively
+                # transform child layers. If a parent ran one, do not call another
+                # matching hook on its descendants and risk duplicate repacking.
+                if any(
+                    _is_same_or_descendant(name, prefix)
+                    for prefix in finalized_prefixes
+                ):
+                    continue
+
+                module_finalized = False
+                for finalizer_name in _VLLM_POST_LOAD_FINALIZER_NAMES:
+                    finalizer = getattr(module, finalizer_name, None)
+                    if not callable(finalizer):
+                        continue
+
+                    logger.info(
+                        "Running vLLM model-specific post-load finalizer %s on %s",
+                        finalizer_name,
+                        name or type(module).__name__,
+                    )
+                    finalizer()
+                    module_finalized = True
+
+                if module_finalized:
+                    finalized_prefixes.append(name)
         return result
 
     def _resolve_target_device(self) -> torch.device:
@@ -197,6 +253,10 @@ def _set_load_config_extra_config(load_config, extra_config: dict) -> None:
         load_config.model_loader_extra_config = extra_config
     except AttributeError:
         object.__setattr__(load_config, "model_loader_extra_config", extra_config)
+
+
+def _is_same_or_descendant(name: str, prefix: str) -> bool:
+    return prefix == "" or name == prefix or name.startswith(f"{prefix}.")
 
 
 def _get_vllm_worker_rank(

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -4,9 +4,10 @@
 """Tests for the vLLM engine adapter."""
 
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 
 from modelexpress.engines.vllm.adapter import (
@@ -15,6 +16,7 @@ from modelexpress.engines.vllm.adapter import (
     _get_vllm_worker_rank,
     build_vllm_load_context,
 )
+from modelexpress.load_strategy.context import LoadResult
 
 
 def _vllm_config(*, rank: int, tp_size: int, pp_size: int):
@@ -113,6 +115,48 @@ def test_build_vllm_load_context_keeps_explicit_cuda_index(monkeypatch):
     assert ctx.device_id == ctx.target_device.index
 
 
+def test_before_rdma_receive_runs_model_specific_finalizers(monkeypatch):
+    events = []
+
+    def process_weights_after_loading(model, model_config, target_device):
+        events.append(("process", target_device))
+
+    _stub_vllm_process_weights_after_loading(monkeypatch, process_weights_after_loading)
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    model = _TopLevelModel(events)
+
+    result = adapter.before_rdma_receive(LoadResult(value=model, model=model))
+
+    assert result.model is model
+    assert events == [
+        ("finalize", "model", "finalize_mega_moe_weights"),
+        ("process", torch.device("cpu")),
+    ]
+
+
+def test_finalize_model_specific_weights_requires_model():
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+
+    with pytest.raises(RuntimeError, match="RDMA post-load processing"):
+        adapter._finalize_model_specific_weights(LoadResult(value=object()))
+
+
+def test_after_weight_iter_load_does_not_rerun_model_specific_finalizers(monkeypatch):
+    events = []
+
+    def process_weights_after_loading(model, model_config, target_device):
+        events.append(("process", target_device))
+
+    _stub_vllm_process_weights_after_loading(monkeypatch, process_weights_after_loading)
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    model = _TopLevelModel(events)
+
+    result = adapter.after_weight_iter_load(LoadResult(value=model, model=model))
+
+    assert result.model is model
+    assert events == [("process", torch.device("cpu"))]
+
+
 def _stub_vllm_current_device(monkeypatch, *, current_device: int) -> None:
     fake_platforms = SimpleNamespace(
         current_platform=SimpleNamespace(
@@ -120,6 +164,22 @@ def _stub_vllm_current_device(monkeypatch, *, current_device: int) -> None:
         ),
     )
     monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
+
+
+def _stub_vllm_process_weights_after_loading(monkeypatch, process_fn) -> None:
+    packages = [
+        "vllm",
+        "vllm.model_executor",
+        "vllm.model_executor.model_loader",
+    ]
+    for name in packages:
+        module = ModuleType(name)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    utils = ModuleType("vllm.model_executor.model_loader.utils")
+    utils.process_weights_after_loading = process_fn
+    monkeypatch.setitem(sys.modules, utils.__name__, utils)
 
 
 def _stub_metadata_client(monkeypatch) -> None:
@@ -148,3 +208,55 @@ def _model_config():
         quantization=None,
         revision=None,
     )
+
+
+class _TopLevelModel(torch.nn.Module):
+    def __init__(self, events):
+        super().__init__()
+        self.model = _MegaMoeModel(events)
+        self.standalone = _StandaloneFinalizer(events)
+
+
+class _MegaMoeModel(torch.nn.Module):
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+        self.layer = _MegaMoeLayer(events)
+
+    def finalize_mega_moe_weights(self) -> None:
+        self.events.append(("finalize", "model", "finalize_mega_moe_weights"))
+
+
+class _MegaMoeLayer(torch.nn.Module):
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+
+    def finalize_mega_moe_weights(self) -> None:
+        self.events.append(("finalize", "layer", "finalize_mega_moe_weights"))
+
+
+class _StandaloneFinalizer(torch.nn.Module):
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+
+    def finalize_weights(self) -> None:
+        self.events.append(("finalize", "standalone", "finalize_weights"))
+
+    def finalize_weight(self) -> None:
+        self.events.append(("finalize", "standalone", "finalize_weight"))
+
+    def post_load_weights(self) -> None:
+        self.events.append(("finalize", "standalone", "post_load_weights"))
+
+    def finalize_cache(self) -> None:
+        self.events.append(("finalize", "standalone", "finalize_cache"))
+
+    def finalize_cache_weights(self) -> None:
+        self.events.append(("finalize", "standalone", "finalize_cache_weights"))
+
+    def finalize_requires_arg_weights(self, context) -> None:
+        self.events.append(
+            ("finalize", "standalone", "finalize_requires_arg_weights", context)
+        )


### PR DESCRIPTION
## Overview

Run vLLM model-specific post-load finalizers on RDMA targets before receiving tensors.

## Details

DeepSeek V4's vLLM loader finalizes MegaMoE weights from `load_weights()`. The ModelExpress RDMA target path initializes the model with vLLM's dummy loader, which bypasses that model-level hook. As a result, the target could receive/publish a tensor layout that did not match the source and then rerun finalization later during vLLM warmup, increasing the chance of target-side OOM.

This change mirrors the relevant vLLM finalizer before RDMA receive so the target exposes the same transformed tensor layout and hidden buffers that the source publishes. Native disk load and ModelStreamer iterator load continue to use the existing post-load path only.

## Validation

- `git diff --check origin/main...HEAD`
- `uv run pytest tests/test_vllm_adapter.py -q` from `modelexpress_client/python` (`9 passed`)
- nscale DeepSeek V4 Pro TP=8 manual e2e on DGD `dsv4-pro-agg` in namespace `zheng`, image `nvcr.io/nvidian/dynamo-dev/modelexpress-vllm-runtime:vllm-finalize-3e893cc`, PVC `shared-model-cache`, UCX backend:
  - Source replica cold-loaded from PVC/ModelStreamer, published 8 P2P worker endpoints with 2139 tensors/rank, and became Ready.
  - Target replica discovered the source through P2P metadata, fetched each source tensor manifest, and RDMA transferred 2139 tensors / 109.76 GB per rank.
  - Transfer timings by rank: 17.25-31.63s, 27.8-50.9 Gbps. `MxModelLoader.load_model()` completed in 33.02-47.41s.
  - Target completed DeepGEMM warmup, CUDA graph capture, vLLM engine init (`503.13s`, compilation `128.00s`), registered `deepseek-ai/DeepSeek-V4-Pro`, and pod `dsv4-pro-agg-0-vllmdecodeworker-jvf68` became Ready with 0 restarts.
  - Both source and target are Ready service endpoints (`10.0.16.242`, `10.0.20.217`); 16 Ready MX worker records are present.
- Test harness notes for the nscale run:
  - The runtime still needed the temporary CUTLASS DSL `fmin` startup patch for DeepSeek-V4 sparse-attention compilation. That is a runtime image issue, separate from this PR.
  - The run used `MX_P2P_METADATA=1`; in that mode Kubernetes `ModelMetadata` rows intentionally show `tensorCount=0` and the target fetches the heavy tensor manifest directly from the source worker gRPC endpoint.
  - Frontend `/v1/models` remained empty because this PVC test manifest passed the local snapshot path as vLLM `--model`, so Dynamo frontend tried to resolve `/models/.../snapshots/...` as a Hugging Face model id and got 404. The worker-level source and target e2e completed; a PVC-serving manifest should keep `--model deepseek-ai/DeepSeek-V4-Pro` with pinned `--revision 5e74e6987d2007a261efc812d357ae75f9b8263a` and `HF_HOME=/models`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model initialization reliability by ensuring proper finalization of model-specific operations before tensor transfer.

* **Tests**  
  * Added comprehensive test cases for model finalization and weight processing in distributed load scenarios, including error handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->