### PR TITLE
fix(client): drop nixl[cu12] pin blocking CUDA-13 installs

### DIFF
--- a/ci/k8s/client/trt-llm/Dockerfile
+++ b/ci/k8s/client/trt-llm/Dockerfile
@@ -40,13 +40,12 @@ USER root
 # Proto stubs (p2p_pb2.py, p2p_pb2_grpc.py) are checked-in source artifacts;
 # regenerate with grpcio-tools when p2p.proto changes.
 #
-# Pip's default upgrade strategy (only-if-needed) keeps the base image's
-# pre-installed nixl 0.10.1 untouched because modelexpress's constraint
-# `nixl[cu12]; sys_platform == 'linux'` is unbounded and 0.10.1 satisfies it.
-# Do NOT add a `>=` lower bound to that constraint in pyproject.toml without
-# updating this Dockerfile — it would force pip to upgrade nixl to 1.1.0 here,
-# which would re-introduce the UCX ABI mismatch the base image was chosen
-# to avoid. See docs/NIXL_UCX_COMPATIBILITY.md.
+# MX does not pin a NIXL distribution; it imports `nixl._api` against
+# whatever variant the base image provides. This image's pre-installed
+# nixl-cu12 0.10.1 stays untouched and satisfies MX's runtime path,
+# and the layer keeps working unchanged if Dynamo's tensorrtllm-runtime
+# ever switches its bundled NIXL to a different version or to
+# nixl-cu13. See docs/NIXL_UCX_COMPATIBILITY.md for the UCX ABI story.
 COPY modelexpress_client/python /opt/modelexpress/client
 WORKDIR /opt/modelexpress/client
 RUN pip uninstall -y modelexpress 2>/dev/null || true && \

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -19,6 +19,11 @@ pip install -e .
 pip install -e ".[dev]"
 ```
 
+NIXL is expected to be supplied by the runtime environment (TRT-LLM,
+SGLang, Dynamo, and NemoRL runtime images all ship `nixl-cu12` or
+`nixl-cu13`). For a bare-environment install, run `pip install nixl-cu12`
+or `pip install nixl-cu13` separately, matching your host CUDA toolkit.
+
 ### Requirements
 
 - Python >= 3.10

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "grpcio>=1.66.2",
     "google-crc32c>=1.5.0",
     "huggingface_hub>=0.20.0",
-    "nixl[cu12]; sys_platform == 'linux'",
     "numpy>=1.24.0",
     "protobuf>=5.27.0,<6.0.0", # protobuf 5.x compatibility
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary

Drops the unconditional `nixl[cu12]` pin from MX's top-level dependencies. MX imports NIXL through the variant-agnostic `nixl._api` namespace, so it does not need to pin a CUDA toolkit at all — the runtime environment owns that choice. This unblocks clean installs into CUDA-13 hosts (e.g. TRT-LLM 1.3.0+ release containers, which ship `nixl-cu13` pre-installed) without affecting any existing CUDA-12 deployment.

No version bump. The whole change is one removed line in `pyproject.toml` plus matching cleanup in the TRT-LLM CI Dockerfile and the Python client README.

## Motivation

- The TRT-LLM 1.3.0 upstream release container is CUDA 13 and pre-installs `nixl-cu13` for its own KV / disagg paths.
- MX previously hard-pinned `nixl[cu12]; sys_platform == 'linux'`, so installing MX on top of a CUDA-13 host pulled `nixl-cu12` in alongside the pre-existing `nixl-cu13`. The two wheels carry separate `_bindings.so` linked against different CUDA toolkits, which produces RPATH / undefined-symbol failures at runtime.
- The Dynamo-curated `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.1` image bundles `nixl-cu12 0.10.1` (per the comment in `ci/k8s/client/trt-llm/Dockerfile`), so pip's only-if-needed strategy was a no-op there and the pin did not bite in-repo CI. The conflict only manifests when MX is installed into an image that ships a different NIXL variant.

## What changed

- **`modelexpress_client/python/pyproject.toml`**: removed `"nixl[cu12]; sys_platform == 'linux'"`. No comment, no extras, no version bump (stays at `0.5.0`).
- **`ci/k8s/client/trt-llm/Dockerfile`**: `pip install .` (no extra). Since MX no longer declares a NIXL distribution, pip leaves the base image's pre-installed `nixl-cu12 0.10.1` alone and we rely on it for the runtime `from nixl._api import nixl_agent` path. The comment block above the install was rewritten to reflect this.
- **`modelexpress_client/python/README.md`**: install section back to plain `pip install modelexpress`, with a short note that NIXL must be supplied by the runtime environment and which images ship it.

## Why no `[cu12]` / `[cu13]` extras

An earlier iteration of this PR added `[cu12]` and `[cu13]` extras so bare-environment installs could pick a NIXL variant. Dropped because every real MX consumer (TRT-LLM CI, SGL CI, Dynamo runtime, RL training images) layers MX onto a base image that already ships NIXL — nobody actually does a from-scratch `pip install modelexpress` on a clean Linux box. The extras were vestigial and added cognitive load to the README. For the rare bare-environment case, the README points the user at `pip install nixl-cu12` / `pip install nixl-cu13` directly.

## Why no separate sibling PyPI wheels

`tensorrt-llm` / `tensorrt-llm-cu13` ship as two separate distributions. Most durable design long-term, but it is a separate maintenance project (dual PyPI accounts, dual CI lanes, version-bump coordination) and is not needed today because MX's runtime path is genuinely CUDA-variant-agnostic.

## Caller migration

Two install patterns going forward:

| Scenario | Install command |
|---|---|
| Layering on an image that already ships NIXL (in-repo TRT-LLM and SGL CI, Dynamo `trtllm_runtime.Dockerfile`, RL training images, etc.) | `pip install modelexpress` |
| Bare Linux box without a pre-installed NIXL | `pip install nixl-cu12` (or `nixl-cu13`), then `pip install modelexpress` |

In-repo TRT-LLM CI Dockerfile updated in this PR; SGL Dockerfile already uses `--no-deps` so it is unaffected. Downstream consumers (Dynamo `container/templates/trtllm_runtime.Dockerfile`, RL training images, etc.) require no install-side changes — `pip install modelexpress` is exactly what they already do.

## Test plan

- [ ] CI: `ci/k8s/client/trt-llm/Dockerfile` builds cleanly against `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.1` and the `nixl-cu12 0.10.1` baked into the base image is not upgraded.
- [ ] CI: SGL Dockerfile build is unaffected (uses `--no-deps`).
- [ ] Verify `from modelexpress.client import MxClient` and `from modelexpress.nixl_transfer import NixlTransferManager` still import on both `nixl-cu12` and `nixl-cu13` environments.
- [ ] Spot-check: install MX into a fresh `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rcXX` upstream container (the actual CUDA-13 production target) and confirm `pip install modelexpress` leaves the pre-installed `nixl-cu13` alone and MX imports successfully.

## Out of scope

- Downstream `trtllm_runtime.Dockerfile` updates in Dynamo (no migration needed; the existing `pip install modelexpress @ git+...` already works against this PR).
- Splitting the Python client into sibling PyPI wheels `modelexpress` / `modelexpress-cu13` (future durability work if a maintainer ever wants stronger guarantees than "env provides NIXL").
- Documenting the `nixl_cu12 / nixl_cu13` ABI / UCX compatibility story in `docs/NIXL_UCX_COMPATIBILITY.md` (file is referenced in CI Dockerfile comments but does not yet exist in-repo).
