### PR TITLE
feat(ucx_utils): add MX_RDMA_NIC_PIN=stripe for multi-NIC parallelism

### DIFF
--- a/modelexpress_client/python/modelexpress/ucx_utils.py
+++ b/modelexpress_client/python/modelexpress/ucx_utils.py
@@ -355,11 +355,42 @@ def probe_nic_pin_for_device(
     return f"{chosen_name}:1"
 
 
+def _stripe_all_compute_nics(min_rate_gbps: float | None = None) -> str | None:
+    """Return a UCX_NET_DEVICES string listing ALL compute-fabric NICs.
+
+    This is the "stripe across all NICs" mode — every visible IB-class
+    NIC at the max compute rate is included, so UCX can spread traffic
+    across all of them. Pairs with ``UCX_MAX_RMA_RAILS`` to actually
+    use the multi-NIC paths (see ``apply_nic_pin_for_device``).
+
+    Surfaced by tracking issue ai-dynamo/modelexpress#449: NCCL's
+    advantage over MX/NIXL in the 16-receiver Llama 3.1 8B benchmark
+    (~0.05s vs ~6s pre-caching, ~0.32s post-caching single-NIC) is
+    almost entirely NIC under-utilization — NCCL stripes the broadcast
+    across all 4 (GB200) or 8 (GB300) RDMA NICs allocated to the pod;
+    MX's existing ``auto`` mode pins each receiver to ONE NIC via PCIe
+    topology affinity.
+
+    On topologies with 1 NIC visible, this degenerates to the same
+    behavior as ``auto`` (just that one NIC). On 4+ NIC pods, this
+    returns the comma-separated list of all of them.
+    """
+    compute_nics = _list_compute_ib_nics(min_rate_gbps=min_rate_gbps)
+    if not compute_nics:
+        return None
+    return ",".join(f"{name}:1" for name, _numa, _rate, _path in compute_nics)
+
+
 def _resolve_nic_pin(device_id: int) -> str | None:
     """Resolve MX_RDMA_NIC_PIN env var into a UCX_NET_DEVICES value.
 
     Modes:
       - unset / "off" / "0" / "false" / "no": returns None (no pinning).
+      - "stripe" / "all": list ALL compute-rate IB NICs in
+        UCX_NET_DEVICES so UCX can stripe across them. Pair with
+        ``UCX_MAX_RMA_RAILS=<N>`` for actual multi-NIC parallelism.
+        See ai-dynamo/modelexpress#449 for the motivation (closing
+        the MX↔NCCL bandwidth gap by ending single-NIC pinning).
       - explicit comma-separated list: indexed by device_id, like the
         original hardcoded shape. Useful for unusual topologies where
         the auto-probe heuristic doesn't fit (e.g. fabrics outside the
@@ -375,6 +406,33 @@ def _resolve_nic_pin(device_id: int) -> str | None:
     if raw == "" or raw.lower() in ("off", "0", "false", "no"):
         return None
 
+    raw_min = os.environ.get("MX_RDMA_NIC_PIN_MIN_RATE_GBPS")
+    if raw_min is None or raw_min.strip() == "":
+        min_rate: float | None = None
+    else:
+        try:
+            min_rate = float(raw_min)
+        except ValueError:
+            logger.warning(
+                f"MX_RDMA_NIC_PIN_MIN_RATE_GBPS={raw_min!r} not a float; "
+                f"falling back to max-rate auto-detect"
+            )
+            min_rate = None
+
+    if raw.lower() in ("stripe", "all"):
+        striped = _stripe_all_compute_nics(min_rate_gbps=min_rate)
+        if striped is None:
+            logger.warning(
+                "MX_RDMA_NIC_PIN=stripe: no compute IB-class NICs found; "
+                "skipping pin"
+            )
+            return None
+        logger.info(
+            f"MX_RDMA_NIC_PIN=stripe: device {device_id} -> "
+            f"UCX_NET_DEVICES={striped} (all compute-rate NICs)"
+        )
+        return striped
+
     if "," in raw:
         nic_list = [n.strip() for n in raw.split(",") if n.strip()]
         if 0 <= device_id < len(nic_list):
@@ -389,18 +447,6 @@ def _resolve_nic_pin(device_id: int) -> str | None:
         )
         return None
 
-    raw_min = os.environ.get("MX_RDMA_NIC_PIN_MIN_RATE_GBPS")
-    if raw_min is None or raw_min.strip() == "":
-        min_rate: float | None = None
-    else:
-        try:
-            min_rate = float(raw_min)
-        except ValueError:
-            logger.warning(
-                f"MX_RDMA_NIC_PIN_MIN_RATE_GBPS={raw_min!r} not a float; "
-                f"falling back to max-rate auto-detect"
-            )
-            min_rate = None
     return probe_nic_pin_for_device(device_id, min_rate_gbps=min_rate)
 
 
@@ -413,14 +459,37 @@ def apply_nic_pin_for_device(device_id: int) -> None:
     is the default. Designed to be called once per worker before NIXL
     agent construction.
 
+    When ``MX_RDMA_NIC_PIN=stripe`` (multi-NIC), also bumps
+    ``UCX_MAX_RMA_RAILS`` to the NIC count so UCX actually uses all of
+    them. UCX defaults ``MAX_RMA_RAILS=2`` and NIXL also hard-sets it
+    to 2 in its UCX backend (see ai-dynamo/modelexpress#449); without
+    the env override the stripe list would be ignored.
+
     See module docstring for the full semantics, including the explicit
     NIC-list override and the rate-filter env var.
     """
     pinned = _resolve_nic_pin(device_id)
-    if pinned:
-        prev = os.environ.get("UCX_NET_DEVICES")
-        os.environ["UCX_NET_DEVICES"] = pinned
-        logger.info(
-            f"NIXL NIC pin: device {device_id} -> "
-            f"UCX_NET_DEVICES={pinned} (was: {prev})"
-        )
+    if not pinned:
+        return
+
+    prev = os.environ.get("UCX_NET_DEVICES")
+    os.environ["UCX_NET_DEVICES"] = pinned
+    logger.info(
+        f"NIXL NIC pin: device {device_id} -> "
+        f"UCX_NET_DEVICES={pinned} (was: {prev})"
+    )
+
+    # When striping across multiple NICs, also bump MAX_RMA_RAILS so
+    # UCX actually uses them. Only do this when the caller is opting
+    # into multi-NIC explicitly (mode == "stripe") — leave single-NIC
+    # / explicit-list / auto modes alone, since they're intentionally
+    # single-NIC and bumping rails wouldn't help.
+    mode = os.environ.get("MX_RDMA_NIC_PIN", "").strip().lower()
+    if mode in ("stripe", "all"):
+        nic_count = pinned.count(",") + 1 if pinned else 0
+        if nic_count >= 2 and "UCX_MAX_RMA_RAILS" not in os.environ:
+            os.environ["UCX_MAX_RMA_RAILS"] = str(nic_count)
+            logger.info(
+                f"NIXL stripe mode: set UCX_MAX_RMA_RAILS={nic_count} "
+                f"to match {nic_count} striped NICs"
+            )

--- a/modelexpress_client/python/tests/test_nic_pin_stripe.py
+++ b/modelexpress_client/python/tests/test_nic_pin_stripe.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MX_RDMA_NIC_PIN=stripe multi-NIC mode.
+
+Surfaced by ai-dynamo/modelexpress#449: single-NIC pinning leaves
+75% of allocated NIC bandwidth idle on 4-NIC GB200 / 8-NIC GB300
+pods, accounting for most of the MX-vs-NCCL gap in the
+16-receiver Llama 3.1 8B refit benchmark.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from modelexpress import ucx_utils
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Make sure each test starts from a clean env."""
+    for var in (
+        "MX_RDMA_NIC_PIN",
+        "MX_RDMA_NIC_PIN_MIN_RATE_GBPS",
+        "UCX_NET_DEVICES",
+        "UCX_MAX_RMA_RAILS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _fake_nics(*names_rates_paths):
+    """Return a list shaped like _list_compute_ib_nics: (name, numa, rate, path)."""
+    return [(name, 0, rate, path) for name, rate, path in names_rates_paths]
+
+
+def test_stripe_lists_all_compute_nics(monkeypatch):
+    """stripe mode returns comma-joined NIC list with :1 suffix on each."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "stripe")
+    monkeypatch.setattr(
+        ucx_utils,
+        "_list_compute_ib_nics",
+        lambda min_rate_gbps=None: _fake_nics(
+            ("mlx5_0", 400.0, ["a", "b"]),
+            ("mlx5_1", 400.0, ["a", "c"]),
+            ("mlx5_2", 400.0, ["a", "d"]),
+            ("mlx5_3", 400.0, ["a", "e"]),
+        ),
+    )
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert os.environ["UCX_NET_DEVICES"] == "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1"
+
+
+def test_stripe_bumps_max_rma_rails_to_nic_count(monkeypatch):
+    """Multi-NIC stripe bumps UCX_MAX_RMA_RAILS to NIC count if not already set."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "stripe")
+    monkeypatch.setattr(
+        ucx_utils,
+        "_list_compute_ib_nics",
+        lambda min_rate_gbps=None: _fake_nics(
+            ("mlx5_0", 400.0, []),
+            ("mlx5_1", 400.0, []),
+            ("mlx5_2", 400.0, []),
+            ("mlx5_3", 400.0, []),
+        ),
+    )
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert os.environ["UCX_MAX_RMA_RAILS"] == "4"
+
+
+def test_stripe_respects_explicit_max_rma_rails(monkeypatch):
+    """If user already set UCX_MAX_RMA_RAILS, don't overwrite."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "stripe")
+    monkeypatch.setenv("UCX_MAX_RMA_RAILS", "2")
+    monkeypatch.setattr(
+        ucx_utils,
+        "_list_compute_ib_nics",
+        lambda min_rate_gbps=None: _fake_nics(
+            ("mlx5_0", 400.0, []),
+            ("mlx5_1", 400.0, []),
+            ("mlx5_2", 400.0, []),
+            ("mlx5_3", 400.0, []),
+        ),
+    )
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert os.environ["UCX_MAX_RMA_RAILS"] == "2"
+
+
+def test_stripe_single_nic_skips_rails_bump(monkeypatch):
+    """1-NIC pod: stripe degenerates to single-NIC, don't set rails."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "stripe")
+    monkeypatch.setattr(
+        ucx_utils,
+        "_list_compute_ib_nics",
+        lambda min_rate_gbps=None: _fake_nics(("mlx5_0", 400.0, [])),
+    )
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert os.environ["UCX_NET_DEVICES"] == "mlx5_0:1"
+    assert "UCX_MAX_RMA_RAILS" not in os.environ
+
+
+def test_stripe_no_nics_visible(monkeypatch):
+    """Topologically NIC-less host: stripe is a no-op, no env vars set."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "stripe")
+    monkeypatch.setattr(
+        ucx_utils, "_list_compute_ib_nics", lambda min_rate_gbps=None: []
+    )
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert "UCX_NET_DEVICES" not in os.environ
+    assert "UCX_MAX_RMA_RAILS" not in os.environ
+
+
+def test_stripe_alias_all(monkeypatch):
+    """'all' is an accepted alias of 'stripe' for ergonomic ops use."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "all")
+    monkeypatch.setattr(
+        ucx_utils,
+        "_list_compute_ib_nics",
+        lambda min_rate_gbps=None: _fake_nics(
+            ("mlx5_0", 400.0, []),
+            ("mlx5_1", 400.0, []),
+        ),
+    )
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert os.environ["UCX_NET_DEVICES"] == "mlx5_0:1,mlx5_1:1"
+    assert os.environ["UCX_MAX_RMA_RAILS"] == "2"
+
+
+def test_auto_mode_does_not_set_rails(monkeypatch):
+    """Existing 'auto' mode preserves its single-NIC behavior — no rails bump."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "auto")
+    monkeypatch.setattr(
+        ucx_utils,
+        "probe_nic_pin_for_device",
+        lambda device_id, min_rate_gbps=None: "mlx5_0:1",
+    )
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert os.environ["UCX_NET_DEVICES"] == "mlx5_0:1"
+    assert "UCX_MAX_RMA_RAILS" not in os.environ
+
+
+def test_min_rate_filter_passed_to_stripe(monkeypatch):
+    """MX_RDMA_NIC_PIN_MIN_RATE_GBPS is forwarded to the stripe lister."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "stripe")
+    monkeypatch.setenv("MX_RDMA_NIC_PIN_MIN_RATE_GBPS", "200")
+    captured = {}
+
+    def fake_list(min_rate_gbps=None):
+        captured["min_rate"] = min_rate_gbps
+        return _fake_nics(("mlx5_0", 400.0, []))
+
+    monkeypatch.setattr(ucx_utils, "_list_compute_ib_nics", fake_list)
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert captured["min_rate"] == 200.0
+
+
+def test_off_mode_unchanged(monkeypatch):
+    """Sanity check: 'off' / unset still does nothing."""
+    monkeypatch.setenv("MX_RDMA_NIC_PIN", "off")
+    ucx_utils.apply_nic_pin_for_device(0)
+    assert "UCX_NET_DEVICES" not in os.environ
+    assert "UCX_MAX_RMA_RAILS" not in os.environ


### PR DESCRIPTION
## Summary

Adds `MX_RDMA_NIC_PIN=stripe` mode to `modelexpress.ucx_utils.apply_nic_pin_for_device`. Lists all visible compute-rate IB NICs in `UCX_NET_DEVICES` (comma-joined) and bumps `UCX_MAX_RMA_RAILS` to the NIC count, so UCX actually uses all of them for parallel RDMA pulls.

Closes #449.

## Motivation

MX/NIXL's per-receiver RDMA pull is single-NIC-pinned by default. On multi-NIC pods (4-NIC GB200, 8-NIC GB300, 32-NIC AWS p5) this leaves 75-87.5% of allocated NIC bandwidth idle. Single-receiver bulk-pull on a 4-NIC GB200 pod measures at ~316 Gbps — saturating one NIC, but well below the ~1.2 Tbps the four NICs are capable of.

Striping the pull across all allocated NICs lifts per-receiver bandwidth proportionally to the number of NICs UCX can fan out across, which is the dominant lever for refit-cycle wall time on many-receiver setups.

## Change

One file changed in production code (`modelexpress/ucx_utils.py`): adds `_stripe_all_compute_nics`, extends `_resolve_nic_pin` to handle `stripe` / `all` aliases, and extends `apply_nic_pin_for_device` to bump `UCX_MAX_RMA_RAILS` to the NIC count when striping.

Existing modes (`auto`, explicit list, `off`/unset) are unchanged. Stripe is opt-in.

Note on `MAX_RMA_RAILS`: UCX defaults this to 2, AND NIXL hardcodes it to 2 in `nixl/src/plugins/ucx/ucx_utils.cpp:422`. The NIXL hardcode overrides our env-set value unless we also patch NIXL — tracked in #449 as Layer 3. For now this PR is the deployment-side fix; users opting into `stripe` mode should also ensure they're on a NIXL build that respects the env-var override (or apply the future NIXL patch alongside).

## Tests

9 new unit tests in `tests/test_nic_pin_stripe.py`:

| Test | Asserts |
|---|---|
| `test_stripe_lists_all_compute_nics` | 4 NICs → `mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1` |
| `test_stripe_bumps_max_rma_rails_to_nic_count` | `UCX_MAX_RMA_RAILS=4` set on 4-NIC pod |
| `test_stripe_respects_explicit_max_rma_rails` | User-set rails value is not overwritten |
| `test_stripe_single_nic_skips_rails_bump` | 1-NIC pod degenerates cleanly |
| `test_stripe_no_nics_visible` | NIC-less host is a no-op |
| `test_stripe_alias_all` | `MX_RDMA_NIC_PIN=all` works as alias |
| `test_auto_mode_does_not_set_rails` | Existing `auto` mode unchanged |
| `test_min_rate_filter_passed_to_stripe` | Rate filter env var forwarded |
| `test_off_mode_unchanged` | Sanity check for `off` mode |

All 9 pass.

## Cluster validation

Validated on a 4-NIC GB200 pod with the existing multi-cycle Qwen3-4B-Thinking refit benchmark, with both the trainer (publisher) and receiver opted into `MX_RDMA_NIC_PIN=stripe`. Real Megatron-Bridge-loaded model, 290 source tensors, 8.04 GB total, 3 back-to-back refit cycles per run.

| Mode (both sides) | Cycle 1 wall | Warm pull (cycle 2/3) | Warm wall | Bandwidth |
|---|---|---|---|---|
| `auto` (current default — 1 NIC) | 0.417 s | 0.203 s | 0.215 s | 316 Gbps |
| `stripe` (this PR — 4 NICs) | 0.543 s | 0.103 s | **0.114 s** | **622 Gbps** |
| Δ | +30% (cold) | -49% | **-47%** | **+97%** |

Cycle-1 wall regresses ~30% because there are 4× more NICs to register against; cycles 2+ recover that and net out ahead because the cached registration carries forward (paired with #421 / #429 / ai-dynamo/dynamo#10901 buffer caching).

### Why only ~2× scaling on a 4-NIC pod

Bumping `UCX_MAX_RMA_RAILS` from 4 to 8 didn't help — bandwidth plateaus at ~625 Gbps. Likely causes:

1. **NIXL hardcodes `MAX_RMA_RAILS=2`** in `nixl/src/plugins/ucx/ucx_utils.cpp:422` via `config.modify(...)`. Per UCX semantics that variant is "modify if not already set via env var", so our env should win — but the empirical bandwidth ceiling is suspiciously close to 2-rail behavior. Worth instrumenting with `UCX_LOG_LEVEL=debug` to confirm which rail count UCX actually picked.
2. **NUMA crossings**: NICs 0/1 are NUMA 0 and NICs 2/3 are NUMA 1 on this pod. If the GPU and scratch buffer are NUMA-0-affine, traffic over NICs 2/3 crosses NUMA, halving effective bandwidth.
3. **UCX's internal striping uses round-robin across rails** — for many small tensors (290 buffers, avg 28 MB each), the protocol overhead may cap us before we hit the bandwidth ceiling.

#449's Layer 3 (expose `max_rma_rails` as a NIXL backend param) targets cause 1.

## Test plan

- [x] Unit tests (9 new, all pass)
- [x] Cluster validation on 4-NIC GB200 pod — A/B confirmed, 47% warm-cycle wall reduction, ~2× pull bandwidth
- [ ] Update example manifests in `examples_dgd/k8s_exemplars/V*/` to use stripe mode (separate small PR after this lands)
- [ ] NIXL Layer 3 — instrument why we plateau at ~2× scaling, expose `max_rma_rails` as a backend param

## Related

- Tracking issue: #449
- Buffer-caching pair: #421, #429, ai-dynamo/dynamo#10901, jthomson04/RL#7