### PR TITLE
fix: deregister NIXL scratch tensors after refit receive

### DIFF
--- a/modelexpress_client/python/modelexpress/nemo_rl_v2.py
+++ b/modelexpress_client/python/modelexpress/nemo_rl_v2.py
@@ -1335,9 +1335,7 @@ class MxV2RefitReceiver:
         return mx_source_id
 
     def shutdown(self) -> None:
-        # MxRefitReceiver has no shutdown method in the existing code; the
-        # NIXL transfer manager and MxClient are torn down by Python's gc.
-        # Future: when refit_receiver gains a shutdown(), call it here.
+        self._receiver.shutdown()
         self._initialized = False
 
 

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -111,6 +112,7 @@ class NixlTransferManager:
         self._metadata: bytes = b""
         self._tensor_descriptors: list[TensorDescriptor] = []
         self._tensors: dict[str, torch.Tensor] = {}
+        self._tensor_registrations: list[Any] = []
 
     @property
     def agent_name(self) -> str:
@@ -190,26 +192,19 @@ class NixlTransferManager:
             elif "UCX_TLS" in os.environ:
                 os.environ.pop("UCX_TLS")
 
-    def _build_tensor_descriptors(
+    def _make_tensor_descriptors(
         self, tensors: dict[str, torch.Tensor]
     ) -> list[TensorDescriptor]:
         """Build NIXL TensorDescriptors from a name -> tensor mapping.
 
         Validates each tensor is contiguous (non-contiguous tensors would
-        require copies that misalign RDMA writes) and records the tensor
-        objects + descriptor list on self for the receiver path to resolve
-        descriptors back by name.
+        require copies that misalign RDMA writes).
 
         CRITICAL: self._tensors must hold the SAME tensor objects as
         param.data in vLLM. Do NOT call .contiguous() here - that would
         create copies and RDMA writes would land in the wrong memory.
 
-        We take a shallow copy of the caller's dict (``dict(tensors)``)
-        so ``shutdown()``'s cleanup cannot mutate the caller's
-        container. The tensor VALUES are the same objects as
-        ``param.data``; only the dict container is owned by the manager.
         """
-        self._tensors = dict(tensors)
         tensor_descriptors = []
         for name, tensor in tensors.items():
             if not tensor.is_contiguous():
@@ -224,8 +219,96 @@ class NixlTransferManager:
                 device_id=self._device_id,
                 dtype=str(tensor.dtype),
             ))
-        self._tensor_descriptors = tensor_descriptors
         return tensor_descriptors
+
+    def _set_tensor_registry(
+        self,
+        tensors: dict[str, torch.Tensor],
+        tensor_descriptors: list[TensorDescriptor],
+    ) -> None:
+        """Record the tensors/descriptors used by receive_from_source."""
+        self._tensors = dict(tensors)
+        self._tensor_descriptors = tensor_descriptors
+
+    def _record_tensor_registration(
+        self,
+        registered: Any,
+        tensors: dict[str, torch.Tensor],
+        tensor_descriptors: list[TensorDescriptor],
+    ) -> None:
+        if registered is not None:
+            self._tensor_registrations.append(registered)
+        self._set_tensor_registry(tensors, tensor_descriptors)
+
+    def _deregister_registered_memory(self, registered: Any) -> None:
+        if registered is not None and self._agent is not None:
+            self._agent.deregister_memory(registered)
+            self._metadata = self._agent.get_agent_metadata()
+
+    def _register_tensor_memory(
+        self,
+        tensors: dict[str, torch.Tensor],
+        tensor_descriptors: list[TensorDescriptor],
+    ) -> Any:
+        """Register tensor memory with NIXL and refresh agent metadata."""
+
+        # Phase 1: Discover CUDA allocation boundaries (if pool reg enabled)
+        alloc_discovery_start = time.perf_counter()
+        if _pool_reg_enabled():
+            if self._accelerator_backend.supports_pool_reg():
+                allocations = self._find_cuda_allocations(tensor_descriptors)
+            else:
+                allocations = None
+                logger.warning(
+                    "MX_POOL_REG=1 set but %s does not support pool "
+                    "registration; using per-tensor registration",
+                    self._accelerator_backend.name,
+                )
+        else:
+            allocations = None
+            logger.info("Pool registration disabled (MX_POOL_REG != '1'), using per-tensor registration")
+        alloc_discovery_time = time.perf_counter() - alloc_discovery_start
+
+        # Phase 2: Register memory with NIXL (ibv_reg_mr kernel calls)
+        nixl_reg_start = time.perf_counter()
+        if allocations:
+            alloc_tuples = [
+                (base, size, self._device_id, "")
+                for base, size in allocations
+            ]
+            registered = self._agent.register_memory(
+                alloc_tuples,
+                mem_type=self._accelerator_backend.nixl_mem_type,
+                backends=self._backends,
+            )
+            reg_count = len(allocations)
+        else:
+            tensor_list = list(tensors.values())
+            registered = self._agent.register_memory(tensor_list, backends=self._backends)
+            reg_count = len(tensor_list)
+        nixl_reg_time = time.perf_counter() - nixl_reg_start
+
+        # Phase 3: Get agent metadata blob
+        metadata_start = time.perf_counter()
+        self._metadata = self._agent.get_agent_metadata()
+        metadata_time = time.perf_counter() - metadata_start
+
+        total_time = alloc_discovery_time + nixl_reg_time + metadata_time
+        reduction = (1 - reg_count / len(tensor_descriptors)) * 100 if tensor_descriptors else 0
+        total_bytes = sum(d.size for d in tensor_descriptors)
+
+        logger.info(
+            f"[TIMING] register_tensors: {total_time:.3f}s total "
+            f"(alloc_discovery={alloc_discovery_time:.3f}s, "
+            f"nixl_register={nixl_reg_time:.3f}s [{reg_count} regions], "
+            f"get_metadata={metadata_time:.3f}s [{len(self._metadata)} bytes])"
+        )
+        logger.info(
+            f"Registered {reg_count} regions from {len(tensor_descriptors)} tensors "
+            f"({reduction:.1f}% reduction), {total_bytes / 1e9:.2f} GB total"
+        )
+
+        return registered
 
     def register_tensors(self, tensors: dict[str, torch.Tensor]) -> bytes:
         """
@@ -261,65 +344,37 @@ class NixlTransferManager:
         if self._agent is None:
             raise RuntimeError("NIXL agent not initialized")
 
-        tensor_descriptors = self._build_tensor_descriptors(tensors)
-
-        # Phase 1: Discover CUDA allocation boundaries (if pool reg enabled)
-        alloc_discovery_start = time.perf_counter()
-        if _pool_reg_enabled():
-            if self._accelerator_backend.supports_pool_reg():
-                allocations = self._find_cuda_allocations(tensor_descriptors)
-            else:
-                allocations = None
-                logger.warning(
-                    "MX_POOL_REG=1 set but %s does not support pool "
-                    "registration; using per-tensor registration",
-                    self._accelerator_backend.name,
-                )
-        else:
-            allocations = None
-            logger.info("Pool registration disabled (MX_POOL_REG != '1'), using per-tensor registration")
-        alloc_discovery_time = time.perf_counter() - alloc_discovery_start
-
-        # Phase 2: Register memory with NIXL (ibv_reg_mr kernel calls)
-        nixl_reg_start = time.perf_counter()
-        if allocations:
-            alloc_tuples = [
-                (base, size, self._device_id, "")
-                for base, size in allocations
-            ]
-            self._agent.register_memory(
-                alloc_tuples,
-                mem_type=self._accelerator_backend.nixl_mem_type,
-                backends=self._backends,
-            )
-            reg_count = len(allocations)
-        else:
-            tensor_list = list(tensors.values())
-            self._agent.register_memory(tensor_list, backends=self._backends)
-            reg_count = len(tensor_list)
-        nixl_reg_time = time.perf_counter() - nixl_reg_start
-
-        # Phase 3: Get agent metadata blob
-        metadata_start = time.perf_counter()
-        self._metadata = self._agent.get_agent_metadata()
-        metadata_time = time.perf_counter() - metadata_start
-
-        total_time = alloc_discovery_time + nixl_reg_time + metadata_time
-        reduction = (1 - reg_count / len(tensor_descriptors)) * 100 if tensor_descriptors else 0
-        total_bytes = sum(d.size for d in tensor_descriptors)
-
-        logger.info(
-            f"[TIMING] register_tensors: {total_time:.3f}s total "
-            f"(alloc_discovery={alloc_discovery_time:.3f}s, "
-            f"nixl_register={nixl_reg_time:.3f}s [{reg_count} regions], "
-            f"get_metadata={metadata_time:.3f}s [{len(self._metadata)} bytes])"
+        tensor_descriptors = self._make_tensor_descriptors(tensors)
+        registered = self._register_tensor_memory(
+            tensors,
+            tensor_descriptors,
         )
-        logger.info(
-            f"Registered {reg_count} regions from {len(tensor_descriptors)} tensors "
-            f"({reduction:.1f}% reduction), {total_bytes / 1e9:.2f} GB total"
-        )
+        self._record_tensor_registration(registered, tensors, tensor_descriptors)
 
         return self._metadata
+
+    @contextmanager
+    def temporary_registered_tensors(self, tensors: dict[str, torch.Tensor]):
+        """Temporarily register tensors for one receive without replacing persistent buffers."""
+        if self._agent is None:
+            raise RuntimeError("NIXL agent not initialized")
+
+        saved_tensors = self._tensors
+        saved_tensor_descriptors = self._tensor_descriptors
+        saved_metadata = self._metadata
+
+        tensor_descriptors = self._make_tensor_descriptors(tensors)
+        registered = self._register_tensor_memory(tensors, tensor_descriptors)
+        self._set_tensor_registry(tensors, tensor_descriptors)
+        try:
+            yield self._metadata
+        finally:
+            try:
+                self._deregister_registered_memory(registered)
+            finally:
+                self._tensors = saved_tensors
+                self._tensor_descriptors = saved_tensor_descriptors
+                self._metadata = saved_metadata
 
     def register_arena(self, arena: VmmArena, tensors: dict[str, torch.Tensor]) -> bytes:
         """Register a VmmArena's full bump range as a single NIXL region.
@@ -351,7 +406,7 @@ class NixlTransferManager:
         if self._agent is None:
             raise RuntimeError("NIXL agent not initialized")
 
-        tensor_descriptors = self._build_tensor_descriptors(tensors)
+        tensor_descriptors = self._make_tensor_descriptors(tensors)
 
         base, used = arena.registered_range()
         if used == 0:
@@ -370,7 +425,7 @@ class NixlTransferManager:
             return self.register_tensors(tensors)
 
         nixl_reg_start = time.perf_counter()
-        self._agent.register_memory(
+        registered = self._agent.register_memory(
             [(base, used, self._device_id, "")],
             mem_type=self._accelerator_backend.nixl_mem_type,
             backends=self._backends,
@@ -393,6 +448,8 @@ class NixlTransferManager:
             f"({reduction:.1f}% reduction), {total_bytes / 1e9:.2f} GB live in "
             f"{used / 1e9:.2f} GB arena bump range"
         )
+
+        self._record_tensor_registration(registered, tensors, tensor_descriptors)
 
         return self._metadata
 
@@ -664,9 +721,7 @@ class NixlTransferManager:
         """Deregister a memory descriptor returned by register_memory."""
         if self._agent is None:
             raise RuntimeError("NIXL agent not initialized")
-        if registered is not None:
-            self._agent.deregister_memory(registered)
-            self._metadata = self._agent.get_agent_metadata()
+        self._deregister_registered_memory(registered)
 
     def receive_dram_into_buffer(
         self,
@@ -758,6 +813,12 @@ class NixlTransferManager:
         aliases ``_tensors`` directly, shutdown will not mutate the
         shared container out from under them.
         """
+        for registered in reversed(self._tensor_registrations):
+            try:
+                self._deregister_registered_memory(registered)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Failed to deregister NIXL tensor memory during shutdown: %s", e)
+        self._tensor_registrations = []
         self._agent = None
         self._metadata = b""
         self._tensor_descriptors = []

--- a/modelexpress_client/python/modelexpress/refit_receiver.py
+++ b/modelexpress_client/python/modelexpress/refit_receiver.py
@@ -448,14 +448,16 @@ class MxRefitReceiver:
             f"({sum(t.numel() * t.element_size() for t in scratch_tensors.values()) / 1e9:.2f} GB)"
         )
 
-        self._nixl.register_tensors(scratch_tensors)
-
         # See `receive_weights` above for tuple-semantics rationale.
-        transferred, matched_tensors, elapsed = self._nixl.receive_from_source(
-            source_metadata=worker.nixl_metadata,
-            source_tensors=source_tensors,
-            timeout_seconds=timeout_seconds,
-        )
+        # Scratch buffers are only RDMA targets for this receive. Keep their
+        # NIXL registration scoped to the transfer so repeated refits do not
+        # accumulate stale registrations or replace pre-registered model buffers.
+        with self._nixl.temporary_registered_tensors(scratch_tensors):
+            transferred, matched_tensors, elapsed = self._nixl.receive_from_source(
+                source_metadata=worker.nixl_metadata,
+                source_tensors=source_tensors,
+                timeout_seconds=timeout_seconds,
+            )
         advertised_bytes = sum(td.size for td in source_tensors)
 
         stats = TransferStats(

--- a/modelexpress_client/python/tests/test_v2_source_picker.py
+++ b/modelexpress_client/python/tests/test_v2_source_picker.py
@@ -156,6 +156,9 @@ def v2():
             for name, tensor in payload.items():
                 yield name, tensor
 
+        def shutdown(self):
+            pass
+
     refit_mod.MxRefitReceiver = _RefitStub
     refit_mod.SourceRef = _SourceRef
     _install("modelexpress.refit_receiver", refit_mod)

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -538,19 +538,24 @@ class TestNixlTransferManagerDictOwnership:
     def _make_manager(self):
         mgr = NixlTransferManager(agent_name="test", device_id=0)
         mgr._agent = MagicMock()
+        mgr._agent.get_agent_metadata.return_value = b"meta"
         return mgr
+
+    @staticmethod
+    def _tensor(addr: int = 0x1000):
+        tensor = MagicMock()
+        tensor.is_contiguous.return_value = True
+        tensor.data_ptr.return_value = addr
+        tensor.numel.return_value = 1
+        tensor.element_size.return_value = 1
+        tensor.dtype = torch.float32
+        return tensor
 
     def test_register_takes_shallow_copy_of_caller_dict(self):
         mgr = self._make_manager()
-        t = MagicMock()
-        t.is_contiguous.return_value = True
-        t.data_ptr.return_value = 0x1000
-        t.numel.return_value = 1
-        t.element_size.return_value = 1
-        t.dtype = torch.float32
+        t = self._tensor()
         caller = {"w": t}
 
-        mgr._agent.get_local_md.return_value = b"meta"
         mgr.register_tensors(caller)
 
         assert mgr._tensors is not caller
@@ -558,15 +563,9 @@ class TestNixlTransferManagerDictOwnership:
 
     def test_shutdown_does_not_clear_caller_dict(self):
         mgr = self._make_manager()
-        t = MagicMock()
-        t.is_contiguous.return_value = True
-        t.data_ptr.return_value = 0x1000
-        t.numel.return_value = 1
-        t.element_size.return_value = 1
-        t.dtype = torch.float32
+        t = self._tensor()
         caller = {"w": t}
 
-        mgr._agent.get_local_md.return_value = b"meta"
         mgr.register_tensors(caller)
         mgr.shutdown()
 
@@ -587,6 +586,76 @@ class TestNixlTransferManagerDictOwnership:
         )
         assert mgr._tensors == {}
         assert mgr._tensor_descriptors == []
+
+    def test_re_register_tracks_each_tensor_registration(self, monkeypatch):
+        monkeypatch.delenv("MX_POOL_REG", raising=False)
+        mgr = self._make_manager()
+        mgr._agent.register_memory.side_effect = ["reg-1", "reg-2"]
+
+        first = {"w1": self._tensor(0x1000)}
+        second = {"w2": self._tensor(0x2000)}
+
+        mgr.register_tensors(first)
+        mgr.register_tensors(second)
+
+        mgr._agent.deregister_memory.assert_not_called()
+        assert mgr._tensor_registrations == ["reg-1", "reg-2"]
+        assert mgr._tensors == second
+
+    def test_failed_re_register_keeps_previous_tensor_registrations(self, monkeypatch):
+        monkeypatch.delenv("MX_POOL_REG", raising=False)
+        mgr = self._make_manager()
+        mgr._agent.register_memory.side_effect = ["reg-1", RuntimeError("boom")]
+
+        first = {"w1": self._tensor(0x1000)}
+        second = {"w2": self._tensor(0x2000)}
+
+        mgr.register_tensors(first)
+        with pytest.raises(RuntimeError, match="boom"):
+            mgr.register_tensors(second)
+
+        mgr._agent.deregister_memory.assert_not_called()
+        assert mgr._tensor_registrations == ["reg-1"]
+        assert mgr._tensors == first
+
+    def test_shutdown_deregisters_tensor_registrations(self, monkeypatch):
+        monkeypatch.delenv("MX_POOL_REG", raising=False)
+        mgr = self._make_manager()
+        mgr._agent.register_memory.side_effect = ["reg-1", "reg-2"]
+
+        mgr.register_tensors({"w1": self._tensor(0x1000)})
+        mgr.register_tensors({"w2": self._tensor(0x2000)})
+        agent = mgr._agent
+        mgr.shutdown()
+
+        assert agent.deregister_memory.call_args_list == [
+            call("reg-2"),
+            call("reg-1"),
+        ]
+        assert mgr._tensor_registrations == []
+
+    def test_temporary_registered_tensors_restores_previous_registry(self, monkeypatch):
+        monkeypatch.delenv("MX_POOL_REG", raising=False)
+        mgr = self._make_manager()
+        persistent = {"model": self._tensor(0x1000)}
+        persistent_descs = [MagicMock()]
+        mgr._tensors = persistent
+        mgr._tensor_descriptors = persistent_descs
+        mgr._metadata = b"persistent-meta"
+        mgr._agent.register_memory.return_value = "scratch-reg"
+        mgr._agent.get_agent_metadata.side_effect = [b"scratch-meta", b"after-deregister"]
+
+        scratch = {"scratch": self._tensor(0x2000)}
+        with mgr.temporary_registered_tensors(scratch) as metadata:
+            assert metadata == b"scratch-meta"
+            assert mgr._tensors == scratch
+            assert mgr._metadata == b"scratch-meta"
+
+        mgr._agent.deregister_memory.assert_called_once_with("scratch-reg")
+        assert mgr._tensors is persistent
+        assert mgr._tensor_descriptors is persistent_descs
+        assert mgr._metadata == b"persistent-meta"
+        assert mgr._tensor_registrations == []
 
 
 class TestPublishMetadataErrorHandling:

--- a/modelexpress_client/python/tests/test_vllm_weight_transfer.py
+++ b/modelexpress_client/python/tests/test_vllm_weight_transfer.py
@@ -166,6 +166,9 @@ def vllm_wt():
         def receive_weights_scratch(self, ref, timeout_seconds=300.0, tensor_shapes=None):
             return iter([])
 
+        def shutdown(self):
+            pass
+
     refit_mod.MxRefitReceiver = _RefitStub
     refit_mod.SourceRef = _SourceRef
     refit_mod.TransferStats = _TransferStats


### PR DESCRIPTION
## Summary

Fixes a NIXL registration leak in the scratch receive path.

`MxRefitReceiver.receive_weights_scratch()` allocates fresh GPU scratch tensors per receive and registers them via `NixlTransferManager.register_tensors()`.  Previously, this flow invoked `register_memory()` without retaining or releasing the returned registration descriptors, causing registrations to accumulate across repeated refits.

This change scopes scratch tensor registrations to the duration of a single receive and ensures they are deregistered immediately after the transfer completes. Persistent tensor registrations are now tracked and released on shutdown, preserving existing publisher assumptions about stable, long-lived metadata.

## Changes

- Add registration descriptor tracking to `NixlTransferManager`.
- Introduce `temporary_registered_tensors()` for scoped, one-shot registrations.
- Use temporary registration in `receive_weights_scratch()`.
- Ensure proper teardown by explicitly shutting down the wrapped `MxRefitReceiver` from `MxV2RefitReceiver.shutdown()`.
- Add unit tests (mocked) covering:
  - registration tracking
  - shutdown cleanup
  - temporary registration lifecycle

## Validation

Baseline metadata grew linearly across repeated scratch receives:

```txt
9878 -> 19190 -> 28502 -> 37814 -> 47126
```

After this patch, metadata stayed bounded:

```txt
count: 21
first 10: [9882, 9878, 9878, 9878, 9878, 9878, 9878, 9878, 9878, 9878]
last 10: [9878, 9878, 9878, 9878, 9878, 9878, 9878, 9878, 9878, 9878]
first: 9882 last: 9878 delta: -4
```

Validation command:

```sh
python benchmarks/bench_elastic_scaling.py \
  --mode=live \
  --scenario=elastic_scale \
  --num-receivers=1 \
  --steps=30 \
  --num-tensors=32 \
  --tensor-bytes=$((8*1024*1024)) \
  --trainer-device-id=0 \
  --receiver-device-base=1 \
  --step-interval=1.0 \
  --join-interval=0.2 \
  --trainer-warmup=2.0 \
  --cycle-timeout=120 \
  --deadline=900 \
  --output=/tmp/elastic_fixed.json \
  -v 2>&1 | tee /tmp/elastic_fixed.log
```
