### PR TITLE
fix(client): drop nixl[cu12] pin blocking CUDA-13 installs (backport to 0.4.0)

### DIFF
--- a/ci/k8s/client/trt-llm/Dockerfile
+++ b/ci/k8s/client/trt-llm/Dockerfile
@@ -40,13 +40,12 @@ USER root
 # Proto stubs (p2p_pb2.py, p2p_pb2_grpc.py) are checked-in source artifacts;
 # regenerate with grpcio-tools when p2p.proto changes.
 #
-# Pip's default upgrade strategy (only-if-needed) keeps the base image's
-# pre-installed nixl 0.10.1 untouched because modelexpress's constraint
-# `nixl[cu12]; sys_platform == 'linux'` is unbounded and 0.10.1 satisfies it.
-# Do NOT add a `>=` lower bound to that constraint in pyproject.toml without
-# updating this Dockerfile — it would force pip to upgrade nixl to 1.1.0 here,
-# which would re-introduce the UCX ABI mismatch the base image was chosen
-# to avoid. See docs/NIXL_UCX_COMPATIBILITY.md.
+# MX does not pin a NIXL distribution; it imports `nixl._api` against
+# whatever variant the base image provides. This image's pre-installed
+# nixl-cu12 0.10.1 stays untouched and satisfies MX's runtime path,
+# and the layer keeps working unchanged if Dynamo's tensorrtllm-runtime
+# ever switches its bundled NIXL to a different version or to
+# nixl-cu13. See docs/NIXL_UCX_COMPATIBILITY.md for the UCX ABI story.
 COPY modelexpress_client/python /opt/modelexpress/client
 WORKDIR /opt/modelexpress/client
 RUN pip uninstall -y modelexpress 2>/dev/null || true && \

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -17,6 +17,11 @@ pip install -e .
 pip install -e ".[dev]"
 ```
 
+NIXL is expected to be supplied by the runtime environment (TRT-LLM,
+SGLang, Dynamo, and NemoRL runtime images all ship `nixl-cu12` or
+`nixl-cu13`). For a bare-environment install, run `pip install nixl-cu12`
+or `pip install nixl-cu13` separately, matching your host CUDA toolkit.
+
 ### Requirements
 
 - Python >= 3.10

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
     "grpcio>=1.66.2",
     "huggingface_hub>=0.20.0",
-    "nixl[cu12]; sys_platform == 'linux'",
     "numpy>=1.24.0",
     "protobuf>=5.27.0,<6.0.0", # protobuf 5.x compatibility
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary

Backport of #447 (`d35d4a16b3810dd8f825e78ceed3f07cdb8b74e1`) to `release/0.4.0`.

Drops the `"nixl[cu12]; sys_platform == 'linux'"` pin from `modelexpress_client/python/pyproject.toml` so `pip install modelexpress` no longer fails in CUDA-13 host environments (where no matching `nixl[cu12]` wheel resolves). MX itself is variant-blind at the source level — `nixl_transfer.py` imports `from nixl._api import nixl_agent`, and both `nixl-cu12` and `nixl-cu13` wheels export the same `nixl._api` module — so MX runs against whichever variant the runtime image already provides.

Doc updates that ride along:
- `modelexpress_client/python/README.md` — note that NIXL is supplied by the runtime image (TRT-LLM, SGLang, Dynamo, NemoRL all ship `nixl-cu12` or `nixl-cu13`); bare-env installs should `pip install nixl-cu{12,13}` separately.
- `ci/k8s/client/trt-llm/Dockerfile` — comment rewrite reflecting the new "MX does not pin a NIXL distribution" contract. Pre-installed `nixl-cu12 0.10.1` from `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.1` stays untouched.

No behavior change in any MX CI image today — all worker bases still ship `nixl-cu12`. The PR is a permission change (unblocks cu13 installs in downstream environments), not a default-behavior change.

## Changes

3 files, +11 / −8 — identical to upstream #447:
- `modelexpress_client/python/pyproject.toml` (−1)
- `modelexpress_client/python/README.md` (+5)
- `ci/k8s/client/trt-llm/Dockerfile` (+6 / −7)

## Cherry-pick details

- Source merge commit: `d35d4a16b3810dd8f825e78ceed3f07cdb8b74e1` on `main`
- Squash-merge (single parent), applied via `git cherry-pick -x`
- Auto-merging on `pyproject.toml` and `README.md` reported by git is positional context only — no conflict markers, no manual resolution required
- Local branch: `kavink/backport-447-nixl-cu13-to-0.4.0`

## Test plan

- [ ] CI green on this PR (build-client, build-server, vLLM/TRT-LLM/SGLang worker image builds, P2P tests on all three frameworks) — confirms `pip install .` still resolves cleanly inside each worker base image and `nixl._api` still imports
- [ ] Spot-check: `pip show nixl-cu12` inside the post-merge `mx-worker-trt-llm` image still reports `0.10.1` (unchanged from base)

## Follow-ups (not in this PR, tracked separately)

Two stale references identified during review of #447 — non-blockers, should land on `main` first then potentially be cherry-picked here if anyone reports cu13 install friction on 0.4.0:

1. `docs/NIXL_UCX_COMPATIBILITY.md` is referenced from the trt-llm `Dockerfile` and `README.md` but the file does not exist in `docs/`.
2. `modelexpress_client/python/modelexpress/gds_transfer.py:125` still instructs `pip install nixl[cu12]` in its `NIXL_AVAILABLE` error path; should match the new README guidance (`pip install nixl-cu12` or `pip install nixl-cu13`).