### PR TITLE
ci: migrate image registry to new NGC org registry

### DIFF
--- a/.github/actions/run-mx-p2p-test/action.yml
+++ b/.github/actions/run-mx-p2p-test/action.yml
@@ -133,7 +133,7 @@ runs:
         echo "::group::Create worker-registry pull secret"
         # docker-server is hardcoded to nvcr.io so this single secret
         # authenticates ALL nvcr.io images — both the team's worker images
-        # (nvcr.io/nvidian/...) and the public base images (nvcr.io/nvidia/...).
+        # (nvcr.io/0980761089281446/...) and the public base images (nvcr.io/nvidia/...).
         # Replaces the previous two-secret setup (worker-registry + ngc-registry).
         kubectl create secret docker-registry worker-registry \
           --docker-server="nvcr.io" \

--- a/.github/actions/setup-mx-vcluster/action.yml
+++ b/.github/actions/setup-mx-vcluster/action.yml
@@ -222,7 +222,7 @@ runs:
         # (nvcr.io/nvidia/ai-dynamo/kubernetes-operator) lives under the
         # public `nvidia` NGC org and is pullable anonymously. The
         # `worker-registry` secret used by test pods is created per-run by
-        # the test actions for our private nvcr.io/nvidian/dynamo-dev/*
+        # the test actions for our private nvcr.io/0980761089281446/*
         # images, separately from this operator install.
         kubectl create namespace dynamo-system --dry-run=client -o yaml \
           | kubectl apply -f -

--- a/.github/workflows/modelexpress-ci-tests.yml
+++ b/.github/workflows/modelexpress-ci-tests.yml
@@ -138,7 +138,7 @@ env:
   VCLUSTER_NAMESPACE: mx-ci
   MX_CI_S3_BUCKET: ai-dynamo-modelexpress-ci
   MX_CI_S3_REGION: us-east-1
-  MX_IMAGE_REPO: nvcr.io/nvidian/dynamo-dev
+  MX_IMAGE_REPO: nvcr.io/0980761089281446
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Points CI image push/pull at the new NGC org's registry path via the
`MX_IMAGE_REPO` env var. All build/push and test-pull references derive from
that single var, so this moves the whole pipeline. Two stale path references in
composite-action comments are updated to match.

## Testing

Build jobs push successfully to the new registry with the existing
`NGC_API_KEY` secret (verified on a CI run for this branch).

## Out of scope

Example manifests under `examples/` still reference the old path; left out of
this PR (not CI-critical, can migrate separately as needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image repository references used by CI and setup workflows.
  * Clarified registry notes for pulling both internal worker images and public base images.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->