### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (backport to 0.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",


### PR DESCRIPTION
## Summary

Bumps `quinn-proto` 0.11.14 → 0.11.15 in `Cargo.lock` on `release/0.4.0` to address [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) (filed 2026-06-22, severity 7.5 high — remote memory exhaustion via unbounded out-of-order stream reassembly).

Mirrors the same bump that already landed on `main` via #443 (commit `f1ac6f4`). Only the `Cargo.lock` portion of that commit is carried here; the SGLang doc changes in #443 don't apply to this branch.

## Why now

The `Security Audit` CI job (`cargo audit`) started failing on **every PR targeting `release/0.4.0`** the moment the RustSec advisory database picked up RUSTSEC-2026-0185 — including unrelated Python/docs backports. Most recent example: #462 (cherry-pick of #447, no Rust changes whatsoever) failed Security Audit only because of this pre-existing transitive-dep vulnerability.

Landing this small lockfile bump unblocks the Audit gate on all current and future 0.4.0 backports.

## Changes

```
Cargo.lock | 4 ++--
1 file changed, 2 insertions(+), 2 deletions(-)
```

Single block change — version + checksum for the `quinn-proto` entry:

```diff
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
```

No `Cargo.toml` change required — `quinn` parent crate's existing semver range already allows 0.11.x patch versions. Bytes are byte-identical to `cargo update -p quinn-proto --precise 0.11.15` and identical to the bump on `main`.

## Test plan

- [ ] CI green on this PR, particularly the `Security Audit` job (the whole point of this PR)
- [ ] After merge: rebase #462 on the new `release/0.4.0` tip; the Security Audit job there should now flip from FAILURE to SUCCESS

## Stacking note

#462 (`fix(client): drop nixl[cu12] pin blocking CUDA-13 installs (backport to 0.4.0)`) is currently red on Security Audit for this same reason. Once this PR merges, #462 just needs a rebase / re-run to go fully green.