### PR TITLE
fix: add namespace to Helm resources and auto-set MX_METADATA_NAMESPACE

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,10 +48,16 @@ spec:
               containerPort: {{ .Values.service.port | default 8001 }}
               protocol: TCP
           env:
+            {{- $hasNsInExtra := false }}
+            {{- range .Values.extraEnv }}
+              {{- if eq .name "MX_METADATA_NAMESPACE" }}
+                {{- $hasNsInExtra = true }}
+              {{- end }}
+            {{- end }}
+            {{- if and (not (hasKey .Values.env "MX_METADATA_NAMESPACE")) (not $hasNsInExtra) }}
             - name: MX_METADATA_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: {{ .Release.Namespace | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "modelexpress.fullname" . }}
+  namespace: {{ .Release.Namespace }} 
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
 spec:
@@ -46,8 +47,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port | default 8001 }}
               protocol: TCP
-          {{- if or .Values.env .Values.extraEnv }}
           env:
+            - name: MX_METADATA_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
@@ -55,7 +59,6 @@ spec:
             {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
-          {{- end }}
           {{- if .Values.command }}
           command:
             {{- toYaml .Values.command | nindent 12 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "modelexpress.fullname" . }}
-  namespace: {{ .Release.Namespace }} 
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "modelexpress.fullname" . }}-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -10,6 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "modelexpress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
 rules:
@@ -29,6 +30,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "modelexpress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
 roleRef:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "modelexpress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "modelexpress.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
   {{- if and .Values.serviceAccount .Values.serviceAccount.annotations }}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "modelexpress.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
When deploying Model Express to a specific namespace in a cluster, I noticed that the Helm chart does not fully support this. This PR adds support for deploying Model Express to a user-specified namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm-rendered resources now consistently use the release namespace by default.
  * The application environment now includes a default metadata namespace value unless overridden.

* **Documentation**
  * Added a configuration example showing how to customize the metadata namespace.

* **Bug Fixes**
  * Improved namespace consistency across workload, service, account, role, and test resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->