### PR TITLE
refactor: centralize environment variables into envs.rs / envs.py

### DIFF
--- a/.cursor/rules/rust.mdc
+++ b/.cursor/rules/rust.mdc
@@ -57,7 +57,7 @@ Client CLI arguments are defined in a shared struct to avoid duplication:
 
 1. **Add to `ClientArgs`** in `modelexpress_common/src/client_config.rs`
    - Single source of truth for shared arguments
-   - Use `#[arg(long, env = "MODEL_EXPRESS_...")]` for environment variable support
+   - Register the variable name in `modelexpress_common/src/envs.rs` and reference the constant: `#[arg(long, env = crate::envs::MODEL_EXPRESS_...)]` (never a bare string literal, so the CLI and the `envs` getters cannot drift). All env-var names live in `modelexpress_common/src/envs.rs` (Rust) and `modelexpress/envs.py` (Python).
    - Do NOT use `-v` short flag (reserved for CLI's verbose)
 
 2. **Update `ClientConfig::load()`** in the same file

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,7 +57,7 @@ Client CLI arguments are defined in a shared struct to avoid duplication:
 
 1. **Add to `ClientArgs`** in `modelexpress_common/src/client_config.rs`
    - Single source of truth for shared arguments
-   - Use `#[arg(long, env = "MODEL_EXPRESS_...")]` for environment variable support
+   - Register the variable name in `modelexpress_common/src/envs.rs` and reference the constant: `#[arg(long, env = crate::envs::MODEL_EXPRESS_...)]` (never a bare string literal, so the CLI and the `envs` getters cannot drift). All env-var names live in `modelexpress_common/src/envs.rs` (Rust) and `modelexpress/envs.py` (Python).
    - Do NOT use `-v` short flag (reserved for CLI's verbose)
 
 2. **Update `ClientConfig::load()`** in the same file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Client CLI arguments are defined in a shared struct to avoid duplication:
 
 1. **Add to `ClientArgs`** in `modelexpress_common/src/client_config.rs`
    - Single source of truth for shared arguments
-   - Use `#[arg(long, env = "MODEL_EXPRESS_...")]` for environment variable support
+   - Register the variable name in `modelexpress_common/src/envs.rs` and reference the constant: `#[arg(long, env = crate::envs::MODEL_EXPRESS_...)]` (never a bare string literal, so the CLI and the `envs` getters cannot drift). All env-var names live in `modelexpress_common/src/envs.rs` (Rust) and `modelexpress/envs.py` (Python).
    - Do NOT use `-v` short flag (reserved for CLI's verbose)
 
 2. **Update `ClientConfig::load()`** in the same file

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -16,7 +16,7 @@ ModelExpress uses a layered configuration system. Sources are applied in order o
 3. **Configuration file** (YAML)
 4. **Default values** (lowest priority)
 
-> Every environment variable the code reads — its name, default, and fallback chain — is defined in one place per language: `modelexpress_common/src/envs.rs` (Rust server/client) and `modelexpress_client/python/modelexpress/envs.py` (Python client). Treat those modules as the canonical inventory; the tables below mirror them.
+> Most environment variables the code reads — including their defaults and fallback chains — are defined in one place per language: `modelexpress_common/src/envs.rs` (Rust server/client) and `modelexpress_client/python/modelexpress/envs.py` (Python client). Treat those modules as the canonical inventory; the tables below mirror them, and the documented exceptions are called out where needed.
 
 ### Generating a Configuration File
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -16,6 +16,8 @@ ModelExpress uses a layered configuration system. Sources are applied in order o
 3. **Configuration file** (YAML)
 4. **Default values** (lowest priority)
 
+> Every environment variable the code reads — its name, default, and fallback chain — is defined in one place per language: `modelexpress_common/src/envs.rs` (Rust server/client) and `modelexpress_client/python/modelexpress/envs.py` (Python client). Treat those modules as the canonical inventory; the tables below mirror them.
+
 ### Generating a Configuration File
 
 ```bash

--- a/modelexpress_client/python/modelexpress/__init__.py
+++ b/modelexpress_client/python/modelexpress/__init__.py
@@ -19,7 +19,8 @@ Quick Start (vLLM):
 """
 
 import logging
-import os
+
+from . import envs
 
 _logger = logging.getLogger(__name__)
 _loaders_registered = False
@@ -39,7 +40,7 @@ def configure_vllm_logging():
     vllm_logger = logging.getLogger("vllm")
     for handler in vllm_logger.handlers:
         mx_root.addHandler(handler)
-    mx_level = os.environ.get("MODEL_EXPRESS_LOG_LEVEL", "").upper()
+    mx_level = envs.MODEL_EXPRESS_LOG_LEVEL
     if mx_level and hasattr(logging, mx_level):
         mx_root.setLevel(getattr(logging, mx_level))
     elif vllm_logger.level != logging.NOTSET:

--- a/modelexpress_client/python/modelexpress/client.py
+++ b/modelexpress_client/python/modelexpress/client.py
@@ -13,11 +13,11 @@ registered by the owning process for GPUDirect RDMA.
 """
 
 import logging
-import os
 from abc import ABC, abstractmethod
 
 import grpc
 
+from . import envs
 from . import p2p_pb2
 from . import p2p_pb2_grpc
 
@@ -101,10 +101,11 @@ def _get_server_url(explicit_url: str | None = None) -> str:
     """
     if explicit_url:
         return _parse_server_address(explicit_url)
-    url = os.environ.get(
-        "MODEL_EXPRESS_URL",
-        os.environ.get("MX_SERVER_ADDRESS", "localhost:8001"),
-    )
+    url = envs.MODEL_EXPRESS_URL
+    if url is None:
+        url = envs.MX_SERVER_ADDRESS
+        if url is None:
+            url = "localhost:8001"
     return _parse_server_address(url)
 
 

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 
 import copy
 import logging
-import os
 import uuid
 from importlib.metadata import version as pkg_version
 from typing import TYPE_CHECKING, Iterator
 
 import torch
 
+from ... import envs
 from ... import p2p_pb2
 from ...adapter import EngineAdapter
 from ...accelerators import accelerator_backend_for
@@ -188,7 +188,7 @@ class SglangAdapter(EngineAdapter):
         return (
             tp_size > 1
             and self.is_cuda_alike()
-            and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
+            and envs.MX_MS_DISTRIBUTED
         )
 
 
@@ -289,7 +289,7 @@ def _get_quantization(model_config: ModelConfig) -> str:
 
 
 def _get_revision(model_config: ModelConfig) -> str:
-    override = os.environ.get("MX_MODEL_REVISION", "")
+    override = envs.MX_MODEL_REVISION
     if override:
         return override
     return str(getattr(model_config, "revision", "") or "")

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import copy
 import logging
-import os
 import uuid
 from typing import TYPE_CHECKING, Iterator
 
 import torch
 
+from ... import envs
 from ...adapter import EngineAdapter
 from ...accelerators import accelerator_backend_for
 from ...load_strategy.context import LoadContext, LoadResult
@@ -246,7 +246,7 @@ class VllmAdapter(EngineAdapter):
         tp_size = getattr(self.vllm_config.parallel_config, "tensor_parallel_size", 1)
         return (
             tp_size > 1
-            and os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true")
+            and envs.MX_MS_DISTRIBUTED
         )
 
 

--- a/modelexpress_client/python/modelexpress/engines/vllm/artifacts.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/artifacts.py
@@ -22,6 +22,7 @@ from typing import Iterator
 
 import torch
 
+from ... import envs
 from ... import p2p_pb2
 from ...load_strategy.base import (
     _init_nixl_manager,
@@ -45,17 +46,9 @@ from ...nixl_transfer import is_nixl_available
 
 logger = logging.getLogger("modelexpress.engines.vllm.artifacts")
 
-_ENABLE_ENV = "MX_ARTIFACT_TRANSFER"
-_BUNDLE_ROOT_ENV = "MX_ARTIFACT_BUNDLE_ROOT"
-_COMPILE_CONFIG_DIGEST_ENV = "MX_ARTIFACT_COMPILE_CONFIG_DIGEST"
-_DEEP_GEMM_CACHE_DIR_ENV = "DEEP_GEMM_CACHE_DIR"
-_DG_JIT_CACHE_DIR_ENV = "DG_JIT_CACHE_DIR"
-_READY_URL_ENV = "MX_ARTIFACT_READY_URL"
-_READY_TIMEOUT_ENV = "MX_ARTIFACT_READY_TIMEOUT_SECS"
 _DEFAULT_READY_URL = "http://127.0.0.1:8000/health"
 _READY_POLL_SECS = 5
 _CACHE_SETTLE_SECS = 5
-_TRUTHY = {"1", "true", "yes", "on"}
 
 _published_sources: dict[tuple[int, int], PublishedArtifactSource] = {}
 _scheduled_publishers: dict[tuple[int, int], PublisherThread] = {}
@@ -166,7 +159,7 @@ def schedule_vllm_cache_artifact_publish(ctx: LoadContext) -> None:
                 _publish_vllm_cache_artifact(ctx, transfer, identity).endpoint.mx_source_id
             ),
             ready_fn=_vllm_artifact_ready_fn(transfer.source_root),
-            publish_timeout_secs=_ready_timeout_secs(),
+            publish_timeout_secs=envs.MX_ARTIFACT_READY_TIMEOUT_SECS,
             interval_secs=_READY_POLL_SECS,
             heartbeat_after_publish=False,
             cleanup_fn=lambda marker_path=marker_path, publisher_ref=publisher_ref: (
@@ -286,7 +279,7 @@ def _publish_vllm_cache_artifact(
 
 
 def _artifact_transfer_enabled() -> bool:
-    return os.environ.get(_ENABLE_ENV, "").strip().lower() in _TRUTHY
+    return envs.MX_ARTIFACT_TRANSFER
 
 
 def _artifact_source_worker_id(
@@ -360,7 +353,7 @@ def _p2p_metadata_enabled_for_artifacts(ctx: LoadContext) -> bool:
 def _ensure_nixl_manager(ctx: LoadContext) -> None:
     if ctx.nixl_manager is not None:
         return
-    base_port = _env_int("MX_METADATA_PORT", 5555)
+    base_port = envs.MX_METADATA_PORT
     try:
         ctx.nixl_manager = _init_nixl_manager(
             ctx.global_rank,
@@ -433,30 +426,28 @@ def _torch_compile_cache_root() -> Path:
 
 
 def _triton_cache_root() -> Path:
-    configured = os.environ.get("TRITON_CACHE_DIR")
+    configured = envs.TRITON_CACHE_DIR
     if configured:
         return Path(configured)
     return Path.home() / ".triton" / "cache"
 
 
 def _deep_gemm_cache_root() -> Path:
-    configured = os.environ.get(_DG_JIT_CACHE_DIR_ENV) or os.environ.get(
-        _DEEP_GEMM_CACHE_DIR_ENV
-    )
+    configured = envs.DG_JIT_CACHE_DIR or envs.DEEP_GEMM_CACHE_DIR
     if configured:
         return Path(configured)
     return _vllm_cache_root() / "deep_gemm"
 
 
 def _tilelang_cache_root() -> Path:
-    configured = os.environ.get("TILELANG_CACHE_DIR")
+    configured = envs.TILELANG_CACHE_DIR
     if configured:
         return Path(configured)
     return Path.home() / ".tilelang" / "cache"
 
 
 def _cute_dsl_cache_root() -> Path:
-    configured = os.environ.get("CUTE_DSL_CACHE_DIR")
+    configured = envs.CUTE_DSL_CACHE_DIR
     if configured:
         return Path(configured)
     try:
@@ -467,21 +458,21 @@ def _cute_dsl_cache_root() -> Path:
 
 
 def _flashinfer_cache_root() -> Path:
-    workspace_base = os.environ.get("FLASHINFER_WORKSPACE_BASE")
+    workspace_base = envs.FLASHINFER_WORKSPACE_BASE
     if workspace_base:
         return Path(workspace_base) / ".cache" / "flashinfer"
     return Path.home() / ".cache" / "flashinfer"
 
 
 def _vllm_cache_root() -> Path:
-    configured = os.environ.get("VLLM_CACHE_ROOT")
+    configured = envs.VLLM_CACHE_ROOT
     if configured:
         return Path(configured)
     return Path.home() / ".cache" / "vllm"
 
 
 def _bundle_root(ctx: LoadContext) -> Path:
-    configured = os.environ.get(_BUNDLE_ROOT_ENV)
+    configured = envs.MX_ARTIFACT_BUNDLE_ROOT
     if configured:
         return Path(configured) / f"rank-{ctx.worker_rank}"
     return (
@@ -528,7 +519,7 @@ def _torch_compile_cache_identity(ctx: LoadContext) -> p2p_pb2.SourceIdentity:
         cuda_version=torch.version.cuda or "",
         triton_version=_triton_version(),
         gpu_arch=_gpu_arch(ctx.device_id),
-        compile_config_digest=os.environ.get(_COMPILE_CONFIG_DIGEST_ENV, ""),
+        compile_config_digest=envs.MX_ARTIFACT_COMPILE_CONFIG_DIGEST,
     )
     _set_extra_if_present(identity, "triton_key", _triton_key())
     return identity
@@ -673,13 +664,13 @@ def _vllm_health_ready() -> bool:
 
 
 def _vllm_health_url() -> str:
-    configured = os.environ.get(_READY_URL_ENV, "").strip()
+    configured = envs.MX_ARTIFACT_READY_URL.strip()
     fallback = _statefulset_head_health_url() or _DEFAULT_READY_URL
     if not configured or configured == _DEFAULT_READY_URL:
         return fallback
     if _is_http_url(configured):
         return configured
-    logger.warning("Invalid %s=%r; using %s", _READY_URL_ENV, configured, fallback)
+    logger.warning("Invalid MX_ARTIFACT_READY_URL=%r; using %s", configured, fallback)
     return fallback
 
 
@@ -689,29 +680,14 @@ def _is_http_url(url: str) -> bool:
 
 
 def _statefulset_head_health_url() -> str | None:
-    pod_name, _, ordinal = os.environ.get("HOSTNAME", "").rpartition("-")
+    pod_name, _, ordinal = envs.HOSTNAME.rpartition("-")
     if not pod_name or not ordinal.isdigit() or ordinal == "0":
         return None
-    namespace = os.environ.get("POD_NAMESPACE", "").strip()
+    namespace = envs.POD_NAMESPACE.strip()
     host = f"{pod_name}-0.{pod_name}"
     if namespace:
         host = f"{host}.{namespace}.svc"
     return f"http://{host}:8000/health"
-
-
-def _ready_timeout_secs() -> int:
-    return _env_int(_READY_TIMEOUT_ENV, 1800)
-
-
-def _env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        logger.warning("Invalid %s=%r; using default %d", name, raw, default)
-        return default
 
 
 def _vllm_version() -> str:

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Centralized registry of environment variables the ModelExpress client reads.
+
+Modeled on vLLM's ``envs.py``. ``environment_variables`` maps each variable
+name to a zero-argument callable that reads ``os.environ`` and applies the
+variable's parsing and default. Access is by attribute, so values are computed
+live on every read (tests can ``monkeypatch`` and callers see fresh values
+without re-importing)::
+
+    from modelexpress import envs
+    if envs.MX_NIXL_BACKEND == "LIBFABRIC":
+        ...
+
+This is a leaf module: it imports only the standard library, so any package
+module can import it without creating a cycle.
+
+Reads are centralized here; **writes stay at their call sites** (vLLM's
+registry is read-only). ``UCX_TLS`` and ``UCX_NET_DEVICES`` are registered for
+reading, but the code that sets them does so inline.
+
+Not covered here (intentional exceptions):
+- ``MX_SKIP_EXT`` and ``CXX`` are read by ``setup.py`` before the package is
+  importable, so they cannot route through this module.
+- ``MODEL_EXPRESS_SOURCE`` only appears in a docstring example, not live code.
+- The deprecated ``MX_VMM_ARENA_BYTES`` / ``MX_VMM_ARENA_CHUNK_BYTES`` are
+  presence-only deprecation warnings; check them with :func:`is_set`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+logger = logging.getLogger("modelexpress.envs")
+
+# Static type hints for editors/type-checkers. The actual values are produced
+# by ``__getattr__`` below; these annotations never execute at runtime.
+if TYPE_CHECKING:
+    # ModelExpress server address / logging
+    MODEL_EXPRESS_URL: Optional[str]
+    MX_SERVER_ADDRESS: Optional[str]
+    MODEL_EXPRESS_LOG_LEVEL: str
+    MODEL_NAME: Optional[str]
+    # Metadata / worker
+    MX_METADATA_BACKEND: str
+    MX_METADATA_PORT: int
+    MX_WORKER_GRPC_PORT: int
+    MX_WORKER_HOST: str
+    MX_HEARTBEAT_INTERVAL_SECS: int
+    MX_PUBLISH_TIMEOUT_SECS: int
+    MX_MODEL_REVISION: str
+    MX_MODEL_URI: Optional[str]
+    MX_P2P_METADATA: str
+    # Kubernetes service backend
+    MX_K8S_SERVICE_PATTERN: str
+    MX_K8S_SOURCE_RETRIES: str
+    MX_K8S_SOURCE_BACKOFF_SECONDS: str
+    # NIXL / transport
+    MX_NIXL_BACKEND: str
+    MX_POOL_REG: bool
+    NIXL_UCX_TLS: Optional[str]
+    UCX_TLS: Optional[str]
+    UCX_NET_DEVICES: Optional[str]
+    MX_RDMA_NIC_PIN: str
+    MX_RDMA_NIC_PIN_MIN_RATE_GBPS: Optional[str]
+    # GPUDirect Storage
+    MX_GDS_MAX_CHUNK_KB: Optional[str]
+    MX_GDS_THREADS: int
+    MX_GDS_TIMEOUT: float
+    # Model streamer
+    MX_MS_DISTRIBUTED: bool
+    # TRT-LLM live transfer
+    MX_SOURCE_QUERY_TIMEOUT: int
+    MX_TRANSFER_TIMEOUT: int
+    MX_TRANSFER_LOG_DIR: str
+    # VMM arena
+    MX_VMM_ARENA: bool
+    # vLLM artifact (JIT cache) transfer
+    MX_ARTIFACT_TRANSFER: bool
+    MX_ARTIFACT_BUNDLE_ROOT: Optional[str]
+    MX_ARTIFACT_COMPILE_CONFIG_DIGEST: str
+    MX_ARTIFACT_READY_URL: str
+    MX_ARTIFACT_READY_TIMEOUT_SECS: int
+    MX_ARTIFACT_TRANSFER_CHUNK_SIZE: Optional[str]
+    # Third-party JIT/compile cache locations read for artifact transfer
+    TRITON_CACHE_DIR: Optional[str]
+    DG_JIT_CACHE_DIR: Optional[str]
+    DEEP_GEMM_CACHE_DIR: Optional[str]
+    TILELANG_CACHE_DIR: Optional[str]
+    CUTE_DSL_CACHE_DIR: Optional[str]
+    FLASHINFER_WORKSPACE_BASE: Optional[str]
+    VLLM_CACHE_ROOT: Optional[str]
+    # Other third-party / system
+    VLLM_ATTENTION_BACKEND: str
+    HOSTNAME: str
+    POD_NAMESPACE: str
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    """Parse an int env var, falling back to ``default`` (and warning) on error."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %d", name, raw, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env var, falling back to ``default`` (and warning) on error."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+
+
+# One entry per variable. The lambda owns the default and parsing; callers that
+# need a site-specific default receive the raw value (``None`` when unset) and
+# apply their own fallback.
+environment_variables: dict[str, Callable[[], Any]] = {
+    # ── ModelExpress server address / logging ──────────────────────────────
+    # Site-varying defaults: return raw (None when unset), callers add defaults.
+    "MODEL_EXPRESS_URL": lambda: os.environ.get("MODEL_EXPRESS_URL"),
+    "MX_SERVER_ADDRESS": lambda: os.environ.get("MX_SERVER_ADDRESS"),
+    "MODEL_EXPRESS_LOG_LEVEL": lambda: os.environ.get("MODEL_EXPRESS_LOG_LEVEL", "").upper(),
+    "MODEL_NAME": lambda: os.environ.get("MODEL_NAME"),
+    # ── Metadata / worker ──────────────────────────────────────────────────
+    "MX_METADATA_BACKEND": lambda: os.environ.get("MX_METADATA_BACKEND", "").lower().strip(),
+    "MX_METADATA_PORT": lambda: _env_int("MX_METADATA_PORT", 5555),
+    "MX_WORKER_GRPC_PORT": lambda: _env_int("MX_WORKER_GRPC_PORT", 6555),
+    "MX_WORKER_HOST": lambda: os.environ.get("MX_WORKER_HOST", ""),
+    "MX_HEARTBEAT_INTERVAL_SECS": lambda: _env_int("MX_HEARTBEAT_INTERVAL_SECS", 30),
+    "MX_PUBLISH_TIMEOUT_SECS": lambda: _env_int("MX_PUBLISH_TIMEOUT_SECS", 30 * 60),
+    "MX_MODEL_REVISION": lambda: os.environ.get("MX_MODEL_REVISION", ""),
+    "MX_MODEL_URI": lambda: os.environ.get("MX_MODEL_URI"),
+    "MX_P2P_METADATA": lambda: os.environ.get("MX_P2P_METADATA", ""),
+    # ── Kubernetes service backend ─────────────────────────────────────────
+    "MX_K8S_SERVICE_PATTERN": lambda: os.environ.get("MX_K8S_SERVICE_PATTERN", "mx-sources"),
+    "MX_K8S_SOURCE_RETRIES": lambda: os.environ.get("MX_K8S_SOURCE_RETRIES", ""),
+    "MX_K8S_SOURCE_BACKOFF_SECONDS": lambda: os.environ.get("MX_K8S_SOURCE_BACKOFF_SECONDS", ""),
+    # ── NIXL / transport ───────────────────────────────────────────────────
+    "MX_NIXL_BACKEND": lambda: os.environ.get("MX_NIXL_BACKEND", "UCX").strip().upper(),
+    "MX_POOL_REG": lambda: os.environ.get("MX_POOL_REG", "0") == "1",
+    "NIXL_UCX_TLS": lambda: os.environ.get("NIXL_UCX_TLS"),
+    "UCX_TLS": lambda: os.environ.get("UCX_TLS"),
+    "UCX_NET_DEVICES": lambda: os.environ.get("UCX_NET_DEVICES"),
+    "MX_RDMA_NIC_PIN": lambda: os.environ.get("MX_RDMA_NIC_PIN", "").strip(),
+    "MX_RDMA_NIC_PIN_MIN_RATE_GBPS": lambda: os.environ.get("MX_RDMA_NIC_PIN_MIN_RATE_GBPS"),
+    # ── GPUDirect Storage ──────────────────────────────────────────────────
+    "MX_GDS_MAX_CHUNK_KB": lambda: os.environ.get("MX_GDS_MAX_CHUNK_KB"),
+    "MX_GDS_THREADS": lambda: _env_int("MX_GDS_THREADS", 8),
+    "MX_GDS_TIMEOUT": lambda: _env_float("MX_GDS_TIMEOUT", 120.0),
+    # ── Model streamer ─────────────────────────────────────────────────────
+    "MX_MS_DISTRIBUTED": lambda: os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true"),
+    # ── TRT-LLM live transfer ──────────────────────────────────────────────
+    "MX_SOURCE_QUERY_TIMEOUT": lambda: _env_int("MX_SOURCE_QUERY_TIMEOUT", 3600),
+    "MX_TRANSFER_TIMEOUT": lambda: _env_int("MX_TRANSFER_TIMEOUT", 900),
+    "MX_TRANSFER_LOG_DIR": lambda: os.environ.get("MX_TRANSFER_LOG_DIR", "/tmp/mx_logs"),
+    # ── VMM arena ──────────────────────────────────────────────────────────
+    "MX_VMM_ARENA": lambda: os.environ.get("MX_VMM_ARENA") == "1",
+    # ── vLLM artifact (JIT cache) transfer ─────────────────────────────────
+    "MX_ARTIFACT_TRANSFER": lambda: os.environ.get("MX_ARTIFACT_TRANSFER", "").strip().lower()
+    in _TRUTHY,
+    "MX_ARTIFACT_BUNDLE_ROOT": lambda: os.environ.get("MX_ARTIFACT_BUNDLE_ROOT"),
+    "MX_ARTIFACT_COMPILE_CONFIG_DIGEST": lambda: os.environ.get(
+        "MX_ARTIFACT_COMPILE_CONFIG_DIGEST", ""
+    ),
+    "MX_ARTIFACT_READY_URL": lambda: os.environ.get("MX_ARTIFACT_READY_URL", ""),
+    "MX_ARTIFACT_READY_TIMEOUT_SECS": lambda: _env_int("MX_ARTIFACT_READY_TIMEOUT_SECS", 1800),
+    # Raw string: artifact_manifest.artifact_transfer_chunk_size() owns the
+    # int parse plus its non-positive/max-bound validation and default param.
+    "MX_ARTIFACT_TRANSFER_CHUNK_SIZE": lambda: os.environ.get("MX_ARTIFACT_TRANSFER_CHUNK_SIZE"),
+    # ── Third-party JIT/compile cache locations (raw; caller builds path) ──
+    "TRITON_CACHE_DIR": lambda: os.environ.get("TRITON_CACHE_DIR"),
+    "DG_JIT_CACHE_DIR": lambda: os.environ.get("DG_JIT_CACHE_DIR"),
+    "DEEP_GEMM_CACHE_DIR": lambda: os.environ.get("DEEP_GEMM_CACHE_DIR"),
+    "TILELANG_CACHE_DIR": lambda: os.environ.get("TILELANG_CACHE_DIR"),
+    "CUTE_DSL_CACHE_DIR": lambda: os.environ.get("CUTE_DSL_CACHE_DIR"),
+    "FLASHINFER_WORKSPACE_BASE": lambda: os.environ.get("FLASHINFER_WORKSPACE_BASE"),
+    "VLLM_CACHE_ROOT": lambda: os.environ.get("VLLM_CACHE_ROOT"),
+    # ── Other third-party / system ─────────────────────────────────────────
+    "VLLM_ATTENTION_BACKEND": lambda: os.environ.get("VLLM_ATTENTION_BACKEND", "auto"),
+    "HOSTNAME": lambda: os.environ.get("HOSTNAME", ""),
+    "POD_NAMESPACE": lambda: os.environ.get("POD_NAMESPACE", ""),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in environment_variables:
+        return environment_variables[name]()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(environment_variables)
+
+
+def is_set(name: str) -> bool:
+    """Return ``True`` if the environment variable is present, regardless of value."""
+    return name in os.environ

--- a/modelexpress_client/python/modelexpress/gds_transfer.py
+++ b/modelexpress_client/python/modelexpress/gds_transfer.py
@@ -16,12 +16,12 @@ Environment variables:
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import Any
 
 import torch
 
+from . import envs
 from .accelerators import AcceleratorBackend
 
 logger = logging.getLogger("modelexpress.gds_transfer")
@@ -103,7 +103,7 @@ class GdsTransferManager:
         self._device_id: int | None = None
         self._agent: Any = None
         self._accelerator_backend = accelerator_backend
-        override = os.environ.get("MX_GDS_MAX_CHUNK_KB")
+        override = envs.MX_GDS_MAX_CHUNK_KB
         self._max_chunk_size = int(override) * 1024 if override else _DEFAULT_MAX_CHUNK
 
     def __enter__(self) -> GdsTransferManager:
@@ -129,7 +129,7 @@ class GdsTransferManager:
 
         self._device_id = self._accelerator_backend.current_device()
 
-        thread_count = int(os.environ.get("MX_GDS_THREADS", "8"))
+        thread_count = envs.MX_GDS_THREADS
         config = NixlAgentConfig(backends=["GDS_MT"], num_threads=thread_count)
         self._agent = NixlAgent(self._agent_name, config)
 
@@ -205,7 +205,7 @@ class GdsTransferManager:
             raise RuntimeError("GDS batch transfer failed")
 
         # Phase 4: Wait for completion
-        timeout = float(os.environ.get("MX_GDS_TIMEOUT", "120"))
+        timeout = envs.MX_GDS_TIMEOUT
         t0 = time.perf_counter()
         spins = 0
         while True:

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -6,13 +6,13 @@
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
 import torch.nn as nn
 
+from .. import envs
 from ..nixl_transfer import is_nixl_available
 from ..tensor_utils import log_tensor_summary
 from ..metadata.publish import publish_metadata_and_ready
@@ -112,7 +112,7 @@ def _as_load_result(result_or_model: LoadResult | nn.Module) -> LoadResult:
 
 def _metadata_publication_configured(ctx: LoadContext) -> bool:
     """Return whether this worker has a metadata path for P2P serving."""
-    server_addr = os.environ.get("MODEL_EXPRESS_URL") or os.environ.get("MX_SERVER_ADDRESS")
+    server_addr = envs.MODEL_EXPRESS_URL or envs.MX_SERVER_ADDRESS
     if server_addr:
         return True
     return getattr(ctx.mx_client, "REQUIRES_P2P_METADATA", False) is True
@@ -183,7 +183,7 @@ def register_tensors(
             log_tensor_summary(ctx.tensors, ctx.global_rank, "Registering tensors")
 
         if ctx.nixl_manager is None:
-            base_port = int(os.environ.get("MX_METADATA_PORT", "5555"))
+            base_port = envs.MX_METADATA_PORT
             listen_port = base_port + ctx.device_id
             ctx.nixl_manager = _init_nixl_manager(
                 ctx.global_rank,

--- a/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/model_streamer_strategy.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 
 import importlib.util
 import logging
-import os
 from typing import Iterator
 
 import torch
 
+from .. import envs
 from ..adapter import EngineAdapter, StrategyFailed
 from .base import LoadContext, LoadStrategy, _as_load_result, register_tensors
 from .context import LoadResult
@@ -26,7 +26,7 @@ logger = logging.getLogger("modelexpress.strategy_model_streamer")
 
 def _resolve_model_uri(ctx: LoadContext) -> str:
     """Resolve the model URI used by ModelStreamer across engine configs."""
-    if model_uri := os.environ.get("MX_MODEL_URI"):
+    if model_uri := envs.MX_MODEL_URI:
         return model_uri
     for attr in ("model_weights", "model", "model_path"):
         value = getattr(ctx.model_config, attr, None)
@@ -58,7 +58,7 @@ class ModelStreamerStrategy(LoadStrategy):
             )
             return False
 
-        model_uri = os.environ.get("MX_MODEL_URI", "")
+        model_uri = envs.MX_MODEL_URI or ""
         if not model_uri:
             logger.info(
                 f"[Worker {ctx.global_rank}] MX_MODEL_URI not set, skipping model streamer"

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -6,10 +6,10 @@
 from __future__ import annotations
 
 import logging
-import os
 import random
 import time
 
+from .. import envs
 from ..adapter import EngineAdapter, StrategyFailed
 from .base import (
     LoadContext,
@@ -69,7 +69,7 @@ class RdmaStrategy(LoadStrategy):
         # metadata; skip the central-server precondition for them.
         # Strict `is True` check so MagicMock's auto-attribute doesn't
         # masquerade as the flag in tests.
-        server_addr = os.environ.get("MODEL_EXPRESS_URL") or os.environ.get("MX_SERVER_ADDRESS")
+        server_addr = envs.MODEL_EXPRESS_URL or envs.MX_SERVER_ADDRESS
         requires_p2p = getattr(ctx.mx_client, "REQUIRES_P2P_METADATA", False) is True
         if not server_addr and not requires_p2p:
             logger.info(f"[Worker {ctx.global_rank}] No MX server configured, skipping RDMA")

--- a/modelexpress_client/python/modelexpress/metadata/artifact_manifest.py
+++ b/modelexpress_client/python/modelexpress/metadata/artifact_manifest.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
 from pathlib import Path
 
 import google_crc32c
 
+from .. import envs
 from .. import p2p_pb2
 
 ARTIFACT_MANIFEST_VERSION = 1
@@ -80,7 +80,7 @@ def build_artifact_manifest(
 def artifact_transfer_chunk_size(
     default: int = DEFAULT_ARTIFACT_TRANSFER_CHUNK_SIZE,
 ) -> int:
-    raw = os.environ.get(MX_ARTIFACT_TRANSFER_CHUNK_SIZE_ENV)
+    raw = envs.MX_ARTIFACT_TRANSFER_CHUNK_SIZE
     if raw is None:
         return default
     try:

--- a/modelexpress_client/python/modelexpress/metadata/client_factory.py
+++ b/modelexpress_client/python/modelexpress/metadata/client_factory.py
@@ -21,8 +21,8 @@ Supported values:
 from __future__ import annotations
 
 import logging
-import os
 
+from .. import envs
 from ..client import MxClient, MxClientBase
 from .k8s_service_client import MxK8sServiceClient
 
@@ -44,7 +44,7 @@ def create_metadata_client(
     specific endpoint (currently :class:`MxK8sServiceClient`);
     others ignore it.
     """
-    backend = os.environ.get("MX_METADATA_BACKEND", "").lower().strip()
+    backend = envs.MX_METADATA_BACKEND
     if backend in _CENTRAL_BACKEND_ALIASES:
         logger.debug("create_metadata_client: central MxClient (backend=%r)", backend)
         return MxClient(server_url=server_url)

--- a/modelexpress_client/python/modelexpress/metadata/k8s_service_client.py
+++ b/modelexpress_client/python/modelexpress/metadata/k8s_service_client.py
@@ -41,11 +41,11 @@ object is the source list, maintained by K8s based on pod readiness.
 from __future__ import annotations
 
 import logging
-import os
 import time
 
 import grpc
 
+from .. import envs
 from .. import p2p_pb2
 from .payload import tensor_source_metadata
 from .. import p2p_pb2_grpc
@@ -78,16 +78,14 @@ class MxK8sServiceClient(MxClientBase):
         backoff_seconds: float | None = None,
     ):
         self._worker_rank = worker_rank
-        self._service_pattern = service_pattern or os.environ.get(
-            "MX_K8S_SERVICE_PATTERN", _DEFAULT_SERVICE_PATTERN,
-        )
-        env_retries = os.environ.get("MX_K8S_SOURCE_RETRIES", "")
+        self._service_pattern = service_pattern or envs.MX_K8S_SERVICE_PATTERN
+        env_retries = envs.MX_K8S_SOURCE_RETRIES
         self._max_retries = (
             max_retries if max_retries is not None
             else int(env_retries) if env_retries
             else _DEFAULT_MAX_RETRIES
         )
-        env_backoff = os.environ.get("MX_K8S_SOURCE_BACKOFF_SECONDS", "")
+        env_backoff = envs.MX_K8S_SOURCE_BACKOFF_SECONDS
         self._backoff_seconds = (
             backoff_seconds if backoff_seconds is not None
             else float(env_backoff) if env_backoff
@@ -313,7 +311,5 @@ class MxK8sServiceClient(MxClientBase):
         resolved = self._service_pattern.format(rank=self._worker_rank)
         if ":" in resolved:
             return resolved
-        base_port = int(
-            os.environ.get("MX_WORKER_GRPC_PORT", str(_DEFAULT_WORKER_GRPC_PORT)),
-        )
+        base_port = envs.MX_WORKER_GRPC_PORT
         return f"{resolved}:{base_port + self._worker_rank}"

--- a/modelexpress_client/python/modelexpress/metadata/publish.py
+++ b/modelexpress_client/python/modelexpress/metadata/publish.py
@@ -6,13 +6,13 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import TYPE_CHECKING
 
 import grpc
 import torch
 
+from .. import envs
 from .publisher import PublisherThread
 from .payload import tensor_source_metadata
 from ..client import MxClient
@@ -86,7 +86,7 @@ def _resolve_model_revision(model_config) -> str:
        identity fields only, and decentralized deployments lose the
        bit-identical guarantee).
     """
-    override = os.environ.get("MX_MODEL_REVISION", "")
+    override = envs.MX_MODEL_REVISION
     if override:
         return override
     revision = getattr(model_config, "revision", None)
@@ -139,7 +139,7 @@ def publish_metadata_and_ready(
 
         host = _get_worker_host()
 
-        grpc_base = int(os.environ.get("MX_WORKER_GRPC_PORT", "6555"))
+        grpc_base = envs.MX_WORKER_GRPC_PORT
         worker_grpc_port = grpc_base + device_id
 
         grpc_server = WorkerGrpcServer(
@@ -268,7 +268,7 @@ def _is_p2p_metadata_enabled(mx_client) -> bool:
     # (and any other non-literal truthy value) doesn't accidentally
     # force the P2P path in tests or misconfigured clients.
     if getattr(mx_client, "REQUIRES_P2P_METADATA", False) is True:
-        env_value = os.environ.get("MX_P2P_METADATA", "")
+        env_value = envs.MX_P2P_METADATA
         if env_value not in ("", "1"):
             logger.warning(
                 "MX_P2P_METADATA=%r is ignored for backend %s which "
@@ -276,7 +276,7 @@ def _is_p2p_metadata_enabled(mx_client) -> bool:
                 env_value, type(mx_client).__name__,
             )
         return True
-    return os.environ.get("MX_P2P_METADATA", "0") == "1"
+    return envs.MX_P2P_METADATA == "1"
 
 
 def _get_worker_host() -> str:
@@ -286,7 +286,7 @@ def _get_worker_host() -> str:
     Falls back to FQDN. Rejects localhost variants.
     """
     import socket
-    explicit = os.environ.get("MX_WORKER_HOST", "")
+    explicit = envs.MX_WORKER_HOST
     if explicit:
         return explicit
     try:

--- a/modelexpress_client/python/modelexpress/metadata/publisher.py
+++ b/modelexpress_client/python/modelexpress/metadata/publisher.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 
 import atexit
 import logging
-import os
 import threading
 import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
+
+from .. import envs
 
 if TYPE_CHECKING:
     from ..client import MxClient
@@ -86,12 +87,7 @@ class PublisherThread:
         self._publish_timeout = (
             publish_timeout_secs
             if publish_timeout_secs is not None
-            else int(
-                os.environ.get(
-                    "MX_PUBLISH_TIMEOUT_SECS",
-                    str(PUBLISH_TIMEOUT_SECS_DEFAULT),
-                )
-            )
+            else envs.MX_PUBLISH_TIMEOUT_SECS
         )
         self._publish_started_at: float | None = None
         self._publish_given_up = False
@@ -100,7 +96,7 @@ class PublisherThread:
         self._interval = (
             interval_secs
             if interval_secs is not None
-            else int(os.environ.get("MX_HEARTBEAT_INTERVAL_SECS", "30"))
+            else envs.MX_HEARTBEAT_INTERVAL_SECS
         )
         self._stop_event = threading.Event()
         self._status_lock = threading.Lock()

--- a/modelexpress_client/python/modelexpress/metadata/publisher.py
+++ b/modelexpress_client/python/modelexpress/metadata/publisher.py
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("modelexpress.metadata.publisher")
 
-PUBLISH_TIMEOUT_SECS_DEFAULT = 30 * 60
-
 
 class PublisherThread:
     """Background thread that publishes a source and keeps it READY.

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from . import envs
 from . import ucx_utils
 from .accelerators import (
     AcceleratorBackend,
@@ -59,7 +60,7 @@ def _resolve_nixl_backend() -> str:
 
     Defaults to UCX. Set MX_NIXL_BACKEND=LIBFABRIC on AWS EFA.
     """
-    raw = os.environ.get("MX_NIXL_BACKEND", DEFAULT_NIXL_BACKEND).strip().upper()
+    raw = envs.MX_NIXL_BACKEND
     if raw not in SUPPORTED_NIXL_BACKENDS:
         raise ValueError(
             f"MX_NIXL_BACKEND={raw!r} is not supported. "
@@ -74,7 +75,7 @@ def _pool_reg_enabled() -> bool:
     MX_POOL_REG=1 enables it; default is per-tensor registration. Read at
     call time so tests can toggle the env var without re-importing.
     """
-    return os.environ.get("MX_POOL_REG", "0") == "1"
+    return envs.MX_POOL_REG
 
 
 class NixlTransferManager:
@@ -150,8 +151,8 @@ class NixlTransferManager:
         # Let UCX auto-detect transports (RoCE, TCP, etc).
         # OMPI_MCA_pml=ob1 keeps MPI on TCP independently.
         # Only override UCX_TLS if explicitly set to "tcp" (legacy compat).
-        saved_ucx_tls = os.environ.get("UCX_TLS")
-        nixl_ucx_tls = os.environ.get("NIXL_UCX_TLS")
+        saved_ucx_tls = envs.UCX_TLS
+        nixl_ucx_tls = envs.NIXL_UCX_TLS
         if nixl_ucx_tls:
             os.environ["UCX_TLS"] = nixl_ucx_tls
             logger.info(f"NIXL UCX_TLS override: {nixl_ucx_tls} (was: {saved_ucx_tls})")
@@ -187,7 +188,7 @@ class NixlTransferManager:
         finally:
             if saved_ucx_tls is not None:
                 os.environ["UCX_TLS"] = saved_ucx_tls
-            elif "UCX_TLS" in os.environ:
+            elif envs.is_set("UCX_TLS"):
                 os.environ.pop("UCX_TLS")
 
     def _build_tensor_descriptors(

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 
 import torch
 
+from . import envs
+
 logger = logging.getLogger("modelexpress.transfer_safety")
 
 # ---------------------------------------------------------------------------
@@ -104,7 +106,7 @@ def _get_attention_backend() -> str:
                 return getattr(cache_config, "attention_backend", "unknown") or "unknown"
     except Exception:
         pass
-    return os.environ.get("VLLM_ATTENTION_BACKEND", "auto")
+    return envs.VLLM_ATTENTION_BACKEND
 
 
 def get_deep_gemm_version() -> str:

--- a/modelexpress_client/python/modelexpress/trtllm_live_transfer.py
+++ b/modelexpress_client/python/modelexpress/trtllm_live_transfer.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 
 import torch
 
+from . import envs
 from .client import MxClient
 from .metadata.payload import tensor_source_metadata, worker_tensor_descriptors
 from . import p2p_pb2
@@ -79,8 +80,8 @@ def publish_model_params(torch_model: Any) -> None:
     except Exception:
         mpi_rank = device_id
 
-    model_name = os.environ.get("MODEL_NAME", "unknown")
-    mx_server = os.environ.get("MODEL_EXPRESS_URL", "modelexpress-server:8001")
+    model_name = envs.MODEL_NAME or "unknown"
+    mx_server = envs.MODEL_EXPRESS_URL or "modelexpress-server:8001"
 
     param_tensors = {}
     seen_data_ptrs = set()
@@ -186,8 +187,8 @@ def publish_from_worker(worker: Any) -> None:
     except Exception:
         mpi_rank = getattr(worker, "rank", device_id)
 
-    model_name = os.environ.get("MODEL_NAME", "unknown")
-    mx_server = os.environ.get("MODEL_EXPRESS_URL", "modelexpress-server:8001")
+    model_name = envs.MODEL_NAME or "unknown"
+    mx_server = envs.MODEL_EXPRESS_URL or "modelexpress-server:8001"
 
     param_tensors = {}
     seen_data_ptrs = set()
@@ -286,8 +287,8 @@ class MxLiveWeightLoader:
         from .types import TensorDescriptor
 
         # Use provided URL, then env var, then default
-        mx_server = self._mx_server or os.environ.get("MODEL_EXPRESS_URL") or os.environ.get("MX_SERVER_ADDRESS", "localhost:8001")
-        model_name = os.environ.get("MODEL_NAME", os.path.basename(checkpoint_dir))
+        mx_server = self._mx_server or envs.MODEL_EXPRESS_URL or envs.MX_SERVER_ADDRESS or "localhost:8001"
+        model_name = envs.MODEL_NAME or os.path.basename(checkpoint_dir)
 
         if model is None:
             raise RuntimeError(
@@ -307,7 +308,7 @@ class MxLiveWeightLoader:
             mpi_rank = device_id
 
         # MPI workers' stdout is swallowed by TRT-LLM — write to per-rank file
-        log_dir = os.environ.get("MX_TRANSFER_LOG_DIR", "/tmp/mx_logs")
+        log_dir = envs.MX_TRANSFER_LOG_DIR
         os.makedirs(log_dir, exist_ok=True)
         rank_log = os.path.join(log_dir, f"rank{mpi_rank}.log")
         fh = logging.FileHandler(rank_log, mode="w")
@@ -320,7 +321,7 @@ class MxLiveWeightLoader:
         )
 
         # 1. Query source metadata
-        query_timeout = int(os.environ.get("MX_SOURCE_QUERY_TIMEOUT", "3600"))
+        query_timeout = envs.MX_SOURCE_QUERY_TIMEOUT
         source_meta = self._query_source(mx_server, model_name, timeout=query_timeout)
 
         # Find my rank's source worker — use MPI rank, not local GPU index
@@ -421,7 +422,7 @@ class MxLiveWeightLoader:
         ]
 
         # 7. RDMA transfer: source params → target params
-        xfer_timeout = int(os.environ.get("MX_TRANSFER_TIMEOUT", "900"))
+        xfer_timeout = envs.MX_TRANSFER_TIMEOUT
         t0 = time.perf_counter()
         bytes_transferred, n_tensors, _ = nixl_mgr.receive_from_source(
             source_metadata=source_worker.nixl_metadata,

--- a/modelexpress_client/python/modelexpress/ucx_utils.py
+++ b/modelexpress_client/python/modelexpress/ucx_utils.py
@@ -28,6 +28,8 @@ import re
 
 import torch
 
+from . import envs
+
 logger = logging.getLogger("modelexpress.ucx_utils")
 
 
@@ -371,7 +373,7 @@ def _resolve_nic_pin(device_id: int) -> str | None:
         number). MX_RDMA_NIC_PIN_MIN_RATE_GBPS overrides with an
         explicit absolute lower bound when needed.
     """
-    raw = os.environ.get("MX_RDMA_NIC_PIN", "").strip()
+    raw = envs.MX_RDMA_NIC_PIN
     if raw == "" or raw.lower() in ("off", "0", "false", "no"):
         return None
 
@@ -389,7 +391,7 @@ def _resolve_nic_pin(device_id: int) -> str | None:
         )
         return None
 
-    raw_min = os.environ.get("MX_RDMA_NIC_PIN_MIN_RATE_GBPS")
+    raw_min = envs.MX_RDMA_NIC_PIN_MIN_RATE_GBPS
     if raw_min is None or raw_min.strip() == "":
         min_rate: float | None = None
     else:
@@ -418,7 +420,7 @@ def apply_nic_pin_for_device(device_id: int) -> None:
     """
     pinned = _resolve_nic_pin(device_id)
     if pinned:
-        prev = os.environ.get("UCX_NET_DEVICES")
+        prev = envs.UCX_NET_DEVICES
         os.environ["UCX_NET_DEVICES"] = pinned
         logger.info(
             f"NIXL NIC pin: device {device_id} -> "

--- a/modelexpress_client/python/modelexpress/vmm/runtime.py
+++ b/modelexpress_client/python/modelexpress/vmm/runtime.py
@@ -19,9 +19,10 @@ runs after the load body returns.
 from __future__ import annotations
 
 import logging
-import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator
+
+from .. import envs
 
 if TYPE_CHECKING:
     from ..load_strategy.context import LoadContext
@@ -103,7 +104,7 @@ def maybe_enter_vmm_arena(ctx: "LoadContext") -> Iterator[None]:
       allocation, not peak live size. With 16 TiB reserved, this is
       bounded only by HBM (we never exhaust VA).
     """
-    if os.environ.get("MX_VMM_ARENA") != "1":
+    if not envs.MX_VMM_ARENA:
         yield
         return
 
@@ -124,7 +125,7 @@ def maybe_enter_vmm_arena(ctx: "LoadContext") -> Iterator[None]:
     # the old env vars forward from a pre-refactor manifest sees one
     # clear message rather than silent behavior change.
     for stale_var in ("MX_VMM_ARENA_BYTES", "MX_VMM_ARENA_CHUNK_BYTES"):
-        if os.environ.get(stale_var):
+        if envs.is_set(stale_var):
             logger.warning(
                 "[Worker %d] %s is set but no longer honored; the new VMM "
                 "arena reserves 16 TiB of VA unconditionally and uses one "

--- a/modelexpress_client/python/tests/test_envs.py
+++ b/modelexpress_client/python/tests/test_envs.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the centralized environment-variable registry."""
+
+import pytest
+
+from modelexpress import envs
+
+
+def test_defaults_when_unset(monkeypatch):
+    for name in (
+        "MX_NIXL_BACKEND",
+        "MX_METADATA_PORT",
+        "MX_WORKER_GRPC_PORT",
+        "MX_POOL_REG",
+        "MX_VMM_ARENA",
+        "MX_MS_DISTRIBUTED",
+        "VLLM_ATTENTION_BACKEND",
+        "MODEL_EXPRESS_URL",
+        "MX_SERVER_ADDRESS",
+        "MX_GDS_TIMEOUT",
+        "MX_HEARTBEAT_INTERVAL_SECS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    assert envs.MX_NIXL_BACKEND == "UCX"
+    assert envs.MX_METADATA_PORT == 5555
+    assert envs.MX_WORKER_GRPC_PORT == 6555
+    assert envs.MX_POOL_REG is False
+    assert envs.MX_VMM_ARENA is False
+    assert envs.MX_MS_DISTRIBUTED is False
+    assert envs.VLLM_ATTENTION_BACKEND == "auto"
+    assert envs.MODEL_EXPRESS_URL is None
+    assert envs.MX_SERVER_ADDRESS is None
+    assert envs.MX_GDS_TIMEOUT == pytest.approx(120.0)
+    assert envs.MX_HEARTBEAT_INTERVAL_SECS == 30
+
+
+def test_int_and_float_parsing(monkeypatch):
+    monkeypatch.setenv("MX_METADATA_PORT", "1234")
+    monkeypatch.setenv("MX_GDS_TIMEOUT", "1.5")
+    monkeypatch.setenv("MX_SOURCE_QUERY_TIMEOUT", "42")
+    assert envs.MX_METADATA_PORT == 1234
+    assert envs.MX_GDS_TIMEOUT == pytest.approx(1.5)
+    assert envs.MX_SOURCE_QUERY_TIMEOUT == 42
+
+
+def test_invalid_int_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("MX_METADATA_PORT", "not-a-number")
+    assert envs.MX_METADATA_PORT == 5555
+
+
+def test_bool_parsing(monkeypatch):
+    monkeypatch.setenv("MX_POOL_REG", "1")
+    assert envs.MX_POOL_REG is True
+    monkeypatch.setenv("MX_POOL_REG", "0")
+    assert envs.MX_POOL_REG is False
+
+    monkeypatch.setenv("MX_MS_DISTRIBUTED", "true")
+    assert envs.MX_MS_DISTRIBUTED is True
+    monkeypatch.setenv("MX_MS_DISTRIBUTED", "no")
+    assert envs.MX_MS_DISTRIBUTED is False
+
+    monkeypatch.setenv("MX_VMM_ARENA", "1")
+    assert envs.MX_VMM_ARENA is True
+
+    for truthy in ("1", "TRUE", "yes", "On"):
+        monkeypatch.setenv("MX_ARTIFACT_TRANSFER", truthy)
+        assert envs.MX_ARTIFACT_TRANSFER is True
+    monkeypatch.setenv("MX_ARTIFACT_TRANSFER", "maybe")
+    assert envs.MX_ARTIFACT_TRANSFER is False
+
+
+def test_normalization(monkeypatch):
+    monkeypatch.setenv("MX_NIXL_BACKEND", "  libfabric ")
+    assert envs.MX_NIXL_BACKEND == "LIBFABRIC"
+    monkeypatch.setenv("MX_METADATA_BACKEND", "  Redis  ")
+    assert envs.MX_METADATA_BACKEND == "redis"
+    monkeypatch.setenv("MODEL_EXPRESS_LOG_LEVEL", "debug")
+    assert envs.MODEL_EXPRESS_LOG_LEVEL == "DEBUG"
+
+
+def test_raw_optional_passthrough(monkeypatch):
+    monkeypatch.delenv("MX_MODEL_URI", raising=False)
+    assert envs.MX_MODEL_URI is None
+    monkeypatch.setenv("MX_MODEL_URI", "s3://bucket/model")
+    assert envs.MX_MODEL_URI == "s3://bucket/model"
+    # Raw string; artifact_manifest owns the parse/validation.
+    monkeypatch.setenv("MX_ARTIFACT_TRANSFER_CHUNK_SIZE", "12345")
+    assert envs.MX_ARTIFACT_TRANSFER_CHUNK_SIZE == "12345"
+
+
+def test_is_set(monkeypatch):
+    monkeypatch.delenv("MX_WORKER_HOST", raising=False)
+    assert envs.is_set("MX_WORKER_HOST") is False
+    monkeypatch.setenv("MX_WORKER_HOST", "")
+    assert envs.is_set("MX_WORKER_HOST") is True
+
+
+def test_unknown_attribute_raises():
+    with pytest.raises(AttributeError):
+        _ = envs.NOT_A_REAL_ENV_VAR
+
+
+def test_dir_lists_registered_names():
+    names = dir(envs)
+    assert "MX_NIXL_BACKEND" in names
+    assert "VLLM_ATTENTION_BACKEND" in names
+    assert names == sorted(names)

--- a/modelexpress_common/src/cache.rs
+++ b/modelexpress_common/src/cache.rs
@@ -72,7 +72,7 @@ impl CacheConfig {
         }
 
         // Try environment variable
-        if let Ok(path) = env::var("MODEL_EXPRESS_CACHE_DIRECTORY") {
+        if let Some(path) = crate::envs::cache_directory() {
             return Self::from_path(path);
         }
 
@@ -215,10 +215,7 @@ impl CacheConfig {
 
     /// Get default server endpoint
     fn get_default_server_endpoint() -> String {
-        normalize_grpc_endpoint(
-            env::var("MODEL_EXPRESS_SERVER_ENDPOINT")
-                .unwrap_or_else(|_| format!("http://localhost:{}", constants::DEFAULT_GRPC_PORT)),
-        )
+        normalize_grpc_endpoint(crate::envs::server_endpoint_or_default())
     }
 
     /// Get configuration file path

--- a/modelexpress_common/src/client_config.rs
+++ b/modelexpress_common/src/client_config.rs
@@ -41,23 +41,23 @@ pub struct ClientArgs {
     pub config: Option<PathBuf>,
 
     /// Server endpoint
-    #[arg(short, long, env = "MODEL_EXPRESS_ENDPOINT")]
+    #[arg(short, long, env = crate::envs::MODEL_EXPRESS_ENDPOINT)]
     pub endpoint: Option<String>,
 
     /// Request timeout in seconds
-    #[arg(short, long, env = "MODEL_EXPRESS_TIMEOUT")]
+    #[arg(short, long, env = crate::envs::MODEL_EXPRESS_TIMEOUT)]
     pub timeout: Option<u64>,
 
     /// Cache path override
-    #[arg(long, env = "MODEL_EXPRESS_CACHE_DIRECTORY")]
+    #[arg(long, env = crate::envs::MODEL_EXPRESS_CACHE_DIRECTORY)]
     pub cache_path: Option<PathBuf>,
 
     /// Log level (no short flag to avoid conflict with CLI's -v/--verbose)
-    #[arg(long, env = "MODEL_EXPRESS_LOG_LEVEL", value_enum)]
+    #[arg(long, env = crate::envs::MODEL_EXPRESS_LOG_LEVEL, value_enum)]
     pub log_level: Option<LogLevel>,
 
     /// Log format
-    #[arg(long, env = "MODEL_EXPRESS_LOG_FORMAT", value_enum)]
+    #[arg(long, env = crate::envs::MODEL_EXPRESS_LOG_FORMAT, value_enum)]
     pub log_format: Option<LogFormat>,
 
     /// Quiet mode (suppress all output except errors)
@@ -65,19 +65,19 @@ pub struct ClientArgs {
     pub quiet: bool,
 
     /// Maximum number of retries
-    #[arg(long, env = "MODEL_EXPRESS_MAX_RETRIES")]
+    #[arg(long, env = crate::envs::MODEL_EXPRESS_MAX_RETRIES)]
     pub max_retries: Option<u32>,
 
     /// Retry delay in seconds
-    #[arg(long, env = "MODEL_EXPRESS_RETRY_DELAY")]
+    #[arg(long, env = crate::envs::MODEL_EXPRESS_RETRY_DELAY)]
     pub retry_delay: Option<u64>,
 
     /// Disable shared storage mode (will transfer files from server to client)
-    #[arg(long, env = "MODEL_EXPRESS_NO_SHARED_STORAGE")]
+    #[arg(long, env = crate::envs::MODEL_EXPRESS_NO_SHARED_STORAGE)]
     pub no_shared_storage: bool,
 
     /// Chunk size in bytes for file transfer when shared storage is disabled
-    #[arg(long, env = "MODEL_EXPRESS_TRANSFER_CHUNK_SIZE")]
+    #[arg(long, env = crate::envs::MODEL_EXPRESS_TRANSFER_CHUNK_SIZE)]
     pub transfer_chunk_size: Option<usize>,
 }
 
@@ -120,8 +120,11 @@ impl ClientConfig {
     /// 3. Add a test in the `tests` module to verify the override works
     pub fn load(args: ClientArgs) -> Result<Self, ConfigError> {
         // Start with layered config loading (file + env + defaults)
-        let mut config =
-            load_layered_config(args.config.clone(), "MODEL_EXPRESS", Self::default())?;
+        let mut config = load_layered_config(
+            args.config.clone(),
+            crate::envs::MODEL_EXPRESS_PREFIX,
+            Self::default(),
+        )?;
 
         // ==================== APPLY CLI ARGUMENT OVERRIDES ====================
         // When adding a new field to ClientArgs, add the override logic here.

--- a/modelexpress_common/src/envs.rs
+++ b/modelexpress_common/src/envs.rs
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Centralized registry of every environment variable the workspace reads.
+//!
+//! Inspired by vLLM's `envs.py`: this module is the single source of truth for
+//! env-var *names* (the `pub const` block) and provides typed *getters* that
+//! encapsulate defaults, fallback chains, and parsing. Both ModelExpress-owned
+//! variables (`MODEL_EXPRESS_*`, `MX_*`) and third-party variables the code
+//! depends on (`HF_*`, `NGC_*`, `REDIS_*`, `POD_NAMESPACE`, `HOME`) live here.
+//!
+//! # Conventions
+//! - Getters read `std::env` on **every** call and never cache. Some callers
+//!   (and tests via [`crate::test_support::EnvVarGuard`]) mutate the process
+//!   environment at runtime, so a cached value would go stale.
+//! - The name constants are referenced directly from clap `#[arg(env = ...)]`
+//!   attributes so the CLI and the getters can never drift apart.
+//!
+//! # Not covered here
+//! - `CARGO_PKG_VERSION` is read at compile time via the `env!` macro in
+//!   `modelexpress_server::services`; it is not a runtime variable.
+//! - `HF_ENDPOINT` is read directly by the `hf_hub` crate (via
+//!   `ApiBuilder::from_env`); ModelExpress only sets it in tests. Its name is
+//!   registered below for reference.
+
+use crate::Error;
+use crate::constants;
+use std::env;
+use std::path::PathBuf;
+
+// ── Config-loader prefix ────────────────────────────────────────────────────
+/// Prefix consumed by the `config` crate's `Environment` source in
+/// [`crate::config::load_layered_config`] (env vars like `MODEL_EXPRESS_*`
+/// override matching config-file fields).
+pub const MODEL_EXPRESS_PREFIX: &str = "MODEL_EXPRESS";
+
+// ── ModelExpress-owned variables ────────────────────────────────────────────
+/// Client server endpoint (`ClientArgs::endpoint`).
+pub const MODEL_EXPRESS_ENDPOINT: &str = "MODEL_EXPRESS_ENDPOINT";
+/// Client request timeout in seconds (`ClientArgs::timeout`).
+pub const MODEL_EXPRESS_TIMEOUT: &str = "MODEL_EXPRESS_TIMEOUT";
+/// Local model cache directory (client, server, and both providers).
+pub const MODEL_EXPRESS_CACHE_DIRECTORY: &str = "MODEL_EXPRESS_CACHE_DIRECTORY";
+/// Log level (client and server).
+pub const MODEL_EXPRESS_LOG_LEVEL: &str = "MODEL_EXPRESS_LOG_LEVEL";
+/// Log output format (client and server).
+pub const MODEL_EXPRESS_LOG_FORMAT: &str = "MODEL_EXPRESS_LOG_FORMAT";
+/// Maximum connection/request retries (`ClientArgs::max_retries`).
+pub const MODEL_EXPRESS_MAX_RETRIES: &str = "MODEL_EXPRESS_MAX_RETRIES";
+/// Delay between retries in seconds (`ClientArgs::retry_delay`).
+pub const MODEL_EXPRESS_RETRY_DELAY: &str = "MODEL_EXPRESS_RETRY_DELAY";
+/// Disable shared-storage mode (`ClientArgs::no_shared_storage`).
+pub const MODEL_EXPRESS_NO_SHARED_STORAGE: &str = "MODEL_EXPRESS_NO_SHARED_STORAGE";
+/// File-transfer chunk size in bytes (`ClientArgs::transfer_chunk_size`).
+pub const MODEL_EXPRESS_TRANSFER_CHUNK_SIZE: &str = "MODEL_EXPRESS_TRANSFER_CHUNK_SIZE";
+/// gRPC server listen port (`ServerArgs::port`).
+pub const MODEL_EXPRESS_SERVER_PORT: &str = "MODEL_EXPRESS_SERVER_PORT";
+/// Server host/bind address (`ServerArgs::host`).
+pub const MODEL_EXPRESS_SERVER_HOST: &str = "MODEL_EXPRESS_SERVER_HOST";
+/// Toggle the background cache-eviction sweeper (`ServerArgs::cache_eviction_enabled`).
+pub const MODEL_EXPRESS_CACHE_EVICTION_ENABLED: &str = "MODEL_EXPRESS_CACHE_EVICTION_ENABLED";
+/// Server endpoint used by the cache module's default-endpoint helper.
+pub const MODEL_EXPRESS_SERVER_ENDPOINT: &str = "MODEL_EXPRESS_SERVER_ENDPOINT";
+
+// ── HuggingFace ─────────────────────────────────────────────────────────────
+/// HuggingFace Hub auth token.
+pub const HF_TOKEN: &str = "HF_TOKEN";
+/// HuggingFace Hub cache directory.
+pub const HF_HUB_CACHE: &str = "HF_HUB_CACHE";
+/// Enables HuggingFace offline mode.
+pub const HF_HUB_OFFLINE: &str = "HF_HUB_OFFLINE";
+/// HuggingFace Hub endpoint override. Read directly by the `hf_hub` crate;
+/// registered here for reference (ModelExpress only sets it in tests).
+pub const HF_ENDPOINT: &str = "HF_ENDPOINT";
+
+// ── NGC ─────────────────────────────────────────────────────────────────────
+/// Base URL for the NGC artifact/download API.
+pub const NGC_API_ENDPOINT: &str = "NGC_API_ENDPOINT";
+/// Base URL for the NGC authentication endpoint.
+pub const NGC_AUTH_ENDPOINT: &str = "NGC_AUTH_ENDPOINT";
+/// NGC API key.
+pub const NGC_API_KEY: &str = "NGC_API_KEY";
+/// Alternate NGC CLI API key.
+pub const NGC_CLI_API_KEY: &str = "NGC_CLI_API_KEY";
+/// Root directory used to locate the NGC CLI config file (`~/.ngc/config`).
+pub const NGC_CLI_HOME: &str = "NGC_CLI_HOME";
+
+/// Default NGC API base URL when [`NGC_API_ENDPOINT`] is unset.
+pub const DEFAULT_NGC_API_BASE: &str = "https://api.ngc.nvidia.com";
+/// Default NGC auth base URL when [`NGC_AUTH_ENDPOINT`] is unset.
+pub const DEFAULT_NGC_AUTHN_BASE: &str = "https://authn.nvidia.com";
+
+// ── Redis / metadata backend (server) ───────────────────────────────────────
+/// Selects the metadata backend implementation (`redis`, `kubernetes`, `memory`).
+pub const MX_METADATA_BACKEND: &str = "MX_METADATA_BACKEND";
+/// Full Redis connection URL for the redis metadata backend.
+pub const REDIS_URL: &str = "REDIS_URL";
+/// Redis host (preferred) when building the URL from host + port.
+pub const MX_REDIS_HOST: &str = "MX_REDIS_HOST";
+/// Redis host alias for charts predating the `MX_` prefix.
+pub const REDIS_HOST: &str = "REDIS_HOST";
+/// Redis port (preferred) when building the URL from host + port.
+pub const MX_REDIS_PORT: &str = "MX_REDIS_PORT";
+/// Redis port alias for charts predating the `MX_` prefix.
+pub const REDIS_PORT: &str = "REDIS_PORT";
+/// Kubernetes namespace for ModelCacheEntry CRs (overrides [`POD_NAMESPACE`]).
+pub const MX_METADATA_NAMESPACE: &str = "MX_METADATA_NAMESPACE";
+/// Kubernetes namespace injected via the downward API for in-cluster pods.
+pub const POD_NAMESPACE: &str = "POD_NAMESPACE";
+
+// ── Reaper (server) ─────────────────────────────────────────────────────────
+/// Interval (seconds) between reaper scans for stale/GC worker sweeps.
+pub const MX_REAPER_SCAN_INTERVAL_SECS: &str = "MX_REAPER_SCAN_INTERVAL_SECS";
+/// Age (seconds) after which an active worker's heartbeat is considered stale.
+pub const MX_HEARTBEAT_TIMEOUT_SECS: &str = "MX_HEARTBEAT_TIMEOUT_SECS";
+/// Age (seconds) after which a STALE worker is garbage-collected.
+pub const MX_GC_TIMEOUT_SECS: &str = "MX_GC_TIMEOUT_SECS";
+
+// ── System ──────────────────────────────────────────────────────────────────
+/// Primary source for the user's home directory.
+pub const HOME: &str = "HOME";
+/// Windows fallback for the home directory when [`HOME`] is unset.
+pub const USERPROFILE: &str = "USERPROFILE";
+/// Path to a kubeconfig file (consumed by the k8s integration tests).
+pub const KUBECONFIG: &str = "KUBECONFIG";
+
+// ── Default reaper timings ───────────────────────────────────────────────────
+const DEFAULT_REAPER_SCAN_INTERVAL_SECS: u64 = 30;
+const DEFAULT_HEARTBEAT_TIMEOUT_SECS: u64 = 90;
+const DEFAULT_GC_TIMEOUT_SECS: u64 = 3600;
+
+// ── Getters ───────────────────────────────────────────────────────────────
+
+/// Resolve the user's home directory: [`HOME`], then [`USERPROFILE`].
+///
+/// # Errors
+/// Returns an error when neither variable is set.
+pub fn home_dir() -> std::result::Result<String, Box<Error>> {
+    env::var(HOME)
+        .or_else(|_| env::var(USERPROFILE))
+        .map_err(|e| Error::Generic(format!("Failed to get home directory: {e}")).into())
+}
+
+/// Home directory as a `PathBuf`, falling back to `.` when unresolved.
+pub fn home_dir_or_cwd() -> PathBuf {
+    PathBuf::from(home_dir().unwrap_or_else(|_| ".".to_string()))
+}
+
+/// Model cache directory override from [`MODEL_EXPRESS_CACHE_DIRECTORY`].
+pub fn cache_directory() -> Option<PathBuf> {
+    env::var(MODEL_EXPRESS_CACHE_DIRECTORY)
+        .ok()
+        .map(PathBuf::from)
+}
+
+/// Default server gRPC endpoint: [`MODEL_EXPRESS_SERVER_ENDPOINT`] or
+/// `http://localhost:{DEFAULT_GRPC_PORT}`. Not normalized.
+pub fn server_endpoint_or_default() -> String {
+    env::var(MODEL_EXPRESS_SERVER_ENDPOINT)
+        .unwrap_or_else(|_| format!("http://localhost:{}", constants::DEFAULT_GRPC_PORT))
+}
+
+/// HuggingFace Hub token from [`HF_TOKEN`].
+pub fn hf_token() -> Option<String> {
+    env::var(HF_TOKEN).ok()
+}
+
+/// HuggingFace Hub cache directory from [`HF_HUB_CACHE`].
+pub fn hf_hub_cache() -> Option<PathBuf> {
+    env::var(HF_HUB_CACHE).ok().map(PathBuf::from)
+}
+
+/// Whether HuggingFace offline mode is enabled via [`HF_HUB_OFFLINE`].
+/// Enabled when the value is one of `1`, `ON`, `YES`, `TRUE` (case-insensitive).
+pub fn hf_offline() -> bool {
+    env::var(HF_HUB_OFFLINE)
+        .map(|v| matches!(v.to_uppercase().as_str(), "1" | "ON" | "YES" | "TRUE"))
+        .unwrap_or(false)
+}
+
+/// NGC API base URL: [`NGC_API_ENDPOINT`] or [`DEFAULT_NGC_API_BASE`].
+pub fn ngc_api_base() -> String {
+    env::var(NGC_API_ENDPOINT).unwrap_or_else(|_| DEFAULT_NGC_API_BASE.to_string())
+}
+
+/// NGC auth base URL: [`NGC_AUTH_ENDPOINT`] or [`DEFAULT_NGC_AUTHN_BASE`].
+pub fn ngc_authn_base() -> String {
+    env::var(NGC_AUTH_ENDPOINT).unwrap_or_else(|_| DEFAULT_NGC_AUTHN_BASE.to_string())
+}
+
+/// NGC API key from [`NGC_API_KEY`], then [`NGC_CLI_API_KEY`].
+/// Returns the first non-empty, trimmed value found.
+pub fn ngc_api_key() -> Option<String> {
+    for var in [NGC_API_KEY, NGC_CLI_API_KEY] {
+        if let Ok(v) = env::var(var) {
+            let trimmed = v.trim().to_string();
+            if !trimmed.is_empty() {
+                return Some(trimmed);
+            }
+        }
+    }
+    None
+}
+
+/// Root directory for the NGC CLI config from [`NGC_CLI_HOME`].
+pub fn ngc_cli_home() -> Option<PathBuf> {
+    env::var(NGC_CLI_HOME).ok().map(PathBuf::from)
+}
+
+/// Raw value of [`MX_METADATA_BACKEND`] (empty string when unset).
+pub fn metadata_backend() -> String {
+    env::var(MX_METADATA_BACKEND).unwrap_or_default()
+}
+
+/// Full Redis URL from [`REDIS_URL`].
+pub fn redis_url() -> Option<String> {
+    env::var(REDIS_URL).ok()
+}
+
+/// Redis host from [`MX_REDIS_HOST`], then [`REDIS_HOST`].
+pub fn redis_host() -> Option<String> {
+    env::var(MX_REDIS_HOST)
+        .or_else(|_| env::var(REDIS_HOST))
+        .ok()
+}
+
+/// Redis port from [`MX_REDIS_PORT`], then [`REDIS_PORT`].
+pub fn redis_port() -> Option<String> {
+    env::var(MX_REDIS_PORT)
+        .or_else(|_| env::var(REDIS_PORT))
+        .ok()
+}
+
+/// Kubernetes namespace from [`MX_METADATA_NAMESPACE`], then [`POD_NAMESPACE`].
+pub fn metadata_namespace() -> Option<String> {
+    env::var(MX_METADATA_NAMESPACE)
+        .or_else(|_| env::var(POD_NAMESPACE))
+        .ok()
+}
+
+/// Reaper scan interval in seconds ([`MX_REAPER_SCAN_INTERVAL_SECS`], default 30).
+pub fn reaper_scan_interval_secs() -> u64 {
+    env_u64(
+        MX_REAPER_SCAN_INTERVAL_SECS,
+        DEFAULT_REAPER_SCAN_INTERVAL_SECS,
+    )
+}
+
+/// Heartbeat staleness timeout in seconds ([`MX_HEARTBEAT_TIMEOUT_SECS`], default 90).
+pub fn heartbeat_timeout_secs() -> u64 {
+    env_u64(MX_HEARTBEAT_TIMEOUT_SECS, DEFAULT_HEARTBEAT_TIMEOUT_SECS)
+}
+
+/// Garbage-collection timeout in seconds ([`MX_GC_TIMEOUT_SECS`], default 3600).
+pub fn gc_timeout_secs() -> u64 {
+    env_u64(MX_GC_TIMEOUT_SECS, DEFAULT_GC_TIMEOUT_SECS)
+}
+
+/// Read an environment variable as `u64`, falling back to `default`.
+fn env_u64(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::test_support::{EnvVarGuard, acquire_env_mutex};
+
+    #[test]
+    fn name_constants_match_their_literals() {
+        assert_eq!(MODEL_EXPRESS_PREFIX, "MODEL_EXPRESS");
+        assert_eq!(MODEL_EXPRESS_ENDPOINT, "MODEL_EXPRESS_ENDPOINT");
+        assert_eq!(MODEL_EXPRESS_TIMEOUT, "MODEL_EXPRESS_TIMEOUT");
+        assert_eq!(
+            MODEL_EXPRESS_CACHE_DIRECTORY,
+            "MODEL_EXPRESS_CACHE_DIRECTORY"
+        );
+        assert_eq!(MODEL_EXPRESS_LOG_LEVEL, "MODEL_EXPRESS_LOG_LEVEL");
+        assert_eq!(MODEL_EXPRESS_LOG_FORMAT, "MODEL_EXPRESS_LOG_FORMAT");
+        assert_eq!(MODEL_EXPRESS_MAX_RETRIES, "MODEL_EXPRESS_MAX_RETRIES");
+        assert_eq!(MODEL_EXPRESS_RETRY_DELAY, "MODEL_EXPRESS_RETRY_DELAY");
+        assert_eq!(
+            MODEL_EXPRESS_NO_SHARED_STORAGE,
+            "MODEL_EXPRESS_NO_SHARED_STORAGE"
+        );
+        assert_eq!(
+            MODEL_EXPRESS_TRANSFER_CHUNK_SIZE,
+            "MODEL_EXPRESS_TRANSFER_CHUNK_SIZE"
+        );
+        assert_eq!(MODEL_EXPRESS_SERVER_PORT, "MODEL_EXPRESS_SERVER_PORT");
+        assert_eq!(MODEL_EXPRESS_SERVER_HOST, "MODEL_EXPRESS_SERVER_HOST");
+        assert_eq!(
+            MODEL_EXPRESS_CACHE_EVICTION_ENABLED,
+            "MODEL_EXPRESS_CACHE_EVICTION_ENABLED"
+        );
+        assert_eq!(
+            MODEL_EXPRESS_SERVER_ENDPOINT,
+            "MODEL_EXPRESS_SERVER_ENDPOINT"
+        );
+        assert_eq!(HF_TOKEN, "HF_TOKEN");
+        assert_eq!(HF_HUB_CACHE, "HF_HUB_CACHE");
+        assert_eq!(HF_HUB_OFFLINE, "HF_HUB_OFFLINE");
+        assert_eq!(HF_ENDPOINT, "HF_ENDPOINT");
+        assert_eq!(NGC_API_ENDPOINT, "NGC_API_ENDPOINT");
+        assert_eq!(NGC_AUTH_ENDPOINT, "NGC_AUTH_ENDPOINT");
+        assert_eq!(NGC_API_KEY, "NGC_API_KEY");
+        assert_eq!(NGC_CLI_API_KEY, "NGC_CLI_API_KEY");
+        assert_eq!(NGC_CLI_HOME, "NGC_CLI_HOME");
+        assert_eq!(MX_METADATA_BACKEND, "MX_METADATA_BACKEND");
+        assert_eq!(REDIS_URL, "REDIS_URL");
+        assert_eq!(MX_REDIS_HOST, "MX_REDIS_HOST");
+        assert_eq!(REDIS_HOST, "REDIS_HOST");
+        assert_eq!(MX_REDIS_PORT, "MX_REDIS_PORT");
+        assert_eq!(REDIS_PORT, "REDIS_PORT");
+        assert_eq!(MX_METADATA_NAMESPACE, "MX_METADATA_NAMESPACE");
+        assert_eq!(POD_NAMESPACE, "POD_NAMESPACE");
+        assert_eq!(MX_REAPER_SCAN_INTERVAL_SECS, "MX_REAPER_SCAN_INTERVAL_SECS");
+        assert_eq!(MX_HEARTBEAT_TIMEOUT_SECS, "MX_HEARTBEAT_TIMEOUT_SECS");
+        assert_eq!(MX_GC_TIMEOUT_SECS, "MX_GC_TIMEOUT_SECS");
+        assert_eq!(HOME, "HOME");
+        assert_eq!(USERPROFILE, "USERPROFILE");
+        assert_eq!(KUBECONFIG, "KUBECONFIG");
+    }
+
+    #[test]
+    fn hf_offline_parses_truthy_values() {
+        let lock = acquire_env_mutex();
+        for truthy in ["1", "on", "YES", "true", "True"] {
+            let _g = EnvVarGuard::set(&lock, HF_HUB_OFFLINE, truthy);
+            assert!(hf_offline(), "expected {truthy} to enable offline mode");
+        }
+        for falsey in ["0", "off", "no", "maybe"] {
+            let _g = EnvVarGuard::set(&lock, HF_HUB_OFFLINE, falsey);
+            assert!(!hf_offline(), "expected {falsey} to disable offline mode");
+        }
+        let _g = EnvVarGuard::remove(&lock, HF_HUB_OFFLINE);
+        assert!(!hf_offline(), "unset should disable offline mode");
+    }
+
+    #[test]
+    fn ngc_bases_default_then_override() {
+        let lock = acquire_env_mutex();
+        let _api = EnvVarGuard::remove(&lock, NGC_API_ENDPOINT);
+        let _authn = EnvVarGuard::remove(&lock, NGC_AUTH_ENDPOINT);
+        assert_eq!(ngc_api_base(), DEFAULT_NGC_API_BASE);
+        assert_eq!(ngc_authn_base(), DEFAULT_NGC_AUTHN_BASE);
+
+        let _api = EnvVarGuard::set(&lock, NGC_API_ENDPOINT, "https://api.example.com");
+        let _authn = EnvVarGuard::set(&lock, NGC_AUTH_ENDPOINT, "https://authn.example.com");
+        assert_eq!(ngc_api_base(), "https://api.example.com");
+        assert_eq!(ngc_authn_base(), "https://authn.example.com");
+    }
+
+    #[test]
+    fn ngc_api_key_prefers_primary_then_falls_back() {
+        let lock = acquire_env_mutex();
+        let _p = EnvVarGuard::set(&lock, NGC_API_KEY, "  primary  ");
+        let _s = EnvVarGuard::set(&lock, NGC_CLI_API_KEY, "secondary");
+        assert_eq!(ngc_api_key().as_deref(), Some("primary"));
+
+        let _p = EnvVarGuard::remove(&lock, NGC_API_KEY);
+        assert_eq!(ngc_api_key().as_deref(), Some("secondary"));
+
+        let _s = EnvVarGuard::remove(&lock, NGC_CLI_API_KEY);
+        assert_eq!(ngc_api_key(), None);
+    }
+
+    #[test]
+    fn redis_and_namespace_fallbacks() {
+        let lock = acquire_env_mutex();
+        let _h1 = EnvVarGuard::remove(&lock, MX_REDIS_HOST);
+        let _h2 = EnvVarGuard::set(&lock, REDIS_HOST, "legacy-host");
+        assert_eq!(redis_host().as_deref(), Some("legacy-host"));
+        let _h1 = EnvVarGuard::set(&lock, MX_REDIS_HOST, "mx-host");
+        assert_eq!(redis_host().as_deref(), Some("mx-host"));
+
+        let _n1 = EnvVarGuard::remove(&lock, MX_METADATA_NAMESPACE);
+        let _n2 = EnvVarGuard::set(&lock, POD_NAMESPACE, "pod-ns");
+        assert_eq!(metadata_namespace().as_deref(), Some("pod-ns"));
+    }
+
+    #[test]
+    fn reaper_getters_default_parse_and_fallback() {
+        let lock = acquire_env_mutex();
+        let _g = EnvVarGuard::remove(&lock, MX_REAPER_SCAN_INTERVAL_SECS);
+        assert_eq!(
+            reaper_scan_interval_secs(),
+            DEFAULT_REAPER_SCAN_INTERVAL_SECS
+        );
+
+        let _g = EnvVarGuard::set(&lock, MX_HEARTBEAT_TIMEOUT_SECS, "120");
+        assert_eq!(heartbeat_timeout_secs(), 120);
+
+        let _g = EnvVarGuard::set(&lock, MX_GC_TIMEOUT_SECS, "not-a-number");
+        assert_eq!(gc_timeout_secs(), DEFAULT_GC_TIMEOUT_SECS);
+    }
+}

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::env;
 use std::error::Error as StdError;
 
 pub mod artifact_manifest;
@@ -10,6 +9,7 @@ pub mod cache;
 pub mod client_config;
 pub mod config;
 pub mod download;
+pub mod envs;
 pub mod models;
 pub mod providers;
 #[cfg(any(test, feature = "test-support"))]
@@ -121,11 +121,10 @@ pub type Result<T> = std::result::Result<T, Box<Error>>;
 pub struct Utils;
 
 impl Utils {
-    /// Get home directory from environment variables
+    /// Get home directory from environment variables ([`envs::HOME`], then
+    /// [`envs::USERPROFILE`]).
     pub fn get_home_dir() -> std::result::Result<String, Box<Error>> {
-        env::var("HOME")
-            .or_else(|_| env::var("USERPROFILE"))
-            .map_err(|e| Error::Generic(format!("Failed to get home directory: {e}")).into())
+        envs::home_dir()
     }
 }
 

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    Utils,
     cache::{ModelInfo, ProviderCache, directory_size},
-    constants,
+    constants, envs,
     models::ModelProvider,
     providers::ModelProviderTrait,
 };
@@ -12,29 +11,22 @@ use anyhow::{Context, Result};
 use hf_hub::Cache;
 use hf_hub::api::tokio::{ApiBuilder, ApiError};
 use std::collections::HashSet;
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
-const HF_TOKEN_ENV_VAR: &str = "HF_TOKEN";
-const HF_HUB_CACHE_ENV_VAR: &str = "HF_HUB_CACHE";
-const MODEL_EXPRESS_CACHE_ENV_VAR: &str = "MODEL_EXPRESS_CACHE_DIRECTORY";
-const HF_HUB_OFFLINE_ENV_VAR: &str = "HF_HUB_OFFLINE";
-
-/// Check if offline mode is enabled via HF_HUB_OFFLINE environment variable.
-/// The variable is considered enabled if its value is one of: "1", "ON", "YES", "TRUE" (case-insensitive).
+/// Check if offline mode is enabled via `HF_HUB_OFFLINE`.
+/// See [`crate::envs::hf_offline`] for the accepted truthy values.
 fn is_offline_mode() -> bool {
-    env::var(HF_HUB_OFFLINE_ENV_VAR)
-        .map(|v| matches!(v.to_uppercase().as_str(), "1" | "ON" | "YES" | "TRUE"))
-        .unwrap_or(false)
+    envs::hf_offline()
 }
 
 /// Get the cache directory for Hugging Face models
 /// Priority order:
 /// 1. Provided cache_dir parameter
-/// 2. HF_HUB_CACHE environment variable
-/// 3. Default location (~/.cache/huggingface/hub)
+/// 2. MODEL_EXPRESS_CACHE_DIRECTORY environment variable
+/// 3. HF_HUB_CACHE environment variable
+/// 4. Default location (~/.cache/huggingface/hub)
 fn get_cache_dir(cache_dir: Option<PathBuf>) -> PathBuf {
     // Use provided cache directory if available
     if let Some(dir) = cache_dir {
@@ -42,18 +34,17 @@ fn get_cache_dir(cache_dir: Option<PathBuf>) -> PathBuf {
     }
 
     // Try MODEL_EXPRESS_CACHE_DIRECTORY environment variable first
-    if let Ok(cache_path) = env::var(MODEL_EXPRESS_CACHE_ENV_VAR) {
-        return PathBuf::from(cache_path);
+    if let Some(cache_path) = envs::cache_directory() {
+        return cache_path;
     }
 
-    // Try environment variable
-    if let Ok(cache_path) = env::var(HF_HUB_CACHE_ENV_VAR) {
-        return PathBuf::from(cache_path);
+    // Try HF_HUB_CACHE environment variable
+    if let Some(cache_path) = envs::hf_hub_cache() {
+        return cache_path;
     }
 
     // Fall back to default location
-    let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(constants::DEFAULT_HF_CACHE_PATH)
+    envs::home_dir_or_cwd().join(constants::DEFAULT_HF_CACHE_PATH)
 }
 
 /// Hugging Face model provider implementation
@@ -200,7 +191,7 @@ impl ModelProviderTrait for HuggingFaceProvider {
             return self.get_model_path(model_name, cache_dir).await;
         }
 
-        let token = env::var(HF_TOKEN_ENV_VAR).ok();
+        let token = envs::hf_token();
 
         info!("Using cache directory: {:?}", cache_dir);
         // High CPU download
@@ -292,7 +283,7 @@ impl ModelProviderTrait for HuggingFaceProvider {
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
     async fn delete_model(&self, model_name: &str, cache_dir: PathBuf) -> Result<()> {
         info!("Deleting model from Hugging Face cache: {model_name}");
-        let token = env::var(HF_TOKEN_ENV_VAR).ok();
+        let token = envs::hf_token();
         let api = ApiBuilder::from_env()
             .with_token(token)
             .with_cache_dir(cache_dir.clone())
@@ -400,7 +391,7 @@ impl ModelProviderTrait for HuggingFaceProvider {
         }
 
         // Check against the latest commit hash from HF
-        let token = env::var(HF_TOKEN_ENV_VAR).ok();
+        let token = envs::hf_token();
         let api = ApiBuilder::from_env().with_token(token).build()?;
         let repo = api.model(model_name.to_string());
         let info = repo.info().await.map_err(|e| {
@@ -503,7 +494,8 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let hf_endpoint_guard = EnvVarGuard::set(env_lock, "HF_ENDPOINT", &server.uri());
+            let hf_endpoint_guard =
+                EnvVarGuard::set(env_lock, crate::envs::HF_ENDPOINT, &server.uri());
 
             Self {
                 _server: server,
@@ -584,9 +576,13 @@ mod tests {
         );
 
         let env_cache_path = env_cache.path().to_str().expect("Expected env cache path");
-        let _model_express_cache_guard =
-            EnvVarGuard::set(&env_lock, MODEL_EXPRESS_CACHE_ENV_VAR, env_cache_path);
-        let _hf_hub_cache_guard = EnvVarGuard::set(&env_lock, HF_HUB_CACHE_ENV_VAR, env_cache_path);
+        let _model_express_cache_guard = EnvVarGuard::set(
+            &env_lock,
+            crate::envs::MODEL_EXPRESS_CACHE_DIRECTORY,
+            env_cache_path,
+        );
+        let _hf_hub_cache_guard =
+            EnvVarGuard::set(&env_lock, crate::envs::HF_HUB_CACHE, env_cache_path);
 
         let delete_result = provider
             .delete_model("test/model", explicit_cache.path().to_path_buf())
@@ -653,9 +649,13 @@ mod tests {
             .await;
 
         let temp_cache_path = temp_cache.path().to_str().expect("Expected cache path");
-        let _model_express_cache_guard =
-            EnvVarGuard::set(&env_lock, MODEL_EXPRESS_CACHE_ENV_VAR, temp_cache_path);
-        let _hf_endpoint_guard = EnvVarGuard::set(&env_lock, "HF_ENDPOINT", &server.uri());
+        let _model_express_cache_guard = EnvVarGuard::set(
+            &env_lock,
+            crate::envs::MODEL_EXPRESS_CACHE_DIRECTORY,
+            temp_cache_path,
+        );
+        let _hf_endpoint_guard =
+            EnvVarGuard::set(&env_lock, crate::envs::HF_ENDPOINT, &server.uri());
 
         let result = provider
             .delete_model(model_name, temp_cache.path().to_path_buf())
@@ -772,7 +772,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _hf_endpoint_guard = EnvVarGuard::set(&env_lock, "HF_ENDPOINT", &server.uri());
+        let _hf_endpoint_guard =
+            EnvVarGuard::set(&env_lock, crate::envs::HF_ENDPOINT, &server.uri());
 
         let provider = HuggingFaceProvider;
         let result = provider
@@ -789,17 +790,17 @@ mod tests {
     fn test_is_offline_mode() {
         let env_lock = acquire_env_mutex();
         {
-            let _offline_guard = EnvVarGuard::set(&env_lock, HF_HUB_OFFLINE_ENV_VAR, "1");
+            let _offline_guard = EnvVarGuard::set(&env_lock, crate::envs::HF_HUB_OFFLINE, "1");
             assert!(is_offline_mode());
         }
 
         {
-            let _offline_guard = EnvVarGuard::set(&env_lock, HF_HUB_OFFLINE_ENV_VAR, "0");
+            let _offline_guard = EnvVarGuard::set(&env_lock, crate::envs::HF_HUB_OFFLINE, "0");
             assert!(!is_offline_mode());
         }
 
         {
-            let _offline_guard = EnvVarGuard::remove(&env_lock, HF_HUB_OFFLINE_ENV_VAR);
+            let _offline_guard = EnvVarGuard::remove(&env_lock, crate::envs::HF_HUB_OFFLINE);
             assert!(!is_offline_mode());
         }
     }
@@ -816,7 +817,7 @@ mod tests {
             .join("abc1234");
         std::fs::create_dir_all(&snapshots_path).expect("Failed to create directory");
 
-        let _offline_guard = EnvVarGuard::set(&env_lock, HF_HUB_OFFLINE_ENV_VAR, "1");
+        let _offline_guard = EnvVarGuard::set(&env_lock, crate::envs::HF_HUB_OFFLINE, "1");
 
         let result = HuggingFaceProvider
             .download_model("test/model", Some(temp_dir.path().into()), false)
@@ -832,7 +833,7 @@ mod tests {
         let env_lock = acquire_env_mutex();
         let temp_dir = TempDir::new().expect("Failed to create temporary directory");
 
-        let _offline_guard = EnvVarGuard::set(&env_lock, HF_HUB_OFFLINE_ENV_VAR, "1");
+        let _offline_guard = EnvVarGuard::set(&env_lock, crate::envs::HF_HUB_OFFLINE, "1");
 
         let result = HuggingFaceProvider
             .download_model("nonexistent/model", Some(temp_dir.path().into()), false)

--- a/modelexpress_common/src/providers/ngc.rs
+++ b/modelexpress_common/src/providers/ngc.rs
@@ -2,34 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    Utils,
     cache::{ModelInfo, ProviderCache, directory_size},
+    envs,
     models::ModelProvider,
     providers::ModelProviderTrait,
 };
 use anyhow::{Context, Result};
 use reqwest::header::{AUTHORIZATION, HeaderValue};
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
-const NGC_API_ENDPOINT_ENV_VAR: &str = "NGC_API_ENDPOINT";
-const NGC_AUTH_ENDPOINT_ENV_VAR: &str = "NGC_AUTH_ENDPOINT";
-const DEFAULT_NGC_API_BASE: &str = "https://api.ngc.nvidia.com";
-const DEFAULT_NGC_AUTHN_BASE: &str = "https://authn.nvidia.com";
-
-fn ngc_api_base() -> String {
-    std::env::var(NGC_API_ENDPOINT_ENV_VAR).unwrap_or_else(|_| DEFAULT_NGC_API_BASE.to_string())
-}
-
-fn ngc_authn_base() -> String {
-    std::env::var(NGC_AUTH_ENDPOINT_ENV_VAR).unwrap_or_else(|_| DEFAULT_NGC_AUTHN_BASE.to_string())
-}
-const NGC_API_KEY_ENV_VAR: &str = "NGC_API_KEY";
-const NGC_CLI_API_KEY_ENV_VAR: &str = "NGC_CLI_API_KEY";
 const NGC_CLI_CONFIG_PATH: &str = ".ngc/config";
-const MODEL_EXPRESS_CACHE_ENV_VAR: &str = "MODEL_EXPRESS_CACHE_DIRECTORY";
 const DEFAULT_NGC_CACHE_SUBDIR: &str = ".cache";
 const PAGE_SIZE: u32 = 500;
 
@@ -114,11 +98,10 @@ fn get_cache_dir(cache_dir: Option<PathBuf>) -> PathBuf {
     if let Some(dir) = cache_dir {
         return dir;
     }
-    if let Ok(path) = env::var(MODEL_EXPRESS_CACHE_ENV_VAR) {
-        return PathBuf::from(path);
+    if let Some(path) = envs::cache_directory() {
+        return path;
     }
-    let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(DEFAULT_NGC_CACHE_SUBDIR)
+    envs::home_dir_or_cwd().join(DEFAULT_NGC_CACHE_SUBDIR)
 }
 
 /// Build the local directory path for an NGC artifact.
@@ -144,21 +127,12 @@ fn model_dir(cache_root: &Path, id: &NgcArtifactId) -> PathBuf {
 /// 2. `NGC_CLI_API_KEY` env var
 /// 3. `~/.ngc/config` (or `$NGC_CLI_HOME/.ngc/config`) — INI or JSON
 fn get_ngc_api_key() -> Result<String> {
-    for var in [NGC_API_KEY_ENV_VAR, NGC_CLI_API_KEY_ENV_VAR] {
-        if let Ok(v) = env::var(var) {
-            let trimmed = v.trim().to_string();
-            if !trimmed.is_empty() {
-                return Ok(trimmed);
-            }
-        }
+    if let Some(key) = envs::ngc_api_key() {
+        return Ok(key);
     }
 
-    let config_path = env::var("NGC_CLI_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let home = Utils::get_home_dir().unwrap_or_else(|_| ".".to_string());
-            PathBuf::from(home)
-        })
+    let config_path = envs::ngc_cli_home()
+        .unwrap_or_else(envs::home_dir_or_cwd)
         .join(NGC_CLI_CONFIG_PATH);
 
     if config_path.exists() {
@@ -170,8 +144,10 @@ fn get_ngc_api_key() -> Result<String> {
     }
 
     anyhow::bail!(
-        "NGC API key not set. Set {NGC_API_KEY_ENV_VAR} or {NGC_CLI_API_KEY_ENV_VAR}, \
-         or run 'ngc config set' to configure the NGC CLI."
+        "NGC API key not set. Set {} or {}, \
+         or run 'ngc config set' to configure the NGC CLI.",
+        envs::NGC_API_KEY,
+        envs::NGC_CLI_API_KEY
     )
 }
 
@@ -290,7 +266,7 @@ async fn fetch_token(
         Some(team) => format!("group/ngc:{}/{}", id.org, team),
         None => format!("group/ngc:{}", id.org),
     };
-    let url = format!("{}/token", ngc_authn_base());
+    let url = format!("{}/token", envs::ngc_authn_base());
     let response = client
         .get(&url)
         .query(&[("service", "ngc"), ("scope", scope.as_str())])
@@ -347,7 +323,7 @@ async fn fetch_artifact_files(
     auth: &HeaderValue,
     id: &NgcArtifactId,
 ) -> Result<(Vec<String>, Vec<String>, bool)> {
-    let api_base = ngc_api_base();
+    let api_base = envs::ngc_api_base();
     let artifact_base = match &id.team {
         Some(team) => format!(
             "{api_base}/v2/org/{}/team/{}/{}/{}",
@@ -1467,13 +1443,13 @@ mod tests {
                 .await;
 
             let api_endpoint_guard =
-                EnvVarGuard::set(env_lock, NGC_API_ENDPOINT_ENV_VAR, &server.uri());
+                EnvVarGuard::set(env_lock, envs::NGC_API_ENDPOINT, &server.uri());
             let auth_endpoint_guard =
-                EnvVarGuard::set(env_lock, NGC_AUTH_ENDPOINT_ENV_VAR, &server.uri());
-            let api_key_guard = EnvVarGuard::set(env_lock, NGC_API_KEY_ENV_VAR, "mock-legacy-key");
+                EnvVarGuard::set(env_lock, envs::NGC_AUTH_ENDPOINT, &server.uri());
+            let api_key_guard = EnvVarGuard::set(env_lock, envs::NGC_API_KEY, "mock-legacy-key");
             let cache_guard = EnvVarGuard::set(
                 env_lock,
-                MODEL_EXPRESS_CACHE_ENV_VAR,
+                envs::MODEL_EXPRESS_CACHE_DIRECTORY,
                 temp_dir.path().to_str().expect("path"),
             );
 
@@ -1546,9 +1522,9 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _api = EnvVarGuard::set(&env_lock, NGC_API_ENDPOINT_ENV_VAR, &server.uri());
-        let _auth = EnvVarGuard::set(&env_lock, NGC_AUTH_ENDPOINT_ENV_VAR, &server.uri());
-        let _key = EnvVarGuard::set(&env_lock, NGC_API_KEY_ENV_VAR, "mock-key");
+        let _api = EnvVarGuard::set(&env_lock, envs::NGC_API_ENDPOINT, &server.uri());
+        let _auth = EnvVarGuard::set(&env_lock, envs::NGC_AUTH_ENDPOINT, &server.uri());
+        let _key = EnvVarGuard::set(&env_lock, envs::NGC_API_KEY, "mock-key");
 
         let result = NgcProvider
             .download_model(
@@ -1609,9 +1585,9 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _api = EnvVarGuard::set(&env_lock, NGC_API_ENDPOINT_ENV_VAR, &server.uri());
-        let _auth = EnvVarGuard::set(&env_lock, NGC_AUTH_ENDPOINT_ENV_VAR, &server.uri());
-        let _key = EnvVarGuard::set(&env_lock, NGC_API_KEY_ENV_VAR, "mock-key");
+        let _api = EnvVarGuard::set(&env_lock, envs::NGC_API_ENDPOINT, &server.uri());
+        let _auth = EnvVarGuard::set(&env_lock, envs::NGC_AUTH_ENDPOINT, &server.uri());
+        let _key = EnvVarGuard::set(&env_lock, envs::NGC_API_KEY, "mock-key");
 
         let result = NgcProvider
             .download_model(
@@ -1652,9 +1628,9 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _api = EnvVarGuard::set(&env_lock, NGC_API_ENDPOINT_ENV_VAR, &server.uri());
-        let _auth = EnvVarGuard::set(&env_lock, NGC_AUTH_ENDPOINT_ENV_VAR, &server.uri());
-        let _key = EnvVarGuard::set(&env_lock, NGC_API_KEY_ENV_VAR, "nvapi-test-key-xyz");
+        let _api = EnvVarGuard::set(&env_lock, envs::NGC_API_ENDPOINT, &server.uri());
+        let _auth = EnvVarGuard::set(&env_lock, envs::NGC_AUTH_ENDPOINT, &server.uri());
+        let _key = EnvVarGuard::set(&env_lock, envs::NGC_API_KEY, "nvapi-test-key-xyz");
 
         let result = NgcProvider
             .download_model(

--- a/modelexpress_server/src/backend_config.rs
+++ b/modelexpress_server/src/backend_config.rs
@@ -104,14 +104,20 @@ impl BackendConfig {
             return Ok(url);
         }
         let host = modelexpress_common::envs::redis_host().ok_or_else(|| {
-            "MX_METADATA_BACKEND=redis requires REDIS_URL or MX_REDIS_HOST (alias \
-             REDIS_HOST) to be set."
-                .to_string()
+            format!(
+                "MX_METADATA_BACKEND=redis requires {} or {} (alias {}) to be set.",
+                modelexpress_common::envs::REDIS_URL,
+                modelexpress_common::envs::MX_REDIS_HOST,
+                modelexpress_common::envs::REDIS_HOST,
+            )
         })?;
         let port = modelexpress_common::envs::redis_port().ok_or_else(|| {
-            "MX_METADATA_BACKEND=redis requires REDIS_URL or MX_REDIS_PORT (alias \
-             REDIS_PORT) to be set."
-                .to_string()
+            format!(
+                "MX_METADATA_BACKEND=redis requires {} or {} (alias {}) to be set.",
+                modelexpress_common::envs::REDIS_URL,
+                modelexpress_common::envs::MX_REDIS_PORT,
+                modelexpress_common::envs::REDIS_PORT,
+            )
         })?;
         Ok(format!("redis://{host}:{port}"))
     }
@@ -122,9 +128,11 @@ impl BackendConfig {
     /// can't silently land ModelCacheEntry CRs in the `default` namespace.
     fn k8s_namespace_from_env() -> Result<String, String> {
         modelexpress_common::envs::metadata_namespace().ok_or_else(|| {
-            "MX_METADATA_BACKEND=kubernetes requires MX_METADATA_NAMESPACE or \
-             POD_NAMESPACE to be set."
-                .to_string()
+            format!(
+                "MX_METADATA_BACKEND=kubernetes requires {} or {} to be set.",
+                modelexpress_common::envs::MX_METADATA_NAMESPACE,
+                modelexpress_common::envs::POD_NAMESPACE,
+            )
         })
     }
 }

--- a/modelexpress_server/src/backend_config.rs
+++ b/modelexpress_server/src/backend_config.rs
@@ -44,7 +44,7 @@ impl BackendConfig {
     /// the selected backend is missing (no silent fallback to `localhost:6379` /
     /// `default` namespace, since those mask misconfig in production).
     pub fn from_env() -> Result<Self, String> {
-        let backend_type = std::env::var("MX_METADATA_BACKEND").unwrap_or_default();
+        let backend_type = modelexpress_common::envs::metadata_backend();
         match backend_type.to_lowercase().as_str() {
             "redis" => Ok(Self::Redis {
                 url: Self::redis_url_from_env()?,
@@ -100,23 +100,19 @@ impl BackendConfig {
     /// compatibility with charts that predate the `MX_` prefix). Errors when neither the
     /// URL nor both host-and-port pieces are provided.
     pub fn redis_url_from_env() -> Result<String, String> {
-        if let Ok(url) = std::env::var("REDIS_URL") {
+        if let Some(url) = modelexpress_common::envs::redis_url() {
             return Ok(url);
         }
-        let host = std::env::var("MX_REDIS_HOST")
-            .or_else(|_| std::env::var("REDIS_HOST"))
-            .map_err(|_| {
-                "MX_METADATA_BACKEND=redis requires REDIS_URL or MX_REDIS_HOST (alias \
-                 REDIS_HOST) to be set."
-                    .to_string()
-            })?;
-        let port = std::env::var("MX_REDIS_PORT")
-            .or_else(|_| std::env::var("REDIS_PORT"))
-            .map_err(|_| {
-                "MX_METADATA_BACKEND=redis requires REDIS_URL or MX_REDIS_PORT (alias \
-                 REDIS_PORT) to be set."
-                    .to_string()
-            })?;
+        let host = modelexpress_common::envs::redis_host().ok_or_else(|| {
+            "MX_METADATA_BACKEND=redis requires REDIS_URL or MX_REDIS_HOST (alias \
+             REDIS_HOST) to be set."
+                .to_string()
+        })?;
+        let port = modelexpress_common::envs::redis_port().ok_or_else(|| {
+            "MX_METADATA_BACKEND=redis requires REDIS_URL or MX_REDIS_PORT (alias \
+             REDIS_PORT) to be set."
+                .to_string()
+        })?;
         Ok(format!("redis://{host}:{port}"))
     }
 
@@ -125,13 +121,11 @@ impl BackendConfig {
     /// out-of-cluster operators. Errors when neither is set so a typo in the chart
     /// can't silently land ModelCacheEntry CRs in the `default` namespace.
     fn k8s_namespace_from_env() -> Result<String, String> {
-        std::env::var("MX_METADATA_NAMESPACE")
-            .or_else(|_| std::env::var("POD_NAMESPACE"))
-            .map_err(|_| {
-                "MX_METADATA_BACKEND=kubernetes requires MX_METADATA_NAMESPACE or \
-                 POD_NAMESPACE to be set."
-                    .to_string()
-            })
+        modelexpress_common::envs::metadata_namespace().ok_or_else(|| {
+            "MX_METADATA_BACKEND=kubernetes requires MX_METADATA_NAMESPACE or \
+             POD_NAMESPACE to be set."
+                .to_string()
+        })
     }
 }
 

--- a/modelexpress_server/src/config.rs
+++ b/modelexpress_server/src/config.rs
@@ -21,27 +21,27 @@ pub struct ServerArgs {
     pub config: Option<PathBuf>,
 
     /// Server port
-    #[arg(short, long, env = "MODEL_EXPRESS_SERVER_PORT")]
+    #[arg(short, long, env = modelexpress_common::envs::MODEL_EXPRESS_SERVER_PORT)]
     pub port: Option<NonZeroU16>,
 
     /// Server host address
-    #[arg(long, env = "MODEL_EXPRESS_SERVER_HOST")]
+    #[arg(long, env = modelexpress_common::envs::MODEL_EXPRESS_SERVER_HOST)]
     pub host: Option<String>,
 
     /// Log level
-    #[arg(short, long, env = "MODEL_EXPRESS_LOG_LEVEL", value_enum)]
+    #[arg(short, long, env = modelexpress_common::envs::MODEL_EXPRESS_LOG_LEVEL, value_enum)]
     pub log_level: Option<LogLevel>,
 
     /// Log format
-    #[arg(long, env = "MODEL_EXPRESS_LOG_FORMAT", value_enum)]
+    #[arg(long, env = modelexpress_common::envs::MODEL_EXPRESS_LOG_FORMAT, value_enum)]
     pub log_format: Option<LogFormat>,
 
     /// Cache directory path
-    #[arg(long, env = "MODEL_EXPRESS_CACHE_DIRECTORY")]
+    #[arg(long, env = modelexpress_common::envs::MODEL_EXPRESS_CACHE_DIRECTORY)]
     pub cache_directory: Option<PathBuf>,
 
     /// Enable cache eviction
-    #[arg(long, env = "MODEL_EXPRESS_CACHE_EVICTION_ENABLED")]
+    #[arg(long, env = modelexpress_common::envs::MODEL_EXPRESS_CACHE_EVICTION_ENABLED)]
     pub cache_eviction_enabled: Option<bool>,
 
     /// Validate configuration and exit
@@ -144,7 +144,11 @@ impl ServerConfig {
             }
         } else {
             // Use layered config loading with fallbacks to defaults
-            load_layered_config(args.config.clone(), "MODEL_EXPRESS", Self::default())?
+            load_layered_config(
+                args.config.clone(),
+                modelexpress_common::envs::MODEL_EXPRESS_PREFIX,
+                Self::default(),
+            )?
         };
 
         // Apply command line overrides (same for both modes)

--- a/modelexpress_server/src/p2p/reaper.rs
+++ b/modelexpress_server/src/p2p/reaper.rs
@@ -16,19 +16,11 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
 
-/// Read an environment variable as `u64`, falling back to `default`.
-fn env_u64(name: &str, default: u64) -> u64 {
-    std::env::var(name)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
-}
-
 /// Run the reaper loop until the shutdown signal fires.
 pub async fn run_reaper(state: Arc<P2pStateManager>, shutdown: oneshot::Receiver<()>) {
-    let scan_interval_secs = env_u64("MX_REAPER_SCAN_INTERVAL_SECS", 30);
-    let heartbeat_timeout_secs = env_u64("MX_HEARTBEAT_TIMEOUT_SECS", 90);
-    let gc_timeout_secs = env_u64("MX_GC_TIMEOUT_SECS", 3600);
+    let scan_interval_secs = modelexpress_common::envs::reaper_scan_interval_secs();
+    let heartbeat_timeout_secs = modelexpress_common::envs::heartbeat_timeout_secs();
+    let gc_timeout_secs = modelexpress_common::envs::gc_timeout_secs();
     let heartbeat_timeout_ms = heartbeat_timeout_secs.saturating_mul(1000);
     let gc_timeout_ms = gc_timeout_secs.saturating_mul(1000);
 

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -38,9 +38,7 @@ fn get_server_cache_dir() -> Option<std::path::PathBuf> {
         Some(config.local_path)
     } else {
         // Fall back to environment variable
-        std::env::var("HF_HUB_CACHE")
-            .ok()
-            .map(std::path::PathBuf::from)
+        modelexpress_common::envs::hf_hub_cache()
     }
 }
 


### PR DESCRIPTION
## Summary

Centralizes all environment-variable access into one canonical module per language, modeled on [vLLM's `envs.py`](https://github.com/vllm-project/vllm/blob/main/vllm/envs.py). Covers ModelExpress-owned vars (`MODEL_EXPRESS_*`, `MX_*`) **and** third-party vars the code reads (`HF_*`, `NGC_*`, `REDIS_*`, `UCX_*`, `NIXL_*`, `VLLM_*`, `TRITON_CACHE_DIR`, `POD_NAMESPACE`, `HOME`, …).

**Why:** env names were scattered as string literals across ~30 files; 3 clap names were duplicated between the client and server arg structs (a silent drift risk); there was no single inventory of what the code reads, its defaults, or fallback chains.

## What changed

- **Rust** — new `modelexpress_common/src/envs.rs`: `pub const` name constants + typed getters that own defaults/fallbacks/parsing. Every clap `#[arg(env = ...)]` now references a constant, and every `std::env::var` read (cache, HF/NGC providers, `backend_config`, p2p reaper, services, `Utils::get_home_dir`, the `config`-crate prefix) routes through it. Error strings and precedence preserved verbatim.
- **Python** — new `modelexpress/envs.py`: vLLM-style `environment_variables` dict + module `__getattr__`/`__dir__`/`is_set`, read live (monkeypatch-safe). All `os.environ` reads across the client migrated. Inline writes (`UCX_TLS`, `UCX_NET_DEVICES`) stay put but read through `envs`.
- **Docs** — `docs/DEPLOYMENT.md` + the three "Adding CLI Arguments" guides point at the `envs` modules as the canonical inventory.

## Behavior / safety

- Getters read the environment live (no caching) so runtime mutation and tests still work.
- Documented non-runtime exceptions: `CARGO_PKG_VERSION` (compile-time `env!`), `HF_ENDPOINT` (read by `hf_hub` itself), Python `setup.py` build vars (`MX_SKIP_EXT`, `CXX`), and the `MODEL_EXPRESS_SOURCE` docstring example.

## Testing

| Layer | Result |
|---|---|
| Rust workspace | **405 tests green** — `cargo test --workspace` (common 167, server 194, client 25, cli 14, contract 5, integration 4; k8s/redis integration `#[ignore]`d, need live infra). `cargo clippy --workspace --all-targets` + `cargo fmt --check` clean. |
| Python — local (macOS) | **435 passed, 32 skipped**; the only non-passing were 7 `test_pool_registration` tests that require Linux-only `cuda-python`. |
| Python — GPU dev cluster | **442 passed, 32 skipped, 0 failed** — full `pytest` suite on `dynamo-nscale-dev-cluster` in a real Linux env (torch 2.12, `cuda-python` 13.3, protobuf 5.29, `_alloc_ext` compiled), covering every test unrunnable on macOS (`test_pool_registration`, `test_vmm_arena`, `test_vmm_hook`, artifact/nixl). |

Additional checks:

- A one-field `cargo check` spike confirmed clap 4.5 accepts `env = <const path>` (path to a `pub const &str`), not just a string literal.
- Behavior parity: the local failing set was proven byte-identical to a pristine `origin/main` checkout, and `tests/test_envs.py` adds 9 new passing cases — the refactor introduces zero new failures.
- Greps confirm no production env access remains outside the two `envs` modules (besides the documented exceptions).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified configuration system for environment variables, making CLI and runtime settings more consistent across the app.
  * Improved environment-variable support for server, client, and transfer-related settings, including clearer defaults and fallback behavior.

* **Bug Fixes**
  * Fixed several cases where settings could be read inconsistently or ignored, improving reliability for cache paths, endpoints, logging, and transfer options.
  * Updated docs and guidance so configuration examples now match the supported behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->