### PR TITLE
test(ci): make per-rank source-agent assertion DP-aware

### DIFF
--- a/.github/actions/run-mx-p2p-test/action.yml
+++ b/.github/actions/run-mx-p2p-test/action.yml
@@ -90,6 +90,15 @@ inputs:
       Catches silent TP collapse and rank-pairing regressions.
     required: false
     default: '1'
+  dp_size:
+    description: |
+      Data-parallel size of the target deployment. Forwarded to pytest as
+      --dp-size. DP replicas are interchangeable copies at the same
+      worker_rank, so the per-rank agent assertion accepts a distinct-agent
+      count in [tp_size, tp_size * dp_size] instead of exactly tp_size.
+      Defaults to 1 (pure TP / single copy).
+    required: false
+    default: '1'
   measure_vram:
     description: 'When true, sample source/target VRAM and enable the pytest VRAM parity assertions.'
     required: false
@@ -423,6 +432,7 @@ runs:
         WORKER_PORT: ${{ inputs.worker_port }}
         TEST_SCRIPT: ${{ inputs.test_script }}
         TP_SIZE: ${{ inputs.tp_size }}
+        DP_SIZE: ${{ inputs.dp_size }}
         PYTEST_ARGS: ${{ inputs.pytest_args }}
         EXPECTED_ARTIFACT_SOURCES: ${{ inputs.expected_artifact_sources }}
         EXPECTED_ARTIFACT_SOURCE_TYPES: ${{ inputs.expected_artifact_source_types }}
@@ -451,6 +461,7 @@ runs:
           --source-port "${SOURCE_PORT}" \
           --worker-port "${WORKER_PORT}" \
           --tp-size "${TP_SIZE}" \
+          --dp-size "${DP_SIZE}" \
           "${EXTRA[@]}"
 
     - name: Dump pod logs

--- a/.github/workflows/modelexpress-ci-tests.yml
+++ b/.github/workflows/modelexpress-ci-tests.yml
@@ -653,8 +653,13 @@ jobs:
           source_port: ${{ matrix.source_port }}
           worker_port: ${{ matrix.worker_port }}
           # tp_size omitted — defaults to 1. DP cores are full, interchangeable
-          # copies at worker_rank 0; the source publishes one CR and the target
-          # pulls a single rank-0 weight set per DP core.
+          # copies at worker_rank 0, so each DP core publishes its own rank-0
+          # source agent and the target's DP cores each select one at random.
+          # dp_size=2 widens the per-rank agent assertion to [tp_size,
+          # tp_size*dp_size] = [1, 2]: the two target cores may converge on one
+          # source (1 distinct agent) or split across both (2), both valid. The
+          # source_ranks == range(tp_size) check still pins rank pairing to 0.
+          dp_size: "2"
 
       - name: Dump vCluster diagnostics on failure
         if: failure()

--- a/ci/k8s/client/conftest.py
+++ b/ci/k8s/client/conftest.py
@@ -52,6 +52,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Tensor-parallel size — the per-rank transfer test expects this many distinct ranks.",
     )
     parser.addoption(
+        "--dp-size",
+        default=_positive_int(os.environ.get("DP_SIZE", "1")),
+        type=_positive_int,
+        help=(
+            "Data-parallel size — DP replicas are interchangeable full copies "
+            "at the same worker_rank, so the per-rank transfer test accepts a "
+            "distinct-agent count anywhere in [tp_size, tp_size * dp_size] "
+            "instead of exactly tp_size. Defaults to 1 (pure TP / single copy)."
+        ),
+    )
+    parser.addoption(
         "--transport",
         default=os.environ.get("TRANSPORT", "nixl"),
         help=(
@@ -153,6 +164,11 @@ def p2p_marker(request: pytest.FixtureRequest) -> str:
 @pytest.fixture(scope="session")
 def tp_size(request: pytest.FixtureRequest) -> int:
     return request.config.getoption("--tp-size")
+
+
+@pytest.fixture(scope="session")
+def dp_size(request: pytest.FixtureRequest) -> int:
+    return request.config.getoption("--dp-size")
 
 
 @pytest.fixture(scope="session")

--- a/ci/k8s/client/test_p2p_k8s.py
+++ b/ci/k8s/client/test_p2p_k8s.py
@@ -6,8 +6,10 @@
 Runs after the workflow has applied the source and target Jobs and both pods
 have reached Running state.  Asserts:
   1. Target pod logs contain the framework-specific P2P transfer marker (--p2p-marker).
-  2. Target connected to `--tp-size` distinct source NIXL agents covering ranks
-     0..tp_size-1 (catches TP collapse and source-rank-pairing regressions).
+  2. Target connected to source NIXL agents covering ranks 0..tp_size-1, with a
+     distinct-agent count in [tp_size, tp_size * dp_size] (catches TP collapse
+     and source-rank-pairing regressions; the range accommodates interchangeable
+     DP replicas that share a rank — see --dp-size).
   3. Both source and target servers respond to /v1/completions — confirms weights
      are loaded and the model is serving correctly on each.
   4. When enabled by the workflow, target peak and final VRAM do not materially
@@ -20,6 +22,7 @@ Invoked by the workflow as:
       --source-port $SOURCE_PORT \
       --worker-port $WORKER_PORT \
       --tp-size $TP_SIZE \
+      [--dp-size $DP_SIZE] \
       [--p2p-marker "framework-specific transfer complete string"]
 
 --p2p-marker defaults:
@@ -28,6 +31,11 @@ Invoked by the workflow as:
 
 --tp-size default is 1 — every existing TP=1 P2P test still asserts exactly
 one source agent, which is the correct expectation and adds a free safety net.
+
+--dp-size default is 1 — with a single copy per rank the accepted range
+collapses to exactly tp_size, so TP-only jobs are unaffected. Set it to the
+target's data-parallel size (e.g. 2 for the DP=2 job) so the range widens to
+[tp_size, tp_size * dp_size] for the interchangeable replicas DP publishes.
 """
 
 import json
@@ -189,8 +197,10 @@ def test_rdma_transfer_logged(namespace: str, p2p_marker: str) -> None:
     )
 
 
-def test_per_rank_source_agents(namespace: str, tp_size: int, transport: str) -> None:
-    """Target must connect to one distinct source NIXL agent per target rank.
+def test_per_rank_source_agents(
+    namespace: str, tp_size: int, dp_size: int, transport: str
+) -> None:
+    """Target's source NIXL agents must cover every rank without mis-pairing.
 
     NIXL-only: the assertion scans for remote-agent log lines that the shared
     NixlTransferManager emits. The Mooncake TransferEngine path
@@ -200,17 +210,29 @@ def test_per_rank_source_agents(namespace: str, tp_size: int, transport: str) ->
     Each source rank publishes exactly one NIXL agent. The shared
     NixlTransferManager.receive_from_source (in modelexpress.nixl_transfer)
     logs either `add_remote_agent: ... (agent=b'<name>')` for central metadata
-    or `Using pre-loaded remote agent <name>` for P2P metadata. Failure modes:
+    or `Using pre-loaded remote agent <name>` for P2P metadata.
 
-      - TP collapse: fewer than `tp_size` remote-agent lines.
-      - Source-rank collapse (e.g. all target ranks pulling from source rank 0
-        because the rank filter regressed in _find_source_instances): same agent
-        name repeats across target ranks → distinct-count < tp_size.
-      - Wrong source-rank set: source ranks observed don't cover 0..tp_size-1.
+    Two orthogonal checks:
 
-    Inference alone can't catch source-rank collapse because TP shards have the
-    same shape per rank, so the load succeeds with wrong values and produces
-    plausible-but-garbage text — which the current non-empty assertion passes.
+      1. source_ranks == range(tp_size). This is the deterministic invariant:
+         the observed source ranks must cover exactly 0..tp_size-1, no matter
+         which replica each target core selected. It catches TP collapse (a
+         target rank never ran → missing rank) and source-rank collapse (the
+         rank filter in _find_source_instances regressed so a target rank
+         pulled from the wrong rank). Inference alone can't catch the latter:
+         shards share a shape per rank, so a wrong-rank load succeeds with
+         garbage values and still produces plausible text.
+
+      2. tp_size <= distinct_agents <= tp_size * dp_size. Distinct-agent count
+         is NOT deterministic under DP: DP replicas are interchangeable full
+         copies at the SAME worker_rank, so a rank can expose up to dp_size
+         agents and each target core of that rank picks one at random (default
+         `random` selector). The dp_size cores at a rank therefore land on
+         1..dp_size distinct replicas → the total is anywhere in
+         [tp_size, tp_size * dp_size]. Asserting == tp_size is only correct
+         when dp_size == 1 (pure TP, one candidate per rank); it is a coin-flip
+         flake under DP > 1. The lower bound still catches full collapse; the
+         upper bound catches agents outside the expected rank set.
     """
     if transport != "nixl":
         pytest.skip(
@@ -231,10 +253,13 @@ def test_per_rank_source_agents(namespace: str, tp_size: int, transport: str) ->
     source_ranks = sorted({int(r) for _, r in distinct_pairs})
     print(f"[mx-target] distinct source agents: {distinct_agents}  source_ranks={source_ranks}")
 
-    assert len(distinct_agents) == tp_size, (
-        f"Expected {tp_size} distinct source agent(s), got {len(distinct_agents)}: "
-        f"{distinct_agents}. Fewer means TP collapse (target rank didn't run) or "
-        f"source-rank collapse (multiple target ranks pulled from the same source)."
+    lo, hi = tp_size, tp_size * dp_size
+    assert lo <= len(distinct_agents) <= hi, (
+        f"Expected between {lo} and {hi} distinct source agent(s) "
+        f"(tp_size={tp_size}, dp_size={dp_size}), got {len(distinct_agents)}: "
+        f"{distinct_agents}. Below {lo} means TP collapse (a target rank didn't "
+        f"run) or source-rank collapse (a rank's target cores all pulled from a "
+        f"single source); above {hi} means agents outside the expected rank set."
     )
     assert source_ranks == list(range(tp_size)), (
         f"Expected source ranks {list(range(tp_size))}, got {source_ranks}."

--- a/ci/k8s/client/vllm/manifest-azure-dp2.yaml
+++ b/ci/k8s/client/vllm/manifest-azure-dp2.yaml
@@ -12,14 +12,17 @@
 #     and the copies are interchangeable, so the ModelExpress identity carries
 #     no DP dimension (build_source_identity has tp/pp/ep, not dp) and every
 #     DP core resolves to the same worker_rank (0). The transfer pattern is
-#     therefore "N concurrent full-weight pulls from a single source," not
-#     rank-paired transfers (TEST_PLAN row 5.2).
+#     therefore "N concurrent full-weight pulls from interchangeable rank-0
+#     sources," not rank-paired transfers (TEST_PLAN row 5.2).
 #
-# Consequence for the CI wiring: this job runs with tp_size=1. The source
-# publishes a single rank-0 CR, and the target's DP cores each pull the full
-# rank-0 weight set over RDMA. The per-rank agent assertion expects exactly
-# one distinct source agent (rank 0), which is correct for DP — it is not the
-# TP fan-out.
+# Consequence for the CI wiring: this job runs with tp_size=1, dp_size=2. Each
+# source DP core publishes its OWN rank-0 agent (uuid worker_id suffix), so the
+# source exposes dp_size interchangeable rank-0 agents; the target's dp_size
+# cores each select one at random (default `random` selector). The per-rank
+# agent assertion therefore accepts a distinct-agent count in
+# [tp_size, tp_size*dp_size] = [1, 2] (both cores may converge on one source or
+# split across both), and still pins source_ranks == [0] to catch real rank
+# mis-pairing — it is not the TP fan-out.
 #
 # Differences vs manifest-azure-tp2.yaml:
 #   - --data-parallel-size 2 + --tensor-parallel-size 1 (was --tensor-parallel-size 2)


### PR DESCRIPTION
## Summary

Fixes the flaky **P2P DP test (vllm DP=2 single-node)** →
`test_per_rank_source_agents`, which fails ~50% of runs with e.g.:

```
Expected 1 distinct source agent(s), got 2:
{mx-auto-worker0-45390a7e, mx-auto-worker0-caf48b7d}  source_ranks=[0]
```

## Root cause

`test_per_rank_source_agents` asserted `len(distinct_agents) == tp_size`.
That equality is only correct for **pure TP**, where each `worker_rank`
owns a distinct shard and the source publishes exactly one candidate per
rank.

Under **data parallelism** the source runs `dp_size` interchangeable full
copies at the **same** `worker_rank` (0). Each DP core self-assigns a
random `worker_id` (`engines/vllm/adapter.py`), so the source publishes
`dp_size` distinct rank-0 NIXL agents (`mx-auto-worker0-<uuid>`). The
target's `dp_size` cores each pick one at random (default `random`
selector), so they land on **1..dp_size** distinct sources. The
distinct-agent count is therefore non-deterministic in
`[tp_size, tp_size * dp_size]`; the DP=2 job passed only when both target
cores happened to converge on the same source (a coin flip).

This is not a weight-correctness bug: the dense DP replicas are identical,
so any of them is a valid pull. `source_ranks` was always `[0]` (correct).

## Change

- Replace the equality with a range check
  `tp_size <= distinct_agents <= tp_size * dp_size`.
- Keep `source_ranks == range(tp_size)` — the deterministic invariant that
  still catches TP collapse and real source-rank mis-pairing (the class of
  bug #363 fixed via world-rank pairing).
- Add a `--dp-size` pytest option + `dp_size` fixture; thread `dp_size`
  through the `run-mx-p2p-test` action; set `dp_size: "2"` on the DP job.
- `dp_size` defaults to **1**, so the range collapses to exactly `tp_size`
  and every TP-only job (TP=1, TP=2, EP tp_size=2) is unaffected.
- Correct the `manifest-azure-dp2.yaml` header, which wrongly stated a DP
  source publishes a single rank-0 CR / the assertion expects exactly one
  agent.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable data-parallel test sizing, letting CI and tests run with a chosen `dp_size` value.
  * Updated automated checks to account for multiple data-parallel replicas.

* **Bug Fixes**
  * Improved per-rank agent assertions so they work correctly when data-parallelism is greater than 1.
  * Clarified expected agent-selection behavior in the Azure DP2 test setup.

* **Documentation**
  * Expanded inline test guidance to better explain how data-parallel settings affect CI expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->