### PR TITLE
chore(deps): bump crossbeam-epoch 0.9.18 -> 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Single-crate lockfile bump: `crossbeam-epoch` 0.9.18 -> 0.9.20 (`cargo update -p crossbeam-epoch`; no manifest or code changes).

## Why

[RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`) was published against `crossbeam-epoch` <0.9.20 today. The Security Audit CI job re-checks the dependency tree against the advisory DB on every run, so **every PR and `main` itself now fails Security Audit** until this lands.

## Testing

- `cargo test -p modelexpress-server`: 181 passed
- The identical bump already passed the full 16-check CI pipeline on #477 (whose Security Audit failure prompted this fix)