### PR TITLE
fix: filter stale READY sources from ListSources

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -749,11 +749,11 @@ graph TD
 1. **Source loads**: Loads weights from storage (S3/GCS/Azure/local via ModelStreamer, GDS, or disk), runs `process_weights_after_loading()`
 2. **Source publishes**: Registers tensors with NIXL, or prepares a sealed cache artifact bundle, then a `PublisherThread` calls `PublishMetadata(identity, worker, worker_id)` -> gets `mx_source_id` (status=INITIALIZING). In P2P mode (`MX_P2P_METADATA=1`, or auto-forced on by decentralized backends like `k8s-service`), publishes only lightweight endpoint pointers and starts a `WorkerGrpcServer` for tensor manifests or artifact manifest/chunk serving.
 3. **Publisher heartbeats**: `PublisherThread` sends `UpdateStatus(READY)` every 30s after publication succeeds, refreshing `updated_at`
-4. **Target discovers**: Calls `ListSources(identity, status=READY)`, filters by `worker_rank`
+4. **Target discovers**: Calls `ListSources(identity, status=READY)`, which returns only READY workers whose `updated_at` is still within `MX_HEARTBEAT_TIMEOUT_SECS`, then filters by `worker_rank`
 5. **Target fetches on demand**: Calls `GetMetadata(mx_source_id, worker_id)` for the chosen candidate. Auto-detects P2P mode if `worker_grpc_endpoint` is populated - fetches tensors or artifact manifest metadata from the source worker's `WorkerService` and NIXL metadata via the listen thread instead of from the central server.
 6. **Target transfers**: Executes RDMA reads from source; for cache artifacts, it prepares one source chunk lease at a time, receives into target registered DRAM, verifies CRC32C, writes to target-local staging, releases the lease, then installs the staged tar into the runtime cache directory. On `SourceTransferError` tries next candidate (max 3)
 7. **Target becomes source**: After receiving weights or installing a cache artifact, publishes own metadata and starts its own heartbeat
-8. **Stale detection**: Server-side reaper marks workers STALE if `updated_at` > 90s old; GC deletes after 1 hour
+8. **Stale detection**: Server-side reaper marks workers STALE if `updated_at` > 90s old; `ListSources(READY)` also applies this heartbeat freshness check at query time so expired READY records are not returned while waiting for the next reaper pass. GC deletes STALE workers after 1 hour
 
 Cache artifact checksums protect transfer integrity but do not authenticate the
 source or attest the contents. TorchInductor, Triton, DeepGEMM, TileLang, CuTe

--- a/modelexpress_server/src/p2p/service.rs
+++ b/modelexpress_server/src/p2p/service.rs
@@ -30,6 +30,19 @@ impl P2pServiceImpl {
     }
 }
 
+fn ready_source_is_fresh(
+    info: &SourceInstanceInfo,
+    now_ms: i64,
+    heartbeat_timeout_ms: u64,
+) -> bool {
+    if info.updated_at <= 0 {
+        return false;
+    }
+
+    let age_ms = now_ms.saturating_sub(info.updated_at).max(0) as u64;
+    age_ms <= heartbeat_timeout_ms
+}
+
 fn worker_tensor_count(worker: &WorkerMetadata) -> usize {
     use modelexpress_common::grpc::p2p::worker_metadata::SourcePayload;
 
@@ -165,6 +178,18 @@ impl P2pService for P2pServiceImpl {
                     instances: Vec::new(),
                 }));
             }
+        };
+
+        let workers = if status_filter == Some(SourceStatus::Ready) {
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            let heartbeat_timeout_ms =
+                modelexpress_common::envs::heartbeat_timeout_secs().saturating_mul(1000);
+            workers
+                .into_iter()
+                .filter(|info| ready_source_is_fresh(info, now_ms, heartbeat_timeout_ms))
+                .collect()
+        } else {
+            workers
         };
 
         let refs: Vec<SourceInstanceRef> = workers
@@ -634,8 +659,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_sources_returns_instances() {
+        let now = chrono::Utc::now().timestamp_millis();
         let mut mock = MockMetadataBackend::new();
-        mock.expect_list_workers().once().returning(|_, _| {
+        mock.expect_list_workers().once().returning(move |_, _| {
             Ok(vec![
                 SourceInstanceInfo {
                     source_id: "abc123def456abcd".to_string(),
@@ -643,7 +669,7 @@ mod tests {
                     model_name: "my-model".to_string(),
                     worker_rank: 0,
                     status: SourceStatus::Ready as i32,
-                    updated_at: 1234567890000,
+                    updated_at: now,
                 },
                 SourceInstanceInfo {
                     source_id: "abc123def456abcd".to_string(),
@@ -651,7 +677,7 @@ mod tests {
                     model_name: "my-model".to_string(),
                     worker_rank: 1,
                     status: SourceStatus::Ready as i32,
-                    updated_at: 1234567890000,
+                    updated_at: now,
                 },
             ])
         });
@@ -674,6 +700,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_sources_filters_artifact_sources_by_worker_status() {
+        let now = chrono::Utc::now().timestamp_millis();
         let identity = test_artifact_identity();
         let expected_source_id = compute_mx_source_id(&identity);
         let mut mock = MockMetadataBackend::new();
@@ -683,14 +710,14 @@ mod tests {
                     && *status_filter == Some(SourceStatus::Ready)
             })
             .once()
-            .returning(|source_id, _| {
+            .returning(move |source_id, _| {
                 Ok(vec![SourceInstanceInfo {
                     source_id: source_id.expect("source id"),
                     worker_id: "artifact-worker".to_string(),
                     model_name: "my-model".to_string(),
                     worker_rank: 0,
                     status: SourceStatus::Ready as i32,
-                    updated_at: 1234567890000,
+                    updated_at: now,
                 }])
             });
 
@@ -706,6 +733,48 @@ mod tests {
 
         assert_eq!(resp.instances.len(), 1);
         assert_eq!(resp.instances[0].worker_id, "artifact-worker");
+    }
+
+    #[tokio::test]
+    async fn test_list_sources_ready_filter_excludes_expired_heartbeats() {
+        let now = chrono::Utc::now().timestamp_millis();
+        let expired_updated_at =
+            now - ((modelexpress_common::envs::heartbeat_timeout_secs() + 1) * 1000) as i64;
+
+        let mut mock = MockMetadataBackend::new();
+        mock.expect_list_workers().once().returning(move |_, _| {
+            Ok(vec![
+                SourceInstanceInfo {
+                    source_id: "abc123def456abcd".to_string(),
+                    worker_id: "fresh-worker".to_string(),
+                    model_name: "my-model".to_string(),
+                    worker_rank: 0,
+                    status: SourceStatus::Ready as i32,
+                    updated_at: now,
+                },
+                SourceInstanceInfo {
+                    source_id: "abc123def456abcd".to_string(),
+                    worker_id: "expired-worker".to_string(),
+                    model_name: "my-model".to_string(),
+                    worker_rank: 1,
+                    status: SourceStatus::Ready as i32,
+                    updated_at: expired_updated_at,
+                },
+            ])
+        });
+
+        let svc = make_service(mock);
+        let resp = svc
+            .list_sources(Request::new(ListSourcesRequest {
+                identity: Some(test_identity()),
+                status_filter: Some(SourceStatus::Ready as i32),
+            }))
+            .await
+            .expect("rpc")
+            .into_inner();
+
+        assert_eq!(resp.instances.len(), 1);
+        assert_eq!(resp.instances[0].worker_id, "fresh-worker");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds a server-side heartbeat freshness check to `ListSources(status_filter=READY)`. READY worker records whose `updated_at` is zero or older than `MX_HEARTBEAT_TIMEOUT_SECS` are filtered before the response is returned, so expired READY metadata is not selectable while waiting for the next reaper pass.

This partially addresses #484. It reduces the stale READY discovery window, but runtime identity/self-exclusion and RDMA candidate retry are still needed for freshly crashed sources and same-pod restart cases.

## Changes

- Filters `ListSources(READY)` results by `updated_at` freshness in the P2P service layer.
- Keeps non-READY and unfiltered `ListSources` behavior unchanged.
- Adds a unit test covering expired READY heartbeat filtering.
- Updates architecture docs to describe the query-time freshness check.

## Validation

- `cargo test -p modelexpress-server p2p::service::tests::test_list_sources -- --nocapture`
- `cargo clippy -p modelexpress-server --all-targets -- -D warnings`
- `cargo fmt --check && git diff --check`

`pre-commit run --all-files` was attempted, but `pre-commit` was not installed locally. I started a `pipx run pre-commit ...` fallback and stopped it when asked not to run further local tests/compilation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source selection for P2P transfers so only recently active ready workers are returned.
  * Prevents stale ready workers from appearing while waiting for background cleanup, reducing failed or delayed transfers.

* **Documentation**
  * Updated the architecture documentation to reflect the latest coordination flow and readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->