### PR TITLE
fix: MTP loading

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -578,6 +578,8 @@ Manages a NIXL agent and RDMA transfers for a single GPU worker:
 
 Thin orchestration layer that delegates to `LoadStrategyChain.run()`. Builds a `LoadContext` from vLLM config, initializes the model, runs the strategy chain, and updates global registries.
 
+**MTP two-pass load.** Multi-token-prediction models (Qwen3.5 MTP, DeepSeek MTP) call the loader twice on one worker: the target, then the draft head. `_is_speculative_draft()` detects the second pass via `model_config.runner_type == "draft"` and sets `ctx.p2p_enabled = False`. A P2P draft would collide on the target's NIXL metadata port, and since the merged draft shares the target's `SourceIdentity` it could poison source discovery, so registration, publication, and RDMA stay off for the draft while the target keeps serving. The draft loads through the ModelStreamer/default path. To avoid re-reading the whole checkpoint for a small head, `build_model_streamer_weight_iter` streams only the shards holding the draft's tensors: it reads `model.safetensors.index.json` (locally, or via the runai streamer's `pull_files` for object storage) and keeps shards whose tensor names start with `mtp.`. The draft's embedding and `lm_head` come from the target, so they are not streamed. If there is no index or no draft shard, it streams every shard.
+
 ### SGLang Loader
 
 **MxModelLoader** is instantiated by SGLang's `remote_instance` loader when

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -6,7 +6,10 @@
 from __future__ import annotations
 
 import copy
+import json
 import logging
+import os
+import tempfile
 import uuid
 from typing import TYPE_CHECKING, Iterator
 
@@ -30,8 +33,80 @@ _VLLM_POST_LOAD_FINALIZER_NAMES = (
     "finalize_mega_moe_weights",
 )
 
+# MTP draft weights live under an "mtp." prefix in the shared checkpoint. The
+# draft's embedding and lm_head come from the target, so these are all it needs.
+_DRAFT_WEIGHT_PREFIXES: tuple[str, ...] = ("mtp.",)
+
+_SAFETENSORS_INDEX_NAME = "model.safetensors.index.json"
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+
+
+def _is_speculative_draft(vllm_config, model_config) -> bool:
+    """True for the draft pass of a speculative load.
+
+    vLLM gives the draft ModelConfig runner="draft" and the target "generate".
+    Reading runner_type avoids the ngram/custom_class case where the draft
+    config aliases the target's.
+    """
+    if getattr(vllm_config, "speculative_config", None) is None:
+        return False
+    return getattr(model_config, "runner_type", None) == "draft"
+
+
+def _read_safetensors_index(model_uri: str) -> dict | None:
+    """Read model.safetensors.index.json from a local dir or object store.
+
+    Returns the parsed index, or None if it cannot be read.
+    """
+    local_index = os.path.join(model_uri, _SAFETENSORS_INDEX_NAME)
+    if os.path.isfile(local_index):
+        with open(local_index, encoding="utf-8") as handle:
+            return json.load(handle)
+
+    from runai_model_streamer import pull_files
+
+    with tempfile.TemporaryDirectory() as tmp:
+        pull_files(model_uri, tmp, allow_pattern=[_SAFETENSORS_INDEX_NAME])
+        for root, _dirs, files in os.walk(tmp):
+            if _SAFETENSORS_INDEX_NAME in files:
+                with open(
+                    os.path.join(root, _SAFETENSORS_INDEX_NAME), encoding="utf-8"
+                ) as handle:
+                    return json.load(handle)
+    return None
+
+
+def _select_draft_weight_files(
+    model_uri: str,
+    hf_weights_files: list[str],
+) -> list[str] | None:
+    """Return the shards holding the draft's own weights.
+
+    Keeps shards whose index tensors carry a draft prefix. Returns None to
+    signal the caller to stream every shard, so a checkpoint without a draft
+    head (or without an index) is never truncated to nothing.
+    """
+    try:
+        index = _read_safetensors_index(model_uri)
+        if not index:
+            return None
+        weight_map = index.get("weight_map") or {}
+        wanted = {
+            fname
+            for tname, fname in weight_map.items()
+            if tname.startswith(_DRAFT_WEIGHT_PREFIXES)
+        }
+        if not wanted:
+            return None
+        subset = [f for f in hf_weights_files if os.path.basename(f) in wanted]
+        return subset or None
+    except Exception as exc:
+        logger.warning(
+            "Draft weight-file selection failed (%s); streaming all shards", exc
+        )
+        return None
 
 
 class VllmAdapter(EngineAdapter):
@@ -119,7 +194,39 @@ class VllmAdapter(EngineAdapter):
 
         loader = RunaiModelStreamerLoader(load_config)
         revision = getattr(self.model_config, "revision", None)
-        return loader._get_weights_iterator(model_uri, revision)
+
+        if not _is_speculative_draft(self.vllm_config, self.model_config):
+            return loader._get_weights_iterator(model_uri, revision)
+
+        # An MTP draft shares the target's checkpoint but needs only its own
+        # shards. Stream just those so we do not re-read the whole model from
+        # storage for a small head. Fall back to the full set if unrecognized.
+        from vllm.model_executor.model_loader.weight_utils import (
+            runai_safetensors_weights_iterator,
+        )
+
+        hf_weights_files = loader._prepare_weights(model_uri, revision)
+        subset = _select_draft_weight_files(model_uri, hf_weights_files)
+        if subset is None:
+            logger.info(
+                "[draft] no draft-only shards identified for %s; streaming all "
+                "%d shards",
+                model_uri,
+                len(hf_weights_files),
+            )
+            return loader._get_weights_iterator(model_uri, revision)
+
+        logger.info(
+            "[draft] streaming %d of %d safetensors shards for draft weights: %s",
+            len(subset),
+            len(hf_weights_files),
+            [os.path.basename(f) for f in subset],
+        )
+        return runai_safetensors_weights_iterator(
+            subset,
+            load_config.use_tqdm_on_load,
+            loader._is_distributed,
+        )
 
     def load_via_native(self, result: LoadResult) -> LoadResult:
         if result.model is None:

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -34,7 +34,7 @@ from ... import configure_vllm_logging
 from ...load_strategy import LoadContext, LoadStrategyChain
 from ...nixl_transfer import NixlTransferManager
 from ...vmm.runtime import log_arena_post_load, maybe_enter_vmm_arena
-from .adapter import build_vllm_load_context
+from .adapter import _is_speculative_draft, build_vllm_load_context
 from .artifacts import install_vllm_cache_artifacts, schedule_vllm_cache_artifact_publish
 
 from vllm.config import ModelConfig, VllmConfig
@@ -50,19 +50,6 @@ logger = logging.getLogger(__name__)
 # Global storage for tensor metadata, keyed by device_id (local CUDA ordinal).
 _tensor_registry: dict[int, dict[str, torch.Tensor]] = {}
 _nixl_managers: dict[int, NixlTransferManager] = {}
-
-
-def _is_speculative_draft(vllm_config: VllmConfig, model_config: ModelConfig) -> bool:
-    """True when this load is the speculative draft model, not the target.
-
-    vLLM builds the draft ModelConfig with runner="draft"; the target resolves
-    to "generate". This is more reliable than comparing against
-    speculative_config.draft_model_config, which ngram/custom_class alias to
-    the target's own config.
-    """
-    if getattr(vllm_config, "speculative_config", None) is None:
-        return False
-    return getattr(model_config, "runner_type", None) == "draft"
 
 
 class MxModelLoader(BaseModelLoader):

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -53,11 +53,16 @@ _nixl_managers: dict[int, NixlTransferManager] = {}
 
 
 def _is_speculative_draft(vllm_config: VllmConfig, model_config: ModelConfig) -> bool:
-    """True when this load is the speculative drafter, not the target."""
-    spec = getattr(vllm_config, "speculative_config", None)
-    if spec is None:
+    """True when this load is the speculative draft model, not the target.
+
+    vLLM builds the draft ModelConfig with runner="draft"; the target resolves
+    to "generate". This is more reliable than comparing against
+    speculative_config.draft_model_config, which ngram/custom_class alias to
+    the target's own config.
+    """
+    if getattr(vllm_config, "speculative_config", None) is None:
         return False
-    return getattr(spec, "draft_model_config", None) is model_config
+    return getattr(model_config, "runner_type", None) == "draft"
 
 
 class MxModelLoader(BaseModelLoader):

--- a/modelexpress_client/python/modelexpress/engines/vllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/loader.py
@@ -52,6 +52,14 @@ _tensor_registry: dict[int, dict[str, torch.Tensor]] = {}
 _nixl_managers: dict[int, NixlTransferManager] = {}
 
 
+def _is_speculative_draft(vllm_config: VllmConfig, model_config: ModelConfig) -> bool:
+    """True when this load is the speculative drafter, not the target."""
+    spec = getattr(vllm_config, "speculative_config", None)
+    if spec is None:
+        return False
+    return getattr(spec, "draft_model_config", None) is model_config
+
+
 class MxModelLoader(BaseModelLoader):
     """
     Auto-detecting model loader for ModelExpress.
@@ -82,15 +90,17 @@ class MxModelLoader(BaseModelLoader):
         load_start = time.perf_counter()
 
         ctx = build_vllm_load_context(vllm_config, model_config)
+        ctx.p2p_enabled = not _is_speculative_draft(vllm_config, model_config)
         self._ctx = ctx
 
         logger.info(
             f"[Worker {ctx.global_rank}] MxModelLoader starting "
-            f"(model={ctx.identity.model_name})"
+            f"(model={ctx.identity.model_name}, p2p_enabled={ctx.p2p_enabled})"
         )
 
         with maybe_enter_vmm_arena(ctx):
-            install_vllm_cache_artifacts(ctx)
+            if ctx.p2p_enabled:
+                install_vllm_cache_artifacts(ctx)
             with set_default_torch_dtype(model_config.dtype):
                 with ctx.target_device:
                     model = initialize_model(
@@ -101,14 +111,14 @@ class MxModelLoader(BaseModelLoader):
 
                 model = LoadStrategyChain.run(model, ctx)
 
-                # Update global registries
-                _tensor_registry[ctx.device_id] = ctx.tensors
-                if ctx.nixl_manager is not None:
-                    _nixl_managers[ctx.device_id] = ctx.nixl_manager
-                else:
-                    _nixl_managers.pop(ctx.device_id, None)
+                if ctx.p2p_enabled:
+                    _tensor_registry[ctx.device_id] = ctx.tensors
+                    if ctx.nixl_manager is not None:
+                        _nixl_managers[ctx.device_id] = ctx.nixl_manager
+                    else:
+                        _nixl_managers.pop(ctx.device_id, None)
 
-                schedule_vllm_cache_artifact_publish(ctx)
+                    schedule_vllm_cache_artifact_publish(ctx)
 
         log_arena_post_load(ctx)
 

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -152,6 +152,8 @@ def register_tensors(
             Falls back to discovery if ``ctx.tensors`` is empty so the
             flag is safe even if the caller misuses it.
     """
+    if not ctx.p2p_enabled:
+        return
     if not _metadata_publication_configured(ctx):
         logger.info(
             f"[Worker {ctx.global_rank}] No MX metadata path configured, "

--- a/modelexpress_client/python/modelexpress/load_strategy/context.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/context.py
@@ -64,6 +64,8 @@ class LoadContext:
     node_rank: int = 0
     adapter: EngineAdapter | None = None
     accelerator_backend: AcceleratorBackend = field(default_factory=CudaAcceleratorBackend)
+    # False keeps a secondary in-process load (the MTP drafter) out of P2P.
+    p2p_enabled: bool = True
     nixl_manager: NixlTransferManager | None = None
     tensors: dict[str, torch.Tensor] = field(default_factory=dict)
     # When MX_VMM_ARENA=1, maybe_enter_vmm_arena populates this with the

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -56,6 +56,8 @@ class RdmaStrategy(LoadStrategy):
         ctx.nixl_manager = None
 
     def is_available(self, ctx: LoadContext) -> bool:
+        if not ctx.p2p_enabled:
+            return False
         if not super().is_available(ctx):
             return False
         if not is_nixl_available():

--- a/modelexpress_client/python/modelexpress/vmm/runtime.py
+++ b/modelexpress_client/python/modelexpress/vmm/runtime.py
@@ -104,7 +104,9 @@ def maybe_enter_vmm_arena(ctx: "LoadContext") -> Iterator[None]:
       allocation, not peak live size. With 16 TiB reserved, this is
       bounded only by HBM (we never exhaust VA).
     """
-    if not envs.MX_VMM_ARENA:
+    if not envs.MX_VMM_ARENA or not ctx.p2p_enabled:
+        # p2p_enabled is False for the speculative draft's second load;
+        # skip the arena so it does not replace the target model's.
         yield
         return
 

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -214,6 +214,7 @@ class TestAcceleratorCapabilityGates:
             global_rank = 0
             device_id = 0
             target_device = nullcontext()
+            p2p_enabled = True
 
         ctx = Ctx()
         ctx.accelerator_backend = mock_accelerator_backend_cls(vmm=False)

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -3,6 +3,8 @@
 
 """Tests for the vLLM engine adapter."""
 
+import json
+import os
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
@@ -15,6 +17,7 @@ from modelexpress.engines.vllm.adapter import (
     VllmAdapter,
     _get_vllm_device_id,
     _get_vllm_worker_rank,
+    _select_draft_weight_files,
     build_vllm_load_context,
 )
 from modelexpress.load_strategy.context import LoadResult
@@ -304,3 +307,41 @@ class _StandaloneFinalizer(torch.nn.Module):
         self.events.append(
             ("finalize", "standalone", "finalize_requires_arg_weights", context)
         )
+
+
+class TestDraftWeightFileSelection:
+    """A draft load streams only its own shards, and falls back to the full
+    set when the checkpoint has no draft head."""
+
+    def _write_index(self, tmp_path, weight_map):
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": weight_map}), encoding="utf-8"
+        )
+
+    def test_selects_only_mtp_shard(self, tmp_path):
+        self._write_index(
+            tmp_path,
+            {
+                "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+                "lm_head.weight": "model-00002-of-00002.safetensors",
+                "mtp.fc.weight": "model-mtp.safetensors",
+            },
+        )
+        files = [
+            os.path.join(str(tmp_path), name)
+            for name in (
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors",
+                "model-mtp.safetensors",
+            )
+        ]
+        assert _select_draft_weight_files(str(tmp_path), files) == [
+            os.path.join(str(tmp_path), "model-mtp.safetensors")
+        ]
+
+    def test_falls_back_without_draft_head(self, tmp_path):
+        self._write_index(
+            tmp_path, {"model.embed_tokens.weight": "model-00001-of-00001.safetensors"}
+        )
+        files = [os.path.join(str(tmp_path), "model-00001-of-00001.safetensors")]
+        assert _select_draft_weight_files(str(tmp_path), files) is None

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -430,8 +430,8 @@ class TestAbstractMethodCompleteness:
 
 class TestMtpDrafterSecondLoad:
     """vLLM loads MTP in two passes on one worker: the target, then the drafter
-    via a second load_model whose speculative draft_model_config reuses the
-    target's device and model name. The test drives both passes on device 0."""
+    via a second load_model whose draft ModelConfig has runner_type="draft" and
+    reuses the target's device and model name. The test drives both on device 0."""
 
     def _load(self, loader, vllm_config, model_config, ctx):
         with patch(
@@ -460,11 +460,11 @@ class TestMtpDrafterSecondLoad:
         target_ctx = _make_load_context(device_id=0)
         target_ctx.tensors = {"target.weight": MagicMock()}
         target_ctx.nixl_manager = MagicMock()
-        self._load(loader, MagicMock(), MagicMock(dtype=torch.float32), target_ctx)
+        target_config = MagicMock(dtype=torch.float32, runner_type="generate")
+        self._load(loader, MagicMock(), target_config, target_ctx)
 
-        draft_config = MagicMock(dtype=torch.float32)
+        draft_config = MagicMock(dtype=torch.float32, runner_type="draft")
         draft_vllm_config = MagicMock()
-        draft_vllm_config.speculative_config.draft_model_config = draft_config
         draft_ctx = _make_load_context(device_id=0)
         draft_ctx.tensors = {"drafter.mtp": MagicMock()}
         draft_ctx.nixl_manager = MagicMock()
@@ -476,6 +476,21 @@ class TestMtpDrafterSecondLoad:
         finally:
             loader_mod._tensor_registry.pop(0, None)
             loader_mod._nixl_managers.pop(0, None)
+
+    def test_is_speculative_draft(self):
+        from modelexpress.engines.vllm.loader import _is_speculative_draft
+
+        # No speculative decoding: never a draft.
+        no_spec = MagicMock(speculative_config=None)
+        assert _is_speculative_draft(no_spec, MagicMock(runner_type="generate")) is False
+
+        # Draft model load under speculative decoding.
+        spec = MagicMock()
+        assert _is_speculative_draft(spec, MagicMock(runner_type="draft")) is True
+
+        # Target load with spec on (e.g. ngram aliases draft to the target):
+        # runner_type stays "generate", so the target keeps P2P.
+        assert _is_speculative_draft(spec, MagicMock(runner_type="generate")) is False
 
     @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
     @patch("modelexpress.load_strategy.base._init_nixl_manager")

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -451,10 +451,9 @@ class TestMtpDrafterSecondLoad:
             loader.load_model(vllm_config, model_config)
         return schedule
 
-    @pytest.mark.xfail(strict=True, reason="mx does not yet handle the MTP drafter's second load")
     def test_drafter_does_not_clobber_target(self):
-        """The drafter's second load overwrites the target's device registry and
-        re-schedules P2P publish."""
+        """The drafter's second load leaves the target's device registry and
+        P2P publish untouched."""
         from modelexpress.engines.vllm import loader as loader_mod
 
         loader = _make_loader()
@@ -477,6 +476,30 @@ class TestMtpDrafterSecondLoad:
         finally:
             loader_mod._tensor_registry.pop(0, None)
             loader_mod._nixl_managers.pop(0, None)
+
+    @patch("modelexpress.load_strategy.base.is_nixl_available", return_value=True)
+    @patch("modelexpress.load_strategy.base._init_nixl_manager")
+    def test_register_tensors_skips_when_p2p_disabled(self, mock_init, _avail):
+        from modelexpress.load_strategy.base import register_tensors
+
+        ctx = _make_load_context()
+        ctx.p2p_enabled = False
+        ctx.adapter.discover_tensors = MagicMock(return_value={"w": MagicMock()})
+        with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
+            register_tensors(MagicMock(), ctx)
+
+        mock_init.assert_not_called()
+        ctx.adapter.discover_tensors.assert_not_called()
+        assert ctx.nixl_manager is None
+
+    @patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True)
+    def test_rdma_unavailable_when_p2p_disabled(self, _mock):
+        from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
+
+        ctx = _make_load_context()
+        ctx.p2p_enabled = False
+        with patch.dict("os.environ", {"MX_SERVER_ADDRESS": "server:8001"}):
+            assert RdmaStrategy().is_available(ctx) is False
 
 
 # ---------------------------------------------------------------------------

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -428,6 +428,57 @@ class TestAbstractMethodCompleteness:
         assert registered["mx"] is MxModelLoader
 
 
+class TestMtpDrafterSecondLoad:
+    """vLLM loads MTP in two passes on one worker: the target, then the drafter
+    via a second load_model whose speculative draft_model_config reuses the
+    target's device and model name. The test drives both passes on device 0."""
+
+    def _load(self, loader, vllm_config, model_config, ctx):
+        with patch(
+            "modelexpress.engines.vllm.loader.build_vllm_load_context",
+            return_value=ctx,
+        ), patch(
+            "modelexpress.engines.vllm.loader.install_vllm_cache_artifacts",
+        ), patch(
+            "modelexpress.engines.vllm.loader.initialize_model",
+            return_value=MagicMock(),
+        ), patch(
+            "modelexpress.engines.vllm.loader.LoadStrategyChain.run",
+            side_effect=lambda model, _ctx: model,
+        ), patch(
+            "modelexpress.engines.vllm.loader.schedule_vllm_cache_artifact_publish",
+        ) as schedule:
+            loader.load_model(vllm_config, model_config)
+        return schedule
+
+    @pytest.mark.xfail(strict=True, reason="mx does not yet handle the MTP drafter's second load")
+    def test_drafter_does_not_clobber_target(self):
+        """The drafter's second load overwrites the target's device registry and
+        re-schedules P2P publish."""
+        from modelexpress.engines.vllm import loader as loader_mod
+
+        loader = _make_loader()
+        target_ctx = _make_load_context(device_id=0)
+        target_ctx.tensors = {"target.weight": MagicMock()}
+        target_ctx.nixl_manager = MagicMock()
+        self._load(loader, MagicMock(), MagicMock(dtype=torch.float32), target_ctx)
+
+        draft_config = MagicMock(dtype=torch.float32)
+        draft_vllm_config = MagicMock()
+        draft_vllm_config.speculative_config.draft_model_config = draft_config
+        draft_ctx = _make_load_context(device_id=0)
+        draft_ctx.tensors = {"drafter.mtp": MagicMock()}
+        draft_ctx.nixl_manager = MagicMock()
+        try:
+            schedule = self._load(loader, draft_vllm_config, draft_config, draft_ctx)
+            assert loader_mod._tensor_registry[0] is target_ctx.tensors
+            assert loader_mod._nixl_managers[0] is target_ctx.nixl_manager
+            schedule.assert_not_called()
+        finally:
+            loader_mod._tensor_registry.pop(0, None)
+            loader_mod._nixl_managers.pop(0, None)
+
+
 # ---------------------------------------------------------------------------
 # register_tensors (load_strategy.base)
 # ---------------------------------------------------------------------------

--- a/modelexpress_client/python/tests/test_vmm_hook.py
+++ b/modelexpress_client/python/tests/test_vmm_hook.py
@@ -288,6 +288,7 @@ class TestOptionalExtension:
             global_rank = 0
             device_id = 0
             accelerator_backend = _StubBackend()
+            p2p_enabled = True
 
         with caplog.at_level("WARNING", logger=vmm_runtime.logger.name):
             # Entering the context manager must not raise; the body must
@@ -318,11 +319,32 @@ class TestOptionalExtension:
             global_rank = 0
             device_id = 0
             accelerator_backend = _StubBackend()
+            p2p_enabled = True
 
         entered = False
         with vmm_runtime.maybe_enter_vmm_arena(_Ctx()):
             entered = True
         assert entered
+
+    def test_no_op_when_p2p_disabled(self, monkeypatch):
+        """The speculative draft's second load has p2p_enabled=False; the
+        helper must yield without installing arena machinery even with
+        MX_VMM_ARENA=1, so it does not replace the target model's arena."""
+        from modelexpress.vmm import runtime as vmm_runtime
+
+        monkeypatch.setenv("MX_VMM_ARENA", "1")
+
+        class _Ctx:
+            global_rank = 0
+            device_id = 0
+            accelerator_backend = _StubBackend()
+            p2p_enabled = False
+
+        entered = False
+        with vmm_runtime.maybe_enter_vmm_arena(_Ctx()):
+            entered = True
+        assert entered
+        assert 0 not in vmm_runtime._vmm_arenas
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +368,7 @@ class _StubCtx:
     target_device = _StubTargetDevice()
     vmm_arena = None
     accelerator_backend = _StubBackend()
+    p2p_enabled = True
 
 
 class _StubCudaVmmBackend:


### PR DESCRIPTION
## Description

We encountered an error when deploying a native multi-token-prediction (MTP) model such as Qwen3.5 MTP or Holo3-35B with `--load-format=mx` enabled. The base model loads, then the engine fails while loading the MTP drafter:

```
(Worker_TP1_EP1) E  [metadata_stream.cpp:83] Socket Bind failed ... Address already in use [98]
(Worker_TP1_EP1) WARNING NIXL registration failed ...
...
RuntimeError: [Worker 1] No loading strategy succeeded for model '.../model_streamer/7ef1add9'
(EngineCore) ERROR EngineCore failed to start.
```

Root cause seems to be that MX assumes the loader runs once per worker (the main model). MTP breaks that assumption: vLLM invokes the loader a second time in the same worker process for the draft head. That second pass tries to open a NIXL metadata listener on a port the target already holds, so RDMA fails on bind, and the remaining strategies then fail too.

## Proposed fix

This PR proposes the following changes to fix the error:
- Keep the draft out of P2P. `_is_speculative_draft()` detects the second pass through `model_config.runner_type == "draft"` (vLLM builds the draft ModelConfig with `runner="draft"`) and sets `ctx.p2p_enabled = False`. With that flag off, the draft skips NIXL registration, metadata publication, and the RDMA strategy, so it no longer collides on the target's port and does not touch the per-device tensor/manager registries the target populated.
- Stream only the draft's shards. With RDMA disabled, the draft loads through the ModelStreamer path, which was re-reading the entire checkpoint from S3 (about 38.5 GB, 45 s) to extract a roughly 0.85 GB head. `build_model_streamer_weight_iter` now reads `model.safetensors.index.json` and streams only the shards whose tensors start with `mtp.`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-token prediction models with a separate draft loading path.
  * Improved shard streaming by loading only the draft-related weights when available.

* **Bug Fixes**
  * Prevented connection and metadata conflicts during draft loading by disabling peer-to-peer handling for that pass.
  * Added safer fallback behavior when draft-specific shard metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->