### PR TITLE
ci: bump dynamo vllm-runtime base image to 1.2.1

### DIFF
--- a/ci/k8s/client/vllm/dynamo/Dockerfile
+++ b/ci/k8s/client/vllm/dynamo/Dockerfile
@@ -10,7 +10,7 @@
 #
 # Built and pushed by the `build` job in .github/workflows/modelexpress-ci-tests.yml
 # under tag <MX_IMAGE_REPO>/mx-worker-vllm-dynamo:<sha>.
-FROM nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+FROM nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
 
 # Layer the ModelExpress Python client on top. Build context is the repo root
 # (matches the existing build job's build context), so the COPY path is

--- a/examples/dynamo_p2p_transfer_k8s/Dockerfile
+++ b/examples/dynamo_p2p_transfer_k8s/Dockerfile
@@ -17,7 +17,7 @@
 #       --build-arg ENABLE_MODELEXPRESS_P2P=true \
 #       --build-arg MODELEXPRESS_REF=main \
 #       -t <your-tag> .
-ARG DYNAMO_VLLM_RUNTIME_IMAGE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+ARG DYNAMO_VLLM_RUNTIME_IMAGE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
 FROM ${DYNAMO_VLLM_RUNTIME_IMAGE}
 
 # Copy and install ModelExpress Python client


### PR DESCRIPTION
### Problem

The Dynamo P2P CI tests (aggregated and disaggregated) started failing today across all PRs. HuggingFace recently migrated Qwen/Qwen2.5-0.5B (the model used in CI) to their XET distributed storage backend. vllm-runtime:1.0.1's dynamo_llm::hub downloader makes raw HTTP range requests and does not handle XET, it either gets a 403 from cas-bridge.xethub.hf.co or fails with Header content-range is missing when XET responds without a Content-Range header.

Other CI tests were unaffected because they use the Python huggingface_hub library which handles XET transparently.

### Fix

Bump nvcr.io/nvidia/ai-dynamo/vllm-runtime from 1.0.1 to 1.2.1 (current latest stable). The newer release includes an updated dynamo_llm::hub that handles HF's XET storage correctly.

### Testing

CI on this PR specifically the "P2P test with Dynamo (aggregated)" and "P2P test with Dynamo (disaggregated)" jobs which were consistently failing before this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Dynamo and ModelExpress worker runtime to the latest supported version.
  * Improved compatibility and access to runtime updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->