### PR TITLE
fix: dropped tensors field regression

### DIFF
--- a/.github/actions/run-mx-p2p-test/action.yml
+++ b/.github/actions/run-mx-p2p-test/action.yml
@@ -61,12 +61,11 @@ inputs:
   mx_p2p_metadata:
     description: |
       Value for the ${MX_P2P_METADATA} substitution in manifests that
-      template it (currently vllm/manifest-azure.yaml). "1" (default) keeps
-      the P2P-metadata path (source serves the tensor manifest on-demand via
-      a WorkerGrpcServer). "0" exercises the non-P2P embedded-metadata path
-      (tensors carried in the WorkerMetadata proto) — the path where the
-      MX-396 dropped-tensors regression surfaces. Applied to both source and
-      target manifest applies.
+      template it (currently vllm/manifest-azure.yaml). "1" (default) serves
+      the tensor manifest on-demand via a WorkerGrpcServer. "0" exercises the
+      full tensor-manifest publish path, where the source embeds the full
+      tensor manifest in the WorkerMetadata proto it publishes. Applied to
+      both source and target manifest applies.
     required: false
     default: '1'
   source_port:
@@ -249,8 +248,14 @@ runs:
             | awk '$1 != "weights" && $2 == "Ready" && $3 != "" { count++ } END { print count + 0 }'
         }
         count_weight_sources() {
+          # Count weight sources. `sourceType` is a newer CR field; servers
+          # predating it (e.g. the released image the mixed-version
+          # full-manifest entry runs against) publish weight CRs with no
+          # sourceType, so an empty value is treated as a weight source too.
+          # Current servers always set sourceType on non-weight (artifact)
+          # sources, so this never miscounts an artifact source as a weight one.
           kubectl get modelmetadata -n "${NAMESPACE}" -o jsonpath='{range .items[*]}{.spec.sourceType}{"\n"}{end}' 2>/dev/null \
-            | awk '$1 == "weights" { count++ } END { print count + 0 }'
+            | awk '$1 == "weights" || $1 == "" { count++ } END { print count + 0 }'
         }
         wait_for_artifact_sources() {
           local expected="$1"

--- a/.github/actions/run-mx-p2p-test/action.yml
+++ b/.github/actions/run-mx-p2p-test/action.yml
@@ -58,6 +58,17 @@ inputs:
         S3_BUCKET=my-model-bucket
     required: false
     default: ''
+  mx_p2p_metadata:
+    description: |
+      Value for the ${MX_P2P_METADATA} substitution in manifests that
+      template it (currently vllm/manifest-azure.yaml). "1" (default) keeps
+      the P2P-metadata path (source serves the tensor manifest on-demand via
+      a WorkerGrpcServer). "0" exercises the non-P2P embedded-metadata path
+      (tensors carried in the WorkerMetadata proto) — the path where the
+      MX-396 dropped-tensors regression surfaces. Applied to both source and
+      target manifest applies.
+    required: false
+    default: '1'
   source_port:
     description: 'Port the source worker listens on — exported as WORKER_PORT for the source manifest and passed to pytest as --source-port'
     required: false
@@ -195,6 +206,7 @@ runs:
         WORKER_PORT: ${{ inputs.source_port }}
         SOURCE_EXTRA_ENV: ${{ inputs.source_extra_env }}
         MANIFEST: ${{ inputs.manifest }}
+        MX_P2P_METADATA: ${{ inputs.mx_p2p_metadata }}
       run: |
         echo "::group::Apply source manifest (WORKER_PORT=${WORKER_PORT})"
         while IFS= read -r line; do
@@ -212,7 +224,7 @@ runs:
         # trt-llm source/target split) goes on the list too — otherwise
         # the literal `${VAR}` survives into the pod env, which Python
         # sees as a non-empty truthy string and reads as "set."
-        envsubst '${WORKER_IMAGE} ${MX_SERVER_IMAGE} ${MX_CI_MODEL} ${WORKER_PORT} ${NAMESPACE} ${JOB_NAME} ${MODEL_EXPRESS_SOURCE}' \
+        envsubst '${WORKER_IMAGE} ${MX_SERVER_IMAGE} ${MX_CI_MODEL} ${WORKER_PORT} ${NAMESPACE} ${JOB_NAME} ${MODEL_EXPRESS_SOURCE} ${MX_P2P_METADATA}' \
           < "${MANIFEST}" | kubectl apply -n ${NAMESPACE} -f -
         echo "::endgroup::"
 
@@ -344,13 +356,15 @@ runs:
         WORKER_PORT: ${{ inputs.worker_port }}
         EXTRA_ENV: ${{ inputs.extra_env }}
         MANIFEST: ${{ inputs.manifest }}
+        MX_P2P_METADATA: ${{ inputs.mx_p2p_metadata }}
       run: |
         echo "::group::Apply ${MANIFEST} (WORKER_PORT=${WORKER_PORT})"
         while IFS= read -r line; do
           [ -n "$line" ] && export "$line"
         done <<< "${EXTRA_ENV}"
-        # See same-named source-apply step above for allowlist rationale.
-        envsubst '${WORKER_IMAGE} ${MX_SERVER_IMAGE} ${MX_CI_MODEL} ${WORKER_PORT} ${NAMESPACE} ${JOB_NAME} ${MODEL_EXPRESS_SOURCE}' \
+        # See same-named source-apply step above for the allowlist rationale;
+        # ${MX_P2P_METADATA} defaults to "1" via the mx_p2p_metadata input.
+        envsubst '${WORKER_IMAGE} ${MX_SERVER_IMAGE} ${MX_CI_MODEL} ${WORKER_PORT} ${NAMESPACE} ${JOB_NAME} ${MODEL_EXPRESS_SOURCE} ${MX_P2P_METADATA}' \
           < "${MANIFEST}" | kubectl apply -n ${NAMESPACE} -f -
         echo "::endgroup::"
 

--- a/.github/actions/run-mx-stale-metadata-test/action.yml
+++ b/.github/actions/run-mx-stale-metadata-test/action.yml
@@ -49,6 +49,15 @@ inputs:
   manifest:
     description: 'Repo-root-relative path to the source K8s manifest (e.g. ci/k8s/client/vllm/manifest-azure.yaml). Envsubst is run on it before apply.'
     required: true
+  mx_p2p_metadata:
+    description: |
+      Value for the ${MX_P2P_METADATA} substitution in manifests that template
+      it (currently vllm/manifest-azure.yaml). Defaults to "1" (P2P metadata).
+      This test targets the reaper/heartbeat path, not the metadata publish
+      path, so the default is the only value CI exercises here; the input
+      exists so the shared manifest's templated var never blanks.
+    required: false
+    default: '1'
   test_script:
     description: 'Repo-root-relative path to the pytest file to run'
     required: false
@@ -166,6 +175,7 @@ runs:
         NAMESPACE: ${{ inputs.namespace }}
         WORKER_PORT: ${{ inputs.source_port }}
         MANIFEST: ${{ inputs.manifest }}
+        MX_P2P_METADATA: ${{ inputs.mx_p2p_metadata }}
       run: |
         echo "::group::Apply source-only manifest (JOB_NAME=mx-source, WORKER_PORT=${WORKER_PORT})"
         # JOB_NAME=mx-source identifies the Job as a "source" for the
@@ -173,6 +183,9 @@ runs:
         # job-name=mx-source). The existing per-framework manifests are
         # parameterized by JOB_NAME so we reuse them as-is.
         export JOB_NAME=mx-source
+        # manifest-azure.yaml templates ${MX_P2P_METADATA}; this action's
+        # envsubst is unbounded, so an unset value would blank it and flip the
+        # source to non-P2P mode. The mx_p2p_metadata input defaults it to "1".
         envsubst < "${MANIFEST}" | kubectl apply -n ${NAMESPACE} -f -
         echo "::endgroup::"
 

--- a/.github/actions/run-mx-stale-metadata-test/action.yml
+++ b/.github/actions/run-mx-stale-metadata-test/action.yml
@@ -52,10 +52,10 @@ inputs:
   mx_p2p_metadata:
     description: |
       Value for the ${MX_P2P_METADATA} substitution in manifests that template
-      it (currently vllm/manifest-azure.yaml). Defaults to "1" (P2P metadata).
-      This test targets the reaper/heartbeat path, not the metadata publish
-      path, so the default is the only value CI exercises here; the input
-      exists so the shared manifest's templated var never blanks.
+      it (currently vllm/manifest-azure.yaml). Defaults to "1" (tensor manifest
+      served on-demand). This test targets the reaper/heartbeat path, not the
+      metadata publish path, so the default is the only value CI exercises
+      here; the input exists so the shared manifest's templated var never blanks.
     required: false
     default: '1'
   test_script:

--- a/.github/workflows/modelexpress-ci-tests.yml
+++ b/.github/workflows/modelexpress-ci-tests.yml
@@ -329,7 +329,7 @@ jobs:
   # parallel execution in the future (remove max-parallel: 1 to enable).
   # ---------------------------------------------------------------------------
   test-p2p:
-    name: P2P test (${{ matrix.framework }})
+    name: P2P test (${{ matrix.label || matrix.framework }})
     runs-on: prod-modelexpress-builder-amd-v1
     needs: [build-client, build-server, ensure-vcluster]
     permissions:
@@ -385,6 +385,38 @@ jobs:
             extra_env: "JOB_NAME=mx-target"
             source_port: "8007"
             worker_port: "8008"
+          # Non-P2P embedded-metadata path (MX_P2P_METADATA=0): the source
+          # embeds the tensor manifest in the WorkerMetadata proto. The
+          # mixed-version entry (client @ this commit vs the last released
+          # server) is a proto backward-compatibility guard — it catches
+          # client-side proto changes that break older servers (e.g. MX-396,
+          # dropping the legacy `tensors` field). same-version only guards the
+          # path against future same-build breaks.
+          - framework: vllm
+            label: vllm embedded same-version
+            namespace: mx-ci-embedded-same-${{ github.run_id }}
+            manifest: ci/k8s/client/vllm/manifest-azure.yaml
+            test_script: ci/k8s/client/test_p2p_k8s.py
+            source_extra_env: "JOB_NAME=mx-source"
+            extra_env: "JOB_NAME=mx-target"
+            source_port: "8021"
+            worker_port: "8022"
+            mx_p2p_metadata: "0"
+          - framework: vllm
+            label: vllm embedded mixed-version
+            namespace: mx-ci-embedded-mixed-${{ github.run_id }}
+            manifest: ci/k8s/client/vllm/manifest-azure.yaml
+            test_script: ci/k8s/client/test_p2p_k8s.py
+            source_extra_env: "JOB_NAME=mx-source"
+            extra_env: "JOB_NAME=mx-target"
+            source_port: "8023"
+            worker_port: "8024"
+            mx_p2p_metadata: "0"
+            # TODO: resolve this dynamically to the latest released
+            # modelexpress-server tag instead of hardcoding, so the guard
+            # tracks "newest client vs latest released server" without a
+            # manual bump each release.
+            server_image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.0
 
     steps:
       - name: Checkout
@@ -405,7 +437,9 @@ jobs:
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: ${{ matrix.namespace }}
-          server_image: ${{ env.MX_IMAGE_REPO }}/mx-server:${{ github.sha }}
+          # Defaults to this commit's server; matrix.server_image overrides it
+          # (e.g. the mixed-version embedded-metadata entry pins a released tag).
+          server_image: ${{ matrix.server_image || format('{0}/mx-server:{1}', env.MX_IMAGE_REPO, github.sha) }}
           manifest: ${{ matrix.manifest }}
           test_script: ${{ matrix.test_script }}
           worker_image: ${{ env.MX_IMAGE_REPO }}/mx-worker-${{ matrix.framework }}:${{ github.sha }}
@@ -413,6 +447,7 @@ jobs:
           ngc_api_key: ${{ secrets.NGC_API_KEY }}
           model: ${{ env.MX_CI_MODEL }}
           hf_token: ${{ secrets.HF_TOKEN }}
+          mx_p2p_metadata: ${{ matrix.mx_p2p_metadata || '1' }}
           source_extra_env: ${{ matrix.source_extra_env }}
           extra_env: ${{ matrix.extra_env }}
           source_port: ${{ matrix.source_port }}

--- a/.github/workflows/modelexpress-ci-tests.yml
+++ b/.github/workflows/modelexpress-ci-tests.yml
@@ -385,16 +385,17 @@ jobs:
             extra_env: "JOB_NAME=mx-target"
             source_port: "8007"
             worker_port: "8008"
-          # Non-P2P embedded-metadata path (MX_P2P_METADATA=0): the source
-          # embeds the tensor manifest in the WorkerMetadata proto. The
-          # mixed-version entry (client @ this commit vs the last released
-          # server) is a proto backward-compatibility guard — it catches
-          # client-side proto changes that break older servers (e.g. MX-396,
-          # dropping the legacy `tensors` field). same-version only guards the
-          # path against future same-build breaks.
+          # Full tensor-manifest publish path (MX_P2P_METADATA=0): the source
+          # embeds the full tensor manifest in the WorkerMetadata proto it
+          # publishes, instead of serving it on-demand. The mixed-version entry
+          # (client @ this commit vs the last released server) is a proto
+          # backward-compatibility guard — it catches client-side proto changes
+          # that break older servers (e.g. dropping the legacy `tensors`
+          # field). same-version only guards the path against future same-build
+          # breaks.
           - framework: vllm
-            label: vllm embedded same-version
-            namespace: mx-ci-embedded-same-${{ github.run_id }}
+            label: vllm full-manifest same-version
+            namespace: mx-ci-full-manifest-same-${{ github.run_id }}
             manifest: ci/k8s/client/vllm/manifest-azure.yaml
             test_script: ci/k8s/client/test_p2p_k8s.py
             source_extra_env: "JOB_NAME=mx-source"
@@ -403,8 +404,8 @@ jobs:
             worker_port: "8022"
             mx_p2p_metadata: "0"
           - framework: vllm
-            label: vllm embedded mixed-version
-            namespace: mx-ci-embedded-mixed-${{ github.run_id }}
+            label: vllm full-manifest mixed-version
+            namespace: mx-ci-full-manifest-mixed-${{ github.run_id }}
             manifest: ci/k8s/client/vllm/manifest-azure.yaml
             test_script: ci/k8s/client/test_p2p_k8s.py
             source_extra_env: "JOB_NAME=mx-source"

--- a/ci/k8s/client/vllm/manifest-azure.yaml
+++ b/ci/k8s/client/vllm/manifest-azure.yaml
@@ -115,8 +115,14 @@ spec:
               value: "0"
             - name: MX_RDMA_NIC_PIN
               value: "auto"
+            # Substituted per-apply; both consuming actions default it to "1"
+            # (P2P metadata: source serves the tensor manifest on-demand via a
+            # WorkerGrpcServer), so an unset value == current behavior. The
+            # embedded-metadata jobs override to "0" to exercise the non-P2P
+            # publish path (tensors embedded in the WorkerMetadata proto) where
+            # the MX-396 dropped-tensors regression lives.
             - name: MX_P2P_METADATA
-              value: "1"
+              value: "${MX_P2P_METADATA}"
             - name: MX_ARTIFACT_TRANSFER
               value: "1"
             - name: MX_ARTIFACT_READY_URL

--- a/ci/k8s/client/vllm/manifest-azure.yaml
+++ b/ci/k8s/client/vllm/manifest-azure.yaml
@@ -116,11 +116,11 @@ spec:
             - name: MX_RDMA_NIC_PIN
               value: "auto"
             # Substituted per-apply; both consuming actions default it to "1"
-            # (P2P metadata: source serves the tensor manifest on-demand via a
-            # WorkerGrpcServer), so an unset value == current behavior. The
-            # embedded-metadata jobs override to "0" to exercise the non-P2P
-            # publish path (tensors embedded in the WorkerMetadata proto) where
-            # the MX-396 dropped-tensors regression lives.
+            # (tensor manifest served on-demand: the source stands up a
+            # WorkerGrpcServer and serves the manifest on request), so an unset
+            # value == current behavior. The full-tensor-manifest jobs override
+            # to "0", where the source instead embeds the full tensor manifest
+            # in the WorkerMetadata proto it publishes.
             - name: MX_P2P_METADATA
               value: "${MX_P2P_METADATA}"
             - name: MX_ARTIFACT_TRANSFER

--- a/modelexpress_client/python/modelexpress/metadata/publish.py
+++ b/modelexpress_client/python/modelexpress/metadata/publish.py
@@ -183,9 +183,15 @@ def publish_metadata_and_ready(
                 _worker_servers.pop(device_id, None)
             grpc_server.stop()
     else:
+        # Dual-write the legacy `tensors` field alongside `tensor_source`.
+        # Server builds predating the `tensor_source` oneof read only
+        # `tensors`; without it they store 0 tensors and targets fall back to
+        # disk. The server does the same dual-write on its WorkerRecord ->
+        # WorkerMetadata round-trip.
         worker = p2p_pb2.WorkerMetadata(
             worker_rank=worker_rank,
             nixl_metadata=nixl_manager.nixl_metadata,
+            tensors=tensor_protos,
             tensor_source=tensor_source_metadata(tensor_protos),
             accelerator=accelerator,
         )

--- a/modelexpress_client/python/modelexpress/trtllm_live_transfer.py
+++ b/modelexpress_client/python/modelexpress/trtllm_live_transfer.py
@@ -127,9 +127,12 @@ def publish_model_params(torch_model: Any) -> None:
         for name, tensor in param_tensors.items()
     ]
 
+    # Dual-write legacy `tensors` alongside `tensor_source` for servers that
+    # predate the tensor_source oneof (see publish.py for the full rationale).
     worker = p2p_pb2.WorkerMetadata(
         worker_rank=mpi_rank,
         nixl_metadata=nixl_mgr.nixl_metadata,
+        tensors=tensor_protos,
         tensor_source=tensor_source_metadata(tensor_protos),
         accelerator="cuda",
     )
@@ -244,9 +247,12 @@ def publish_from_worker(worker: Any) -> None:
         for name, tensor in param_tensors.items()
     ]
 
+    # Dual-write legacy `tensors` alongside `tensor_source` for servers that
+    # predate the tensor_source oneof (see publish.py for the full rationale).
     my_worker = p2p_pb2.WorkerMetadata(
         worker_rank=mpi_rank,
         nixl_metadata=nixl_mgr.nixl_metadata,
+        tensors=tensor_protos,
         tensor_source=tensor_source_metadata(tensor_protos),
         accelerator="cuda",
     )

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -1260,6 +1260,46 @@ class TestPublishMetadataAndReady:
         assert call_args.args[1].accelerator == "cuda"
         assert call_args.args[2] == "inst-uuid"
 
+    def test_full_manifest_publish_dual_writes_tensor_fields(self):
+        """On the full tensor-manifest publish path (MX_P2P_METADATA=0, source
+        embeds the full manifest in the published WorkerMetadata), both the
+        legacy `tensors` field and the newer `tensor_source` must be populated.
+        Servers predating the tensor_source oneof read only `tensors`; dropping
+        it leaves them with 0 tensors and targets fall back to disk load."""
+        from modelexpress.metadata.publish import publish_metadata_and_ready
+
+        mx_client = MagicMock()
+        nixl_manager = MagicMock()
+        nixl_manager.nixl_metadata = b"nixl-data"
+
+        tensors = {}
+        for i in range(3):
+            t = MagicMock(spec=torch.Tensor)
+            t.data_ptr.return_value = 0x1000 + i * 1024
+            t.numel.return_value = 256
+            t.element_size.return_value = 2
+            t.dtype = torch.bfloat16
+            tensors[f"layer.{i}.weight"] = t
+
+        identity = _make_identity("my-model")
+        mock_publisher = MagicMock()
+        with patch.dict(os.environ, {"MX_P2P_METADATA": "0"}), \
+             patch("modelexpress.metadata.publish.PublisherThread", return_value=mock_publisher) as publisher_cls:
+            publish_metadata_and_ready(mx_client, nixl_manager, tensors, worker_rank=0, device_id=0, identity=identity, worker_id="inst-uuid")
+            publisher_cls.call_args.kwargs["publish_fn"]()
+
+        worker = mx_client.publish_metadata.call_args.args[1]
+        # Legacy field — servers predating tensor_source read only from here.
+        assert len(worker.tensors) == 3
+        # New field — current servers read from here.
+        assert len(worker.tensor_source.tensors) == 3
+        assert {t.name for t in worker.tensors} == {
+            "layer.0.weight", "layer.1.weight", "layer.2.weight",
+        }
+        assert {t.name for t in worker.tensor_source.tensors} == {
+            "layer.0.weight", "layer.1.weight", "layer.2.weight",
+        }
+
     def test_publish_fn_retries_publish(self):
         from modelexpress.metadata.publish import publish_metadata_and_ready
 


### PR DESCRIPTION
### Summary
Fixes a regression where the full tensor-manifest publish path (MX_P2P_METADATA=0) dropped the legacy tensors field from WorkerMetadata, so servers predating the tensor_source field stored 0 tensors per worker and targets silently fell back to disk loading.

### Issue
https://github.com/ai-dynamo/modelexpress/issues/495

### Root cause
Commit 545bdf8 migrated WorkerMetadata construction from the legacy tensors field to the newer tensor_source oneof, but swapped one for the other instead of writing both. A server that only reads tensors (any build predating tensor_source) sees an empty list, logs rank N (0 tensors), and targets skip RDMA.

### Fix
Dual-write both fields at all three publish sites, the same pattern the server already uses on its WorkerRecord → WorkerMetadata round-trip:
- metadata/publish.py (full tensor-manifest branch)
- trtllm_live_transfer.py (publish_model_params, publish_from_worker)

### Test coverage

- Unit test (test_full_manifest_publish_dual_writes_tensor_fields): asserts the published WorkerMetadata populates both tensors and tensor_source. Deterministic — red without the fix, green with it.
- CI, same-version: new test-p2p matrix entry runs the full source→target RDMA path with MX_P2P_METADATA=0 against this commit's server, guarding the full-manifest path end-to-end.
- CI, mixed-version: same path with the last released server (0.4.0), which predates tensor_source. This reproduces the regression (server logged 0 tensors pre-fix) and confirms the fix (267 tensors, target completes RDMA cross-version). A live backward-compatibility guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable tensor-manifest metadata publishing for distributed model workflows.
  * Added support for full tensor-manifest publishing scenarios, including mixed-version server testing.
* **Bug Fixes**
  * Improved compatibility with older servers by preserving both current and legacy tensor metadata formats.
  * Improved handling of metadata sources when server responses use older formats.
* **Tests**
  * Expanded validation for full-manifest publishing and consistent tensor information across supported modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->