### PR TITLE
feat: add XPU accelerator backend

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -637,7 +637,7 @@ Each GPU worker generates a unique `worker_id` (`uuid4().hex[:8]`) at init and p
 
 ### Tensor Discovery
 
-The loader uses `iter_module_tensors()` (in `tensor_utils.py`) to walk the full PyTorch module tree via `named_parameters()` and `named_buffers()`, keeping tensors accepted by the active `AcceleratorBackend.is_accel_tensor()` predicate after post-processing. CUDA is the only concrete backend today, so current behavior still collects CUDA tensors. This discovers three categories:
+The loader uses `iter_module_tensors()` (in `tensor_utils.py`) to walk the full PyTorch module tree via `named_parameters()` and `named_buffers()`, keeping tensors accepted by the active `AcceleratorBackend.is_accel_tensor()` predicate after post-processing. `CudaAcceleratorBackend` and `XpuAcceleratorBackend` are the concrete backends today, so collection targets CUDA or XPU tensors depending on the active backend. This discovers three categories:
 
 | Category | Source | Example |
 |----------|--------|---------|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -529,7 +529,7 @@ Loading precedence: CLI args > environment variables > config file > defaults.
 |--------|---------|
 | `__init__.py` | Package init, exports `register_modelexpress_loaders()` for callers to register the `modelexpress` and `mx` loaders with vLLM |
 | `client.py` | `MxClient` - gRPC client wrapping `PublishMetadata`, `ListSources`, `GetMetadata`, and `UpdateStatus` RPCs |
-| `accelerators/` | `AcceleratorBackend` boundary for accelerator-specific torch device control and fast-path capability gates, split into `base.py` (protocol) and `cuda.py` (`CudaAcceleratorBackend`). CUDA is the implemented backend; non-CUDA backends can be added behind the same interface |
+| `accelerators/` | `AcceleratorBackend` boundary for accelerator-specific torch device control and fast-path capability gates, split into `base.py` (protocol), `cuda.py` (`CudaAcceleratorBackend`), and `xpu.py` (`XpuAcceleratorBackend`). CUDA and XPU are implemented backends; XPU keeps CUDA-only fast paths (pool registration, VMM arena, GDS) disabled and falls back to generic per-tensor NIXL registration. Further backends can be added behind the same interface |
 | `nixl_transfer.py` | `NixlTransferManager` - NIXL agent lifecycle, tensor registration, RDMA transfers |
 | `gds_transfer.py` | GPUDirect Storage availability check and transfer utilities |
 | `gds_loader.py` | `MxGdsLoader` - GDS-based model loader (direct file-to-GPU) |
@@ -606,7 +606,7 @@ Auto-detects the best loading strategy with a prioritized chain. Each strategy i
 | p2 | `GdsStrategy` | Active accelerator backend supports GDS and GDS hardware is available | Load via `MxGdsLoader` (direct file-to-GPU). Falls through on failure. Reads full checkpoint tensors and slices for TP downstream — see [GDS Reads Full Checkpoint Tensors Under TP](#gds-reads-full-checkpoint-tensors-under-tp). |
 | p3 | `DefaultStrategy` | Engine native fallback loader available | Native loader fallback (for vLLM, `DefaultModelLoader`, CPU-staged, auto-downloads from HF Hub). |
 
-Strategies handle the loading path and NIXL tensor registration. `LoadContext.accelerator_backend` centralizes accelerator-specific torch operations and capability gates for CUDA-only fast paths such as pool registration, VMM arena registration, and GDS. Adapter hooks handle engine lifecycle such as vLLM `process_weights_after_loading`, and the chain performs best-effort metadata publication after a successful strategy. New strategies can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
+Strategies handle the loading path and NIXL tensor registration. `LoadContext.accelerator_backend` centralizes accelerator-specific torch operations and capability gates for fast paths such as pool registration, VMM arena registration, and GDS. Backends that do not support those CUDA-specific paths, such as XPU, leave the gates disabled and use the generic fallback path. XPU transfer deployments still require a UCX/NIXL runtime that can register XPU device memory. Adapter hooks handle engine lifecycle such as vLLM `process_weights_after_loading`, and the chain performs best-effort metadata publication after a successful strategy. New strategies can be added by creating a new file in `load_strategy/` and registering it in `LoadStrategyChain.run()`.
 
 ### Source Selection
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -57,7 +57,7 @@ Workers use `torch.distributed.get_rank()` as their global rank, which captures 
 
 ### Runtime Accelerator Compatibility
 
-The source worker's runtime accelerator family, such as `cuda`, comes from the active `AcceleratorBackend.name`. It is published on `WorkerMetadata.accelerator` and also surfaced on the lightweight `SourceInstanceRef.accelerator` returned by `ListSources`. This field is used only for source compatibility filtering. It is not folded into `SourceIdentity`, does not affect `mx_source_id`, and does not change the Rust/Python pinned source-ID cross-check hashes.
+The source worker's runtime accelerator family, such as `cuda` or `xpu`, comes from the active `AcceleratorBackend.name`. It is published on `WorkerMetadata.accelerator` and also surfaced on the lightweight `SourceInstanceRef.accelerator` returned by `ListSources`. This field is used only for source compatibility filtering. It is not folded into `SourceIdentity`, does not affect `mx_source_id`, and does not change the Rust/Python pinned source-ID cross-check hashes.
 
 Targets treat an empty `accelerator` value as unknown and do not reject it, which keeps transfers backward compatible with metadata published before this field existed. If both source and target publish non-empty accelerator values and they differ, the target skips that source. Because `SourceInstanceRef` carries the value, incompatible sources are dropped while handling `ListSources` -- before the selector orders candidates and before the `MAX_SOURCE_RETRIES` slice -- so incompatible sources cannot exhaust the retry budget ahead of a compatible one. The post-`GetMetadata` check on `WorkerMetadata.accelerator` remains as defense-in-depth, before target preparation or RDMA receive.
 

--- a/modelexpress_client/python/modelexpress/accelerators/__init__.py
+++ b/modelexpress_client/python/modelexpress/accelerators/__init__.py
@@ -9,21 +9,53 @@ import torch
 
 from .base import NIXL_ACCELERATOR_MEM_TYPE, AcceleratorBackend
 from .cuda import CudaAcceleratorBackend
+from .xpu import XpuAcceleratorBackend
 
 __all__ = [
     "NIXL_ACCELERATOR_MEM_TYPE",
     "AcceleratorBackend",
     "CudaAcceleratorBackend",
+    "XpuAcceleratorBackend",
     "accelerator_backend_for",
 ]
+
+
+def _is_torch_xpu_available() -> bool:
+    xpu = getattr(torch, "xpu", None)
+    is_available = getattr(xpu, "is_available", None)
+    if is_available is None:
+        return False
+    try:
+        return bool(is_available())
+    except Exception:
+        return False
+
+
+def _supported_device_types() -> str:
+    supported = ["cuda"]
+    if _is_torch_xpu_available():
+        supported.append("xpu")
+    return ", ".join(supported)
 
 
 def accelerator_backend_for(device: torch.device | str) -> AcceleratorBackend:
     """Return the backend implementation for ``device``.
 
-    Only CUDA devices are currently supported by this factory.
+    CUDA is always selectable. XPU is selectable when torch exposes an
+    available ``torch.xpu`` runtime.
     """
     torch_device = torch.device(device)
     if torch_device.type == "cuda":
         return CudaAcceleratorBackend()
-    raise ValueError(f"Unsupported accelerator backend for torch device {torch_device!s}")
+    if torch_device.type == "xpu":
+        if _is_torch_xpu_available():
+            return XpuAcceleratorBackend()
+        raise ValueError(
+            "Unsupported accelerator backend for torch device "
+            f"{torch_device!s}: torch.xpu is not available; "
+            f"supported device types: {_supported_device_types()}"
+        )
+    raise ValueError(
+        "Unsupported accelerator backend for torch device "
+        f"{torch_device!s}; supported device types: {_supported_device_types()}"
+    )

--- a/modelexpress_client/python/modelexpress/accelerators/xpu.py
+++ b/modelexpress_client/python/modelexpress/accelerators/xpu.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""XPU implementation of the accelerator backend boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from .base import NIXL_ACCELERATOR_MEM_TYPE
+
+
+@dataclass(frozen=True)
+class XpuAcceleratorBackend:
+    """XPU implementation of the accelerator backend boundary."""
+
+    @property
+    def name(self) -> str:
+        return "xpu"
+
+    @property
+    def torch_device_type(self) -> str:
+        return "xpu"
+
+    @property
+    def nixl_mem_type(self) -> str:
+        return NIXL_ACCELERATOR_MEM_TYPE
+
+    def _xpu(self):
+        xpu = getattr(torch, "xpu", None)
+        if xpu is None:
+            raise RuntimeError("torch.xpu is not available")
+        return xpu
+
+    def set_device(self, device_id: int) -> None:
+        self._xpu().set_device(device_id)
+
+    def current_device(self) -> int:
+        return int(self._xpu().current_device())
+
+    def synchronize(self, device_id: int | None = None) -> None:
+        xpu = self._xpu()
+        if device_id is None:
+            xpu.synchronize()
+            return
+
+        try:
+            xpu.synchronize(device_id)
+        except TypeError:
+            current_device = int(xpu.current_device())
+            xpu.set_device(device_id)
+            try:
+                xpu.synchronize()
+            finally:
+                xpu.set_device(current_device)
+
+    def empty_cache(self) -> None:
+        empty_cache = getattr(self._xpu(), "empty_cache", None)
+        if callable(empty_cache):
+            empty_cache()
+
+    def torch_device(self, device_id: int) -> torch.device:
+        return torch.device(self.torch_device_type, device_id)
+
+    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
+        return tensor.device.type == self.torch_device_type
+
+    def supports_rdma_p2p(self) -> bool:
+        return True
+
+    def supports_pool_reg(self) -> bool:
+        return False
+
+    def supports_vmm(self) -> bool:
+        return False
+
+    def supports_gds(self) -> bool:
+        return False

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ import torch
 
 from modelexpress.accelerators import (
     CudaAcceleratorBackend,
+    XpuAcceleratorBackend,
     accelerator_backend_for,
 )
 from modelexpress.adapter import EngineAdapter
@@ -83,8 +85,120 @@ class TestCudaAcceleratorBackend:
         )
 
     def test_accelerator_backend_for_rejects_unsupported_device(self):
-        with pytest.raises(ValueError, match="Unsupported accelerator backend"):
+        with pytest.raises(ValueError, match="supported device types"):
             accelerator_backend_for(torch.device("cpu"))
+
+
+class TestXpuAcceleratorBackend:
+    def test_xpu_backend_uses_nixl_vram_segment_and_disables_cuda_fast_paths(self):
+        backend = XpuAcceleratorBackend()
+
+        assert backend.name == "xpu"
+        assert backend.torch_device_type == "xpu"
+        assert backend.nixl_mem_type == "VRAM"
+        assert backend.supports_rdma_p2p() is True
+        assert backend.supports_pool_reg() is False
+        assert backend.supports_vmm() is False
+        assert backend.supports_gds() is False
+
+    def test_xpu_backend_delegates_torch_calls(self, monkeypatch):
+        calls = []
+
+        class FakeXpu:
+            def set_device(self, device_id):
+                calls.append(("set", device_id))
+
+            def current_device(self):
+                return 3
+
+            def synchronize(self, device_id=None):
+                calls.append(("sync", device_id))
+
+            def empty_cache(self):
+                calls.append(("empty", None))
+
+        monkeypatch.setattr(torch, "xpu", FakeXpu(), raising=False)
+
+        backend = XpuAcceleratorBackend()
+        backend.set_device(2)
+        assert backend.current_device() == 3
+        backend.synchronize(2)
+        backend.synchronize()
+        backend.empty_cache()
+
+        assert calls == [
+            ("set", 2),
+            ("sync", 2),
+            ("sync", None),
+            ("empty", None),
+        ]
+
+    def test_xpu_backend_synchronize_falls_back_when_device_arg_unsupported(
+        self,
+        monkeypatch,
+    ):
+        calls = []
+
+        class FakeXpu:
+            def set_device(self, device_id):
+                calls.append(("set", device_id))
+
+            def current_device(self):
+                return 7
+
+            def synchronize(self):
+                calls.append(("sync", None))
+
+        monkeypatch.setattr(torch, "xpu", FakeXpu(), raising=False)
+
+        XpuAcceleratorBackend().synchronize(2)
+
+        assert calls == [
+            ("set", 2),
+            ("sync", None),
+            ("set", 7),
+        ]
+
+    def test_xpu_backend_empty_cache_noops_when_optional_api_absent(self, monkeypatch):
+        class FakeXpu:
+            pass
+
+        monkeypatch.setattr(torch, "xpu", FakeXpu(), raising=False)
+
+        XpuAcceleratorBackend().empty_cache()
+
+    def test_xpu_backend_is_accel_tensor_uses_device_type(self):
+        backend = XpuAcceleratorBackend()
+
+        class FakeTensor:
+            def __init__(self, device_type):
+                self.device = SimpleNamespace(type=device_type)
+
+        assert backend.is_accel_tensor(FakeTensor("xpu")) is True
+        assert backend.is_accel_tensor(FakeTensor("cuda")) is False
+        assert backend.is_accel_tensor(FakeTensor("cpu")) is False
+
+    def test_xpu_backend_torch_device(self):
+        assert XpuAcceleratorBackend().torch_device(1) == torch.device("xpu", 1)
+
+    def test_accelerator_backend_for_xpu_when_available(self, monkeypatch):
+        fake_xpu = SimpleNamespace(is_available=lambda: True)
+        monkeypatch.setattr(torch, "xpu", fake_xpu, raising=False)
+
+        assert isinstance(
+            accelerator_backend_for(torch.device("xpu:0")),
+            XpuAcceleratorBackend,
+        )
+
+    def test_accelerator_backend_for_xpu_rejects_unavailable_runtime(
+        self,
+        monkeypatch,
+    ):
+        fake_xpu = SimpleNamespace(is_available=lambda: False)
+        monkeypatch.setattr(torch, "xpu", fake_xpu, raising=False)
+
+        with pytest.raises(ValueError, match="torch.xpu is not available"):
+            accelerator_backend_for(torch.device("xpu:0"))
 
 
 class TestAcceleratorCapabilityGates:

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -664,6 +664,23 @@ class TestPublishMetadataErrorHandling:
         with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
             publish_metadata(ctx)
 
+    @patch("modelexpress.load_strategy.base.publish_metadata_and_ready")
+    def test_publish_uses_accelerator_backend_name(
+        self,
+        mock_publish,
+        mock_accelerator_backend_cls,
+    ):
+        from modelexpress.load_strategy.base import publish_metadata
+
+        ctx = _make_load_context(
+            accelerator_backend=mock_accelerator_backend_cls(name="xpu"),
+        )
+        ctx.nixl_manager = MagicMock()
+        with patch.dict(os.environ, {"MX_SERVER_ADDRESS": "localhost:8001"}):
+            publish_metadata(ctx)
+
+        assert mock_publish.call_args.kwargs["accelerator"] == "xpu"
+
     def test_unpublish_uses_worker_rank_for_heartbeat_lifecycle(self):
         from modelexpress.load_strategy.base import unpublish_metadata
         from modelexpress.metadata.publish import _heartbeat_threads, _worker_servers
@@ -1179,6 +1196,25 @@ class TestRdmaStrategyLoad:
 
         assert exc.value.mutated is False
         assert attempts == []
+
+    def test_accepts_matching_xpu_accelerator(
+        self,
+        mock_accelerator_backend_cls,
+    ):
+        ctx = _make_load_context(
+            accelerator_backend=mock_accelerator_backend_cls(name="xpu"),
+        )
+        source_resp = _make_metadata_resp(rank=0, worker_id="w-1")
+        source_resp.worker.accelerator = "xpu"
+        candidates = [_make_instance_ref(worker_id="w-1")]
+        strategy, attempts = self._setup(ctx, candidates, [source_resp])
+
+        with patch("modelexpress.load_strategy.rdma_strategy.is_nixl_available", return_value=True), \
+             patch("modelexpress.load_strategy.rdma_strategy.get_configured_selector", return_value=_IdentitySelector()):
+            result = strategy.load(MagicMock(), ctx)
+
+        assert isinstance(result, LoadResult)
+        assert attempts == ["w-1"]
 
     def test_load_as_target_marks_post_prepare_failure_as_mutated(self):
         from modelexpress.load_strategy.rdma_strategy import RdmaStrategy


### PR DESCRIPTION
## Summary

Adds `XpuAcceleratorBackend`, a non-CUDA implementation of the
`AcceleratorBackend` protocol. The backend is selected based on the engine's
resolved torch device and supports both vLLM and SGLang. Existing CUDA
behavior is unchanged.

This change is limited to XPU-to-XPU transfers. CUDA-to-XPU and XPU-to-CUDA
transfers are intentionally blocked when both endpoints publish non-empty
accelerator metadata and the accelerator families differ.

## What Changed

- Added `accelerators/xpu.py` with `XpuAcceleratorBackend`
  - Uses `name = "xpu"` and `torch_device_type = "xpu"`
  - Reports NIXL `VRAM` memory
  - Delegates device operations to `torch.xpu`
  - Falls back to argument-less `torch.xpu.synchronize()` when
    device-specific synchronization is unsupported
  - Treats `torch.xpu.empty_cache()` as optional
  - Detects XPU tensors via `tensor.device.type`
  - Disables CUDA-specific fast paths:
    - Memory pool registration
    - VMM arena allocation
    - GPUDirect Storage (GDS)
- Updated `accelerator_backend_for()` to select the XPU backend when
  `torch.xpu` is available and the resolved device type is `xpu`
- Updated documentation to describe XPU backend support and the currently
  unsupported CUDA-specific fast paths

## Testing

### Unit Tests

- XPU backend properties and capability gating
- `torch.xpu` delegation, synchronization fallback, and optional
  `empty_cache()` handling
- XPU tensor detection and backend factory selection
- RDMA source filtering for matching XPU accelerator metadata
- Metadata publication uses the active backend name

### Hardware Validation

Environment:

- Intel Arc Pro GPUs
- PyTorch 2.12+xpu
- UCX built with `--with-ze`
- NIXL 1.3.0

Validation:

- Verified XPU-to-XPU NIXL RDMA transfers
- Byte-for-byte data validation passed

## Follow-up

- Support heterogeneous CUDA-to-XPU and XPU-to-CUDA transfers
- Add real-XPU CI:
  - `Dockerfile`
  - Gated XPU-to-XPU transfer tests
  - CI workflow integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for XPU accelerator backends in the Python client.
  * XPU devices can now be selected when supported by the runtime.
  * Added XPU-aware loading and metadata compatibility for RDMA transfers.
  * CUDA-specific fast paths remain disabled where unsupported.

* **Documentation**
  * Updated architecture and compatibility documentation to cover XPU support.

* **Tests**
  * Added coverage for XPU device operations, availability checks, loading, and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->