### PR TITLE
ci: install uv via pip to satisfy the Actions allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         python-version: "3.12"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      run: pip install uv
 
     - name: Install dependencies
       working-directory: modelexpress_client/python


### PR DESCRIPTION
## Problem

An org/enterprise GitHub Actions **allowed-actions allowlist** now blocks `astral-sh/setup-uv@v5`, which `ci.yml` uses in the Python Tests job. The effect is repo-wide:

- **On PRs**, `ci.yml` hits the blocked action during startup and `startup_failure`s the whole run, so **Test Suite (stable/beta/nightly), Python Tests, Go Bindings, Integration Tests, and Security Audit never run** — every open PR is affected.
- **On `main`**, the run starts but the Python Tests job fails at the `setup-uv` step (e.g. #502 / `e1816bd`).

Error:
> `The action astral-sh/setup-uv@v5 is not allowed in ai-dynamo/modelexpress because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: …`

`setup-uv` is the only non-allowlisted action in `ci.yml` (all others are `actions/*` / `github/*` or already allowlisted).

## Fix

Replace the `setup-uv` step with `pip install uv`. `actions/setup-python` runs immediately before it, so `pip` is on PATH and `uv` installs into the same bin — the subsequent `uv venv` / `uv pip install` steps are unchanged. No third-party action, no allowlist change needed, and it self-validates (a `pull_request` run uses this PR's own `ci.yml`).

## Alternative

Allow `astral-sh/setup-uv` in the org/enterprise Actions policy (keeps the action and its built-in caching) — but that needs an admin. This PR is the no-admin path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration setup to install the Python package manager through pip.
  * Python tests continue to run as part of the automated build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->