### PR TITLE
fix(server): touch downloaded cache hits

### DIFF
--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -744,6 +744,12 @@ impl ModelDownloadTracker {
                         self.delete_status(model_name).await;
                         continue;
                     }
+                    if existing == ModelStatus::DOWNLOADED {
+                        // Returning an existing downloaded model is a cache hit for LRU purposes.
+                        if let Err(e) = self.registry.touch_model(model_name).await {
+                            error!("Failed to touch cached model {model_name}: {e}");
+                        }
+                    }
                     break (existing, false);
                 }
                 Err(e) => {
@@ -934,6 +940,44 @@ mod tests {
         mock.expect_touch_model().once().returning(|_| Ok(()));
         let tracker = tracker_with_mock(mock);
         assert_eq!(tracker.get_status("m").await, Some(ModelStatus::DOWNLOADED));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_tracker_downloaded_cache_hit_bumps_last_used_at() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let _cache_dir_guard = EnvVarGuard::set(
+            &env_lock,
+            "MODEL_EXPRESS_CACHE_DIRECTORY",
+            temp_dir.path().to_str().expect("Expected temp dir path"),
+        );
+        let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
+        let model_dir = temp_dir.path().join("models--test--model/snapshots/abc123");
+        std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+        std::fs::write(model_dir.join("config.json"), b"{}").expect("Failed to write config");
+
+        let mut mock = crate::registry::backend::MockRegistryBackend::new();
+        mock.expect_try_claim_for_download()
+            .with(
+                mockall::predicate::eq("test/model"),
+                mockall::predicate::eq(ModelProvider::HuggingFace),
+            )
+            .once()
+            .returning(|_, _| Ok(ClaimOutcome::AlreadyExists(ModelStatus::DOWNLOADED)));
+        mock.expect_touch_model()
+            .with(mockall::predicate::eq("test/model"))
+            .once()
+            .returning(|_| Ok(()));
+        let tracker = tracker_with_mock(mock);
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+        assert_eq!(
+            tracker
+                .ensure_model_downloaded("test/model", ModelProvider::HuggingFace, &tx, false,)
+                .await,
+            ModelStatus::DOWNLOADED
+        );
     }
 
     #[tokio::test]

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -563,14 +563,18 @@ impl ModelDownloadTracker {
         }
     }
 
+    async fn touch_and_log(&self, model_name: &str) {
+        if let Err(e) = self.registry.touch_model(model_name).await {
+            error!("Failed to touch model {model_name}: {e}");
+        }
+    }
+
     /// Gets the status of a model from the registry, bumping `last_used_at` on hit.
     /// Returns None on lookup failure (error logged) or unknown model.
     pub async fn get_status(&self, model_name: &str) -> Option<ModelStatus> {
         match self.registry.get_status(model_name).await {
             Ok(Some(status)) => {
-                if let Err(e) = self.registry.touch_model(model_name).await {
-                    error!("Failed to touch model {model_name}: {e}");
-                }
+                self.touch_and_log(model_name).await;
                 Some(status)
             }
             Ok(None) => None,
@@ -746,9 +750,7 @@ impl ModelDownloadTracker {
                     }
                     if existing == ModelStatus::DOWNLOADED {
                         // Returning an existing downloaded model is a cache hit for LRU purposes.
-                        if let Err(e) = self.registry.touch_model(model_name).await {
-                            error!("Failed to touch cached model {model_name}: {e}");
-                        }
+                        self.touch_and_log(model_name).await;
                     }
                     break (existing, false);
                 }


### PR DESCRIPTION
## Summary

- update `last_used_at` when `EnsureModelDownloaded` returns an existing downloaded model
- add a regression test proving a valid cache hit calls `touch_model`

## Root cause

The distributed registry refactor in `b0c94ed` removed the status pre-check that previously touched cache entries. The replacement `AlreadyExists(DOWNLOADED)` path returned success without an equivalent touch, leaving LRU timestamps at their original download time even when clients reused the model.

## Impact

Cache hits now follow the documented LRU semantics without changing the download, retry, or stale-record recovery paths. Touch failures remain non-fatal, matching the existing `get_status` behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p modelexpress-server --lib` (183 passed)
- `cargo clippy -p modelexpress-server --lib --tests -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model caching behavior by refreshing a downloaded model’s recent-use timestamp when it is accessed.
  * Helps keep frequently used models available in the cache longer.
  * Added validation to ensure cached model access updates usage tracking correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->