### PR TITLE
Feat: Add delta weight sync RFC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,181 @@
+---
+name: modelexpress-user-guide
+description: Help users understand, deploy, operate, and debug public ModelExpress. Use for questions about MX concepts, quick starts, Kubernetes, Helm, metadata backends, engine integrations, ModelStreamer, P2P transfer, and troubleshooting.
+license: Apache-2.0
+compatibility: Applies to the public ai-dynamo/modelexpress repository.
+metadata:
+  author: ModelExpress maintainers
+  version: "1.0"
+---
+
+# ModelExpress guide for user-facing agents
+
+Use this file when helping a user get ModelExpress running or debug a
+deployment. Prefer clear operational guidance over internal implementation
+details.
+
+- No hard-wrapped Markdown. Write each paragraph and list item as one continuous line and rely on soft-wrap. Never add manual line breaks mid-paragraph to hit a column width. Newlines are only for separating paragraphs, list items, headings, code fences, and tables.
+
+## What ModelExpress does
+
+ModelExpress manages model weights for LLM inference:
+
+- downloads or resolves model artifacts from Hugging Face, object storage, or
+  local/PVC-backed paths
+- tracks model lifecycle and worker metadata with Redis or Kubernetes CRDs
+- lets new inference replicas receive weights from an already-loaded replica
+  through GPU-to-GPU P2P transfer
+- can also run ModelStreamer paths that stream from object storage without an
+  MX coordination server
+
+ModelExpress can run standalone. Dynamo is one integration path, not a
+requirement. vLLM uses `--load-format modelexpress`; SGLang uses
+`remote_instance` with the `modelexpress` backend; TensorRT-LLM P2P is a beta
+path using the documented patch/runtime flow.
+
+## Route users by goal
+
+| User goal | Send them to | Notes |
+|-----------|--------------|-------|
+| Try MX locally | [`README.md#quick-start`](README.md#quick-start), [`docs/CLI.md`](docs/CLI.md) | Good first path; basic health/cache commands do not require GPUs. |
+| Deploy MX server on Kubernetes | [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md), [`helm/README.md`](helm/README.md) | Choose Redis or Kubernetes CRD metadata before deploying. |
+| Speed up vLLM scale-out with P2P | [`examples/p2p_transfer_k8s/README.md`](examples/p2p_transfer_k8s/README.md) | Requires MX server, metadata backend, GPU workers, and RDMA-capable networking for the fast path. |
+| Use SGLang | [`docs/SGLANG.md`](docs/SGLANG.md) | Use an SGLang image with the ModelExpress delegation hook; install MX with `--no-deps`. |
+| Evaluate TensorRT-LLM P2P | [`examples/p2p_transfer_k8s/client/trtllm/`](examples/p2p_transfer_k8s/client/trtllm/) | Treat as beta and keep the TRT-LLM/Dynamo runtime requirements visible. |
+| Stream from object storage | [`examples/model_streamer_k8s/README.md`](examples/model_streamer_k8s/README.md) | ModelStreamer does not require MX server or RDMA by itself. |
+| Use Dynamo | [`examples/dynamo_model_cache_k8s/README.md`](examples/dynamo_model_cache_k8s/README.md), [`examples/dynamo_p2p_transfer_k8s/README.md`](examples/dynamo_p2p_transfer_k8s/README.md) | Explain Dynamo as optional orchestration around MX. |
+| Check support and tested versions | [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md), [`ci/TEST_PLAN.md`](ci/TEST_PLAN.md) | Do not invent version pins; derive them from these files and Dockerfiles. |
+
+## Deployment questions to answer first
+
+Before recommending a deployment, identify:
+
+- runtime: vLLM, SGLang, TensorRT-LLM, Dynamo, or standalone CLI/server
+- environment: local Docker, Kubernetes, Helm, DynamoGraphDeployment, or cloud
+  managed Kubernetes
+- weight source: Hugging Face, S3, GCS, Azure Blob Storage, local disk, or PVC
+- metadata backend: Redis, Kubernetes CRD, or `k8s-service`
+- networking: InfiniBand/RoCE, AWS EFA, or no RDMA
+- scaling shape: single replica, replica scale-out, tensor parallelism,
+  live-refit/RL, or stable-weight serving
+
+### Metadata backend guidance
+
+- Use `redis` or `kubernetes` for coordinated fleets, live refits, RL loops,
+  mixed revisions, or heterogeneous workers.
+- Use `k8s-service` only for stable-weight inference where all pods behind a
+  Service serve the same checkpoint and avoiding a central MX server is the
+  main simplification.
+- For Redis, set `MX_METADATA_BACKEND=redis` and `REDIS_URL`.
+- For Kubernetes CRD, apply `examples/crds.yaml`, configure RBAC, and set
+  `MX_METADATA_BACKEND=kubernetes` plus namespace wiring.
+
+See [`docs/DEPLOYMENT.md#choosing-a-metadata-backend`](docs/DEPLOYMENT.md#choosing-a-metadata-backend).
+
+## Important environment variables
+
+| Variable | When to mention |
+|----------|-----------------|
+| `MX_METADATA_BACKEND` | Required server-side for Redis/Kubernetes metadata. |
+| `REDIS_URL` | Required when the metadata backend is Redis. |
+| `MX_METADATA_NAMESPACE` | Kubernetes CRD namespace override. |
+| `MX_SERVER_ADDRESS` | Recommended client gRPC endpoint for central-server P2P paths. |
+| `MODEL_EXPRESS_URL` | Deprecated, but still needed by some legacy/client paths; set both during transition when docs say so. |
+| `VLLM_PLUGINS=modelexpress` | vLLM plugin registration when needed by the launch path. |
+| `MX_MODEL_URI` | Enables ModelStreamer storage loading. |
+| `MX_NIXL_BACKEND` | Use `UCX` for InfiniBand/RoCE; use `LIBFABRIC` on AWS EFA examples. |
+| `MX_RDMA_NIC_PIN` | Use for NIC pinning or `auto` topology selection on multi-NIC RDMA hosts. |
+| `MODEL_EXPRESS_LOG_LEVEL` | Set to `DEBUG` for more detailed MX Python logs. |
+
+## Debugging playbook
+
+Start with the failure surface: server unreachable, model cache issue, metadata
+issue, image/config issue, or P2P/RDMA issue.
+
+### Local CLI and server
+
+```bash
+modelexpress-cli -vv health
+nc -vz localhost 8001
+modelexpress-cli model status
+modelexpress-cli model validate
+modelexpress-cli model stats --detailed
+```
+
+The MX server speaks gRPC, not REST; `curl http://localhost:8001/health` is not
+a valid health check.
+
+### Kubernetes server and metadata
+
+```bash
+kubectl -n $NAMESPACE logs -f deploy/modelexpress-server
+kubectl -n $NAMESPACE describe pod -l app=modelexpress-server
+
+# Redis backend
+kubectl -n $NAMESPACE exec deploy/modelexpress-server -c redis -- redis-cli KEYS 'mx:source:*'
+kubectl -n $NAMESPACE exec deploy/modelexpress-server -c redis -- redis-cli HGETALL 'mx:source:<source_id>'
+
+# Kubernetes CRD backend
+kubectl -n $NAMESPACE get modelmetadatas
+kubectl -n $NAMESPACE get modelcacheentries
+```
+
+If stale Redis metadata is suspected after redeploy, flushing Redis is a valid
+debug step, but call out that it clears MX metadata:
+
+```bash
+kubectl -n $NAMESPACE exec deploy/modelexpress-server -c redis -- redis-cli FLUSHALL
+```
+
+### Inference worker and P2P
+
+```bash
+kubectl -n $NAMESPACE logs -f deploy/mx-vllm
+kubectl -n $NAMESPACE exec deploy/mx-vllm -- curl -s http://localhost:8000/v1/models
+kubectl -n $NAMESPACE exec deploy/mx-vllm -c vllm -- ibstat
+kubectl -n $NAMESPACE exec deploy/mx-vllm -c vllm -- ucx_info -d
+```
+
+Look for logs that indicate loader registration, native source load, metadata
+publish, source discovery, transfer start, and transfer completion. If a target
+falls back to storage, check whether a READY source exists, whether the
+`mx_source_id` identity matches, and whether source metadata is stale.
+
+### Storage and ModelStreamer
+
+For ModelStreamer, confirm `MX_MODEL_URI` is set and the pod has the right
+cloud identity or secret. Expected vLLM logs include the ModelExpress loader
+registration, `Trying strategy: model_streamer`, and a storage streaming
+completion message. See [`examples/model_streamer_k8s/README.md`](examples/model_streamer_k8s/README.md).
+
+## Answering standards
+
+- Give the shortest viable path first, then link to deeper docs.
+- Include prerequisites before commands: GPU/RDMA requirements, secrets, CRDs,
+  RBAC, image build/push, or cloud credentials.
+- Be explicit about status: supported, beta, experimental, example-only, or
+  not in CI.
+- Keep public answers free of private repositories, internal registries,
+  internal runner names, and secrets.
+- When editing docs, keep README for orientation and put detailed support,
+  compatibility, and version pins in `docs/COMPATIBILITY.md`.
+
+## Sources to verify before changing docs
+
+- [`README.md`](README.md) for overview and first-run paths.
+- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for server, Kubernetes, metadata,
+  P2P, ModelStreamer, and debugging details.
+- [`docs/CLI.md`](docs/CLI.md) for CLI commands and troubleshooting.
+- [`docs/SGLANG.md`](docs/SGLANG.md) for SGLang-specific launch guidance.
+- [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) and
+  [`ci/TEST_PLAN.md`](ci/TEST_PLAN.md) for support status and tested versions.
+- [`examples/`](examples/) for copy/paste deployment manifests.
+
+For docs-only edits, run:
+
+```bash
+git diff --check
+find AGENTS.md README.md docs CONTRIBUTING.md helm/README.md examples -name '*.md' -print0 \
+  | xargs -0 awk 'BEGIN{bad=0} /^```/{count[FILENAME]++} END{for (f in count) if (count[f] % 2) {print f ": odd fence count " count[f]; bad=1} exit bad}'
+helm lint helm
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Rust-based model cache management service and GPU-to-GPU weight transfer system 
 - Python dependencies go in `pyproject.toml`. Never edit dependency files by hand - use `uv add` so you always get the latest version.
 - `cargo clippy` must pass with no warnings.
 - No emojis in code or comments.
+- No hard-wrapped Markdown. Write each paragraph and list item as one continuous line and rely on soft-wrap. Never add manual line breaks mid-paragraph to hit a column width. Newlines are only for separating paragraphs, list items, headings, code fences, and tables.
 - Do not create markdown files to document code changes or decisions.
 - Do not over-comment code. Removing code is fine without adding comments to explain why.
 - Use mermaid diagrams instead of ASCII art in markdown files.

--- a/docs/DELTA_WEIGHT_SYNC_RFC.md
+++ b/docs/DELTA_WEIGHT_SYNC_RFC.md
@@ -1,0 +1,69 @@
+# RFC: Delta-Compressed Weight Updates
+
+## Summary
+
+- Adds requirements for delta-compressed weight updates as a first-class ModelExpress source type.
+- Frames the requirement around the pattern shown publicly by Cursor/Fireworks, Cognition, and Slime: full checkpoint anchors, compact deltas between anchors, durable shared storage, background fetch/process/stage, integrity checks, and short runtime apply windows.
+- Keeps the proposal at the MX requirements layer instead of prescribing one delta format, storage backend, or framework implementation.
+- Calls out the approval points for each requirement and acceptance criterion so reviewers can agree on the product boundary before we design APIs.
+
+## Why
+
+Async RL only works well if rollout workers can stay close enough to the trainer policy without repeatedly moving full checkpoints or pausing serving for long update windows.
+
+The public Cursor/Fireworks and Cognition writeups point to the same system shape: move less data between trainer and rollout fleets, do most of the work before pausing inference, verify reconstruction, and apply the staged version through the serving runtime.
+
+Slime gives a useful open-source version of the same pattern: non-colocated trainer/rollout weight sync, per-tensor deltas, shared storage, host-local checkpoint patching, per-tensor integrity checks, and reload through the ordinary serving-runtime disk update path.
+
+MX should make this pattern framework-neutral by owning the versioning, readiness, tensor identity, target demand, fallback, and observability contract.
+
+References:
+
+- [Slime: Delta Weight Sync example](https://github.com/THUDM/slime/tree/main/examples/delta_weight_sync)
+- [Fireworks: Cursor Composer 2 + Fireworks AI](https://fireworks.ai/blog/Cursor-Composer-2)
+- [Fireworks: Frontier RL Is Cheaper Than You Think](https://fireworks.ai/blog/frontier-rl-is-cheaper-than-you-think)
+- [Cognition: SWE-1.7](https://cognition.com/blog/swe-1-7)
+- [Cursor: Improving Composer through real-time RL](https://cursor.com/blog/real-time-rl-for-composer)
+- [Sequoia: How Cursor Trained Composer on Fireworks](https://sequoiacap.com/podcast/how-cursor-trained-composer-on-fireworks-distributed-infrastructure-for-high-performance-rl/)
+
+## Requirements
+
+- MX tracks a model-version chain made of full checkpoint anchors and delta updates between anchors. Approval note: approve this if MX needs to understand checkpoint lineage, not just advertise "latest weights available."
+- MX stores enough delta metadata to validate model identity, base version, target version, tensor identity, layout compatibility, checksums, and reconstruction requirements. Approval note: approve this if MX should prevent wrong-version or wrong-layout updates before a runtime attempts to apply them.
+- MX rejects a delta update when the target worker's current version does not match the delta's required base version, unless replay from an earlier anchor is available. Approval note: approve this if silent drift is unacceptable and stale workers must explicitly replay or fall back.
+- MX exposes a pre-pause `fetch/process/stage` phase where workers download deltas, reconstruct required weights or shards, and verify checksums while continuing to serve. Approval note: approve this if the core customer value is reducing rollout downtime rather than only reducing bytes moved.
+- MX exposes a pause-bound `apply/resume` phase where the runtime installs already-staged weights through framework-native hooks. Approval note: approve this if MX should separate expensive transfer/reconstruction work from the short runtime mutation window.
+- MX supports target demand metadata so a worker can declare which tensors, ranges, TP/PP/EP shards, or local experts it needs for a target version. Approval note: approve this if MX should eventually avoid moving tensors, shards, or experts a worker does not need.
+- MX supports ordinary-runtime reload paths, including the case where deltas patch a host-local checkpoint and the serving runtime reloads from disk. Approval note: approve this if MX should work with Slime/SGLang-style flows and not require every runtime to expose a delta-native GPU apply path in P0.
+- MX makes partial-update legality explicit: which tensors can update independently, which must be grouped, which can be skipped, and which require full reload or framework fallback. Approval note: approve this if correctness rules should be visible in MX instead of hidden in per-framework naming conventions.
+- MX supports shared storage as a durable source of truth for delta payloads and associated metadata, including object-store-backed filesystems that may need explicit visibility hooks. Approval note: approve this if the target use case includes wide-area async RL, not only same-cluster transport.
+- MX supports cluster-local fanout after one controller or worker fetches a delta, including local disk, node-local cache, or tree broadcast. Approval note: approve this if MX should help reduce repeated shared-storage downloads and trainer egress at fleet scale.
+- MX provides correctness checks, including post-reconstruction checksums and final runtime version confirmation. Approval note: approve this if MX readiness should mean "this worker is actually on the intended version," not best-effort loading.
+- MX provides recovery behavior for missed versions, corrupted deltas, stale workers, and lost local checkpoint state. Approval note: approve this if restarted or delayed rollout workers are expected in normal async RL operation.
+- MX emits per-update accounting for compressed bytes, reconstructed bytes, skipped bytes, fallback bytes, full-checkpoint bytes, trainer egress bytes, shared-storage egress bytes, and local fanout bytes. Approval note: approve this if we want to compare delta updates fairly against NIXL, NCCL M2N, full checkpoint reload, and framework-native broadcast.
+
+## Acceptance Criteria
+
+- A trainer or publisher can register a full checkpoint anchor and at least one compressed delta update with MX. This proves MX can ingest delta-compressed updates as a first-class source type.
+- A rollout worker can ask MX for the next version, fetch/process/stage the required delta payload before pausing inference, and report staged readiness. This proves MX supports the Cursor/Fireworks/Cognition/Slime lifecycle where most work happens outside the serving pause.
+- A rollout worker can pause, apply the staged version through a framework-native update hook, verify the final version, and resume. This proves the flow works against a real serving runtime boundary instead of only reconstructing offline weights.
+- A disk-based path can patch a host-local checkpoint and reload through an ordinary runtime disk update API. This proves MX can support the open-source Slime/SGLang shape without requiring a new runtime-specific delta apply surface in P0.
+- MX refuses to apply a delta if the base version, tensor metadata, layout tags, or checksum validation do not match. This proves the safety contract is enforced before runtime mutation.
+- MX can recover a worker by replaying deltas from the latest checkpoint anchor or by routing it to a full checkpoint fallback. This proves the system handles normal async RL messiness: missed versions, restarts, and stale workers.
+- MX reports timing split by `manifest_publish_ms`, `fetch_ms`, `process_ms`, `stage_ms`, `pause_ms`, `apply_ms`, and `resume_ms`. This proves reviewers can separate transfer/reconstruction cost from actual inference downtime.
+- Reconstructing from the delta chain produces byte-equivalent or explicitly tolerance-equivalent weights compared with the target full checkpoint reference. This proves delta updates are not accumulating silent corruption or semantic drift.
+
+## Open Questions
+
+- What should MX own versus what should stay framework-owned in the delta update lifecycle?
+- Should P0 be metadata/control plane only, or should MX include a reference fetch/reconstruct/stage client?
+- Should the first MX integration target the disk/local-checkpoint path because it matches Slime's open-source design, or should we prioritize a runtime-native path for vLLM/SGLang?
+- How should MX choose between delta artifacts, NIXL, NCCL M2N, full checkpoint fallback, and framework-native broadcast when multiple paths are available?
+- What freshness target matters most for the first implementation: lowest trainer egress, lowest rollout pause, lowest policy staleness, or best end-to-end throughput?
+- What level of partial update support is required for P0, especially for MoE experts, fused layers, quantized inference formats, and FP8 metadata?
+- What cooperation do we need from vLLM, SGLang, Megatron, NeMo RL, and TRT-LLM to make this robust instead of adapter-specific?
+- What correctness standard should MX enforce for reconstructed weights: byte-exact, tolerance-equivalent, per-tensor checksum, or end-to-end model-version attestation?
+
+## Product Stance
+
+Delta-compressed updates should not be a one-off loader path in MX. They should be a first-class versioned source type that reuses MX's strengths: tensor identity, target demand, partial-update legality, version fences, readiness, fallback policy, and observability.


### PR DESCRIPTION
## Summary

- Adds `docs/DELTA_WEIGHT_SYNC_RFC.md` to frame delta-compressed weight updates as a first-class ModelExpress source type for async RL workflows.
- Calls out requirements for checkpoint anchors, delta lineage, pre-pause fetch/process/stage, pause-bound apply/resume, target demand, fallback, correctness checks, and observability.
- Adds the no-hard-wrapped-Markdown guidance to `CLAUDE.md` and carries forward the scoped `AGENTS.md` user-facing guide content on the new branch.

## Why

Async RL rollout workers need a way to stay close to trainer policy updates without repeatedly moving full checkpoints or stretching the serving pause window.

The RFC keeps the first review at the MX product boundary: what MX should own for versioning, readiness, tensor identity, target demand, fallback, and observability before API or implementation design.

## Validation

- Docs-only change.
- `git diff --check`