### PR TITLE
feat(client): enable ModelStreamer distributed streaming by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ vLLM 0.23.0 recognizes the load format natively; the ModelExpress Python package
 
 ### ModelStreamer on Kubernetes
 
-Set `MX_MODEL_URI` to an `s3://`, `gs://`, or `az://` URI or an absolute local path. For tensor-parallel deployments, set `MX_MS_DISTRIBUTED=1` so participating ranks divide remote reads; TP=1 ignores the setting. [ModelStreamer examples](examples/model_streamer_k8s/README.md) · [vLLM recipes](examples/model_streamer_k8s/client/vllm/README.md).
+Set `MX_MODEL_URI` to an `s3://`, `gs://`, or `az://` URI or an absolute local path. For tensor-parallel deployments, participating ranks divide remote reads via `MX_MS_DISTRIBUTED` (on by default; set to `0` to disable); TP=1 ignores the setting. [ModelStreamer examples](examples/model_streamer_k8s/README.md) · [vLLM recipes](examples/model_streamer_k8s/client/vllm/README.md).
 
 ### Docker
 
@@ -217,7 +217,7 @@ docker compose -f docker/docker-compose.yml up --build
 | `MX_SERVER_ADDRESS` | `localhost:8001` | Client-side gRPC server address (P2P). Recommended. |
 | `MODEL_EXPRESS_URL` | `localhost:8001` | Deprecated, pending removal in a future release. Still read by all client paths and takes precedence when both are set; keep setting it during the transition. |
 | `MX_MODEL_URI` | (unset) | Enable ModelStreamer for an object-store URI or absolute local path. |
-| `MX_MS_DISTRIBUTED` | `0` | Divide ModelStreamer reads across tensor-parallel ranks when TP > 1. |
+| `MX_MS_DISTRIBUTED` | `1` | Divide ModelStreamer reads across tensor-parallel ranks when TP > 1. On by default; set to `0` to disable. |
 | `MX_POOL_REG` | `0` | Register each underlying CUDA allocation once instead of registering every tensor. |
 | `MX_VMM_ARENA` | `0` | Load into a CUDA VMM arena and register the used range once; alternative to `MX_POOL_REG`. |
 | `MX_P2P_SOURCE_SELECTOR` | `random` | Peer ordering policy; set `rendezvous_hash` for deterministic, minimally disruptive selection. |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -583,7 +583,7 @@ All storage backends (S3, GCS, Azure) are included as core dependencies — no e
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MX_MODEL_URI` | (none) | Model location. Must be set to enable ModelStreamer. Accepts a remote URI (`s3://bucket/model`, `gs://...`, `az://...`) or absolute local path (`/models/deepseek-ai/DeepSeek-V4-Pro`). |
-| `MX_MS_DISTRIBUTED` | `0` | Divide ModelStreamer reads across tensor-parallel ranks and share the results instead of having every rank read the full checkpoint. Requires tensor parallelism > 1 and a CUDA-capable platform. Set to `1` to activate. |
+| `MX_MS_DISTRIBUTED` | `1` | Divide ModelStreamer reads across tensor-parallel ranks and share the results instead of having every rank read the full checkpoint. Requires tensor parallelism > 1 and a CUDA-capable platform; a no-op at TP1. On by default. Set to `0` to disable. |
 | `RUNAI_STREAMER_CONCURRENCY` | `8` | Number of concurrent read threads |
 | `RUNAI_STREAMER_MEMORY_LIMIT` | (none) | CPU staging buffer size in bytes. `0` reuses a single-tensor buffer (most memory efficient). See [runai-model-streamer docs](https://github.com/run-ai/runai-model-streamer). |
 

--- a/examples/model_streamer_k8s/README.md
+++ b/examples/model_streamer_k8s/README.md
@@ -32,11 +32,14 @@ The vLLM manifests use:
 - `VLLM_PLUGINS=modelexpress`
 - `MX_MODEL_URI` as the model path passed to vLLM
 
-Distributed streaming is on by default. To disable it for tensor parallel
-deployments with TP > 1, set:
+Distributed streaming is on by default. To disable it for a tensor parallel
+deployment with TP > 1, set the container's `MX_MS_DISTRIBUTED` env var to `0`
+in the manifest (the checked-in manifests set it to `"1"`):
 
-```bash
-MX_MS_DISTRIBUTED=0
+```yaml
+env:
+  - name: MX_MS_DISTRIBUTED
+    value: "0"
 ```
 
 The SGLang manifests use `remote_instance` with backend `modelexpress`, while

--- a/examples/model_streamer_k8s/README.md
+++ b/examples/model_streamer_k8s/README.md
@@ -32,17 +32,19 @@ The vLLM manifests use:
 - `VLLM_PLUGINS=modelexpress`
 - `MX_MODEL_URI` as the model path passed to vLLM
 
-For tensor parallel deployments with TP > 1, set:
+Distributed streaming is on by default. To disable it for tensor parallel
+deployments with TP > 1, set:
 
 ```bash
-MX_MS_DISTRIBUTED=1
+MX_MS_DISTRIBUTED=0
 ```
 
 The SGLang manifests use `remote_instance` with backend `modelexpress`, while
 `MX_MODEL_URI` selects ModelStreamer inside the shared MX strategy chain.
 
-`MX_MS_DISTRIBUTED=1` enables the engine-native distributed ModelStreamer path
-through the corresponding ModelExpress adapter. TP1 runs ignore this setting.
+`MX_MS_DISTRIBUTED` (default `1`) enables the engine-native distributed
+ModelStreamer path through the corresponding ModelExpress adapter. TP1 runs
+ignore this setting.
 
 ## Verify Startup
 

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -180,7 +180,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_GDS_THREADS": lambda: _env_int("MX_GDS_THREADS", 8),
     "MX_GDS_TIMEOUT": lambda: _env_float("MX_GDS_TIMEOUT", 120.0),
     # ── Model streamer ─────────────────────────────────────────────────────
-    "MX_MS_DISTRIBUTED": lambda: os.environ.get("MX_MS_DISTRIBUTED", "0").lower() in ("1", "true"),
+    "MX_MS_DISTRIBUTED": lambda: os.environ.get("MX_MS_DISTRIBUTED", "1").lower() in ("1", "true"),
     # ── TRT-LLM live transfer ──────────────────────────────────────────────
     "MX_SOURCE_QUERY_TIMEOUT": lambda: _env_int("MX_SOURCE_QUERY_TIMEOUT", 3600),
     "MX_TRANSFER_TIMEOUT": lambda: _env_int("MX_TRANSFER_TIMEOUT", 900),

--- a/modelexpress_client/python/tests/test_envs.py
+++ b/modelexpress_client/python/tests/test_envs.py
@@ -31,7 +31,7 @@ def test_defaults_when_unset(monkeypatch):
     assert envs.MX_WORKER_GRPC_PORT == 6555
     assert envs.MX_POOL_REG is False
     assert envs.MX_VMM_ARENA is False
-    assert envs.MX_MS_DISTRIBUTED is False
+    assert envs.MX_MS_DISTRIBUTED is True
     assert envs.VLLM_ATTENTION_BACKEND == "auto"
     assert envs.SGLANG_CACHE_DIR is None
     assert envs.VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR is None

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -367,7 +367,7 @@ class TestVllmModelStreamerIterator:
         native_load_config = loader_cls.call_args.args[0]
         assert native_load_config.model_loader_extra_config == {"concurrency": 4}
 
-    def test_distributed_disabled_by_default_even_with_tp_gt_one(self):
+    def test_distributed_enabled_by_default_when_tp_gt_one(self):
         adapter, _load_config = self._make_adapter(
             tp_size=8,
             extra_config={"concurrency": 4},
@@ -375,6 +375,22 @@ class TestVllmModelStreamerIterator:
         patcher, loader_cls, _loader_instance = self._patch_runai_loader([])
 
         with patcher, patch.dict("os.environ", {}, clear=True):
+            list(adapter.build_model_streamer_weight_iter("az://models/model"))
+
+        native_load_config = loader_cls.call_args.args[0]
+        assert native_load_config.model_loader_extra_config == {
+            "concurrency": 4,
+            "distributed": True,
+        }
+
+    def test_distributed_can_be_disabled_via_env(self):
+        adapter, _load_config = self._make_adapter(
+            tp_size=8,
+            extra_config={"concurrency": 4},
+        )
+        patcher, loader_cls, _loader_instance = self._patch_runai_loader([])
+
+        with patcher, patch.dict("os.environ", {"MX_MS_DISTRIBUTED": "0"}):
             list(adapter.build_model_streamer_weight_iter("az://models/model"))
 
         native_load_config = loader_cls.call_args.args[0]


### PR DESCRIPTION
Default `MX_MS_DISTRIBUTED` to on (`envs.py`), opt-out via `MX_MS_DISTRIBUTED=0`. Still gated by tensor parallelism > 1 (and CUDA for SGLang), so TP1 runs are unaffected.

- `envs.py`: default `"0"` -> `"1"`
- Tests: updated default assertion; added explicit opt-out coverage
- Docs: `docs/DEPLOYMENT.md` and `examples/model_streamer_k8s/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Distributed streaming is now enabled by default for tensor-parallel deployments.
  * Distributed streaming remains inactive for TP1 deployments and requires CUDA with TP greater than 1.
  * Added the ability to disable distributed streaming by setting `MX_MS_DISTRIBUTED=0`.

* **Documentation**
  * Updated deployment and Kubernetes configuration guidance to reflect the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->