### PR TITLE
perf(reshard-refit): bound descriptors for strided TP pulls

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -639,6 +639,16 @@ plan currently assumes a stable source cohort, shard layout, and registration
 addresses; topology-epoch invalidation is a follow-up requirement before
 elastic production use.
 
+Exact strided TP slices can produce one descriptor per row. When a captured
+copy exceeds `MX_RESHARD_MAX_SEGMENTS_PER_COPY` (default 64), the planner pulls
+each gap-free dim-0 source shard once into persistent contiguous staging and
+replays the captured loader views locally. This bounds descriptors by source
+shard count at the cost of extra wire bytes. Plans and update metrics report
+the exact descriptor count, descriptor savings, and extra bytes. If the
+published layout cannot be reconstructed as a complete dim-0 partition, the
+planner keeps the exact known-correct descriptors rather than changing
+correctness behavior.
+
 ### SGLang Loader
 
 **MxModelLoader** is instantiated by SGLang's `remote_instance` loader when

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -120,6 +120,7 @@ register_modelexpress_loaders()
 | `MX_ARTIFACT_COMPILE_CONFIG_DIGEST` | empty | Optional compile-configuration compatibility digest for cache discovery |
 | `MX_ARTIFACT_READY_URL` | Framework default | Readiness endpoint checked before a source publishes weights or JIT cache artifacts (`http://127.0.0.1:8000/health` for vLLM; `http://127.0.0.1:30000/health` for SGLang) |
 | `MX_ARTIFACT_READY_TIMEOUT_SECS` | `1800` | Maximum time to wait for readiness and successful artifact publication |
+| `MX_RESHARD_MAX_SEGMENTS_PER_COPY` | `64` | Maximum exact descriptors for one no-gather refit copy before a compatible dim-0-sharded source is pulled once into contiguous staging and sliced locally |
 
 ### UCX/NIXL Tuning
 
@@ -136,6 +137,7 @@ register_modelexpress_loaders()
 | `modelexpress.client` | `MxClient` -- gRPC client for the ModelExpress server |
 | `modelexpress.metadata` | Metadata clients, source identity, publishing, and worker manifest serving |
 | `modelexpress.engines.vllm.loader` | `MxModelLoader` -- vLLM integration |
+| `modelexpress.refit.reshard` | Engine-agnostic loader-geometry capture and bounded no-gather transfer planning |
 | `modelexpress.engines.sglang.loader` | `MxModelLoader` -- SGLang `remote_instance` integration |
 | `modelexpress.vllm_loader` | Compatibility shim for the vLLM loader |
 | `modelexpress.nixl_transfer` | `NixlTransferManager` -- NIXL agent lifecycle and RDMA transfers |

--- a/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
@@ -9,9 +9,10 @@ intersect those slices against the published source shards (slice_plan.py), and
 emit the exact byte segments to RDMA-pull (plan.py). No all-gather and no
 per-model conversion specs - the engine's real loaders define the reshard.
 
-Overlap is arbitrary per-dim (not just dim-0). Any tensor whose slice can't be
-expressed as a box raises ``UnsupportedReshard`` and falls back to a full
-(non-sliced) pull, so a sync never aborts over one awkward tensor.
+Overlap is arbitrary per-dim (not just dim-0). Descriptor-heavy strided copies
+can pull a complete dim-0-sharded source into contiguous staging and replay the
+captured views locally. Unsupported loader operations raise
+``UnsupportedReshard`` until the general fallback path is implemented.
 """
 
 from modelexpress.refit.reshard.geometry import (
@@ -22,6 +23,7 @@ from modelexpress.refit.reshard.geometry import (
     capture_geometry,
 )
 from modelexpress.refit.reshard.transfer_plan import (
+    FullPullSource,
     SourceInfo,
     TransferPlan,
     execute_transfer,
@@ -53,6 +55,7 @@ from modelexpress.refit.reshard.rendezvous import (
 
 __all__ = [
     "InMemoryReferenceTransport",
+    "FullPullSource",
     "LazyWeight",
     "MxReshardRendezvous",
     "NixlReshardTransport",

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -41,6 +41,18 @@ from modelexpress.refit.reshard.types import CaptureResult, UnsupportedReshard
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 
 
+def _replay_ops(tensor: torch.Tensor, op_chain: tuple) -> torch.Tensor:
+    """Replay a captured loader view chain on a staged full-source tensor."""
+    value = tensor
+    for op_name, args, frozen_kwargs in op_chain:
+        kwargs = dict(frozen_kwargs)
+        if op_name == "__getitem__":
+            value = value.__getitem__(*args)
+        else:
+            value = getattr(value, op_name)(*args, **kwargs)
+    return value
+
+
 class ReshardReceiver:
     """Pull-mode slice-resharding weight receiver (engine-agnostic).
 
@@ -109,6 +121,8 @@ class ReshardReceiver:
             str, torch.Tensor
         ] = {}  # dtype-convert param -> bf16 staging (RDMA target)
         self._staging_ptr: dict[str, int] = {}
+        self._full_staging: dict[str, torch.Tensor] = {}
+        self._full_staging_ptr: dict[str, int] = {}
         self._param_ptr: dict[
             str, int
         ] = {}  # segment param_name -> receive-buffer data_ptr
@@ -227,6 +241,31 @@ class ReshardReceiver:
             )
             self._staging_ptr = {n: t.data_ptr() for n, t in self._staging.items()}
 
+        # Descriptor-heavy strided copies pull each complete source into one
+        # persistent contiguous staging tensor, then replay captured loader views
+        # locally. Each source shard contributes one bounded descriptor.
+        self._full_staging = {}
+        self._full_staging_ptr = {}
+        if plan.full_pulls:
+            with classic_cuda_alloc():
+                self._full_staging = {
+                    full_pull.src_name: torch.empty(
+                        full_pull.global_shape,
+                        dtype=full_pull.dtype,
+                        device=self._device,
+                    )
+                    for full_pull in plan.full_pulls
+                }
+            self._manager.register_tensors(
+                {
+                    f"__full__{name}": tensor
+                    for name, tensor in self._full_staging.items()
+                }
+            )
+            self._full_staging_ptr = {
+                name: tensor.data_ptr() for name, tensor in self._full_staging.items()
+            }
+
         # Receive buffers: one per captured param at its CAPTURED (load-time)
         # shape/dtype, classic cudaMalloc, registered once. The live params are
         # NOT RDMA targets; _install() writes the buffers into the live params.
@@ -251,10 +290,16 @@ class ReshardReceiver:
                 self._param_ptr[name] = self._recv_buffers[name].data_ptr()
 
         logger.info(
-            "[reshard] prepared: %d segments, %d convert(s), %.1f MB/pull, %d fallback",
-            len(plan.segments),
+            "[reshard] prepared: %d descriptor(s), %d full-pull source(s), "
+            "%d convert(s), %.1f MB/pull, %d descriptor(s) saved, "
+            "%.1f MB extra wire, %d unbounded source(s), %d fallback",
+            plan.descriptor_count(),
+            len(plan.full_pulls),
             len(plan.converts),
             plan.bytes_planned() / 1e6,
+            plan.descriptor_savings(),
+            plan.extra_wire_bytes() / 1e6,
+            len(plan.unbounded_sources),
             len(plan.fallback),
         )
 
@@ -281,6 +326,33 @@ class ReshardReceiver:
             resolve_param_ptr=lambda name: self._param_ptr[name],
             transport=self._transport,
         )
+        if self._plan.full_pulls:
+            full_descriptors = [
+                ReadDescriptor(
+                    session=segment.session,
+                    src_addr=segment.src_addr,
+                    dst_addr=(
+                        self._full_staging_ptr[full_pull.src_name] + segment.dst_byte
+                    ),
+                    nbytes=segment.nbytes,
+                )
+                for full_pull in self._plan.full_pulls
+                for segment in full_pull.segments
+            ]
+            self._transport.read(full_descriptors)
+            for full_pull in self._plan.full_pulls:
+                full_tensor = self._full_staging[full_pull.src_name]
+                for copy in full_pull.copies:
+                    source_view = _replay_ops(full_tensor, copy.op_chain)
+                    receive_buffer = self._recv_buffers[copy.param_name]
+                    destination = receive_buffer.as_strided(
+                        copy.dest_shape,
+                        copy.dest_stride,
+                        receive_buffer.storage_offset() + copy.dest_offset,
+                    )
+                    destination.copy_(source_view)
+            stats["segments"] += len(full_descriptors)
+            stats["bytes"] += sum(descriptor.nbytes for descriptor in full_descriptors)
         if self._plan.converts:
             conv_descs = [
                 ReadDescriptor(
@@ -297,6 +369,8 @@ class ReshardReceiver:
             # op, so the RDMA never crosses dtypes. _install writes the buffer.
             for c in self._plan.converts:
                 self._recv_buffers[c.param_name].copy_(self._staging[c.param_name])
+            stats["segments"] += len(conv_descs)
+            stats["bytes"] += sum(descriptor.nbytes for descriptor in conv_descs)
 
         self._install(self._recv_buffers)
         torch.cuda.synchronize(self._device)
@@ -306,14 +380,25 @@ class ReshardReceiver:
             "bytes_received": stats["bytes"],
             "segments": stats["segments"],
             "converts": len(self._plan.converts),
+            "full_pull_sources": len(self._plan.full_pulls),
+            "exact_descriptors": self._plan.exact_descriptor_count,
+            "descriptor_savings": self._plan.descriptor_savings(),
+            "extra_wire_bytes": self._plan.extra_wire_bytes(),
+            "unbounded_sources": len(self._plan.unbounded_sources),
             "fallback": len(stats["fallback"]),
         }
         logger.info(
-            "[reshard] refit step=%d bytes=%.1fMB segments=%d converts=%d fallback=%d",
+            "[reshard] refit step=%d bytes=%.1fMB descriptors=%d "
+            "(saved=%d, extra_wire=%.1fMB) full_pulls=%d converts=%d "
+            "unbounded=%d fallback=%d",
             step,
             stats["bytes"] / 1e6,
             stats["segments"],
+            self._plan.descriptor_savings(),
+            self._plan.extra_wire_bytes() / 1e6,
+            len(self._plan.full_pulls),
             len(self._plan.converts),
+            len(self._plan.unbounded_sources),
             len(stats["fallback"]),
         )
         return metrics

--- a/modelexpress_client/python/modelexpress/refit/reshard/transfer_plan.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/transfer_plan.py
@@ -7,8 +7,8 @@ Ties the pieces together: take a ``CaptureResult`` and the published source
 shards, run ``plan_pull`` per captured copy, and collect the byte segments into a
 ``TransferPlan``. Any source whose slice can't be expressed as a box
 (``UnsupportedReshard``), or that has no published shards, or that capture
-already flagged, is routed to ``fallback`` for a full (non-sliced) pull instead
-- the sync never aborts over one awkward tensor.
+already flagged, is routed to ``fallback``. Descriptor-heavy but otherwise
+supported strided copies use a separate bounded full-source staging path.
 
 ``execute_transfer`` turns the planned segments into absolute-address
 ``ReadDescriptor``s (destination param ``data_ptr()`` resolved at refit time)
@@ -17,10 +17,15 @@ and hands them to a ``Transport``.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from modelexpress.refit.reshard.slice_plan import _row_major_strides, plan_pull
+from modelexpress.refit.reshard.slice_plan import (
+    PullSegment,
+    _row_major_strides,
+    plan_pull,
+)
 from modelexpress.refit.reshard.transport import ReadDescriptor, Transport
 from modelexpress.refit.reshard.types import (
     CaptureResult,
@@ -56,26 +61,142 @@ class ConvertSource:
 
 
 @dataclass
+class FullPullSource:
+    """Descriptor-heavy source reconstructed once in contiguous staging.
+
+    Captured copies are replayed locally from the staged full tensor. This
+    trades bounded extra wire bytes for a bounded number of NIXL descriptors.
+    """
+
+    src_name: str
+    global_shape: tuple
+    dtype: Any
+    elsize: int
+    segments: list
+    copies: list
+
+
+@dataclass
 class TransferPlan:
     """Planned pull: ``segments`` are byte runs READ straight into live params;
-    ``converts`` are dtype-mismatched sources to pull into staging then cast; and
-    ``fallback`` names sources that couldn't be sliced at all (non-box op) and need
-    a full materialization by the caller (the engine's own loader run)."""
+    ``converts`` are dtype-mismatched sources to pull into staging then cast;
+    ``full_pulls`` bound descriptor-heavy copies through contiguous source
+    staging; and ``fallback`` names unsupported sources that cannot be updated."""
 
     segments: list = field(default_factory=list)
     fallback: list = field(default_factory=list)
     converts: list = field(default_factory=list)  # list[ConvertSource]
+    full_pulls: list = field(default_factory=list)  # list[FullPullSource]
+    unbounded_sources: list = field(default_factory=list)
+    exact_descriptor_count: int = 0
+    exact_bytes: int = 0
 
     def bytes_planned(self) -> int:
-        return sum(s.nbytes for s in self.segments)
+        return (
+            sum(segment.nbytes for segment in self.segments)
+            + sum(
+                segment.nbytes
+                for convert in self.converts
+                for segment in convert.segments
+            )
+            + sum(
+                segment.nbytes
+                for full_pull in self.full_pulls
+                for segment in full_pull.segments
+            )
+        )
+
+    def descriptor_count(self) -> int:
+        return (
+            len(self.segments)
+            + sum(len(convert.segments) for convert in self.converts)
+            + sum(len(full_pull.segments) for full_pull in self.full_pulls)
+        )
+
+    def descriptor_savings(self) -> int:
+        return max(0, self.exact_descriptor_count - self.descriptor_count())
+
+    def extra_wire_bytes(self) -> int:
+        return max(0, self.bytes_planned() - self.exact_bytes)
 
 
-def plan_transfer(capture: CaptureResult, sources: dict) -> TransferPlan:
+def _full_pull_segments(src_name: str, source: SourceInfo) -> list:
+    """Reconstruct a complete dim-0-sharded tensor in contiguous staging.
+
+    Layouts that are not a gap-free dim-0 partition are rejected so the caller
+    can retain the exact descriptor plan rather than risking incorrect staging.
+    """
+    if not source.global_shape:
+        raise UnsupportedReshard(f"{src_name}: scalar full-pull is unsupported")
+
+    trailing = 1
+    for extent in source.global_shape[1:]:
+        trailing *= int(extent)
+
+    ordered = sorted(source.shards, key=lambda shard: int(shard.shard_offset[0]))
+    segments = []
+    next_row = 0
+    for shard in ordered:
+        if len(shard.shape) != len(source.global_shape) or len(
+            shard.shard_offset
+        ) != len(source.global_shape):
+            raise UnsupportedReshard(
+                f"{src_name}: shard rank does not match global rank"
+            )
+        if tuple(shard.shape[1:]) != tuple(source.global_shape[1:]) or any(
+            int(offset) != 0 for offset in shard.shard_offset[1:]
+        ):
+            raise UnsupportedReshard(
+                f"{src_name}: bounded full-pull requires dim-0 shards, got "
+                f"offset={shard.shard_offset} shape={shard.shape}"
+            )
+
+        start = int(shard.shard_offset[0])
+        rows = int(shard.shape[0])
+        if start != next_row:
+            raise UnsupportedReshard(
+                f"{src_name}: dim-0 shards have a gap or overlap at row "
+                f"{next_row} (next shard starts at {start})"
+            )
+        elements = rows * trailing
+        segments.append(
+            PullSegment(
+                session=shard.session,
+                src_addr=shard.addr,
+                param_name=src_name,
+                dst_byte=start * trailing * source.elsize,
+                nbytes=elements * source.elsize,
+            )
+        )
+        next_row += rows
+
+    if next_row != int(source.global_shape[0]):
+        raise UnsupportedReshard(
+            f"{src_name}: dim-0 shards cover {next_row} of "
+            f"{source.global_shape[0]} rows"
+        )
+    return segments
+
+
+def plan_transfer(
+    capture: CaptureResult,
+    sources: dict,
+    *,
+    max_segments_per_copy: int | None = None,
+) -> TransferPlan:
     """Build a ``TransferPlan`` from captured copies + published ``sources``
     (``{src_name: SourceInfo}``). Sources flagged unsupported at capture, missing
     from ``sources``, or non-box at ``plan_pull`` fall back to a full pull."""
     plan = TransferPlan()
     fallback_seen: set = set()
+    exact_by_source: dict[str, list[tuple[RecordedCopy, list]]] = {}
+    full_pull_names: set[str] = set()
+    if max_segments_per_copy is None:
+        max_segments_per_copy = int(
+            os.environ.get("MX_RESHARD_MAX_SEGMENTS_PER_COPY", "64")
+        )
+    if max_segments_per_copy < 1:
+        raise ValueError("max_segments_per_copy must be at least 1")
 
     def mark_fallback(name: str) -> None:
         if name not in fallback_seen:
@@ -114,6 +235,8 @@ def plan_transfer(capture: CaptureResult, sources: dict) -> TransferPlan:
             except UnsupportedReshard:
                 mark_fallback(copy.src_name)
                 continue
+            plan.exact_descriptor_count += len(segments)
+            plan.exact_bytes += sum(segment.nbytes for segment in segments)
             plan.converts.append(
                 ConvertSource(
                     copy.param_name, tuple(copy.dest_shape), src.dtype, segments
@@ -128,7 +251,39 @@ def plan_transfer(capture: CaptureResult, sources: dict) -> TransferPlan:
         except UnsupportedReshard:
             mark_fallback(copy.src_name)
             continue
-        plan.segments.extend(segments)
+        plan.exact_descriptor_count += len(segments)
+        plan.exact_bytes += sum(segment.nbytes for segment in segments)
+        exact_by_source.setdefault(copy.src_name, []).append((copy, segments))
+        if len(segments) > max_segments_per_copy:
+            full_pull_names.add(copy.src_name)
+
+    for src_name, entries in exact_by_source.items():
+        if src_name not in full_pull_names:
+            for _copy, segments in entries:
+                plan.segments.extend(segments)
+            continue
+
+        source = sources[src_name]
+        try:
+            full_segments = _full_pull_segments(src_name, source)
+        except UnsupportedReshard:
+            # Descriptor bounding is an optimization. Preserve the known-correct
+            # exact plan when this source cannot be reconstructed contiguously.
+            plan.unbounded_sources.append(src_name)
+            for _copy, segments in entries:
+                plan.segments.extend(segments)
+            continue
+
+        plan.full_pulls.append(
+            FullPullSource(
+                src_name=src_name,
+                global_shape=tuple(source.global_shape),
+                dtype=source.dtype,
+                elsize=source.elsize,
+                segments=full_segments,
+                copies=[copy for copy, _segments in entries],
+            )
+        )
 
     return plan
 

--- a/modelexpress_client/python/tests/test_reshard_refit_transfer.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_transfer.py
@@ -19,13 +19,18 @@ Run: pytest tests/test_reshard_refit_transfer.py
 import torch
 
 from modelexpress.refit.reshard.geometry import capture_geometry
+from modelexpress.refit.reshard.receiver import _replay_ops
 from modelexpress.refit.reshard.slice_plan import Shard
 from modelexpress.refit.reshard.transfer_plan import (
     SourceInfo,
     execute_transfer,
     plan_transfer,
 )
-from modelexpress.refit.reshard.transport import InMemoryReferenceTransport
+from modelexpress.refit.reshard.transport import (
+    InMemoryReferenceTransport,
+    ReadDescriptor,
+)
+from modelexpress.refit.reshard.types import CaptureResult, RecordedCopy
 
 # Reuse the ToyModel + manifest from the geometry test (same package, same dir).
 from tests.test_reshard_refit_geometry import ToyModel, _manifest
@@ -144,6 +149,96 @@ def test_strided_source_reconstructs_exactly():
     )
     assert torch.equal(recon_row, truth_row)
     assert row_src.data_ptr()  # keep alive
+
+
+def test_descriptor_heavy_slice_full_pulls_then_replays_locally():
+    srcs = _full_sources()
+    row_src = srcs["row"]
+    truth_model = ToyModel()
+    truth_model.load_weights(list(srcs.items()))
+    truth_row = dict(truth_model.named_parameters())["row"].detach().clone()
+
+    with torch.device("meta"):
+        meta_model = ToyModel()
+    capture = capture_geometry(meta_model, _manifest())
+    capture.copies = [copy for copy in capture.copies if copy.src_name == "row"]
+    source = SourceInfo(
+        tuple(row_src.shape),
+        torch.float32,
+        EL,
+        [Shard((0, 0), tuple(row_src.shape), "row", row_src.data_ptr(), EL)],
+    )
+    plan = plan_transfer(
+        capture,
+        {"row": source},
+        max_segments_per_copy=1,
+    )
+
+    assert plan.segments == []
+    assert len(plan.full_pulls) == 1
+    assert plan.exact_descriptor_count == 4
+    assert plan.descriptor_count() == 1
+    assert plan.descriptor_savings() == 3
+    assert plan.exact_bytes == truth_row.numel() * EL
+    assert plan.extra_wire_bytes() == row_src.numel() * EL - plan.exact_bytes
+
+    staging = torch.zeros_like(row_src)
+    full_pull = plan.full_pulls[0]
+    descriptors = [
+        ReadDescriptor(
+            session=segment.session,
+            src_addr=segment.src_addr,
+            dst_addr=staging.data_ptr() + segment.dst_byte,
+            nbytes=segment.nbytes,
+        )
+        for segment in full_pull.segments
+    ]
+    InMemoryReferenceTransport().read(descriptors)
+
+    reconstructed = torch.zeros_like(truth_row)
+    copy = full_pull.copies[0]
+    destination = reconstructed.as_strided(
+        copy.dest_shape,
+        copy.dest_stride,
+        reconstructed.storage_offset() + copy.dest_offset,
+    )
+    destination.copy_(_replay_ops(staging, copy.op_chain))
+    assert torch.equal(reconstructed, truth_row)
+
+
+def test_non_dim0_source_keeps_exact_descriptors():
+    source_tensor = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    left = source_tensor[:, :4].contiguous()
+    right = source_tensor[:, 4:].contiguous()
+    copy = RecordedCopy(
+        src_name="row",
+        op_chain=(("narrow", (1, 1, 2), ()),),
+        param_name="row",
+        dest_offset=0,
+        dest_shape=(4, 2),
+        dest_stride=(2, 1),
+        dest_dtype=torch.float32,
+    )
+    source = SourceInfo(
+        global_shape=(4, 8),
+        dtype=torch.float32,
+        elsize=EL,
+        shards=[
+            Shard((0, 0), (4, 4), "left", left.data_ptr(), EL),
+            Shard((0, 4), (4, 4), "right", right.data_ptr(), EL),
+        ],
+    )
+    plan = plan_transfer(
+        CaptureResult(copies=[copy]),
+        {"row": source},
+        max_segments_per_copy=1,
+    )
+
+    assert plan.full_pulls == []
+    assert plan.unbounded_sources == ["row"]
+    assert len(plan.segments) == 4
+    assert plan.descriptor_savings() == 0
+    assert plan.extra_wire_bytes() == 0
 
 
 def test_unsupported_source_routes_to_fallback():


### PR DESCRIPTION
## Summary

- replace descriptor-heavy exact strided copies with one full-source staging pull when a copy exceeds `MX_RESHARD_MAX_SEGMENTS_PER_COPY` (default 64)
- reconstruct only complete, gap-free dim-0 source partitions, then replay loader-captured views locally into existing receive buffers
- preserve the exact known-correct descriptor plan when a source layout cannot use bounded staging
- report exact/actual descriptor counts, descriptors saved, extra wire bytes, full-pull sources, and unbounded sources

## Why

Row-parallel TP placement can produce one NIXL descriptor per row. At model scale, descriptor preparation and dispatch dominate even when the requested bytes are small. This policy makes the tradeoff explicit: bounded descriptors in exchange for extra wire bytes and persistent staging memory.

## Measured Topology A evidence

Real NeMo-RL/Megatron Qwen3-30B-A3B BF16, 16 trainer GPUs -> 16 vLLM GPUs (4 x TP4), AWS EFA:

- exact descriptors avoided per rank: **12,576,768**
- descriptors remaining per rank: **117,123**
- useful bytes/rank: **14.58 GB**
- extra wire bytes/rank: **15.20 GB** (51% redundant)
- `wire_exact` warm median: **0.937 s**
- `wire_full` warm median: **0.668 s**
- total wire warm median: **1.684 s**
- local reslice warm median: **0.072 s**
- `fallback=0`; 48 incompatible sources retained exact descriptors

This row is `PERF_PASS_CORRECTNESS_PENDING`: it validates the descriptor/byte/time tradeoff, not final parameter-equality or FP8 A/B correctness.

## Safety and memory tradeoff

- bounded staging is used only for complete dim-0 partitions with no gaps or overlaps
- non-dim0, incomplete, overlapping, or otherwise incompatible layouts retain exact descriptors; this optimization never converts them into a correctness fallback
- each bounded source adds one complete persistent GPU staging tensor in addition to existing receive buffers, so HBM scales with the number and size of bounded sources
- the threshold is configurable and requires topology/model-specific tuning
- unsupported loader operations remain fail-closed as defined by merged #496

## Test plan

- [x] one signed commit and six changed files on current `main`
- [x] 28 focused reshard/planner/transport tests after rebase
- [x] full Python client suite: 645 passed, 1 skipped
- [x] Ruff check and format
- [x] bit-exact in-memory reconstruction after full staging + local captured-view replay
- [x] incompatible non-dim0 source retains exact descriptors
- [x] descriptor-savings and extra-wire-byte metrics

The managed full-suite process hit the known native dependency teardown SIGSEGV after all tests completed; no assertion failed.

Depends on merged #496.

---

## Correctness status, updated 2026-07-27

Two topologies have since been measured behind a byte-level verification gate
that compares each installed shard against the publisher's digest. The results
change what this PR may claim, so they are stated here rather than left in a
side document.

| Topology | Status | What may be claimed |
| :-- | :-- | :-- |
| A (tensor parallel 2, expert parallel 4, data parallel 8 to tensor parallel 4) | `PERF_PASS_CORRECTNESS_PARTIAL_SCOPE` | Timings, and byte-correctness of the full-pull set only |
| B (pipeline parallel 2, expert parallel 8) | `PERF_PASS_CORRECTNESS_PENDING` | Timings, and byte-correctness of the full-pull set only |

### Topology A: the gate ran and passed, over a partial scope

`checked 6144, skipped_no_digest 0, mismatches 0, divergent_replicas 0`. The
6,144 checks are 48 layers times 128 experts, which is exactly the set this PR
routes through bounded full-pull staging. So the policy this PR introduces is
byte-verified on Topology A.

The scope limit is that attention, normalization and gate/up projections take
the exact-fetch path and carry no digest, so they are unverified rather than
verified-clean. That is a gap in gate coverage, not a known defect.

### Topology B: the mismatches were root-caused, and this path is not the cause

An earlier revision of this description reported nine tensors installing wrong
bytes on Topology B and asked reviewers to treat this path as suspect. That has
since been root-caused to two defects, neither of which is in this PR. The
earlier reading is withdrawn.

The first is a publisher-side naming defect. Megatron's `named_parameters()`
returns pipeline-**local** layer indices, so at `pp_size=2` both stages published
`decoder.layers.0..23`. The shard table is keyed by name with a
first-writer-wins tiebreak, so one stage's 24 layers displaced the other's: 24 of
48 layers were never refit, and where stage 1's offer won, destination layer N
was filled with global layer N+24. The nine reported tensors were the remainder
of that tiebreak, not a transport or geometry fault. Topology A was never
affected, because at `pp_size=1` local index equals global index.

The second is a gate defect. `_prepare()` runs once, so the digests being
compared against described the weights as of the first refit. Any parameter that
training legitimately updated was then reported as corruption. The diagnostic is
unusually clean: across two runs the expected digest was byte-identical while
the delivered one changed, and address re-checking reported no source address
moving across roughly 4.4 million comparisons.

With the naming fix in place, coverage is 100.0% and `params_installed` is
435/435 on all 16 ranks, with 0 real mismatches.

The scope limit that remains is the same one Topology A carries: only full pulls
are digest-checked, so attention other than `o_proj`, normalization and gate/up
projections are unverified rather than verified-clean. Status is therefore
`PENDING` rather than `PASS` on both topologies.

### Topology A and B transport figures

Both rows below were captured with the read batching from #546 and #547 enabled.
The Topology B column is the post-naming-fix run; an earlier revision of this
description quoted a run that refit 51% of the model, and those figures should
not be cited.

| | Topology A | Topology B |
| :-- | --: | --: |
| wire median | 1.512 s | 1.273 s |
| per-rank throughput | 157.6 Gbps | 255.3 Gbps |
| bytes on the wire per rank | 29.78 GB | 40.61 GB |
| useful bytes per rank | 14.58 GB | 30.54 GB |
| extra wire from pulling full tensors | 51% | 24.8% |
| segments per rank | 117,123 | 19,011 |
| unbounded sources | 48 | 0 |
| measured coverage | 100% | 100% |

The geometry, not the fabric, is what separates them: B moves roughly twice the
useful payload of A while issuing about a sixth as many descriptors, and pays a
proportionally smaller redundancy penalty for the strided pulls this PR bounds.

### The promotion threshold is a cliff, and that is a follow-up not a change here

A sweep of `MX_RESHARD_MAX_SEGMENTS_PER_COPY` over 64, 256, 1024 and 4096
produced two distinct plans, not a curve. The first three are identical at
117,123 descriptors and 14.50 GB of extra wire; 4096 promotes nothing and yields
12,693,891 descriptors, which is the explosion this PR exists to prevent. Every
descriptor-heavy copy in this topology needs between 1,025 and 4,096 segments,
so the threshold either promotes all of them or none.

A cost model between two points, one of them catastrophic, re-derives the point
already chosen. The redundancy is reachable only by changing what a promotion
fetches - a bounded full pull covering the union of a source's needed segments
rather than the whole containing tensor, or a per-copy rather than per-source
promotion decision. Both are follow-ups. Reopening this PR for either resets a
review that is otherwise complete.

