### PR TITLE
chore: bump version from 0.5.0 to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "model-express-workspace-tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "Model Express: High-performance model serving and management"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -38,9 +38,9 @@ hf-hub = { version = "0.4.3", default-features = false, features = [
     "rustls-tls",
 ] }
 jiff = { version = "0.2.15", features = ["serde"] }
-modelexpress-common = { path = "modelexpress_common", version = "0.5.0" }
-modelexpress-client = { path = "modelexpress_client", version = "0.5.0" }
-modelexpress-server = { path = "modelexpress_server", version = "0.5.0" }
+modelexpress-common = { path = "modelexpress_common", version = "0.6.0" }
+modelexpress-client = { path = "modelexpress_client", version = "0.6.0" }
+modelexpress-server = { path = "modelexpress_server", version = "0.6.0" }
 once_cell = "1.21.3"
 prost = "0.13"
 rustls = { version = "0.23.37", default-features = false, features = ["ring", "std"] }

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -30,7 +30,7 @@ Every source is identified by a `SourceIdentity` proto containing all fields tha
 
 | Field | Example | Purpose |
 |-------|---------|---------|
-| `mx_version` | `"0.5.0"` | Format compatibility across upgrades |
+| `mx_version` | `"0.6.0"` | Format compatibility across upgrades |
 | `mx_source_type` | `WEIGHTS`, `LORA`, `CUDA_GRAPH`, `TORCH_COMPILE_CACHE`, `TRITON_CACHE`, `DEEP_GEMM_CACHE`, `TILELANG_CACHE`, `CUTE_DSL_CACHE`, `FLASHINFER_CACHE` | Type of source metadata being served |
 | `model_name` | `"deepseek-ai/DeepSeek-V3"` | Model identifier |
 | `backend_framework` | `VLLM`, `SGLANG`, `TRT_LLM` | Inference framework |
@@ -263,7 +263,7 @@ No Redis TTL is applied to keys. P2P stale detection and cleanup are handled by 
 ```
 # Source index -- identity stored once, workers as presence markers
 mx:source:a1b2c3d4e5f67890
-  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.5.0",...}
+  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.6.0",...}
   f3a2b1c4        ->  "0"    # worker_id f3a2b1c4, global rank 0
   e7d6c5b8        ->  "1"    # worker_id e7d6c5b8, global rank 1
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: modelexpress
 description: A Helm chart for ModelExpress - a AI model cache management service
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 keywords:
   - model-serving
   - ai

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modelexpress"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python client for ModelExpress P2P GPU transfer service"
 readme = "README.md"
 license = "Apache-2.0"

--- a/modelexpress_client/python/tests/test_artifact_transfer.py
+++ b/modelexpress_client/python/tests/test_artifact_transfer.py
@@ -835,7 +835,7 @@ def test_publish_artifact_source_registers_mx_discovery_metadata(tmp_path):
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.6.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
@@ -894,7 +894,7 @@ def test_discover_artifact_source_does_not_rank_match_by_default(tmp_path):
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.6.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
     )
@@ -1084,7 +1084,7 @@ def test_publish_artifact_source_stops_server_when_refresh_fails(
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.6.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
     )
@@ -1125,7 +1125,7 @@ def test_torch_compile_cache_transfer_discovers_source_through_mx_server(tmp_pat
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.6.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/tests/test_k8s_service_client.py
+++ b/modelexpress_client/python/tests/test_k8s_service_client.py
@@ -23,7 +23,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.6.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/tests/test_source_id.py
+++ b/modelexpress_client/python/tests/test_source_id.py
@@ -17,7 +17,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.6.0",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
@@ -60,7 +60,7 @@ def test_different_revision_gives_different_id():
 
 
 def test_empty_artifact_fields_preserve_existing_id():
-    assert compute_mx_source_id(_base_identity()) == "5a5f555570065064"
+    assert compute_mx_source_id(_base_identity()) == "0de5c484df9b176f"
 
 
 def test_artifact_compatibility_fields_affect_id():
@@ -144,13 +144,13 @@ def test_extra_parameters_sorted():
 # ---------------------------------------------------------------------------
 
 def test_pinned_hash_base_identity():
-    assert compute_mx_source_id(_base_identity()) == "5a5f555570065064"
+    assert compute_mx_source_id(_base_identity()) == "0de5c484df9b176f"
 
 
 def test_pinned_hash_with_revision():
     pinned = _base_identity()
     pinned.revision = "abc123def4567890"
-    assert compute_mx_source_id(pinned) == "d0c184b2a9a34c82"
+    assert compute_mx_source_id(pinned) == "6012b1c57b659ded"
 
 
 def test_case_colliding_extra_parameters_are_deterministic():
@@ -166,4 +166,4 @@ def test_case_colliding_extra_parameters_are_deterministic():
     b.extra_parameters["foo"] = "b"
     b.extra_parameters["Foo"] = "a"
     assert compute_mx_source_id(a) == compute_mx_source_id(b)
-    assert compute_mx_source_id(a) == "bf71fb9340cd940a"
+    assert compute_mx_source_id(a) == "fb4f05e4252f9c24"

--- a/modelexpress_client/python/tests/test_vllm_artifacts.py
+++ b/modelexpress_client/python/tests/test_vllm_artifacts.py
@@ -79,7 +79,7 @@ def test_torch_compile_artifact_identity_uses_model_cache_criteria(monkeypatch):
     ctx = SimpleNamespace(
         device_id=2,
         identity=p2p_pb2.SourceIdentity(
-            mx_version="0.5.0",
+            mx_version="0.6.0",
             mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
             model_name="test/model",
             backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
@@ -132,7 +132,7 @@ def test_triton_artifact_identity_uses_runtime_cache_criteria(monkeypatch):
     ctx = SimpleNamespace(
         device_id=0,
         identity=p2p_pb2.SourceIdentity(
-            mx_version="0.5.0",
+            mx_version="0.6.0",
             mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
             model_name="test/model",
             tensor_parallel_size=8,
@@ -166,7 +166,7 @@ def test_deep_gemm_artifact_identity_uses_deep_gemm_cache_criteria(monkeypatch):
     ctx = SimpleNamespace(
         device_id=0,
         identity=p2p_pb2.SourceIdentity(
-            mx_version="0.5.0",
+            mx_version="0.6.0",
             mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
             model_name="test/model",
             backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/uv.lock
+++ b/modelexpress_client/python/uv.lock
@@ -908,7 +908,7 @@ wheels = [
 
 [[package]]
 name = "modelexpress"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-crc32c" },

--- a/modelexpress_server/src/p2p/backend/redis.rs
+++ b/modelexpress_server/src/p2p/backend/redis.rs
@@ -1110,7 +1110,7 @@ mod tests {
 
     fn test_identity() -> modelexpress_common::grpc::p2p::SourceIdentity {
         modelexpress_common::grpc::p2p::SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.6.0".to_string(),
             mx_source_type: 0,
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1,
@@ -1136,7 +1136,7 @@ mod tests {
         let attr = SourceAttributesJson::from(&id);
 
         assert_eq!(attr.model_name, "deepseek-ai/DeepSeek-V3");
-        assert_eq!(attr.mx_version, "0.5.0");
+        assert_eq!(attr.mx_version, "0.6.0");
         assert_eq!(attr.tensor_parallel_size, 8);
         assert_eq!(attr.pipeline_parallel_size, 2);
         assert_eq!(attr.expert_parallel_size, 4);

--- a/modelexpress_server/src/p2p/service.rs
+++ b/modelexpress_server/src/p2p/service.rs
@@ -372,7 +372,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.6.0".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,

--- a/modelexpress_server/src/p2p/source_identity.rs
+++ b/modelexpress_server/src/p2p/source_identity.rs
@@ -100,7 +100,7 @@ mod tests {
 
     fn base_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.6.0".to_string(),
             mx_source_type: 0, // Weights (default)
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1, // vllm
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_empty_artifact_fields_preserve_existing_id() {
-        assert_eq!(compute_mx_source_id(&base_identity()), "5a5f555570065064");
+        assert_eq!(compute_mx_source_id(&base_identity()), "0de5c484df9b176f");
     }
 
     #[test]
@@ -260,14 +260,14 @@ mod tests {
     // the mismatch is caught in CI.
     #[test]
     fn test_python_cross_check_base_identity() {
-        assert_eq!(compute_mx_source_id(&base_identity()), "5a5f555570065064");
+        assert_eq!(compute_mx_source_id(&base_identity()), "0de5c484df9b176f");
     }
 
     #[test]
     fn test_python_cross_check_with_revision() {
         let mut pinned = base_identity();
         pinned.revision = "abc123def4567890".to_string();
-        assert_eq!(compute_mx_source_id(&pinned), "d0c184b2a9a34c82");
+        assert_eq!(compute_mx_source_id(&pinned), "6012b1c57b659ded");
     }
 
     #[test]
@@ -283,7 +283,7 @@ mod tests {
             .insert("Foo".to_string(), "a".to_string());
         id.extra_parameters
             .insert("foo".to_string(), "b".to_string());
-        assert_eq!(compute_mx_source_id(&id), "bf71fb9340cd940a");
+        assert_eq!(compute_mx_source_id(&id), "fb4f05e4252f9c24");
     }
 
     #[test]

--- a/modelexpress_server/src/p2p/state.rs
+++ b/modelexpress_server/src/p2p/state.rs
@@ -217,7 +217,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.6.0".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,


### PR DESCRIPTION
Post release/0.5.0 branch cut. Bumps workspace/chart/Python versions and mx_version test fixtures, and recomputes the three pinned mx_source_id hashes in test_source_id.py and source_identity.rs per the versioning runbook in CLAUDE.md. Public image-tag references untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application, packages, and deployment chart to version 0.6.0.
  * Updated metadata examples and source identity records to use version 0.6.0.

* **Tests**
  * Updated identity fixtures, artifact scenarios, and expected source IDs to reflect the 0.6.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->