### PR TITLE
fix(helm): stamp release namespace on Ingress

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "modelexpress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "modelexpress.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/workspace-tests/tests/helm_namespace_scope.rs
+++ b/workspace-tests/tests/helm_namespace_scope.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::expect_used)]
+
+//! Static checks over the Helm chart templates.
+//!
+//! Every namespaced resource the chart renders must stamp the release namespace
+//! onto `metadata.namespace`, so that `helm template | kubectl apply -f -` places
+//! the whole release in one namespace rather than splitting it across the
+//! rendered namespace and the caller's current context.
+//!
+//! These operate on the template source rather than on `helm template` output so
+//! they run under plain `cargo test` without a helm binary, and so they also
+//! cover templates gated off by default (an unrendered template is exactly how
+//! the `ingress.yaml` gap went unnoticed).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Kinds that live outside any namespace. Anything not listed here is treated as
+/// namespaced, so a template introducing an unrecognized kind fails until someone
+/// classifies it. Failing closed is the point: the alternative, an allowlist of
+/// namespaced kinds, silently skips whatever it does not know about.
+const CLUSTER_SCOPED_KINDS: &[&str] = &[
+    "APIService",
+    "ClusterRole",
+    "ClusterRoleBinding",
+    "CustomResourceDefinition",
+    "IngressClass",
+    "MutatingWebhookConfiguration",
+    "Namespace",
+    "PersistentVolume",
+    "PriorityClass",
+    "StorageClass",
+    "ValidatingWebhookConfiguration",
+];
+
+/// `metadata.namespace` sits at two-space indent. Matching on the indent keeps
+/// this from being satisfied by a deeper `namespace:` such as the one under a
+/// RoleBinding's `subjects`.
+const METADATA_NAMESPACE_LINE: &str = "  namespace: {{ .Release.Namespace }}";
+
+fn templates_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace-tests has a parent directory")
+        .join("helm/templates")
+}
+
+fn yaml_templates(dir: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let entries = fs::read_dir(dir).unwrap_or_else(|e| panic!("read {}: {e}", dir.display()));
+    for entry in entries {
+        let path = entry.expect("readable directory entry").path();
+        if path.is_dir() {
+            found.extend(yaml_templates(&path));
+        } else if path.extension().is_some_and(|ext| ext == "yaml") {
+            found.push(path);
+        }
+    }
+    found.sort();
+    found
+}
+
+/// Split a template into YAML documents and return the top-level `kind` of each
+/// alongside its text. Requiring `kind:` at column zero skips the nested `kind:`
+/// keys under `roleRef` and `subjects`.
+fn documents_with_kind(contents: &str) -> Vec<(String, String)> {
+    contents
+        .split('\n')
+        .fold(vec![String::new()], |mut docs, line| {
+            if line.trim_end() == "---" {
+                docs.push(String::new());
+            } else {
+                let current = docs.last_mut().expect("fold seeds one document");
+                current.push_str(line);
+                current.push('\n');
+            }
+            docs
+        })
+        .into_iter()
+        .filter_map(|doc| {
+            let kind = doc
+                .lines()
+                .find_map(|line| line.strip_prefix("kind: "))?
+                .trim()
+                .to_string();
+            Some((kind, doc))
+        })
+        .collect()
+}
+
+#[test]
+fn namespaced_resources_stamp_the_release_namespace() {
+    let dir = templates_dir();
+    let mut checked = 0;
+    let mut missing = Vec::new();
+
+    for path in yaml_templates(&dir) {
+        let contents =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        for (kind, doc) in documents_with_kind(&contents) {
+            if CLUSTER_SCOPED_KINDS.contains(&kind.as_str()) {
+                continue;
+            }
+            checked += 1;
+            if !doc.lines().any(|line| line == METADATA_NAMESPACE_LINE) {
+                missing.push(format!("{} ({kind})", path.display()));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "namespaced resources missing `{METADATA_NAMESPACE_LINE}` in their metadata block: {missing:#?}\n\
+         If a listed kind is actually cluster-scoped, add it to CLUSTER_SCOPED_KINDS instead."
+    );
+    assert!(
+        checked > 0,
+        "no namespaced resources found under {} - the template scan is broken",
+        dir.display()
+    );
+}
+
+#[test]
+fn cluster_scoped_resources_omit_the_release_namespace() {
+    for path in yaml_templates(&templates_dir()) {
+        let contents =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        for (kind, doc) in documents_with_kind(&contents) {
+            if !CLUSTER_SCOPED_KINDS.contains(&kind.as_str()) {
+                continue;
+            }
+            assert!(
+                !doc.lines().any(|line| line == METADATA_NAMESPACE_LINE),
+                "{} ({kind}) is cluster-scoped but sets metadata.namespace; the API server rejects that",
+                path.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`templates/ingress.yaml` is the only namespaced resource in the chart rendered without `metadata.namespace`.

PR #472 ("add namespace to Helm resources and auto-set MX_METADATA_NAMESPACE") added `namespace: {{ .Release.Namespace }}` to every namespaced resource — but its diff touched 6 template files and `ingress.yaml` was not among them:

```
helm/templates/deployment.yaml            | 13 ++++++++---
helm/templates/pvc.yaml                   |  1 +
helm/templates/rbac.yaml                  |  2 ++
helm/templates/service.yaml               |  1 +
helm/templates/serviceaccount.yaml        |  1 +
helm/templates/tests/test-connection.yaml |  1 +
```

Full inventory of what the chart can render — 8 namespaced kinds, 7 covered, plus 1 cluster-scoped kind that correctly has no namespace:

| kind | scope | `metadata.namespace` before this PR |
|---|---|---|
| Deployment / Service / PersistentVolumeClaim | namespaced | yes |
| ServiceAccount / Role / RoleBinding | namespaced | yes |
| Pod (test-connection) | namespaced | yes |
| **Ingress** | namespaced | **no** |
| ClusterRoleBinding | cluster-scoped | correctly absent |

## Impact

`helm install -n X` and `kubectl apply -n X` supply the namespace through the API request path, which masks the missing field. It surfaces with `helm template -n X | kubectl apply -f -` (no `-n`): the Ingress lands in the caller's current-context namespace while every other resource lands in `X`.

Because `spec.rules[].http.paths[].backend.service.name` resolves only within the Ingress's own namespace — there is no syntax for a cross-namespace backend — the backing Service is unreachable and the ingress controller serves 503. Every resource applies successfully and nothing reports an error, so the failure is silent.

`ingress.enabled` defaults to `false`, so this is low severity, but it is a genuine completeness gap in #472's stated scope.

## Fix

One line in `templates/ingress.yaml`, matching `service.yaml:8` and the other namespaced templates. This closes the whole class for this chart, not just the reported symptom — see the inventory above.

## Tests

`ingress.enabled: false` means the template never renders in a default `helm template`, which is exactly how the gap survived review — and why a test over rendered output would miss it the same way. `workspace-tests/tests/helm_namespace_scope.rs` therefore checks the **template source**:

- `namespaced_resources_stamp_the_release_namespace` — every namespaced resource carries `namespace: {{ .Release.Namespace }}` in its metadata block
- `cluster_scoped_resources_omit_the_release_namespace` — cluster-scoped resources do not

Two design notes:

- Kind classification is a **cluster-scoped denylist**, not a namespaced allowlist. An unrecognized kind is treated as namespaced and fails until someone classifies it. Adding an HPA / PDB / ServiceMonitor and forgetting the namespace line turns the test red rather than being silently skipped.
- The match is anchored to two-space indent, so a RoleBinding's four-space `subjects[].namespace` (`rbac.yaml:43`) cannot mask a missing `metadata.namespace`.

These run under plain `cargo test` in the existing `model-express-workspace-tests` crate — no new CI job and no helm binary required.

### Verification

| check | result |
|---|---|
| `cargo test --test helm_namespace_scope` | 2 passed |
| same, with the `ingress.yaml` line reverted | `namespaced_resources_...` FAILS, `cluster_scoped_...` still passes |
| `cargo clippy -p model-express-workspace-tests --tests` | clean |
| `cargo fmt --check` | clean |

The second row is the one that matters: it confirms the test is not vacuously passing and goes red on precisely this defect.

`helm template` was not run directly — no helm binary was available in the authoring environment. The change is a one-line addition to a metadata block, structurally identical to `service.yaml:8`, so rendering is unambiguous; but a reviewer with helm may want to confirm with:

```bash
helm template mx helm/ -n mx-qa-0500 --set ingress.enabled=true | \
  grep -A3 'kind: Ingress'
```

## Out of scope

`rbac.yaml:54` names the cluster-scoped ClusterRoleBinding `{{ include "modelexpress.fullname" . }}-auth-delegator`, with no namespace component. Two same-named releases in different namespaces collide on that single cluster-wide name, and the later install can strip the earlier one's TokenReview permissions. That came in with #424, has a different trigger and blast radius, and is left for a separate PR to keep this one cleanly revertable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Helm-managed Ingress resources are now consistently assigned to the release namespace, improving deployment reliability across namespaces.

* **Tests**
  * Added validation to ensure namespaced resources specify the release namespace while cluster-scoped resources remain namespace-free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->