### PR TITLE
chore(codeowners): assign license policy to devops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Supply-chain and ownership policy require DevOps review.
+/.github/CODEOWNERS @ai-dynamo/devops
+/deny.toml            @ai-dynamo/devops


### PR DESCRIPTION
## Summary

- add a repository CODEOWNERS policy
- assign `@ai-dynamo/devops` to review changes to `.github/CODEOWNERS`
- assign `@ai-dynamo/devops` to review changes to `deny.toml`

## Validation

- confirmed `.github/CODEOWNERS` resolves to `@ai-dynamo/devops`
- confirmed `deny.toml` resolves to `@ai-dynamo/devops`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added licensing and copyright information to repository ownership configuration.
  * Updated review ownership rules for key repository configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->