### PR TITLE
perf(reshard-refit): overlap peer RDMA reads during a reshard pull

### DIFF
--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -876,11 +876,17 @@ class NixlTransferManager:
 
     def _release_xfer_handle(self, handle: Any) -> None:
         """Release one handle, never raising. Used on cleanup paths where a
-        release failure must not mask the error that got us here."""
+        release failure must not mask the error that got us here.
+
+        Logged at WARNING rather than DEBUG: a refused release leaks the
+        descriptor list backing the transfer, and because every caller is a
+        cleanup path the leak has no other symptom. At DEBUG it is invisible in
+        production, where nobody runs the client at that level.
+        """
         try:
             self._agent.release_xfer_handle(handle)
         except Exception as exc:  # noqa: BLE001 - cleanup must not mask the cause
-            logger.debug("release_xfer_handle failed: %r", exc)
+            logger.warning("release_xfer_handle failed, handle leaked: %r", exc)
 
     def await_read_batches(
         self,

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -79,6 +80,22 @@ def _pool_reg_enabled() -> bool:
     return envs.MX_POOL_REG
 
 
+@dataclass
+class PostedRead:
+    """A batched RDMA READ that has been posted but not yet waited on.
+
+    Held by the caller between ``post_read_batch`` and ``await_read_batches`` so
+    several peers can have transfers in flight at once. The handle is owned by
+    ``await_read_batches``, which releases it.
+    """
+
+    handle: Any
+    remote_agent_name: str
+    total_bytes: int
+    num_ranges: int
+    posted_at: float = field(default_factory=time.perf_counter)
+
+
 class NixlTransferManager:
     """
     Manages a single NIXL agent and RDMA transfers.
@@ -118,6 +135,16 @@ class NixlTransferManager:
     def agent_name(self) -> str:
         """Get NIXL agent name."""
         return self._agent_name
+
+    @property
+    def backends(self) -> list[str]:
+        """NIXL backends this agent was created with (see MX_NIXL_BACKEND).
+
+        Callers that issue their own NIXL calls against :attr:`agent` must pass
+        this rather than a literal, or the transfer is prepared on a backend the
+        agent does not have (e.g. UCX on AWS EFA).
+        """
+        return list(self._backends)
 
     @property
     def nixl_metadata(self) -> bytes:
@@ -444,6 +471,41 @@ class NixlTransferManager:
 
         return sorted(seen.items())
 
+    def _wait_for_xfers(
+        self,
+        handles: list,
+        timeout_seconds: float | None,
+        label: str,
+    ) -> None:
+        """Poll several NIXL handles until all complete or one fails.
+
+        Sleeps only when a full sweep completed nothing, so the polling slop is
+        paid once for the whole set rather than once per handle.
+        """
+        if self._agent is None:
+            raise RuntimeError("NIXL agent not initialized")
+        pending = list(handles)
+        wait_start = time.perf_counter()
+        while pending:
+            if (
+                timeout_seconds is not None
+                and time.perf_counter() - wait_start >= timeout_seconds
+            ):
+                raise TimeoutError(
+                    f"{label} timed out with {len(pending)} transfer(s) outstanding"
+                )
+            still_pending = []
+            for handle in pending:
+                status = self._agent.check_xfer_state(handle)
+                if status in ("DONE", "SUCCESS"):
+                    continue
+                if status in ("ERR", "ERROR", "FAIL"):
+                    raise RuntimeError(f"{label} failed with status {status}")
+                still_pending.append(handle)
+            if len(still_pending) == len(pending):
+                time.sleep(0.001)
+            pending = still_pending
+
     def _wait_for_xfer(
         self,
         handle: Any,
@@ -714,13 +776,35 @@ class NixlTransferManager:
         exact sub-tensor runs a reshard pull needs - one dest param filled from
         many non-contiguous source segments across a single READ.
 
+        Equivalent to ``post_read_batch`` followed immediately by
+        ``await_read_batches``, i.e. one peer at a time. Prefer posting several
+        batches and awaiting them together when reading from multiple peers.
+
         Returns ``(total_bytes, num_reads, duration)``.
+        """
+        posted = self.post_read_batch(remote_agent_name, ranges, mem_type=mem_type)
+        if posted is None:
+            return 0, 0, 0.0
+        return self.await_read_batches([posted], timeout_seconds=timeout_seconds)
+
+    def post_read_batch(
+        self,
+        remote_agent_name: str,
+        ranges: list[tuple[int, int, int, int]],
+        mem_type: str | None = None,
+    ) -> PostedRead | None:
+        """Prepare and post one batched RDMA READ **without** waiting for it.
+
+        Same ``ranges`` contract as :meth:`execute_read_batch`. Returns ``None``
+        when there are no bytes to move. Every returned :class:`PostedRead` must
+        be handed to :meth:`await_read_batches`, which owns releasing the handle;
+        dropping one leaks it.
         """
         if self._agent is None:
             raise RuntimeError("NIXL agent not initialized")
         ranges = [r for r in ranges if r[2] > 0]
         if not ranges:
-            return 0, 0, 0.0
+            return None
 
         mem = mem_type or self._accelerator_backend.nixl_mem_type
         remote_descs = [
@@ -741,7 +825,7 @@ class NixlTransferManager:
             except Exception as exc:  # noqa: BLE001 - diagnostics must never break the transfer
                 _known = f"n/a ({exc!r})"
             logger.debug(
-                "execute_read_batch: agent=%s mem=%s reads=%d remote_metadata_loaded=%s remote_sample=%s local_dev=%d",
+                "post_read_batch: agent=%s mem=%s reads=%d remote_metadata_loaded=%s remote_sample=%s local_dev=%d",
                 remote_agent_name,
                 mem,
                 len(remote_descs),
@@ -750,7 +834,7 @@ class NixlTransferManager:
                 self._device_id,
             )
 
-        start_time = time.perf_counter()
+        posted_at = time.perf_counter()
         handle = None
         try:
             src_prepped = self._agent.prep_xfer_dlist(
@@ -775,19 +859,62 @@ class NixlTransferManager:
                 backends=self._backends,
             )
             self._agent.transfer(handle)
+        except Exception:
+            # Nothing is in flight for this batch, so drop its handle here rather
+            # than handing a dead batch to await_read_batches.
+            if handle is not None:
+                self._release_xfer_handle(handle)
+            raise
 
-            self._wait_for_xfer(
-                handle,
+        return PostedRead(
+            handle=handle,
+            remote_agent_name=remote_agent_name,
+            total_bytes=sum(nbytes for (_r, _l, nbytes, _d) in ranges),
+            num_ranges=len(ranges),
+            posted_at=posted_at,
+        )
+
+    def _release_xfer_handle(self, handle: Any) -> None:
+        """Release one handle, never raising. Used on cleanup paths where a
+        release failure must not mask the error that got us here."""
+        try:
+            self._agent.release_xfer_handle(handle)
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask the cause
+            logger.debug("release_xfer_handle failed: %r", exc)
+
+    def await_read_batches(
+        self,
+        posted: list,
+        timeout_seconds: float | None = None,
+    ) -> tuple[int, int, float]:
+        """Wait for posted READ batches to complete, then release every handle.
+
+        Accepts ``None`` entries so callers can pass ``post_read_batch`` results
+        straight through. Releases all handles even when one transfer fails, and
+        synchronizes the device once for the whole set rather than per batch.
+
+        Returns ``(total_bytes, num_reads, duration)`` aggregated over the set.
+        """
+        batches = [p for p in posted if p is not None]
+        if not batches:
+            return 0, 0, 0.0
+
+        try:
+            self._wait_for_xfers(
+                [p.handle for p in batches],
                 timeout_seconds,
                 "NIXL reshard READ batch",
             )
         finally:
-            if handle is not None:
-                self._agent.release_xfer_handle(handle)
+            for batch in batches:
+                self._release_xfer_handle(batch.handle)
 
         self._accelerator_backend.synchronize(self._device_id)
-        total_bytes = sum(nbytes for (_r, _l, nbytes, _d) in ranges)
-        return total_bytes, len(ranges), time.perf_counter() - start_time
+        return (
+            sum(p.total_bytes for p in batches),
+            sum(p.num_ranges for p in batches),
+            time.perf_counter() - min(p.posted_at for p in batches),
+        )
 
     def register_dram_buffer(self, buffer: torch.Tensor) -> Any:
         """Register one CPU buffer as NIXL DRAM and refresh agent metadata."""

--- a/modelexpress_client/python/modelexpress/refit/reshard/transport/nixl.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/transport/nixl.py
@@ -15,12 +15,27 @@ exchange happens out-of-band (see ``refit.reshard.rendezvous``), which yields th
 ``session -> remote agent name`` and ``session -> remote device id`` maps this
 transport is constructed with. Each ``session`` is one published shard's owning
 agent; descriptors are grouped per session into one batched READ.
+
+Those per-session batches are posted **together** and awaited as a set, so a
+receiver pulling from N trainers has N transfers in flight instead of draining
+one peer before starting the next. Set ``MX_RESHARD_SERIAL_READS=1`` to restore
+the one-peer-at-a-time behavior (baseline A/B only).
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from collections import defaultdict
 from typing import Any
+
+logger = logging.getLogger("modelexpress.refit.reshard.transport.nixl")
+
+
+def _serial_reads_enabled() -> bool:
+    """Whether to drain each peer before posting the next. Read at call time so
+    an A/B can toggle it without re-importing."""
+    return os.environ.get("MX_RESHARD_SERIAL_READS", "0") not in ("", "0", "false")
 
 
 class NixlReshardTransport:
@@ -59,24 +74,68 @@ class NixlReshardTransport:
         by_session: dict = defaultdict(list)
         for d in descriptors:
             by_session[d.session].append(d)
+        if not by_session:
+            return
 
-        for session, group in by_session.items():
-            agent = self._session_to_agent.get(session)
-            if agent is None:
-                raise KeyError(
-                    f"no remote NIXL agent registered for session {session!r}"
+        batches = [
+            (self._agent_for(session), self._ranges_for(session, group))
+            for session, group in by_session.items()
+        ]
+
+        if _serial_reads_enabled():
+            for agent, ranges in batches:
+                total_bytes, num_reads, _duration = self._manager.execute_read_batch(
+                    remote_agent_name=agent,
+                    ranges=ranges,
+                    mem_type=self._mem_type,
+                    timeout_seconds=self._timeout,
                 )
-            if session not in self._session_to_device:
-                raise KeyError(
-                    f"no remote device id registered for session {session!r}"
+                self.bytes_moved += total_bytes
+                self.reads_issued += num_reads
+            return
+
+        posted: list = []
+        try:
+            for agent, ranges in batches:
+                posted.append(
+                    self._manager.post_read_batch(
+                        remote_agent_name=agent,
+                        ranges=ranges,
+                        mem_type=self._mem_type,
+                    )
                 )
-            device_id = self._session_to_device[session]
-            ranges = [(d.src_addr, d.dst_addr, d.nbytes, device_id) for d in group]
-            total_bytes, num_reads, _duration = self._manager.execute_read_batch(
-                remote_agent_name=agent,
-                ranges=ranges,
-                mem_type=self._mem_type,
-                timeout_seconds=self._timeout,
-            )
-            self.bytes_moved += total_bytes
-            self.reads_issued += num_reads
+        except Exception:
+            # Batches posted before the failure are in flight and still own
+            # handles. Drain them so nothing leaks, but never let that cleanup
+            # replace the original error.
+            if posted:
+                try:
+                    self._manager.await_read_batches(
+                        posted, timeout_seconds=self._timeout
+                    )
+                except Exception as exc:  # noqa: BLE001 - cleanup must not mask
+                    logger.warning(
+                        "draining %d posted READ batch(es) after a post failure "
+                        "did not complete cleanly: %r",
+                        len(posted),
+                        exc,
+                    )
+            raise
+
+        total_bytes, num_reads, _duration = self._manager.await_read_batches(
+            posted, timeout_seconds=self._timeout
+        )
+        self.bytes_moved += total_bytes
+        self.reads_issued += num_reads
+
+    def _agent_for(self, session: Any) -> str:
+        agent = self._session_to_agent.get(session)
+        if agent is None:
+            raise KeyError(f"no remote NIXL agent registered for session {session!r}")
+        if session not in self._session_to_device:
+            raise KeyError(f"no remote device id registered for session {session!r}")
+        return agent
+
+    def _ranges_for(self, session: Any, group: list) -> list:
+        device_id = self._session_to_device[session]
+        return [(d.src_addr, d.dst_addr, d.nbytes, device_id) for d in group]

--- a/modelexpress_client/python/tests/test_reshard_refit_nixl_transport.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_nixl_transport.py
@@ -3,13 +3,16 @@
 #
 """NixlReshardTransport dispatch logic - no NIXL, no GPU.
 
-A stub manager records execute_read_batch calls so we can assert the transport
+A stub manager records post/await/execute calls so we can assert the transport
 groups descriptors per session into one batch, resolves session -> remote agent
-+ device, and forms the right (remote_addr, local_addr, nbytes, device) ranges.
-The actual RDMA is exercised by the on-cluster smoke harness.
++ device, forms the right (remote_addr, local_addr, nbytes, device) ranges, and
+posts every peer's batch before waiting on any of them. The actual RDMA is
+exercised by the on-cluster smoke harness.
 
 Run: pytest tests/test_reshard_refit_nixl_transport.py
 """
+
+from dataclasses import dataclass
 
 import pytest
 
@@ -19,50 +22,162 @@ from modelexpress.refit.reshard.transport import (
 )
 
 
+@dataclass
+class _StubPosted:
+    remote_agent_name: str
+    total_bytes: int
+    num_ranges: int
+
+
 class _StubManager:
-    def __init__(self):
+    """Records the call sequence so ordering can be asserted, not just counts."""
+
+    def __init__(self, fail_post_on: str | None = None):
         self.calls = []  # (remote_agent_name, ranges, mem_type, timeout)
+        self.events = []  # ("post", agent) / ("await", n) / ("execute", agent)
+        self.released = 0
+        self._fail_post_on = fail_post_on
+
+    def post_read_batch(self, remote_agent_name, ranges, mem_type=None):
+        if remote_agent_name == self._fail_post_on:
+            raise RuntimeError(f"prep failed for {remote_agent_name}")
+        self.calls.append((remote_agent_name, list(ranges), mem_type, None))
+        self.events.append(("post", remote_agent_name))
+        return _StubPosted(
+            remote_agent_name=remote_agent_name,
+            total_bytes=sum(n for (_r, _l, n, _d) in ranges),
+            num_ranges=len(ranges),
+        )
+
+    def await_read_batches(self, posted, timeout_seconds=None):
+        batches = [p for p in posted if p is not None]
+        self.events.append(("await", len(batches)))
+        self.released += len(batches)
+        return (
+            sum(p.total_bytes for p in batches),
+            sum(p.num_ranges for p in batches),
+            0.0,
+        )
 
     def execute_read_batch(
         self, remote_agent_name, ranges, mem_type=None, timeout_seconds=None
     ):
         self.calls.append((remote_agent_name, list(ranges), mem_type, timeout_seconds))
+        self.events.append(("execute", remote_agent_name))
         total = sum(n for (_r, _l, n, _d) in ranges)
         return total, len(ranges), 0.0
 
 
-def test_groups_per_session_and_resolves_agent_device():
-    mgr = _StubManager()
-    transport = NixlReshardTransport(
+def _two_session_descriptors():
+    return [
+        ReadDescriptor(session="sA", src_addr=1000, dst_addr=10, nbytes=16),
+        ReadDescriptor(session="sB", src_addr=2000, dst_addr=20, nbytes=8),
+        ReadDescriptor(session="sA", src_addr=1016, dst_addr=26, nbytes=16),
+    ]
+
+
+def _transport(mgr, **kwargs):
+    return NixlReshardTransport(
         manager=mgr,
         session_to_agent={"sA": "trainer-agent-A", "sB": "trainer-agent-B"},
         session_to_device={"sA": 3, "sB": 5},
         mem_type="VRAM",
         timeout_seconds=30.0,
+        **kwargs,
     )
 
-    descriptors = [
-        ReadDescriptor(session="sA", src_addr=1000, dst_addr=10, nbytes=16),
-        ReadDescriptor(session="sB", src_addr=2000, dst_addr=20, nbytes=8),
-        ReadDescriptor(session="sA", src_addr=1016, dst_addr=26, nbytes=16),
-    ]
-    transport.read(descriptors)
+
+def test_groups_per_session_and_resolves_agent_device():
+    mgr = _StubManager()
+    _transport(mgr).read(_two_session_descriptors())
 
     # One batched READ per session.
     assert len(mgr.calls) == 2
     by_agent = {c[0]: c for c in mgr.calls}
 
-    _a_agent, a_ranges, a_mem, a_timeout = by_agent["trainer-agent-A"]
-    assert a_mem == "VRAM" and a_timeout == 30.0
+    _a_agent, a_ranges, a_mem, _a_timeout = by_agent["trainer-agent-A"]
+    assert a_mem == "VRAM"
     # (remote_addr, local_addr, nbytes, remote_device_id); device 3 for sA.
     assert a_ranges == [(1000, 10, 16, 3), (1016, 26, 16, 3)]
 
     _b_agent, b_ranges, _m, _t = by_agent["trainer-agent-B"]
     assert b_ranges == [(2000, 20, 8, 5)]
 
-    # Stats accumulate across sessions.
+
+def test_stats_accumulate_across_sessions():
+    mgr = _StubManager()
+    transport = _transport(mgr)
+    transport.read(_two_session_descriptors())
+
     assert transport.bytes_moved == 16 + 16 + 8
     assert transport.reads_issued == 3
+
+
+def test_all_peers_posted_before_any_wait():
+    """The point of the post/wait split: N peers in flight, not one at a time."""
+    mgr = _StubManager()
+    _transport(mgr).read(_two_session_descriptors())
+
+    kinds = [kind for kind, _ in mgr.events]
+    assert kinds == ["post", "post", "await"], mgr.events
+    # Nothing was drained peer-by-peer.
+    assert "execute" not in kinds
+
+
+def test_every_posted_batch_is_awaited():
+    mgr = _StubManager()
+    _transport(mgr).read(_two_session_descriptors())
+
+    posted = sum(1 for kind, _ in mgr.events if kind == "post")
+    assert mgr.released == posted
+
+
+def test_serial_env_restores_one_peer_at_a_time(monkeypatch):
+    monkeypatch.setenv("MX_RESHARD_SERIAL_READS", "1")
+    mgr = _StubManager()
+    transport = _transport(mgr)
+    transport.read(_two_session_descriptors())
+
+    # Drains each peer inline; never uses the post/await path.
+    assert [kind for kind, _ in mgr.events] == ["execute", "execute"]
+    assert transport.bytes_moved == 16 + 16 + 8
+    assert transport.reads_issued == 3
+    # Serial mode is the only path that forwards the timeout per batch.
+    assert all(call[3] == 30.0 for call in mgr.calls)
+
+
+def test_post_failure_drains_already_posted_batches():
+    """A mid-loop post failure must not leak the handles already in flight."""
+    mgr = _StubManager(fail_post_on="trainer-agent-B")
+    with pytest.raises(RuntimeError, match="prep failed"):
+        _transport(mgr).read(_two_session_descriptors())
+
+    # The successful post was awaited (and therefore released) on the way out.
+    assert ("await", 1) in mgr.events
+    assert mgr.released == 1
+
+
+def test_drain_failure_does_not_mask_post_failure(monkeypatch):
+    mgr = _StubManager(fail_post_on="trainer-agent-B")
+
+    def _boom(posted, timeout_seconds=None):
+        raise RuntimeError("drain blew up")
+
+    monkeypatch.setattr(mgr, "await_read_batches", _boom)
+
+    # The original post failure surfaces, not the cleanup failure.
+    with pytest.raises(RuntimeError, match="prep failed"):
+        _transport(mgr).read(_two_session_descriptors())
+
+
+def test_no_descriptors_is_a_noop():
+    mgr = _StubManager()
+    transport = _transport(mgr)
+    transport.read([])
+
+    assert mgr.events == []
+    assert transport.bytes_moved == 0
+    assert transport.reads_issued == 0
 
 
 def test_missing_agent_raises():


### PR DESCRIPTION
## What this changes

A generator rank pulling its weight slices from many trainer ranks used to
transfer from one trainer at a time. It posted a batched remote direct memory
access (RDMA) READ to the first peer, waited for that read to finish, and only
then posted the read to the second peer. With sixteen publishing ranks that is
sixteen transfers in a chain, and a single slow peer stalls every peer queued
behind it.

This splits the batched READ into two halves. `post_read_batch` prepares and
issues one peer's transfer and returns a handle. `await_read_batches` waits on a
set of those handles and releases all of them. The reshard transport now posts
every peer's batch first and waits on the set, so N peers are in flight at once.

`execute_read_batch` is kept and reimplemented as a post immediately followed by
a wait, so callers outside the reshard path are unchanged.

```mermaid
sequenceDiagram
    participant R as Receiver
    participant A as Trainer A
    participant B as Trainer B
    Note over R,B: Before - one peer at a time
    R->>A: post READ batch
    A-->>R: complete
    R->>B: post READ batch
    B-->>R: complete
    Note over R,B: After - both in flight
    R->>A: post READ batch
    R->>B: post READ batch
    A-->>R: complete
    B-->>R: complete
```

## Why

Wire time is the dominant cost of a reinforcement-learning weight refit, and
link utilization on this path sat at roughly 37% of the measured per-rank
ceiling. Serialization across peers was the most plausible cause with the
cheapest fix.

## Measured result

**Validated** on Topology A: Qwen3-30B-A3B in BF16, sixteen Megatron trainer
ranks (tensor parallel 2, expert parallel 4, data parallel 8) publishing to
sixteen vLLM generator ranks (tensor parallel 4, four replicas), on AWS EKS with
Elastic Fabric Adapter and the NIXL `LIBFABRIC` backend. Eleven refit steps,
sixteen ranks reporting, 176 stage records.

| metric | serial baseline | this change | delta |
| :-- | --: | --: | --: |
| warm wire median | 1.683 s | 1.474 s | -12.4% (1.14x) |
| warm wire p95 | 2.70 s (1.6x median) | 1.836 s (1.25x median) | variance halved |
| slowest-rank tax | 0.44 s | 0.380 s | -0.06 s |
| raw throughput | 142.3 Gbps (37%) | 161.6 Gbps (42%) | +19.3 Gbps |

The baseline is the median of four independent warm captures spanning
1.674 s to 1.776 s across a full environment rebuild, so the 0.209 s delta is
roughly twenty times the reproducibility spread.

The p95 result is the one that confirms the mechanism. Removing a serial chain
should compress the tail before it moves the median, and it did.

**Not claimed.** The gain is smaller than the roughly 0.54 s a pure
serialization model predicts. The refit issues two `transport.read()` calls, one
for exact segments and one for full-pull staging, and those two calls remain
sequential with respect to each other. This change parallelizes within each
phase and leaves the phase boundary intact. Posting both phases as one batch is
a separate follow-up.

This change moves no additional bytes and changes no plan. It is a scheduling
change only.

## Safety

Three failure modes were designed for explicitly, and each has a test.

- A transfer handle is owned by `await_read_batches`. Dropping a `PostedRead`
  without awaiting it leaks the handle, so the transport awaits every batch it
  posted on every exit path.
- When a mid-loop post fails, the batches already posted are in flight. The
  transport drains them before re-raising.
- A failure during that drain must not replace the original error. The drain is
  logged at WARNING and the original exception propagates.

`MX_RESHARD_SERIAL_READS=1` restores the previous behavior. It is read at call
time, so an A/B does not need a re-import. It is retained deliberately: without
it there is no way to attribute a future regression to this change short of a
revert.

## Reviewer guide

Three files, +344 / -43. Suggested order, highest value first.

| Priority | File | Size | What to check |
| :-- | :-- | --: | :-- |
| 1 | `refit/reshard/transport/nixl.py` | +95 / -22 | The whole point of the change. `read()` builds all batches, posts all, awaits the set. Check the `except` block around the post loop: it drains what it posted and re-raises the original. |
| 2 | `nixl_transfer.py` | +145 / -8 | `post_read_batch` and `await_read_batches` are the new API; `execute_read_batch` is now a thin wrapper over both. Check that `_release_xfer_handle` never raises and that `await_read_batches` releases in a `finally`. |
| 3 | `tests/test_reshard_refit_nixl_transport.py` | +147 / -16 | Runs on CPU with no NIXL, no GPU. Start at `test_all_peers_posted_before_any_wait`, which asserts the event order is post, post, await rather than counting calls. |

Points worth a second look:

- `_wait_for_xfers` sleeps only when a full sweep of the handle set completed
  nothing, so polling slop is paid once for the set rather than once per handle.
  The single-handle `_wait_for_xfer` is unchanged.
- `await_read_batches` reports duration from the earliest post, not from the
  wait, so the reported wire time still covers the whole overlapped window.
- The new `backends` property exists because a caller issuing its own NIXL calls
  against the agent must use the backend the agent was created with. Passing a
  literal breaks on Elastic Fabric Adapter, where the backend is `LIBFABRIC`
  rather than `UCX`.
- `execute_read_batch` returning `(0, 0, 0.0)` for an empty range list is
  preserved; `post_read_batch` signals the same case by returning `None`, and
  `await_read_batches` accepts `None` entries so callers can pass results
  straight through.

## Testing

Ten transport tests pass, and the wider reshard and refit suite is green at
69 passed. All are CPU-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved resharding read performance by posting transfers across multiple sessions before waiting for completion.
  * Added optional serial-read mode through the `MX_RESHARD_SERIAL_READS` setting.
  * Added aggregated transfer statistics across batched reads.

* **Bug Fixes**
  * Improved cleanup when transfer posting or completion fails.
  * Ensured failures during cleanup do not hide the original error.

* **Tests**
  * Expanded coverage for batching, ordering, serial mode, failure handling, and empty reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->