### PR TITLE
perf(reshard-refit): issue the three refit read phases as one batch

### DIFF
--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -150,6 +150,7 @@ register_modelexpress_loaders()
 | `MX_ARTIFACT_READY_TIMEOUT_SECS` | `1800` | Maximum time to wait for readiness and successful artifact publication |
 | `MX_HEARTBEAT_INTERVAL_SECS` | `30` | Seconds between READY status heartbeats for published sources, including reshard rendezvous sources; keep below the server heartbeat timeout |
 | `MX_RESHARD_MAX_SEGMENTS_PER_COPY` | `64` | Maximum exact descriptors for one no-gather refit copy before a compatible dim-0-sharded source is pulled once into contiguous staging and sliced locally |
+| `MX_RESHARD_FUSED_WIRE` | `1` | Issue a refit's exact-segment, full-pull, and convert reads as one transport batch instead of draining each phase in turn. Set to `0` to restore the phased reads for an A/B comparison |
 
 ### UCX/NIXL Tuning
 

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     MX_MODEL_REVISION: str
     MX_MODEL_URI: Optional[str]
     MX_P2P_METADATA: str
+    MX_RESHARD_FUSED_WIRE: bool
     # Kubernetes service backend
     MX_K8S_SERVICE_PATTERN: str
     MX_K8S_SOURCE_RETRIES: str
@@ -149,6 +150,20 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    """Parse a bool env var, falling back to ``default`` (and warning) on error."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+    return default
+
+
 # One entry per variable. The lambda owns the default and parsing; callers that
 # need a site-specific default receive the raw value (``None`` when unset) and
 # apply their own fallback.
@@ -175,6 +190,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_MODEL_REVISION": lambda: os.environ.get("MX_MODEL_REVISION", ""),
     "MX_MODEL_URI": lambda: os.environ.get("MX_MODEL_URI"),
     "MX_P2P_METADATA": lambda: os.environ.get("MX_P2P_METADATA", "1"),
+    "MX_RESHARD_FUSED_WIRE": lambda: _env_bool("MX_RESHARD_FUSED_WIRE", True),
     # ── Kubernetes service backend ─────────────────────────────────────────
     "MX_K8S_SERVICE_PATTERN": lambda: os.environ.get("MX_K8S_SERVICE_PATTERN", "mx-sources"),
     "MX_K8S_SOURCE_RETRIES": lambda: os.environ.get("MX_K8S_SOURCE_RETRIES", ""),

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -24,6 +24,7 @@ transport, buffers and the router dtype-cast are shared here.
 from __future__ import annotations
 
 import logging
+import os
 
 import torch
 
@@ -31,7 +32,11 @@ from modelexpress.client import MxClient
 from modelexpress.nixl_transfer import NixlTransferManager
 from modelexpress.refit.reshard.cuda_pool import classic_cuda_alloc
 from modelexpress.refit.reshard.rendezvous import gather_sources
-from modelexpress.refit.reshard.transfer_plan import execute_transfer, plan_transfer
+from modelexpress.refit.reshard.transfer_plan import (
+    exact_descriptors,
+    execute_transfer,
+    plan_transfer,
+)
 from modelexpress.refit.reshard.transport import (
     NixlReshardTransport,
     ReadDescriptor,
@@ -39,6 +44,15 @@ from modelexpress.refit.reshard.transport import (
 from modelexpress.refit.reshard.types import CaptureResult, UnsupportedReshard
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
+
+
+def _fused_wire_enabled() -> bool:
+    """Whether to issue the exact, full-pull and convert reads as one batch.
+
+    Read at call time so an A/B can toggle it without re-importing. Set
+    ``MX_RESHARD_FUSED_WIRE=0`` to drain each phase in turn.
+    """
+    return os.environ.get("MX_RESHARD_FUSED_WIRE", "1") not in ("0", "false")
 
 
 def _replay_ops(tensor: torch.Tensor, op_chain: tuple) -> torch.Tensor:
@@ -321,56 +335,83 @@ class ReshardReceiver:
 
         # RDMA the sliced bf16 into the receive buffers (segments) and per-param
         # staging (dtype-convert / router). No live param is written by RDMA.
-        stats = execute_transfer(
-            self._plan,
-            resolve_param_ptr=lambda name: self._param_ptr[name],
-            transport=self._transport,
+        #
+        # The three read phases target disjoint destinations - exact segments land
+        # in the receive buffers, full pulls in full staging, converts in convert
+        # staging - and every reader of those buffers (the re-slice below, the
+        # dtype cast) runs after all reads complete. So the phases carry no
+        # ordering dependency and are issued as one batch by default. Phased mode
+        # drains each in turn and is kept for the A/B.
+        full_descriptors = [
+            ReadDescriptor(
+                session=segment.session,
+                src_addr=segment.src_addr,
+                dst_addr=(
+                    self._full_staging_ptr[full_pull.src_name] + segment.dst_byte
+                ),
+                nbytes=segment.nbytes,
+            )
+            for full_pull in self._plan.full_pulls
+            for segment in full_pull.segments
+        ]
+        convert_descriptors = [
+            ReadDescriptor(
+                session=segment.session,
+                src_addr=segment.src_addr,
+                dst_addr=self._staging_ptr[convert.param_name] + segment.dst_byte,
+                nbytes=segment.nbytes,
+            )
+            for convert in self._plan.converts
+            for segment in convert.segments
+        ]
+
+        if _fused_wire_enabled():
+            descriptors = exact_descriptors(
+                self._plan, lambda name: self._param_ptr[name]
+            )
+            stats = {
+                "segments": len(descriptors),
+                "bytes": sum(descriptor.nbytes for descriptor in descriptors),
+                "fallback": list(self._plan.fallback),
+            }
+            self._transport.read(descriptors + full_descriptors + convert_descriptors)
+        else:
+            stats = execute_transfer(
+                self._plan,
+                resolve_param_ptr=lambda name: self._param_ptr[name],
+                transport=self._transport,
+            )
+            if full_descriptors:
+                self._transport.read(full_descriptors)
+            if convert_descriptors:
+                self._transport.read(convert_descriptors)
+
+        stats["segments"] += len(full_descriptors) + len(convert_descriptors)
+        stats["bytes"] += sum(
+            descriptor.nbytes
+            for descriptor in (*full_descriptors, *convert_descriptors)
         )
-        if self._plan.full_pulls:
-            full_descriptors = [
-                ReadDescriptor(
-                    session=segment.session,
-                    src_addr=segment.src_addr,
-                    dst_addr=(
-                        self._full_staging_ptr[full_pull.src_name] + segment.dst_byte
-                    ),
-                    nbytes=segment.nbytes,
+
+        # Local re-slice of every full-pulled source into its receive buffer, and
+        # the dtype cast for every converted param. Both read staging written by
+        # the reads above, so both must run after the wire completes.
+        for full_pull in self._plan.full_pulls:
+            full_tensor = self._full_staging[full_pull.src_name]
+            for copy in full_pull.copies:
+                source_view = _replay_ops(full_tensor, copy.op_chain)
+                receive_buffer = self._recv_buffers[copy.param_name]
+                destination = receive_buffer.as_strided(
+                    copy.dest_shape,
+                    copy.dest_stride,
+                    receive_buffer.storage_offset() + copy.dest_offset,
                 )
-                for full_pull in self._plan.full_pulls
-                for segment in full_pull.segments
-            ]
-            self._transport.read(full_descriptors)
-            for full_pull in self._plan.full_pulls:
-                full_tensor = self._full_staging[full_pull.src_name]
-                for copy in full_pull.copies:
-                    source_view = _replay_ops(full_tensor, copy.op_chain)
-                    receive_buffer = self._recv_buffers[copy.param_name]
-                    destination = receive_buffer.as_strided(
-                        copy.dest_shape,
-                        copy.dest_stride,
-                        receive_buffer.storage_offset() + copy.dest_offset,
-                    )
-                    destination.copy_(source_view)
-            stats["segments"] += len(full_descriptors)
-            stats["bytes"] += sum(descriptor.nbytes for descriptor in full_descriptors)
-        if self._plan.converts:
-            conv_descs = [
-                ReadDescriptor(
-                    session=seg.session,
-                    src_addr=seg.src_addr,
-                    dst_addr=self._staging_ptr[c.param_name] + seg.dst_byte,
-                    nbytes=seg.nbytes,
-                )
-                for c in self._plan.converts
-                for seg in c.segments
-            ]
-            self._transport.read(conv_descs)
-            # Cast the served bf16 staging into the (fp32) receive buffer - a torch
-            # op, so the RDMA never crosses dtypes. _install writes the buffer.
-            for c in self._plan.converts:
-                self._recv_buffers[c.param_name].copy_(self._staging[c.param_name])
-            stats["segments"] += len(conv_descs)
-            stats["bytes"] += sum(descriptor.nbytes for descriptor in conv_descs)
+                destination.copy_(source_view)
+        # Cast the served bf16 staging into the (fp32) receive buffer - a torch
+        # op, so the RDMA never crosses dtypes. _install writes the buffer.
+        for convert in self._plan.converts:
+            self._recv_buffers[convert.param_name].copy_(
+                self._staging[convert.param_name]
+            )
 
         self._install(self._recv_buffers)
         torch.cuda.synchronize(self._device)

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -24,10 +24,10 @@ transport, buffers and the router dtype-cast are shared here.
 from __future__ import annotations
 
 import logging
-import os
 
 import torch
 
+from modelexpress import envs
 from modelexpress.client import MxClient
 from modelexpress.nixl_transfer import NixlTransferManager
 from modelexpress.refit.reshard.cuda_pool import classic_cuda_alloc
@@ -52,7 +52,7 @@ def _fused_wire_enabled() -> bool:
     Read at call time so an A/B can toggle it without re-importing. Set
     ``MX_RESHARD_FUSED_WIRE=0`` to drain each phase in turn.
     """
-    return os.environ.get("MX_RESHARD_FUSED_WIRE", "1") not in ("0", "false")
+    return envs.MX_RESHARD_FUSED_WIRE
 
 
 def _replay_ops(tensor: torch.Tensor, op_chain: tuple) -> torch.Tensor:

--- a/modelexpress_client/python/modelexpress/refit/reshard/transfer_plan.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/transfer_plan.py
@@ -291,6 +291,27 @@ def plan_transfer(
     return plan
 
 
+def exact_descriptors(
+    plan: TransferPlan,
+    resolve_param_ptr: Callable[[str], int],
+) -> list[ReadDescriptor]:
+    """Absolute-address ``ReadDescriptor``s for the exact-segment phase.
+
+    Split out from :func:`execute_transfer` so a caller that issues the exact,
+    full-pull and convert phases as one batch can build the descriptors without
+    also performing the read.
+    """
+    return [
+        ReadDescriptor(
+            session=seg.session,
+            src_addr=seg.src_addr,
+            dst_addr=resolve_param_ptr(seg.param_name) + seg.dst_byte,
+            nbytes=seg.nbytes,
+        )
+        for seg in plan.segments
+    ]
+
+
 def execute_transfer(
     plan: TransferPlan,
     resolve_param_ptr: Callable[[str], int],
@@ -302,15 +323,7 @@ def execute_transfer(
 
     Returns a small stats dict; ``fallback`` is passed through so the receiver
     can reject an unsupported plan."""
-    descriptors = [
-        ReadDescriptor(
-            session=seg.session,
-            src_addr=seg.src_addr,
-            dst_addr=resolve_param_ptr(seg.param_name) + seg.dst_byte,
-            nbytes=seg.nbytes,
-        )
-        for seg in plan.segments
-    ]
+    descriptors = exact_descriptors(plan, resolve_param_ptr)
     transport.read(descriptors)
     return {
         "segments": len(descriptors),

--- a/modelexpress_client/python/tests/test_envs.py
+++ b/modelexpress_client/python/tests/test_envs.py
@@ -24,6 +24,7 @@ def test_defaults_when_unset(monkeypatch):
         "MX_SERVER_ADDRESS",
         "MX_GDS_TIMEOUT",
         "MX_HEARTBEAT_INTERVAL_SECS",
+        "MX_RESHARD_FUSED_WIRE",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -41,6 +42,7 @@ def test_defaults_when_unset(monkeypatch):
     assert envs.MX_SERVER_ADDRESS is None
     assert envs.MX_GDS_TIMEOUT == pytest.approx(120.0)
     assert envs.MX_HEARTBEAT_INTERVAL_SECS == 30
+    assert envs.MX_RESHARD_FUSED_WIRE is True
 
 
 def test_int_and_float_parsing(monkeypatch):
@@ -57,7 +59,7 @@ def test_invalid_int_falls_back_to_default(monkeypatch):
     assert envs.MX_METADATA_PORT == 5555
 
 
-def test_bool_parsing(monkeypatch):
+def test_bool_parsing(monkeypatch, caplog):
     monkeypatch.setenv("MX_POOL_REG", "1")
     assert envs.MX_POOL_REG is True
     monkeypatch.setenv("MX_POOL_REG", "0")
@@ -81,6 +83,16 @@ def test_bool_parsing(monkeypatch):
         assert envs.MX_ARTIFACT_TRANSFER is True
     monkeypatch.setenv("MX_ARTIFACT_TRANSFER", "maybe")
     assert envs.MX_ARTIFACT_TRANSFER is False
+
+    for falsy in ("0", "FALSE", "no", "Off"):
+        monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", falsy)
+        assert envs.MX_RESHARD_FUSED_WIRE is False
+    for truthy in ("1", "TRUE", "yes", "On"):
+        monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", truthy)
+        assert envs.MX_RESHARD_FUSED_WIRE is True
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "maybe")
+    assert envs.MX_RESHARD_FUSED_WIRE is True
+    assert "Invalid MX_RESHARD_FUSED_WIRE='maybe'; using default True" in caplog.text
 
 
 def test_normalization(monkeypatch):

--- a/modelexpress_client/python/tests/test_reshard_refit_fused_wire.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_fused_wire.py
@@ -64,6 +64,7 @@ class _Harness(ReshardReceiver):
 
     def _install(self, recv_buffers) -> None:
         self._install_order.append("install")
+        self._transport.installed_after.append(len(self._transport.batch_sizes))
 
 
 def _build(transport):
@@ -220,9 +221,15 @@ def test_reconstructs_the_expected_values(monkeypatch):
 
 
 def test_install_runs_after_every_read(monkeypatch):
-    harness, transport, _m, _k = _run(monkeypatch, fused=True)
-    assert harness._install_order == ["install"]
-    assert transport.batch_sizes, "no read was issued"
+    fused, fused_transport, _m, _k = _run(monkeypatch, fused=True)
+    assert fused._install_order == ["install"]
+    assert fused_transport.batch_sizes == [3]
+    assert fused_transport.installed_after == [1]
+
+    phased, phased_transport, _m, _k = _run(monkeypatch, fused=False)
+    assert phased._install_order == ["install"]
+    assert phased_transport.batch_sizes == [1, 1, 1]
+    assert phased_transport.installed_after == [3]
 
 
 def test_accounting_covers_all_three_groups(monkeypatch):
@@ -237,14 +244,16 @@ def test_accounting_covers_all_three_groups(monkeypatch):
 
 def test_empty_full_pull_and_convert_groups_are_skipped(monkeypatch):
     """A plan with only exact segments must still issue exactly one batch."""
-    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "0")
     monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
-    transport = _RecordingTransport()
-    harness, keepalive = _build(transport)
-    harness._plan.full_pulls = []
-    harness._plan.converts = []
 
-    harness.update_weights(step=1)
+    for fused in (True, False):
+        monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1" if fused else "0")
+        transport = _RecordingTransport()
+        harness, keepalive = _build(transport)
+        harness._plan.full_pulls = []
+        harness._plan.converts = []
 
-    assert transport.batch_sizes == [1]
-    assert all(t.data_ptr() for t in keepalive)  # keep alive
+        harness.update_weights(step=1)
+
+        assert transport.batch_sizes == [1]
+        assert all(t.data_ptr() for t in keepalive)  # keep alive

--- a/modelexpress_client/python/tests/test_reshard_refit_fused_wire.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_fused_wire.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Fused vs phased wire in ReshardReceiver.update_weights - CPU only, no NIXL.
+
+A refit reads three groups of bytes: exact segments straight into the receive
+buffers, whole sources into full-pull staging, and dtype-mismatched sources into
+convert staging. Those used to be three separate drains. They target disjoint
+destinations and every reader of those destinations runs after all three, so
+they are now issued as one batch.
+
+The tests that matter here are the two that would catch a wrong fusion:
+
+  * the receive buffers are byte-identical whether the reads are fused or
+    phased, checked against a plan that exercises all three groups at once;
+  * the re-slice and the dtype cast run after the wire, not interleaved with it,
+    which is the ordering assumption fusing depends on.
+
+The in-memory reference transport performs real byte moves over CPU addresses,
+so a fusion that mixes up a destination address fails rather than passes.
+
+Run: pytest tests/test_reshard_refit_fused_wire.py
+"""
+
+import torch
+
+from modelexpress.refit.reshard.receiver import ReshardReceiver
+from modelexpress.refit.reshard.slice_plan import PullSegment
+from modelexpress.refit.reshard.transfer_plan import (
+    ConvertSource,
+    FullPullSource,
+    TransferPlan,
+)
+from modelexpress.refit.reshard.transport import InMemoryReferenceTransport
+
+EL = 4  # float32 element size
+
+
+class _RecordingTransport(InMemoryReferenceTransport):
+    """Real byte moves, plus the batch boundaries so ordering can be asserted."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_sizes: list[int] = []
+        self.installed_after: list[int] = []
+
+    def read(self, descriptors) -> None:
+        self.batch_sizes.append(len(descriptors))
+        super().read(descriptors)
+
+
+class _Harness(ReshardReceiver):
+    """A receiver with the plan and buffers set directly.
+
+    ``ReshardReceiver.__init__`` builds a NIXL agent and a metadata client, so
+    this bypasses it. Only the state ``update_weights`` touches is populated.
+    """
+
+    def __init__(self, transport) -> None:  # noqa: D107 - see class docstring
+        self._device = torch.device("cpu")
+        self._timeout = 1.0
+        self._transport = transport
+        self._install_order: list[str] = []
+
+    def _install(self, recv_buffers) -> None:
+        self._install_order.append("install")
+
+
+def _build(transport):
+    """One plan covering all three read groups.
+
+    ``exact`` is read straight into its receive buffer. ``strided`` is a whole
+    source staged contiguously and then re-sliced locally. ``router`` is served
+    bf16 for an fp32 destination, so it stages at the served dtype and is cast
+    afterwards. Returns the harness plus the source tensors, which the caller
+    must keep alive: the plan holds their raw addresses.
+    """
+    harness = _Harness(transport)
+
+    exact_src = torch.arange(8, dtype=torch.float32)
+    strided_src = torch.arange(100, 116, dtype=torch.float32).reshape(4, 4)
+    router_src = torch.arange(200, 204, dtype=torch.float32).to(torch.bfloat16)
+
+    recv_exact = torch.zeros(8, dtype=torch.float32)
+    recv_strided = torch.zeros(4, 2, dtype=torch.float32)
+    recv_router = torch.zeros(4, dtype=torch.float32)
+    full_staging = torch.zeros(4, 4, dtype=torch.float32)
+    convert_staging = torch.zeros(4, dtype=torch.bfloat16)
+
+    harness._recv_buffers = {
+        "exact": recv_exact,
+        "strided": recv_strided,
+        "router": recv_router,
+    }
+    harness._param_ptr = {"exact": recv_exact.data_ptr()}
+    harness._full_staging = {"strided": full_staging}
+    harness._full_staging_ptr = {"strided": full_staging.data_ptr()}
+    harness._staging = {"router": convert_staging}
+    harness._staging_ptr = {"router": convert_staging.data_ptr()}
+
+    plan = TransferPlan(
+        segments=[
+            PullSegment(
+                session="s0",
+                src_addr=exact_src.data_ptr(),
+                dst_byte=0,
+                nbytes=8 * EL,
+                param_name="exact",
+            )
+        ],
+        full_pulls=[
+            FullPullSource(
+                src_name="strided",
+                global_shape=(4, 4),
+                dtype=torch.float32,
+                elsize=EL,
+                segments=[
+                    PullSegment(
+                        session="s1",
+                        src_addr=strided_src.data_ptr(),
+                        dst_byte=0,
+                        nbytes=16 * EL,
+                        param_name="strided",
+                    )
+                ],
+                # Take the first two columns, the shape a tensor-parallel row
+                # split produces and the reason this source is descriptor-heavy.
+                copies=[
+                    _Copy(
+                        param_name="strided",
+                        op_chain=(("narrow", (1, 0, 2), ()),),
+                        dest_shape=(4, 2),
+                        dest_stride=(2, 1),
+                        dest_offset=0,
+                    )
+                ],
+            )
+        ],
+        converts=[
+            ConvertSource(
+                param_name="router",
+                dest_shape=(4,),
+                src_dtype=torch.bfloat16,
+                segments=[
+                    PullSegment(
+                        session="s2",
+                        src_addr=router_src.data_ptr(),
+                        dst_byte=0,
+                        nbytes=4 * 2,
+                        param_name="router",
+                    )
+                ],
+            )
+        ],
+        exact_bytes=8 * EL,
+        exact_descriptor_count=1,
+    )
+    harness._plan = plan
+    keepalive = (exact_src, strided_src, router_src)
+    return harness, keepalive
+
+
+class _Copy:
+    """The subset of ``RecordedCopy`` the re-slice reads."""
+
+    def __init__(self, *, param_name, op_chain, dest_shape, dest_stride, dest_offset):
+        self.param_name = param_name
+        self.op_chain = op_chain
+        self.dest_shape = dest_shape
+        self.dest_stride = dest_stride
+        self.dest_offset = dest_offset
+
+
+def _run(monkeypatch, *, fused: bool):
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1" if fused else "0")
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    transport = _RecordingTransport()
+    harness, keepalive = _build(transport)
+    metrics = harness.update_weights(step=1)
+    return harness, transport, metrics, keepalive
+
+
+def test_fused_issues_one_batch_and_phased_issues_three(monkeypatch):
+    _h, fused_transport, _m, _k = _run(monkeypatch, fused=True)
+    assert fused_transport.batch_sizes == [3]
+
+    _h, phased_transport, _m, _k = _run(monkeypatch, fused=False)
+    assert phased_transport.batch_sizes == [1, 1, 1]
+
+
+def test_fused_and_phased_produce_identical_buffers(monkeypatch):
+    """The correctness gate on fusing: same bytes, same destinations."""
+    fused, _t, fused_metrics, _k = _run(monkeypatch, fused=True)
+    phased, _t, phased_metrics, _k = _run(monkeypatch, fused=False)
+
+    assert fused._recv_buffers.keys() == phased._recv_buffers.keys()
+    for name, buffer in fused._recv_buffers.items():
+        assert torch.equal(buffer, phased._recv_buffers[name]), name
+
+    # And the accounting agrees, so a dashboard cannot tell the paths apart.
+    assert fused_metrics["bytes_received"] == phased_metrics["bytes_received"]
+    assert fused_metrics["segments"] == phased_metrics["segments"]
+
+
+def test_reconstructs_the_expected_values(monkeypatch):
+    """Buffer parity between two wrong paths would still pass, so check values."""
+    harness, _t, _m, _k = _run(monkeypatch, fused=True)
+
+    assert torch.equal(
+        harness._recv_buffers["exact"], torch.arange(8, dtype=torch.float32)
+    )
+    # First two columns of the 4x4 source, re-sliced locally after the full pull.
+    expected = torch.arange(100, 116, dtype=torch.float32).reshape(4, 4)[:, :2]
+    assert torch.equal(harness._recv_buffers["strided"], expected)
+    # Served bf16, cast up to the fp32 destination after the wire.
+    assert torch.equal(
+        harness._recv_buffers["router"],
+        torch.arange(200, 204, dtype=torch.float32).to(torch.bfloat16).float(),
+    )
+
+
+def test_install_runs_after_every_read(monkeypatch):
+    harness, transport, _m, _k = _run(monkeypatch, fused=True)
+    assert harness._install_order == ["install"]
+    assert transport.batch_sizes, "no read was issued"
+
+
+def test_accounting_covers_all_three_groups(monkeypatch):
+    _h, _t, metrics, _k = _run(monkeypatch, fused=True)
+
+    assert metrics["segments"] == 3
+    assert metrics["bytes_received"] == 8 * EL + 16 * EL + 4 * 2
+    assert metrics["full_pull_sources"] == 1
+    assert metrics["converts"] == 1
+    assert metrics["fallback"] == 0
+
+
+def test_empty_full_pull_and_convert_groups_are_skipped(monkeypatch):
+    """A plan with only exact segments must still issue exactly one batch."""
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "0")
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    transport = _RecordingTransport()
+    harness, keepalive = _build(transport)
+    harness._plan.full_pulls = []
+    harness._plan.converts = []
+
+    harness.update_weights(step=1)
+
+    assert transport.batch_sizes == [1]
+    assert all(t.data_ptr() for t in keepalive)  # keep alive

--- a/modelexpress_client/python/tests/test_reshard_refit_transfer.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_transfer.py
@@ -23,6 +23,7 @@ from modelexpress.refit.reshard.receiver import _replay_ops
 from modelexpress.refit.reshard.slice_plan import Shard
 from modelexpress.refit.reshard.transfer_plan import (
     SourceInfo,
+    exact_descriptors,
     execute_transfer,
     plan_transfer,
 )
@@ -340,6 +341,44 @@ def test_execute_transfer_surfaces_fallback_for_the_receiver_to_reject():
     )
     assert stats["fallback"] == plan.fallback
     assert "bad" in stats["fallback"]
+    assert all(t.data_ptr() for t in srcs.values())
+
+
+def test_exact_descriptors_match_what_execute_transfer_reads():
+    """The fused wire builds the exact-phase descriptors itself rather than
+    letting execute_transfer read them, so the two must stay in agreement."""
+    srcs = _full_sources()
+    with torch.device("meta"):
+        meta_model = ToyModel()
+    capture = capture_geometry(meta_model, _manifest())
+
+    sources = {}
+    for name, tensor in srcs.items():
+        shard = Shard(
+            (0,) * tensor.dim(), tuple(tensor.shape), name, tensor.data_ptr(), EL
+        )
+        sources[name] = SourceInfo(tuple(tensor.shape), torch.float32, EL, [shard])
+    plan = plan_transfer(capture, sources)
+
+    model = ToyModel()
+    params = dict(model.named_parameters())
+
+    def resolve(name):
+        return params[name].data_ptr()
+
+    built = exact_descriptors(plan, resolve)
+
+    recorded = []
+
+    class _Recorder:
+        def read(self, descriptors):
+            recorded.extend(descriptors)
+
+    stats = execute_transfer(plan, resolve_param_ptr=resolve, transport=_Recorder())
+
+    assert built == recorded
+    assert stats["segments"] == len(built)
+    assert stats["bytes"] == sum(descriptor.nbytes for descriptor in built)
     assert all(t.data_ptr() for t in srcs.values())
 
 


### PR DESCRIPTION
## Summary

A reshard refit reads three independent groups of bytes:

- exact segments directly into receive buffers;
- descriptor-heavy tensors into full-pull staging;
- dtype-mismatched tensors into conversion staging.

The receiver previously issued and drained each group separately. This PR builds
all three descriptor lists first and issues them as one transport batch. Local
re-slicing and dtype conversion still run only after every read completes.

## Why this is needed

The three sequential drains introduced barriers that the data flow does not
require. A full-pull read could not begin until every exact read completed, and
a conversion read could not begin until every full pull completed, even though
the groups write to different destinations.

```mermaid
flowchart LR
    subgraph Before
        E1[Read exact] --> F1[Read full pulls] --> C1[Read conversions]
        C1 --> R1[Re-slice] --> X1[Cast] --> I1[Install]
    end
    subgraph After
        B2[Read exact + full + conversion] --> R2[Re-slice]
        R2 --> X2[Cast] --> I2[Install]
    end
```

`exact_descriptors()` is extracted from `execute_transfer()` so the receiver can
build the exact-read descriptors without performing that read immediately.

## Correctness argument

Fusion is safe because:

1. Exact reads, full pulls, and conversion reads target disjoint buffers.
2. Full-pull re-slicing starts after the fused batch completes.
3. Dtype conversion starts after the fused batch completes.
4. Installation remains after all reads and transformations.

The CPU reference-transport tests execute real byte copies through both the fused
and phased paths. They compare final buffers against each other and against
independently constructed expected values. Mutation checks confirmed that
removing a read group fails the tests, while reordering independent descriptors
does not.

## Diagnostic control

Fusion is enabled by default. Set `MX_RESHARD_FUSED_WIRE=0` to restore the three
phased drains. Phased mode remains useful for attributing wire time to exact,
full-pull, and conversion traffic separately.

The flag is registered in the centralized environment configuration and
documented in the client README variable table alongside the other reshard
variables. Common case-insensitive boolean spellings are accepted. Invalid values
emit a warning and use the default instead of silently changing an A/B run.

## Performance evidence

Status: `PERF_PASS_CORRECTNESS_PENDING`.

A preliminary Topology A capture used real Qwen3-30B-A3B BF16 tensors, 16
Megatron trainer ranks (TP=2, PP=1, EP=4, ordinary DP=8) and vLLM generation at
TP=4 over AWS Elastic Fabric Adapter with the NIXL `LIBFABRIC` backend. Each
receiver rank planned 29.78 GB across 117,123 segments.

The phased wire median was 1.474 seconds. The fused wire median was 1.388
seconds, a 5.8% reduction. Median per-rank throughput increased from 161.6 to
171.7 Gbps.

These numbers are directional, not a publishable benchmark row:

- only 12 of 16 inference ranks completed the fused capture;
- observed fused rank times ranged from 1.06 to 1.83 seconds, wider than the
  median improvement;
- the capture does not provide the required three cold starts plus ten measured
  warm versions and fleet-critical maxima;

The supported conclusion is that fusion removes unnecessary barriers without
changing the transfer plan or installed bytes. It does not establish a complete
fleet-level speedup claim.

## Scope

This PR changes batching and accounting around existing transfer descriptors. It
does not change:

- source selection or discovery;
- tensor coverage or transfer-plan geometry;
- the number of useful or extra bytes;
- dtype conversion semantics;
- engine-specific installation behavior.

## Validation

- [x] Rebased onto current `main`; the obsolete #528 commit was dropped because
      its patch is already upstream.
- [x] 45 complete `test_reshard_refit_*` tests pass after the rebase.
- [x] 21 focused environment, fused-wire, and transfer tests pass.
- [x] Fused and phased paths produce identical buffers and accounting.
- [x] Expected tensor values are checked independently of path parity.
- [x] Installation is asserted to occur after all wire batches in both modes.
- [x] Empty full-pull and conversion groups issue no empty reads in either mode.
- [x] Boolean flag parsing covers mixed-case true/false, yes/no, and on/off.
- [x] Core Ruff checks and whitespace validation pass.

Full GitHub CI is running again on the rebased branch.

## Reviewer guide

The PR changes seven files (+440/-59). Suggested order:

1. `modelexpress/refit/reshard/receiver.py` — verify that all descriptor lists
   are built before the fused read and that re-slice, cast, and install remain
   after it.
2. `tests/test_reshard_refit_fused_wire.py` — review buffer parity, independent
   expected-value checks, ordering, accounting, and empty-group coverage.
3. `modelexpress/refit/reshard/transfer_plan.py` — confirm
   `exact_descriptors()` is a pure extraction and `execute_transfer()` preserves
   its previous behavior.
4. `modelexpress/envs.py`, `tests/test_envs.py`, and
   `modelexpress_client/python/README.md` — verify default-enabled flag parsing,
   warning behavior for invalid values, and the documented default.
5. `tests/test_reshard_refit_transfer.py` — confirm descriptor extraction returns
   exactly the descriptors `execute_transfer()` reads.
