### PR TITLE
fix(reshard-refit): bound the peer handshake and reject empty publishers

### DIFF
--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -153,6 +153,9 @@ register_modelexpress_loaders()
 | `MX_RESHARD_FUSED_WIRE` | `1` | Issue a refit's exact-segment, full-pull, and convert reads as one transport batch instead of draining each phase in turn. Set to `0` to restore the phased reads for an A/B comparison |
 | `MX_RESHARD_REQUIRE_FULL_COVERAGE` | `0` | Fail a refit that installs less than `MX_RESHARD_COVERAGE_FLOOR` of the engine's parameter bytes. Off by default because partial and subset refit are intended; set to `1` for benchmark runs, where an incomplete refit produces timings that are the wrong magnitude |
 | `MX_RESHARD_COVERAGE_FLOOR` | `0.995` | Fraction of engine parameter bytes a gated refit must install. Not `1.0`: a few engine parameters, such as rotary `inv_freq`, are legitimately not refit material. Values outside `[0.0, 1.0]` are rejected |
+| `MX_RESHARD_HANDSHAKE_TIMEOUT_S` | `900` | Budget for the whole P2P metadata handshake, across every trainer peer and every retry. Bounds the handshake independently of the refit timeout, so one unreachable publisher cannot consume the entire refit |
+| `MX_RESHARD_HANDSHAKE_ATTEMPT_S` | `20` | Ceiling on a single peer dial. A reachable peer answers in well under a second, so a short attempt frees the budget to try a different peer rather than block on one |
+| `MX_RESHARD_HANDSHAKE_BACKOFF_S` | `2` | Pause after a full pass over the pending peers makes no progress, so a transient stall is waited out rather than hammered |
 
 ### UCX/NIXL Tuning
 

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -61,6 +61,9 @@ if TYPE_CHECKING:
     MX_RESHARD_FUSED_WIRE: bool
     MX_RESHARD_REQUIRE_FULL_COVERAGE: bool
     MX_RESHARD_COVERAGE_FLOOR: float
+    MX_RESHARD_HANDSHAKE_TIMEOUT_S: float
+    MX_RESHARD_HANDSHAKE_ATTEMPT_S: float
+    MX_RESHARD_HANDSHAKE_BACKOFF_S: float
     # Kubernetes service backend
     MX_K8S_SERVICE_PATTERN: str
     MX_K8S_SOURCE_RETRIES: str
@@ -205,6 +208,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     .lower()
     in _TRUTHY,
     "MX_RESHARD_COVERAGE_FLOOR": lambda: _env_float("MX_RESHARD_COVERAGE_FLOOR", 0.995),
+    # Whole-handshake budget across every peer and every retry, the per-dial
+    # ceiling, and the pause after a full pass over the pending peers makes no
+    # progress. See modelexpress.refit.reshard.receiver.handshake_with_peers.
+    "MX_RESHARD_HANDSHAKE_TIMEOUT_S": lambda: _env_float("MX_RESHARD_HANDSHAKE_TIMEOUT_S", 900.0),
+    "MX_RESHARD_HANDSHAKE_ATTEMPT_S": lambda: _env_float("MX_RESHARD_HANDSHAKE_ATTEMPT_S", 20.0),
+    "MX_RESHARD_HANDSHAKE_BACKOFF_S": lambda: _env_float("MX_RESHARD_HANDSHAKE_BACKOFF_S", 2.0),
     # ── Kubernetes service backend ─────────────────────────────────────────
     "MX_K8S_SERVICE_PATTERN": lambda: os.environ.get("MX_K8S_SERVICE_PATTERN", "mx-sources"),
     "MX_K8S_SOURCE_RETRIES": lambda: os.environ.get("MX_K8S_SOURCE_RETRIES", ""),

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -169,6 +169,27 @@ def _env_bool(name: str, default: bool) -> bool:
     return default
 
 
+def _env_positive_float(name: str, default: float) -> float:
+    """As :func:`_env_float`, for a variable where zero and negatives are meaningless.
+
+    Timeouts, per-attempt ceilings and backoff pauses are all bounds, and a bound of
+    zero or less is not a smaller bound but an absent one: it turns the loop it
+    governs into an unbounded one, which is the failure the variable exists to
+    prevent. Falling back to the documented default keeps the bound in place, and
+    the warning says which value was ignored.
+    """
+    value = _env_float(name, default)
+    if value <= 0.0:
+        logger.warning(
+            "Invalid %s=%r; a bound must be positive, using default %s",
+            name,
+            os.environ.get(name),
+            default,
+        )
+        return default
+    return value
+
+
 # One entry per variable. The lambda owns the default and parsing; callers that
 # need a site-specific default receive the raw value (``None`` when unset) and
 # apply their own fallback.
@@ -208,12 +229,25 @@ environment_variables: dict[str, Callable[[], Any]] = {
     .lower()
     in _TRUTHY,
     "MX_RESHARD_COVERAGE_FLOOR": lambda: _env_float("MX_RESHARD_COVERAGE_FLOOR", 0.995),
-    # Whole-handshake budget across every peer and every retry, the per-dial
-    # ceiling, and the pause after a full pass over the pending peers makes no
-    # progress. See modelexpress.refit.reshard.receiver.handshake_with_peers.
-    "MX_RESHARD_HANDSHAKE_TIMEOUT_S": lambda: _env_float("MX_RESHARD_HANDSHAKE_TIMEOUT_S", 900.0),
-    "MX_RESHARD_HANDSHAKE_ATTEMPT_S": lambda: _env_float("MX_RESHARD_HANDSHAKE_ATTEMPT_S", 20.0),
-    "MX_RESHARD_HANDSHAKE_BACKOFF_S": lambda: _env_float("MX_RESHARD_HANDSHAKE_BACKOFF_S", 2.0),
+    # Bounds for the reshard peer handshake; see
+    # modelexpress.refit.reshard.receiver.handshake_with_peers.
+    #
+    # TIMEOUT_S is the budget across every peer and every retry. A refit timeout is
+    # the wrong bound, since it lets one unreachable peer consume the whole refit,
+    # but it must stay generous: a peer registering tens of GB with the fabric
+    # provider blocks its listen thread for minutes, and waiting is the correct
+    # response to that. ATTEMPT_S caps a single dial, so an unreachable peer frees
+    # the budget for a different one instead of blocking on it. BACKOFF_S is the
+    # pause after a full pass over the pending peers makes no progress.
+    "MX_RESHARD_HANDSHAKE_TIMEOUT_S": lambda: _env_positive_float(
+        "MX_RESHARD_HANDSHAKE_TIMEOUT_S", 900.0
+    ),
+    "MX_RESHARD_HANDSHAKE_ATTEMPT_S": lambda: _env_positive_float(
+        "MX_RESHARD_HANDSHAKE_ATTEMPT_S", 20.0
+    ),
+    "MX_RESHARD_HANDSHAKE_BACKOFF_S": lambda: _env_positive_float(
+        "MX_RESHARD_HANDSHAKE_BACKOFF_S", 2.0
+    ),
     # ── Kubernetes service backend ─────────────────────────────────────────
     "MX_K8S_SERVICE_PATTERN": lambda: os.environ.get("MX_K8S_SERVICE_PATTERN", "mx-sources"),
     "MX_K8S_SOURCE_RETRIES": lambda: os.environ.get("MX_K8S_SOURCE_RETRIES", ""),

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -30,6 +30,7 @@ Not covered here (intentional exceptions):
 from __future__ import annotations
 
 import logging
+import math
 import os
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
@@ -170,18 +171,23 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def _env_positive_float(name: str, default: float) -> float:
-    """As :func:`_env_float`, for a variable where zero and negatives are meaningless.
+    """As :func:`_env_float`, for a variable that has to be a finite positive bound.
 
-    Timeouts, per-attempt ceilings and backoff pauses are all bounds, and a bound of
-    zero or less is not a smaller bound but an absent one: it turns the loop it
-    governs into an unbounded one, which is the failure the variable exists to
-    prevent. Falling back to the documented default keeps the bound in place, and
-    the warning says which value was ignored.
+    Timeouts, per-attempt ceilings and backoff pauses are all bounds, and anything
+    that is not a finite positive number is not a different bound but an absent
+    one: it turns the loop it governs into an unbounded one, which is the failure
+    the variable exists to prevent. Zero and negatives are the obvious cases;
+    ``inf`` and ``nan`` are the ones worth naming, since both parse happily and
+    both make a ``now >= deadline`` test that never fires.
+
+    Falling back to the documented default keeps the bound in place, and the
+    warning says which value was ignored.
     """
     value = _env_float(name, default)
-    if value <= 0.0:
+    if not math.isfinite(value) or value <= 0.0:
         logger.warning(
-            "Invalid %s=%r; a bound must be positive, using default %s",
+            "Invalid %s=%r; a bound must be a finite positive number, using "
+            "default %s",
             name,
             os.environ.get(name),
             default,

--- a/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
@@ -51,6 +51,7 @@ from modelexpress.refit.reshard.rendezvous import (
     MxReshardRendezvous,
     PublishedShard,
     PublishedTensor,
+    RendezvousPayload,
     gather_sources,
     wrap_rendezvous_blob,
 )
@@ -65,6 +66,7 @@ __all__ = [
     "OpChain",
     "PublishedShard",
     "PublishedTensor",
+    "RendezvousPayload",
     "PullSegment",
     "ReadDescriptor",
     "RecordedCopy",

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -53,6 +53,41 @@ from modelexpress.refit.reshard.types import (
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 
 
+def handshake_endpoints_for_plan(
+    plan, session_to_agent: dict, agent_endpoints: dict
+) -> dict:
+    """Narrow ``agent_endpoints`` to the trainers ``plan`` reads from.
+
+    Discovery has to collect every trainer's shard table, since which trainers own
+    the bytes a receiver is missing is only known once the slice arithmetic is
+    done. Handshaking with every one of them afterwards is a different matter: the
+    handshake exists to resolve remote memory registrations for reads, so a
+    trainer this rank never reads from costs a dial and buys nothing. Left
+    unnarrowed that is one dial per receiver-trainer pair, which grows as the
+    product of both sides.
+
+    Fails closed when a trainer the plan reads from has no endpoint to dial.
+    Skipping it instead would push the failure into ``prep_xfer_dlist``, which
+    cannot say which peer it was missing.
+    """
+    needed = {
+        session_to_agent[session]
+        for session in plan.sessions()
+        if session in session_to_agent
+    }
+    missing = sorted(needed - set(agent_endpoints))
+    if missing:
+        raise RuntimeError(
+            f"[reshard] {len(missing)} trainer(s) in the transfer plan published no "
+            f"metadata endpoint to handshake with: {missing[:10]}"
+        )
+    return {
+        agent_name: endpoint
+        for agent_name, endpoint in agent_endpoints.items()
+        if agent_name in needed
+    }
+
+
 def handshake_with_peers(
     manager,
     agent_endpoints: dict,
@@ -320,8 +355,8 @@ class ReshardReceiver:
 
     # ------------------------------------------------------------------ prepare
     def _prepare(self, timeout: float) -> None:
-        """One-time: discover trainer shards, connect their agents, capture load
-        geometry, build the pull plan, and allocate + register buffers."""
+        """One-time: discover trainer shards, capture load geometry, build the pull
+        plan, connect the trainers it reads from, and allocate + register buffers."""
         logger.info(
             "[reshard] _prepare: discovering %d trainer source(s) (timeout=%.0fs)",
             self._num_trainer_sources,
@@ -336,20 +371,10 @@ class ReshardReceiver:
             timeout=timeout,
         )
         logger.info(
-            "[reshard] _prepare: discovered %d source(s), %d agent(s); P2P-fetching remote metadata",
+            "[reshard] _prepare: discovered %d source(s), %d agent(s)",
             len(sources),
             len(agent_endpoints),
         )
-        # P2P memory handshake (mirrors MX's vLLM RDMA path): fetch each trainer's
-        # NIXL metadata (incl. its memory registrations) via its listen thread, so
-        # prep_xfer_dlist can resolve the remote addresses. The central
-        # add_remote_agent(blob) path does NOT convey the registrations.
-        handshake_with_peers(
-            self._manager,
-            agent_endpoints,
-            envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S,
-        )
-
         manifest = [
             (name, src.dtype, tuple(src.global_shape)) for name, src in sources.items()
         ]
@@ -385,6 +410,29 @@ class ReshardReceiver:
                 f"full-pull path (unsupported reshard ops); refusing to serve stale "
                 f"weights. Params: {plan.fallback[:10]}"
             )
+        # P2P memory handshake (mirrors MX's vLLM RDMA path): fetch each trainer's
+        # NIXL metadata (incl. its memory registrations) via its listen thread, so
+        # prep_xfer_dlist can resolve the remote addresses. The central
+        # add_remote_agent(blob) path does NOT convey the registrations.
+        #
+        # After planning, for two reasons. It only has to precede the first read,
+        # and by here the plan says which trainers are actually read from, so peers
+        # this rank never touches are not dialed. It also means an unsupported plan
+        # is rejected above without spending the handshake budget first.
+        handshake_endpoints = handshake_endpoints_for_plan(
+            plan, session_to_agent, agent_endpoints
+        )
+        logger.info(
+            "[reshard] _prepare: P2P-fetching remote metadata from %d of %d agent(s)",
+            len(handshake_endpoints),
+            len(agent_endpoints),
+        )
+        handshake_with_peers(
+            self._manager,
+            handshake_endpoints,
+            envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S,
+        )
+
         self._transport = NixlReshardTransport(
             self._manager, session_to_agent, session_to_device, timeout_seconds=timeout
         )

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -53,34 +53,6 @@ from modelexpress.refit.reshard.types import (
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 
 
-def _handshake_seconds(name: str) -> float:
-    """Read a handshake duration from the env registry, rejecting non-positives.
-
-    ``MX_RESHARD_HANDSHAKE_TIMEOUT_S`` is the whole-handshake budget across every
-    peer and every retry. A refit timeout is the wrong bound: it lets one
-    unreachable peer consume the entire refit. It must still be generous, because
-    a peer can be unreachable for minutes for a legitimate reason - registering
-    tens of GB with the fabric provider blocks its listen thread - and the
-    receiver's only correct response to that is to keep trying.
-
-    ``MX_RESHARD_HANDSHAKE_ATTEMPT_S`` is the ceiling on a single dial. A reachable
-    peer answers in well under a second, so a short attempt costs nothing when
-    things are healthy and, when they are not, frees the budget to try a different
-    peer instead of blocking on one.
-
-    ``MX_RESHARD_HANDSHAKE_BACKOFF_S`` is the pause after a full pass over the
-    pending peers yields no progress, so a transient stall is waited out rather
-    than hammered.
-
-    A non-positive value turns the corresponding bound off, which silently
-    reintroduces the failure mode it exists to prevent, so it is rejected.
-    """
-    value = float(getattr(envs, name))
-    if not value > 0.0:
-        raise ValueError(f"{name} must be a positive number of seconds, got {value}")
-    return value
-
-
 def handshake_with_peers(
     manager,
     agent_endpoints: dict,
@@ -109,10 +81,8 @@ def handshake_with_peers(
     metadata is being fetched, and there is no way to tell which peer is at
     fault, or whether it stalled on the first dial or the last.
     """
-    attempt_timeout = attempt_timeout or _handshake_seconds(
-        "MX_RESHARD_HANDSHAKE_ATTEMPT_S"
-    )
-    backoff = _handshake_seconds("MX_RESHARD_HANDSHAKE_BACKOFF_S")
+    attempt_timeout = attempt_timeout or envs.MX_RESHARD_HANDSHAKE_ATTEMPT_S
+    backoff = envs.MX_RESHARD_HANDSHAKE_BACKOFF_S
     pending = deque(agent_endpoints.items())
     total = len(pending)
     attempts: dict = {name: 0 for name in agent_endpoints}
@@ -377,7 +347,7 @@ class ReshardReceiver:
         handshake_with_peers(
             self._manager,
             agent_endpoints,
-            _handshake_seconds("MX_RESHARD_HANDSHAKE_TIMEOUT_S"),
+            envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S,
         )
 
         manifest = [

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import time
+from collections import deque
 
 import torch
 
@@ -49,6 +52,135 @@ from modelexpress.refit.reshard.types import (
 )
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
+
+# Whole-handshake budget across every peer and every retry. A refit timeout is the
+# wrong bound: it lets one unreachable peer consume the entire refit. It must still
+# be generous, because a peer can be unreachable for minutes for a legitimate
+# reason - registering tens of GB with the fabric provider blocks its listen
+# thread - and the receiver's only correct response to that is to keep trying.
+_HANDSHAKE_TIMEOUT_S = float(os.environ.get("MX_RESHARD_HANDSHAKE_TIMEOUT_S", "900"))
+# Ceiling on a single dial. A reachable peer answers in well under a second, so a
+# short attempt costs nothing when things are healthy and, when they are not, frees
+# the budget to try a different peer instead of blocking on one.
+_HANDSHAKE_ATTEMPT_S = float(os.environ.get("MX_RESHARD_HANDSHAKE_ATTEMPT_S", "20"))
+# Pause after a full pass over the pending peers yields no progress, so a transient
+# stall is waited out rather than hammered.
+_HANDSHAKE_BACKOFF_S = float(os.environ.get("MX_RESHARD_HANDSHAKE_BACKOFF_S", "2"))
+
+
+def handshake_with_peers(
+    manager,
+    agent_endpoints: dict,
+    total_timeout: float,
+    attempt_timeout: float | None = None,
+) -> None:
+    """Fetch every trainer's NIXL metadata, bounded, retried and logged per peer.
+
+    Three properties, each earned from a failure mode observed on a live fabric:
+
+    *Bounded overall*, not per peer against the refit timeout. A publisher whose
+    process is gone still has its endpoint in the catalog - the reaper only marks
+    it stale after a heartbeat lapse, and an abandoned run can keep heartbeating -
+    so dialing it blocks. Charging a whole refit timeout to one dead peer hangs
+    the refit long past the driver's own deadline.
+
+    *Retried, and deferred rather than fatal on first failure.* A peer can be
+    listening yet transiently unable to accept: its accept loop is a thread in a
+    process that is busy publishing thousands of tensors, and a listen backlog
+    that never drains silently drops connection attempts. That is
+    indistinguishable from a dead peer within a single dial, but not across
+    several seconds, so a failed peer goes to the back of the queue and the next
+    one is tried instead of aborting the refit.
+
+    *Logged per peer.* Without it the last line in the log reports that remote
+    metadata is being fetched, and there is no way to tell which peer is at
+    fault, or whether it stalled on the first dial or the last.
+    """
+    attempt_timeout = attempt_timeout or _HANDSHAKE_ATTEMPT_S
+    pending = deque(agent_endpoints.items())
+    total = len(pending)
+    attempts: dict = {name: 0 for name in agent_endpoints}
+    last_error: dict = {}
+    deadline = time.monotonic() + total_timeout
+    succeeded = 0
+    # Consecutive failures with no success in between; one full pass over the
+    # pending peers without progress means waiting is better than spinning.
+    stalled = 0
+
+    while pending:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            outstanding = ", ".join(
+                f"{name}@{endpoint} ({attempts[name]} attempt(s), last: "
+                f"{type(last_error.get(name)).__name__}: {last_error.get(name)})"
+                for name, endpoint in pending
+            )
+            raise RuntimeError(
+                f"[reshard] P2P handshake incomplete after {total_timeout:.0f}s: "
+                f"{succeeded} of {total} peer(s) answered. Outstanding: "
+                f"{outstanding}. These publishers are advertised in the MX catalog "
+                f"but did not answer - either the process is gone while something "
+                f"still heartbeats its source, or its NIXL listen thread is not "
+                f"accepting."
+            )
+
+        agent_name, endpoint = pending.popleft()
+        host, port_str = endpoint.rsplit(":", 1)
+        this_timeout = max(1.0, min(attempt_timeout, remaining))
+        attempts[agent_name] += 1
+        logger.info(
+            "[reshard] _prepare: handshake %d/%d %s at %s (attempt %d, timeout=%.0fs)",
+            succeeded + 1,
+            total,
+            agent_name,
+            endpoint,
+            attempts[agent_name],
+            this_timeout,
+        )
+        started = time.perf_counter()
+        try:
+            manager.fetch_remote_and_wait(
+                agent_name, host, int(port_str), timeout_seconds=this_timeout
+            )
+        except Exception as exc:  # noqa: BLE001 - any dial failure is retryable
+            last_error[agent_name] = exc
+            logger.warning(
+                "[reshard] _prepare: handshake %s at %s failed after %.1fs on "
+                "attempt %d (%s: %s); deferring, %d peer(s) still pending",
+                agent_name,
+                endpoint,
+                time.perf_counter() - started,
+                attempts[agent_name],
+                type(exc).__name__,
+                exc,
+                len(pending) + 1,
+            )
+            pending.append((agent_name, endpoint))
+            stalled += 1
+            if stalled >= len(pending):
+                time.sleep(
+                    min(_HANDSHAKE_BACKOFF_S, max(0.0, deadline - time.monotonic()))
+                )
+                stalled = 0
+            continue
+
+        succeeded += 1
+        stalled = 0
+        last_error.pop(agent_name, None)
+        logger.info(
+            "[reshard] _prepare: handshake %d/%d %s ok in %.2fs (attempt %d)",
+            succeeded,
+            total,
+            agent_name,
+            time.perf_counter() - started,
+            attempts[agent_name],
+        )
+
+    retried = {name: count for name, count in attempts.items() if count > 1}
+    if retried:
+        logger.warning(
+            "[reshard] _prepare: handshake completed with retries: %s", retried
+        )
 
 
 def _coverage_floor() -> float:
@@ -226,11 +358,7 @@ class ReshardReceiver:
         # NIXL metadata (incl. its memory registrations) via its listen thread, so
         # prep_xfer_dlist can resolve the remote addresses. The central
         # add_remote_agent(blob) path does NOT convey the registrations.
-        for agent_name, endpoint in agent_endpoints.items():
-            host, port_str = endpoint.rsplit(":", 1)
-            self._manager.fetch_remote_and_wait(
-                agent_name, host, int(port_str), timeout_seconds=timeout
-            )
+        handshake_with_peers(self._manager, agent_endpoints, _HANDSHAKE_TIMEOUT_S)
 
         manifest = [
             (name, src.dtype, tuple(src.global_shape)) for name, src in sources.items()

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from collections import deque
 
@@ -53,19 +52,33 @@ from modelexpress.refit.reshard.types import (
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 
-# Whole-handshake budget across every peer and every retry. A refit timeout is the
-# wrong bound: it lets one unreachable peer consume the entire refit. It must still
-# be generous, because a peer can be unreachable for minutes for a legitimate
-# reason - registering tens of GB with the fabric provider blocks its listen
-# thread - and the receiver's only correct response to that is to keep trying.
-_HANDSHAKE_TIMEOUT_S = float(os.environ.get("MX_RESHARD_HANDSHAKE_TIMEOUT_S", "900"))
-# Ceiling on a single dial. A reachable peer answers in well under a second, so a
-# short attempt costs nothing when things are healthy and, when they are not, frees
-# the budget to try a different peer instead of blocking on one.
-_HANDSHAKE_ATTEMPT_S = float(os.environ.get("MX_RESHARD_HANDSHAKE_ATTEMPT_S", "20"))
-# Pause after a full pass over the pending peers yields no progress, so a transient
-# stall is waited out rather than hammered.
-_HANDSHAKE_BACKOFF_S = float(os.environ.get("MX_RESHARD_HANDSHAKE_BACKOFF_S", "2"))
+
+def _handshake_seconds(name: str) -> float:
+    """Read a handshake duration from the env registry, rejecting non-positives.
+
+    ``MX_RESHARD_HANDSHAKE_TIMEOUT_S`` is the whole-handshake budget across every
+    peer and every retry. A refit timeout is the wrong bound: it lets one
+    unreachable peer consume the entire refit. It must still be generous, because
+    a peer can be unreachable for minutes for a legitimate reason - registering
+    tens of GB with the fabric provider blocks its listen thread - and the
+    receiver's only correct response to that is to keep trying.
+
+    ``MX_RESHARD_HANDSHAKE_ATTEMPT_S`` is the ceiling on a single dial. A reachable
+    peer answers in well under a second, so a short attempt costs nothing when
+    things are healthy and, when they are not, frees the budget to try a different
+    peer instead of blocking on one.
+
+    ``MX_RESHARD_HANDSHAKE_BACKOFF_S`` is the pause after a full pass over the
+    pending peers yields no progress, so a transient stall is waited out rather
+    than hammered.
+
+    A non-positive value turns the corresponding bound off, which silently
+    reintroduces the failure mode it exists to prevent, so it is rejected.
+    """
+    value = float(getattr(envs, name))
+    if not value > 0.0:
+        raise ValueError(f"{name} must be a positive number of seconds, got {value}")
+    return value
 
 
 def handshake_with_peers(
@@ -96,7 +109,10 @@ def handshake_with_peers(
     metadata is being fetched, and there is no way to tell which peer is at
     fault, or whether it stalled on the first dial or the last.
     """
-    attempt_timeout = attempt_timeout or _HANDSHAKE_ATTEMPT_S
+    attempt_timeout = attempt_timeout or _handshake_seconds(
+        "MX_RESHARD_HANDSHAKE_ATTEMPT_S"
+    )
+    backoff = _handshake_seconds("MX_RESHARD_HANDSHAKE_BACKOFF_S")
     pending = deque(agent_endpoints.items())
     total = len(pending)
     attempts: dict = {name: 0 for name in agent_endpoints}
@@ -125,7 +141,6 @@ def handshake_with_peers(
             )
 
         agent_name, endpoint = pending.popleft()
-        host, port_str = endpoint.rsplit(":", 1)
         this_timeout = max(1.0, min(attempt_timeout, remaining))
         attempts[agent_name] += 1
         logger.info(
@@ -139,6 +154,9 @@ def handshake_with_peers(
         )
         started = time.perf_counter()
         try:
+            # Parsed inside the retry so a malformed entry is reported as this
+            # peer's failure, not raised past every other peer's handshake.
+            host, port_str = endpoint.rsplit(":", 1)
             manager.fetch_remote_and_wait(
                 agent_name, host, int(port_str), timeout_seconds=this_timeout
             )
@@ -158,9 +176,7 @@ def handshake_with_peers(
             pending.append((agent_name, endpoint))
             stalled += 1
             if stalled >= len(pending):
-                time.sleep(
-                    min(_HANDSHAKE_BACKOFF_S, max(0.0, deadline - time.monotonic()))
-                )
+                time.sleep(min(backoff, max(0.0, deadline - time.monotonic())))
                 stalled = 0
             continue
 
@@ -358,7 +374,11 @@ class ReshardReceiver:
         # NIXL metadata (incl. its memory registrations) via its listen thread, so
         # prep_xfer_dlist can resolve the remote addresses. The central
         # add_remote_agent(blob) path does NOT convey the registrations.
-        handshake_with_peers(self._manager, agent_endpoints, _HANDSHAKE_TIMEOUT_S)
+        handshake_with_peers(
+            self._manager,
+            agent_endpoints,
+            _handshake_seconds("MX_RESHARD_HANDSHAKE_TIMEOUT_S"),
+        )
 
         manifest = [
             (name, src.dtype, tuple(src.global_shape)) for name, src in sources.items()

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -146,7 +146,11 @@ def handshake_with_peers(
             )
 
         agent_name, endpoint = pending.popleft()
-        this_timeout = max(1.0, min(attempt_timeout, remaining))
+        # No floor: the deadline check above already guarantees remaining > 0, and
+        # rounding a sub-second remainder up to a second overruns the very budget
+        # this function exists to hold. A dial that gets 10 ms and fails is the
+        # intended outcome there - the next pass reports the bounded error.
+        this_timeout = min(attempt_timeout, remaining)
         attempts[agent_name] += 1
         logger.info(
             "[reshard] _prepare: handshake %d/%d %s at %s (attempt %d, timeout=%.0fs)",

--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -39,6 +39,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from modelexpress import envs, p2p_pb2
 from modelexpress.client import MxClient
@@ -233,9 +234,22 @@ def wrap_rendezvous_blob(
     return json.dumps(payload).encode("utf-8")
 
 
-def unwrap_rendezvous_blob(blob: bytes) -> tuple:
-    """Inverse of ``wrap_rendezvous_blob``; returns ``(agent_metadata, agent_name,
-    metadata_endpoint, tensors)``."""
+class RendezvousPayload(NamedTuple):
+    """One trainer rank's unwrapped rendezvous blob.
+
+    A plain tuple until now, which read as ``payload[3]`` at the point where the
+    interesting question is asked - whether this rank published any tensors. Being
+    a tuple subclass, it still unpacks and indexes as before.
+    """
+
+    agent_metadata: bytes
+    agent_name: str
+    metadata_endpoint: str
+    tensors: list
+
+
+def unwrap_rendezvous_blob(blob: bytes) -> RendezvousPayload:
+    """Inverse of ``wrap_rendezvous_blob``."""
     payload = json.loads(blob.decode("utf-8"))
     if payload.get("schema") != _SCHEMA:
         raise ValueError(f"unexpected rendezvous blob schema {payload.get('schema')!r}")
@@ -245,7 +259,7 @@ def unwrap_rendezvous_blob(blob: bytes) -> tuple:
     tensors = decode_shard_table(
         json.dumps({"schema": _SCHEMA, "tensors": payload["tensors"]}).encode("utf-8")
     )
-    return agent_metadata, agent_name, metadata_endpoint, tensors
+    return RendezvousPayload(agent_metadata, agent_name, metadata_endpoint, tensors)
 
 
 class MxReshardRendezvous:
@@ -344,8 +358,7 @@ class MxReshardRendezvous:
         """Block until ``expected_trainers`` trainer ranks are visible **with a
         non-empty shard table**, then return them.
 
-        Returns ``list[(agent_metadata, agent_name, metadata_endpoint,
-        tensors)]``, one per trainer rank.
+        Returns ``list[RendezvousPayload]``, one per trainer rank.
 
         A rank counts toward the quorum only once its published table names at
         least one tensor. A rank that advertises READY with nothing to read has
@@ -376,7 +389,7 @@ class MxReshardRendezvous:
                 if not meta.found:
                     continue
                 payload = unwrap_rendezvous_blob(meta.worker.nixl_metadata)
-                if not payload[3]:
+                if not payload.tensors:
                     empty += 1
                     continue
                 payloads.append(payload)
@@ -397,8 +410,8 @@ class MxReshardRendezvous:
             len(payloads),
             f" ({empty} skipped as empty)" if empty else "",
             ", ".join(
-                f"{name}@{endpoint}[{len(tensors)}]"
-                for (_meta, name, endpoint, tensors) in payloads
+                f"{p.agent_name}@{p.metadata_endpoint}[{len(p.tensors)}]"
+                for p in payloads
             ),
         )
         return payloads
@@ -421,8 +434,8 @@ def gather_sources(
     caller to ``fetch_remote_and_wait`` (P2P) before pulling."""
     rdv = MxReshardRendezvous(client, role=role, rank=rank, model_name=model_name)
     payloads = rdv.discover_trainers(expected_trainers, timeout=timeout)
-    tables = [tensors for (_meta, _name, _ep, tensors) in payloads]
-    agent_endpoints = {name: ep for (_meta, name, ep, _tensors) in payloads}
+    tables = [p.tensors for p in payloads]
+    agent_endpoints = {p.agent_name: p.metadata_endpoint for p in payloads}
     merged = merge_shard_tables(tables)
     sources, session_to_agent, session_to_device = build_sources(merged)
     return sources, session_to_agent, session_to_device, agent_endpoints

--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -352,6 +352,11 @@ class MxReshardRendezvous:
         registered no memory, so satisfying the quorum with it makes the receiver
         stop waiting for the ranks that do have bytes and then stall in the P2P
         handshake instead - a timeout attributed to the wrong component.
+
+        Exactly ``expected_trainers`` ranks are returned. A stale source from an
+        earlier run can still be READY, and every extra rank returned here becomes
+        an extra peer to handshake and an extra set of shards competing to describe
+        the same tensor names.
         """
         trainer_id = self._identity("trainer")
         deadline = time.monotonic() + timeout
@@ -362,18 +367,23 @@ class MxReshardRendezvous:
             )
             instances = list(resp.instances)
             payloads, empty = [], 0
-            if len(instances) >= expected_trainers:
-                for inst in instances:
-                    meta = self.client.get_metadata(inst.mx_source_id, inst.worker_id)
-                    if not meta.found:
-                        continue
-                    payload = unwrap_rendezvous_blob(meta.worker.nixl_metadata)
-                    if not payload[3]:
-                        empty += 1
-                        continue
-                    payloads.append(payload)
+            # Every visible READY source is inspected, whatever the count: with
+            # fewer sources than expected the shard-table state is exactly what a
+            # timeout here has to report, and reaching the quorum on instances
+            # alone says nothing about whether any of them published bytes.
+            for inst in instances:
+                meta = self.client.get_metadata(inst.mx_source_id, inst.worker_id)
+                if not meta.found:
+                    continue
+                payload = unwrap_rendezvous_blob(meta.worker.nixl_metadata)
+                if not payload[3]:
+                    empty += 1
+                    continue
+                payloads.append(payload)
                 if len(payloads) >= expected_trainers:
                     break
+            if len(payloads) >= expected_trainers:
+                break
             if time.monotonic() >= deadline:
                 raise TimeoutError(
                     f"timed out after {timeout}s waiting for {expected_trainers} "

--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -341,9 +341,18 @@ class MxReshardRendezvous:
         timeout: float = 1200.0,
         poll_interval: float = 1.0,
     ) -> list:
-        """Block until ``expected_trainers`` trainer ranks are visible, then
-        fetch + unwrap each. Returns ``list[(agent_metadata, agent_name,
-        metadata_endpoint, tensors)]``, one per trainer rank."""
+        """Block until ``expected_trainers`` trainer ranks are visible **with a
+        non-empty shard table**, then return them.
+
+        Returns ``list[(agent_metadata, agent_name, metadata_endpoint,
+        tensors)]``, one per trainer rank.
+
+        A rank counts toward the quorum only once its published table names at
+        least one tensor. A rank that advertises READY with nothing to read has
+        registered no memory, so satisfying the quorum with it makes the receiver
+        stop waiting for the ranks that do have bytes and then stall in the P2P
+        handshake instead - a timeout attributed to the wrong component.
+        """
         trainer_id = self._identity("trainer")
         deadline = time.monotonic() + timeout
         while True:
@@ -352,21 +361,36 @@ class MxReshardRendezvous:
                 status_filter=p2p_pb2.SOURCE_STATUS_READY,
             )
             instances = list(resp.instances)
+            payloads, empty = [], 0
             if len(instances) >= expected_trainers:
-                break
+                for inst in instances:
+                    meta = self.client.get_metadata(inst.mx_source_id, inst.worker_id)
+                    if not meta.found:
+                        continue
+                    payload = unwrap_rendezvous_blob(meta.worker.nixl_metadata)
+                    if not payload[3]:
+                        empty += 1
+                        continue
+                    payloads.append(payload)
+                if len(payloads) >= expected_trainers:
+                    break
             if time.monotonic() >= deadline:
                 raise TimeoutError(
-                    f"timed out after {timeout}s waiting for {expected_trainers} trainer ranks "
-                    f"(saw {len(instances)})"
+                    f"timed out after {timeout}s waiting for {expected_trainers} "
+                    f"trainer ranks (saw {len(instances)} READY source(s), "
+                    f"{len(payloads)} with a non-empty shard table, {empty} empty)"
                 )
             time.sleep(poll_interval)
 
-        payloads = []
-        for inst in instances:
-            meta = self.client.get_metadata(inst.mx_source_id, inst.worker_id)
-            if not meta.found:
-                continue
-            payloads.append(unwrap_rendezvous_blob(meta.worker.nixl_metadata))
+        logger.info(
+            "[reshard] discovered %d trainer rank(s)%s: %s",
+            len(payloads),
+            f" ({empty} skipped as empty)" if empty else "",
+            ", ".join(
+                f"{name}@{endpoint}[{len(tensors)}]"
+                for (_meta, name, endpoint, tensors) in payloads
+            ),
+        )
         return payloads
 
 

--- a/modelexpress_client/python/modelexpress/refit/reshard/transfer_plan.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/transfer_plan.py
@@ -94,27 +94,35 @@ class TransferPlan:
     exact_descriptor_count: int = 0
     exact_bytes: int = 0
 
+    def _all_segments(self):
+        """Every planned segment, wherever it lands.
+
+        Segments live in three places - read straight into live params, into
+        dtype-conversion staging, and into full-pull staging - and any question
+        about the plan as a whole has to ask all three.
+        """
+        yield from self.segments
+        for convert in self.converts:
+            yield from convert.segments
+        for full_pull in self.full_pulls:
+            yield from full_pull.segments
+
     def bytes_planned(self) -> int:
-        return (
-            sum(segment.nbytes for segment in self.segments)
-            + sum(
-                segment.nbytes
-                for convert in self.converts
-                for segment in convert.segments
-            )
-            + sum(
-                segment.nbytes
-                for full_pull in self.full_pulls
-                for segment in full_pull.segments
-            )
-        )
+        return sum(segment.nbytes for segment in self._all_segments())
 
     def descriptor_count(self) -> int:
-        return (
-            len(self.segments)
-            + sum(len(convert.segments) for convert in self.converts)
-            + sum(len(full_pull.segments) for full_pull in self.full_pulls)
-        )
+        return sum(1 for _ in self._all_segments())
+
+    def sessions(self) -> set:
+        """The transport sessions this plan actually reads from.
+
+        A receiver needs every trainer's shard table to build the plan, because it
+        cannot know which trainers hold the bytes it is missing until the slice
+        arithmetic is done. It does not need to *read* from all of them: with
+        enough ranks on both sides, each receiver ends up pulling from a fraction
+        of the trainers. This is that fraction.
+        """
+        return {segment.session for segment in self._all_segments()}
 
     def descriptor_savings(self) -> int:
         return max(0, self.exact_descriptor_count - self.descriptor_count())

--- a/modelexpress_client/python/tests/test_reshard_refit_handshake.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_handshake.py
@@ -168,10 +168,20 @@ def test_a_non_positive_bound_falls_back_to_the_default(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="modelexpress.envs"):
         assert envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S == 900.0
 
-    assert "must be positive" in caplog.text
+    assert "must be a finite positive number" in caplog.text
 
 
 def test_an_unparseable_bound_falls_back_to_the_default(monkeypatch):
     monkeypatch.setenv("MX_RESHARD_HANDSHAKE_BACKOFF_S", "soon")
 
     assert envs.MX_RESHARD_HANDSHAKE_BACKOFF_S == 2.0
+
+
+@pytest.mark.parametrize("raw", ["inf", "-inf", "nan"])
+def test_a_non_finite_bound_falls_back_to_the_default(monkeypatch, raw):
+    """`float()` takes these happily and each one defeats the deadline: `now >=
+    inf` is never true, and every comparison against `nan` is false. Both leave
+    the handshake unbounded, which is what the bound is here to prevent."""
+    monkeypatch.setenv("MX_RESHARD_HANDSHAKE_TIMEOUT_S", raw)
+
+    assert envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S == 900.0

--- a/modelexpress_client/python/tests/test_reshard_refit_handshake.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_handshake.py
@@ -2,21 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """The P2P metadata handshake must be bounded overall, retry transient failures,
-and say who it is talking to.
+say who it is talking to, and dial only the peers it needs.
 
-Two distinct production failures motivate these:
+Two distinct production failures motivate the bounds:
   * a dead publisher still advertised in the catalog previously hung the whole
     refit for the refit timeout, with no indication of which peer stalled;
   * a *live* publisher can be listening yet transiently unable to accept while it
     is busy publishing, which must not be fatal on the first dial.
+
+The peer selection is a scaling concern rather than a failure: the handshake
+resolves remote memory registrations for reads, so dialing a trainer this rank
+never reads from buys nothing, and unnarrowed that is a dial per
+receiver-trainer pair.
 """
 
 import logging
+import types
 
 import pytest
 
 from modelexpress import envs
-from modelexpress.refit.reshard.receiver import handshake_with_peers
+from modelexpress.refit.reshard.receiver import (
+    handshake_endpoints_for_plan,
+    handshake_with_peers,
+)
+from modelexpress.refit.reshard.slice_plan import PullSegment
+from modelexpress.refit.reshard.transfer_plan import TransferPlan
 
 
 class _Manager:
@@ -185,3 +196,71 @@ def test_a_non_finite_bound_falls_back_to_the_default(monkeypatch, raw):
     monkeypatch.setenv("MX_RESHARD_HANDSHAKE_TIMEOUT_S", raw)
 
     assert envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S == 900.0
+
+
+# --------------------------------------------------- narrowing the peer set
+
+
+def _segment(session):
+    return PullSegment(
+        session=session, src_addr=0, param_name="w", dst_byte=0, nbytes=1024
+    )
+
+
+def _session_to_agent(n):
+    return {f"s{i}": f"trainer-r{i}" for i in range(n)}
+
+
+def test_only_the_trainers_the_plan_reads_from_are_dialed():
+    """Four trainers were discovered, the plan reads from two, so two are dialed."""
+    plan = TransferPlan(segments=[_segment("s1"), _segment("s3")])
+
+    narrowed = handshake_endpoints_for_plan(plan, _session_to_agent(4), _endpoints(4))
+
+    assert set(narrowed) == {"trainer-r1", "trainer-r3"}
+
+
+def test_the_narrowed_endpoints_keep_their_addresses():
+    plan = TransferPlan(segments=[_segment("s2")])
+
+    narrowed = handshake_endpoints_for_plan(plan, _session_to_agent(4), _endpoints(4))
+
+    assert narrowed == {"trainer-r2": "10.0.0.2:9999"}
+
+
+def test_reads_are_counted_from_every_phase_of_the_plan():
+    """Segments land in three places - straight into live params, into
+    dtype-conversion staging, and into full-pull staging. Missing any one of them
+    would drop a peer the plan genuinely reads from, and the failure would surface
+    later as an unresolvable address in prep_xfer_dlist."""
+    plan = TransferPlan(
+        segments=[_segment("s0")],
+        converts=[types.SimpleNamespace(segments=[_segment("s1")])],
+        full_pulls=[types.SimpleNamespace(segments=[_segment("s2")])],
+    )
+
+    assert plan.sessions() == {"s0", "s1", "s2"}
+
+    narrowed = handshake_endpoints_for_plan(plan, _session_to_agent(4), _endpoints(4))
+
+    assert set(narrowed) == {"trainer-r0", "trainer-r1", "trainer-r2"}
+
+
+def test_a_planned_trainer_with_no_endpoint_fails_closed():
+    """Silently skipping it would defer the failure to prep_xfer_dlist, which
+    cannot say which peer it was missing metadata for."""
+    plan = TransferPlan(segments=[_segment("s0"), _segment("s3")])
+    endpoints = {"trainer-r0": "10.0.0.0:9999"}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        handshake_endpoints_for_plan(plan, _session_to_agent(4), endpoints)
+
+    assert "trainer-r3" in str(excinfo.value)
+
+
+def test_an_empty_plan_dials_nobody():
+    narrowed = handshake_endpoints_for_plan(
+        TransferPlan(), _session_to_agent(4), _endpoints(4)
+    )
+
+    assert narrowed == {}

--- a/modelexpress_client/python/tests/test_reshard_refit_handshake.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_handshake.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The P2P metadata handshake must be bounded overall, retry transient failures,
+and say who it is talking to.
+
+Two distinct production failures motivate these:
+  * a dead publisher still advertised in the catalog previously hung the whole
+    refit for the refit timeout, with no indication of which peer stalled;
+  * a *live* publisher can be listening yet transiently unable to accept while it
+    is busy publishing, which must not be fatal on the first dial.
+"""
+
+import pytest
+
+from modelexpress.refit.reshard.receiver import handshake_with_peers
+
+
+class _Manager:
+    """Records dials. ``fail_until`` makes a peer fail its first N attempts."""
+
+    def __init__(self, always_fail=(), fail_until=None):
+        self.always_fail = set(always_fail)
+        self.fail_until = dict(fail_until or {})
+        self.calls = []
+
+    def fetch_remote_and_wait(self, agent, host, port, timeout_seconds=None):
+        self.calls.append((agent, host, port, timeout_seconds))
+        if agent in self.always_fail:
+            raise ConnectionRefusedError("peer is gone")
+        if self.fail_until.get(agent, 0) > 0:
+            self.fail_until[agent] -= 1
+            raise TimeoutError(f"timed out after {timeout_seconds}s")
+
+    def dials(self, agent):
+        return [c for c in self.calls if c[0] == agent]
+
+
+def _endpoints(n):
+    return {f"trainer-r{i}": f"10.0.0.{i}:9999" for i in range(n)}
+
+
+def test_every_peer_is_dialed_once_when_all_are_healthy():
+    manager = _Manager()
+
+    handshake_with_peers(manager, _endpoints(3), 300.0)
+
+    assert [c[0] for c in manager.calls] == ["trainer-r0", "trainer-r1", "trainer-r2"]
+
+
+def test_a_single_dial_is_capped_by_the_attempt_timeout_not_the_budget():
+    """The whole point of the split: a 300 s budget must not become a 300 s dial."""
+    manager = _Manager()
+
+    handshake_with_peers(manager, _endpoints(2), 300.0, attempt_timeout=20.0)
+
+    assert {c[3] for c in manager.calls} == {20.0}
+
+
+def test_attempt_timeout_is_clamped_to_the_remaining_budget():
+    manager = _Manager()
+
+    handshake_with_peers(manager, _endpoints(1), 5.0, attempt_timeout=20.0)
+
+    # Derived from the live remaining budget, so it lands just under 5 s.
+    assert manager.calls[0][3] == pytest.approx(5.0, abs=0.1)
+
+
+def test_endpoint_is_split_into_host_and_port():
+    manager = _Manager()
+
+    handshake_with_peers(manager, {"trainer-r0": "10.0.0.7:9999"}, 300.0)
+
+    assert manager.calls[0][:3] == ("trainer-r0", "10.0.0.7", 9999)
+
+
+def test_ipv6_style_endpoint_splits_on_the_last_colon():
+    manager = _Manager()
+
+    handshake_with_peers(manager, {"trainer-r0": "fd00::1:9999"}, 300.0)
+
+    assert manager.calls[0][1:3] == ("fd00::1", 9999)
+
+
+def test_a_transiently_unreachable_peer_is_retried_and_succeeds():
+    """A busy trainer that drops the first SYNs must not fail the refit."""
+    manager = _Manager(fail_until={"trainer-r1": 2})
+
+    handshake_with_peers(manager, _endpoints(3), 300.0, attempt_timeout=1.0)
+
+    assert len(manager.dials("trainer-r1")) == 3
+
+
+def test_a_failing_peer_is_deferred_so_others_are_not_blocked():
+    """The old code aborted on peer 1 of 16 and never dialed the other 15."""
+    manager = _Manager(fail_until={"trainer-r0": 1})
+
+    handshake_with_peers(manager, _endpoints(3), 300.0, attempt_timeout=1.0)
+
+    order = [c[0] for c in manager.calls]
+    # r0 fails, r1 and r2 are tried before r0 is revisited.
+    assert order[0] == "trainer-r0"
+    assert order.index("trainer-r1") < order.index("trainer-r0", 1)
+    assert order.index("trainer-r2") < order.index("trainer-r0", 1)
+
+
+def test_budget_exhaustion_names_outstanding_peers_and_counts_progress():
+    manager = _Manager(always_fail={"trainer-r2"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        handshake_with_peers(manager, _endpoints(3), 2.0, attempt_timeout=0.5)
+
+    message = str(excinfo.value)
+    assert "2 of 3 peer(s) answered" in message
+    assert "trainer-r2@10.0.0.2:9999" in message
+    assert "attempt(s)" in message
+    assert "ConnectionRefusedError" in message
+
+
+def test_healthy_peers_are_not_redialled_after_another_peer_fails():
+    """Re-handshaking a peer that already answered would waste the budget."""
+    manager = _Manager(always_fail={"trainer-r1"})
+
+    with pytest.raises(RuntimeError):
+        handshake_with_peers(manager, _endpoints(3), 2.0, attempt_timeout=0.5)
+
+    assert len(manager.dials("trainer-r0")) == 1
+    assert len(manager.dials("trainer-r2")) == 1
+
+
+def test_no_peers_is_not_an_error():
+    manager = _Manager()
+
+    handshake_with_peers(manager, {}, 300.0)
+
+    assert manager.calls == []

--- a/modelexpress_client/python/tests/test_reshard_refit_handshake.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_handshake.py
@@ -11,12 +11,12 @@ Two distinct production failures motivate these:
     is busy publishing, which must not be fatal on the first dial.
 """
 
+import logging
+
 import pytest
 
-from modelexpress.refit.reshard.receiver import (
-    _handshake_seconds,
-    handshake_with_peers,
-)
+from modelexpress import envs
+from modelexpress.refit.reshard.receiver import handshake_with_peers
 
 
 class _Manager:
@@ -157,12 +157,21 @@ def test_a_malformed_endpoint_fails_only_its_own_peer():
 def test_handshake_bounds_come_from_the_env_registry(monkeypatch):
     monkeypatch.setenv("MX_RESHARD_HANDSHAKE_ATTEMPT_S", "3.5")
 
-    assert _handshake_seconds("MX_RESHARD_HANDSHAKE_ATTEMPT_S") == 3.5
+    assert envs.MX_RESHARD_HANDSHAKE_ATTEMPT_S == 3.5
 
 
-def test_a_non_positive_bound_is_rejected(monkeypatch):
-    """Zero or negative turns the bound off, reinstating the hang it prevents."""
+def test_a_non_positive_bound_falls_back_to_the_default(monkeypatch, caplog):
+    """Zero or negative is not a smaller bound but an absent one, which reinstates
+    the hang the bound exists to prevent. The documented default is kept instead."""
     monkeypatch.setenv("MX_RESHARD_HANDSHAKE_TIMEOUT_S", "0")
 
-    with pytest.raises(ValueError, match="positive number of seconds"):
-        _handshake_seconds("MX_RESHARD_HANDSHAKE_TIMEOUT_S")
+    with caplog.at_level(logging.WARNING, logger="modelexpress.envs"):
+        assert envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S == 900.0
+
+    assert "must be positive" in caplog.text
+
+
+def test_an_unparseable_bound_falls_back_to_the_default(monkeypatch):
+    monkeypatch.setenv("MX_RESHARD_HANDSHAKE_BACKOFF_S", "soon")
+
+    assert envs.MX_RESHARD_HANDSHAKE_BACKOFF_S == 2.0

--- a/modelexpress_client/python/tests/test_reshard_refit_handshake.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_handshake.py
@@ -13,7 +13,10 @@ Two distinct production failures motivate these:
 
 import pytest
 
-from modelexpress.refit.reshard.receiver import handshake_with_peers
+from modelexpress.refit.reshard.receiver import (
+    _handshake_seconds,
+    handshake_with_peers,
+)
 
 
 class _Manager:
@@ -134,3 +137,32 @@ def test_no_peers_is_not_an_error():
     handshake_with_peers(manager, {}, 300.0)
 
     assert manager.calls == []
+
+
+def test_a_malformed_endpoint_fails_only_its_own_peer():
+    """One unparseable catalog entry must not abort the other peers' handshake -
+    the same fault isolation a refused connection already gets."""
+    manager = _Manager()
+    endpoints = {"trainer-r0": "10.0.0.0-no-port", "trainer-r1": "10.0.0.1:9999"}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        handshake_with_peers(manager, endpoints, 1.0, attempt_timeout=0.5)
+
+    message = str(excinfo.value)
+    assert "1 of 2 peer(s) answered" in message
+    assert "trainer-r0@10.0.0.0-no-port" in message
+    assert manager.dials("trainer-r1")
+
+
+def test_handshake_bounds_come_from_the_env_registry(monkeypatch):
+    monkeypatch.setenv("MX_RESHARD_HANDSHAKE_ATTEMPT_S", "3.5")
+
+    assert _handshake_seconds("MX_RESHARD_HANDSHAKE_ATTEMPT_S") == 3.5
+
+
+def test_a_non_positive_bound_is_rejected(monkeypatch):
+    """Zero or negative turns the bound off, reinstating the hang it prevents."""
+    monkeypatch.setenv("MX_RESHARD_HANDSHAKE_TIMEOUT_S", "0")
+
+    with pytest.raises(ValueError, match="positive number of seconds"):
+        _handshake_seconds("MX_RESHARD_HANDSHAKE_TIMEOUT_S")

--- a/modelexpress_client/python/tests/test_reshard_refit_handshake.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_handshake.py
@@ -80,6 +80,16 @@ def test_attempt_timeout_is_clamped_to_the_remaining_budget():
     assert manager.calls[0][3] == pytest.approx(5.0, abs=0.1)
 
 
+def test_a_sub_second_remainder_does_not_overrun_the_budget():
+    """A one-second floor on the dial timeout would let the last attempt run past
+    the total budget, which is the one thing this function has to hold."""
+    manager = _Manager()
+
+    handshake_with_peers(manager, _endpoints(1), 0.4, attempt_timeout=20.0)
+
+    assert manager.calls[0][3] <= 0.4
+
+
 def test_endpoint_is_split_into_host_and_port():
     manager = _Manager()
 

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -10,9 +10,32 @@ import pytest
 from modelexpress import p2p_pb2
 from modelexpress.refit.reshard.rendezvous import (
     MxReshardRendezvous,
+    PublishedShard,
+    PublishedTensor,
     _mx_version,
     wrap_rendezvous_blob,
 )
+
+
+def _one_tensor(agent_name="trainer-agent"):
+    """The smallest publishable shard table: one tensor, one shard."""
+    return [
+        PublishedTensor(
+            name="weight",
+            dtype="torch.bfloat16",
+            elsize=2,
+            full_shape=(4, 4),
+            shards=[
+                PublishedShard(
+                    agent_name=agent_name,
+                    device_id=0,
+                    addr=4096,
+                    shard_offset=(0, 0),
+                    shape=(4, 4),
+                )
+            ],
+        )
+    ]
 
 
 def test_mx_version_falls_back_only_when_package_is_missing(monkeypatch):
@@ -102,7 +125,7 @@ def test_published_rendezvous_stays_ready_and_closes_stale(monkeypatch):
         agent_metadata=b"nixl",
         agent_name="trainer-agent",
         metadata_endpoint="trainer:1234",
-        tensors=[],
+        tensors=_one_tensor(),
     )
 
     try:
@@ -110,9 +133,11 @@ def test_published_rendezvous_stays_ready_and_closes_stale(monkeypatch):
         assert client.worker.status == p2p_pb2.SOURCE_STATUS_READY
         assert client.heartbeat_seen.wait(timeout=1.0)
         assert client.publish_count == 1
-        assert rendezvous.discover_trainers(expected_trainers=1) == [
-            (b"nixl", "trainer-agent", "trainer:1234", [])
+        discovered = rendezvous.discover_trainers(expected_trainers=1)
+        assert [(meta, name, ep) for (meta, name, ep, _t) in discovered] == [
+            (b"nixl", "trainer-agent", "trainer:1234")
         ]
+        assert [t.name for t in discovered[0][3]] == ["weight"]
         assert client.status_filter == p2p_pb2.SOURCE_STATUS_READY
     finally:
         rendezvous.close()
@@ -123,6 +148,87 @@ def test_published_rendezvous_stays_ready_and_closes_stale(monkeypatch):
         "worker_rank": 2,
         "status": p2p_pb2.SOURCE_STATUS_STALE,
     }
+
+
+class _DiscoveryClient:
+    """Serves a fixed set of READY sources, each with its own shard table."""
+
+    def __init__(self, blobs):
+        self._blobs = list(blobs)
+
+    def list_sources(self, _identity, status_filter=None):
+        return SimpleNamespace(
+            instances=[
+                SimpleNamespace(mx_source_id=f"src-{i}", worker_id=f"w-{i}")
+                for i in range(len(self._blobs))
+            ]
+        )
+
+    def get_metadata(self, source_id, _worker_id):
+        index = int(source_id.rsplit("-", 1)[1])
+        return SimpleNamespace(
+            found=True,
+            worker=SimpleNamespace(nixl_metadata=self._blobs[index]),
+        )
+
+
+def _blob(agent_name, tensors):
+    return wrap_rendezvous_blob(
+        agent_metadata=b"nixl",
+        agent_name=agent_name,
+        metadata_endpoint=f"{agent_name}:1234",
+        tensors=tensors,
+    )
+
+
+def _rendezvous(client):
+    return MxReshardRendezvous(client, role="inference", rank=0, model_name="model")
+
+
+def test_a_publisher_with_no_tensors_does_not_count_toward_the_quorum():
+    """It has registered no memory, so counting it makes the receiver stop
+    waiting for the ranks that do have bytes and then stall in the handshake."""
+    client = _DiscoveryClient(
+        [_blob("empty-rank", []), _blob("real-rank", _one_tensor())]
+    )
+
+    with pytest.raises(TimeoutError) as excinfo:
+        _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
+
+    message = str(excinfo.value)
+    assert "2 READY source(s)" in message
+    assert "1 with a non-empty shard table" in message
+    assert "1 empty" in message
+
+
+def test_quorum_is_met_once_every_rank_publishes_tensors():
+    client = _DiscoveryClient(
+        [_blob("rank-0", _one_tensor()), _blob("rank-1", _one_tensor())]
+    )
+
+    discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
+
+    assert [name for (_meta, name, _ep, _tensors) in discovered] == [
+        "rank-0",
+        "rank-1",
+    ]
+
+
+def test_empty_publishers_are_excluded_from_the_returned_payloads():
+    """An extra healthy rank means the quorum is reachable without the empty one,
+    which must still not appear in the plan's sources."""
+    client = _DiscoveryClient(
+        [
+            _blob("rank-0", _one_tensor()),
+            _blob("empty-rank", []),
+            _blob("rank-1", _one_tensor()),
+        ]
+    )
+
+    discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
+
+    assert "empty-rank" not in [name for (_meta, name, _ep, _t) in discovered]
+    assert len(discovered) == 2
 
 
 def test_invalid_heartbeat_period_fails_before_publish(monkeypatch):

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -244,7 +244,20 @@ def test_only_the_requested_number_of_ranks_is_returned():
 
     discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
 
-    assert [name for (_meta, name, _ep, _t) in discovered] == ["rank-0", "rank-1"]
+    assert [p.agent_name for p in discovered] == ["rank-0", "rank-1"]
+
+
+def test_a_discovered_payload_reads_by_field_and_by_position():
+    """Named access is the point of the change; positional access is what every
+    existing caller does, so both have to keep working."""
+    client = _DiscoveryClient([_blob("rank-0", _one_tensor())])
+
+    (payload,) = _rendezvous(client).discover_trainers(expected_trainers=1, timeout=0)
+    agent_metadata, agent_name, endpoint, tensors = payload
+
+    assert (payload.agent_name, payload.metadata_endpoint) == (agent_name, endpoint)
+    assert (payload.agent_metadata, payload.tensors) == (agent_metadata, tensors)
+    assert payload[3] is payload.tensors
 
 
 def test_a_partial_ready_set_still_reports_its_shard_tables():

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -231,6 +231,37 @@ def test_empty_publishers_are_excluded_from_the_returned_payloads():
     assert len(discovered) == 2
 
 
+def test_only_the_requested_number_of_ranks_is_returned():
+    """A stale source from an earlier run stays READY. Returning it adds a peer to
+    handshake and a second set of shards describing the same tensor names."""
+    client = _DiscoveryClient(
+        [
+            _blob("rank-0", _one_tensor()),
+            _blob("rank-1", _one_tensor()),
+            _blob("stale-rank", _one_tensor()),
+        ]
+    )
+
+    discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
+
+    assert [name for (_meta, name, _ep, _t) in discovered] == ["rank-0", "rank-1"]
+
+
+def test_a_partial_ready_set_still_reports_its_shard_tables():
+    """Below the quorum the shard-table state is exactly what the timeout has to
+    report: one READY publisher with nothing to serve is a different failure from
+    one rank that has not come up yet."""
+    client = _DiscoveryClient([_blob("empty-rank", [])])
+
+    with pytest.raises(TimeoutError) as excinfo:
+        _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
+
+    message = str(excinfo.value)
+    assert "1 READY source(s)" in message
+    assert "0 with a non-empty shard table" in message
+    assert "1 empty" in message
+
+
 def test_invalid_heartbeat_period_fails_before_publish(monkeypatch):
     class Client:
         def publish_metadata(self, *_args, **_kwargs):


### PR DESCRIPTION
## Summary

This PR bounds and retries the receiver's peer-metadata handshake, narrows it to
the trainers a receiver actually reads from, and prevents READY publishers with
empty shard tables from satisfying the discovery quorum. Together these turn an
ambiguous refit hang into either successful progress or a bounded error naming
the peers that did not answer.

The PR targets current `main`; #536 is already merged and its former base commits
have been removed.

## Why this is needed

Before weight reads begin, each receiver fetches NIXL metadata from its trainer
peers. The previous loop attempted peers once, in catalog order, and allowed one
peer to consume the full refit timeout. A dead or temporarily busy publisher
could therefore block all healthy peers and produce only a generic timeout.

It also dialed every discovered trainer, including ones it would never read a
byte from. The handshake exists to resolve a peer's remote memory registrations
so reads can address them, so a peer that is never read from costs a dial and
buys nothing. Unnarrowed, the dial count is one per receiver-trainer pair and
grows as the product of both sides.

Discovery had a related problem: a READY source with an empty shard table counted
toward the trainer quorum even though it had no registered tensors to serve. The
receiver could stop discovery early and then stall while handshaking a source
that could never contribute bytes.

## Handshake behavior

`handshake_with_peers()` applies one budget across all peers and retries:

- `MX_RESHARD_HANDSHAKE_TIMEOUT_S` controls the total handshake budget;
- `MX_RESHARD_HANDSHAKE_ATTEMPT_S` caps one dial and is clamped to the remaining
  total budget;
- failed peers move to the back of the queue so healthy peers can progress;
- a full pass without progress waits `MX_RESHARD_HANDSHAKE_BACKOFF_S` before
  retrying;
- timeout errors identify every outstanding peer, endpoint, attempt count, and
  last error.

A peer that succeeds is removed from the queue and is not dialed again.
Endpoints split on the final colon, preserving IPv6 literal handling, and are
parsed inside the retry so an unparseable catalog entry is reported as that
peer's failure rather than raised past every other peer.

All three bounds are registered in `modelexpress/envs.py` and documented in the
client README variable table, so they parse and warn like every other variable
and are read live rather than frozen at import. A value that is not a finite
positive number — zero, negative, unparseable, `inf`, or `nan` — warns and falls
back to the documented default, because each of those disables the bound rather
than tightening it.

## Which peers get dialed

The handshake now runs after `plan_transfer()` rather than immediately after
discovery, and dials only the trainers the plan reads from.

Discovery still has to collect every trainer's shard table: which trainers hold
the bytes a given receiver is missing is only known once the slice arithmetic is
done. The handshake has no such constraint — it only has to precede the first
read. By the time the plan exists, `TransferPlan.sessions()` names the sessions
actually read from, and `handshake_endpoints_for_plan()` narrows the endpoint map
to their agents. On a topology where each receiver pulls from a fraction of the
trainers, that fraction is what gets dialed.

Two smaller consequences of the reorder. An unsupported plan is now rejected
before the handshake budget is spent, which is the ordering a review comment
flagged on the earlier revision. And a trainer that the plan reads from but which
published no endpoint now fails closed with that trainer named, rather than
deferring the failure to `prep_xfer_dlist`, which cannot say which peer's
metadata was missing.

`TransferPlan` grows an `_all_segments()` helper for this. Segments live in three
places — read straight into live params, into dtype-conversion staging, and into
full-pull staging — and any question about the plan as a whole has to ask all
three. `bytes_planned()`, `descriptor_count()`, and the new `sessions()` now
share one traversal instead of each re-enumerating the phases.

**This is scaling headroom, not a measured speedup.** On Topology A the handshake
is a 3.2 s median across 16 peers, about 4% of an 87 s cold start, and `_prepare`
runs once per run because the plan is cached and reused every step. Capture and
plan are 51 s of that same 87 s and remain where cold-start effort belongs.

## Discovery behavior

`discover_trainers()` now fetches metadata while polling and counts a READY rank
only when its decoded shard table is non-empty. Empty publishers are excluded
from the returned payloads, and collection stops once the requested number of
non-empty ranks is in hand: a source left READY by an earlier run is both an
extra peer to handshake and a second set of shards competing to describe the
same tensor names.

Metadata is inspected for every visible READY source, whatever the count.
Gating that inspection on the READY count already meeting the quorum defeated
the purpose of the change, because below the quorum the timeout then reported
zero non-empty and zero empty tables - the one number that distinguishes "a rank
has not come up yet" from "a rank came up with nothing to serve". Timeout
messages report READY, non-empty, and empty counts separately.

This moves metadata reads into the polling loop. That adds repeated catalog reads
while waiting, but it is necessary because the source listing does not contain
the shard table needed to decide whether a publisher can serve tensors.

## Scope and limits

This PR does not terminate a trainer process that outlives its driver, add run or
epoch identity, or recover a transfer already in progress. The shared publisher
heartbeat from #536 and the existing server reaper handle normal freshness and
stale expiry; an orphan process that remains alive can still renew its own
source.

The change limits and identifies handshake failures, and stops the receiver
dialing peers it has no reason to talk to. It does not make an incorrect or
abandoned publisher safe to use.

## Validation

- [x] Rebased onto current `main`; merged #536 base commits were dropped.
- [x] 71 `test_reshard_refit_*` / `test_reshard_*` tests pass, 22 of them in the
      handshake file.
- [x] Tests cover total and per-attempt deadlines, retry ordering, backoff,
      progress logging, IPv6 endpoints, malformed endpoints, fallback on
      non-finite and non-positive bounds, over-quorum collection, and partial
      READY reporting.
- [x] Peer-narrowing tests cover selection from all three plan phases, address
      preservation, the fail-closed missing-endpoint case, and an empty plan
      dialing nobody.
- [x] The merged #536 shared-publisher test still expects one metadata publish;
      READY heartbeats remain status updates rather than full re-publications.
- [x] Core Ruff checks and whitespace validation pass. The 60 failures in
      `test_vmm_*` are pre-existing on this branch point and require CUDA VMM;
      they touch none of these files.

## Reviewer guide

1. `refit/reshard/receiver.py` — review `handshake_with_peers()` and its deadline
   arithmetic first. Confirm each attempt is bounded by both the attempt ceiling
   and remaining total budget, and that everything that can fail per peer sits
   inside the retry.
2. `refit/reshard/receiver.py`, `_prepare()` — check the new ordering: discover,
   capture, plan, reject unsupported, then narrow and handshake. `session_to_agent`
   comes from `gather_sources()` and the handshake must still precede the first
   read in `execute_transfer()`.
3. `refit/reshard/receiver.py`, `handshake_endpoints_for_plan()` — the narrowing
   itself, in particular that it fails closed on a planned trainer with no
   endpoint rather than silently dropping it.
4. `refit/reshard/transfer_plan.py` — `_all_segments()` and `sessions()`.
   Worth confirming the three phases are all walked, since missing one would drop
   a peer the plan genuinely reads from.
5. `tests/test_reshard_refit_handshake.py` — per-attempt capping, failed peer
   deferral, no-progress backoff, completed-peer removal, the malformed endpoint
   case, and the narrowing tests at the end of the file.
6. `refit/reshard/rendezvous.py` — verify only non-empty publishers count toward
   quorum, that collection stops at the requested count, and that timeout
   accounting reflects every visible source.
7. `tests/test_reshard_refit_rendezvous.py` — verify heartbeat behavior from #536
   and the new empty-table, over-quorum, and partial-set cases are all preserved.
8. `modelexpress/envs.py` and `modelexpress_client/python/README.md` — the three
   handshake bounds and their documented defaults.

Catching broad `Exception` around one dial is deliberate: failures remain
retryable inside the bounded budget, while the final error retains peer-specific
diagnostics.
