### PR TITLE
fix(examples): run dynamo P2P vLLM workers as root

### DIFF
--- a/examples/dynamo_p2p_transfer_k8s/README.md
+++ b/examples/dynamo_p2p_transfer_k8s/README.md
@@ -162,3 +162,24 @@ kubectl logs -n <namespace> <pod> -c main | grep "Adopted .* hidden"
 # vLLM's disagg KV-transfer metrics on the decode side
 kubectl logs -n <namespace> <decode-pod> -c main | grep -E "KV Transfer metrics|prefix cache"
 ```
+
+### FlashInfer cubin permission denied
+
+If workers restart during `EngineCore` init with:
+
+```
+[Errno 13] Permission denied:
+  '/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer'
+```
+
+the container is running as the image's default non-root `dynamo` user.
+FlashInfer resolves its cubin directory to the installed `flashinfer-cubin`
+package under root-owned `site-packages`, and downloads any cubin missing for
+the current GPU architecture back into that directory. FP8 MoE models take this
+path by default, so the worker dies before the engine comes up.
+
+The manifests here set `securityContext.runAsUser: 0` on the worker containers
+to avoid this. To stay non-root instead, point `FLASHINFER_CUBIN_DIR` at a
+writable directory - but note that this bypasses the `flashinfer-cubin` package
+entirely, so every cubin is re-downloaded at startup and the pod needs network
+access to the FlashInfer artifact host.

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-multi-node-aggregated.yaml
@@ -141,6 +141,12 @@ spec:
           # Build using examples/dynamo_p2p_transfer_k8s/Dockerfile
           image: <your-registry>/modelexpress-vllm-runtime:latest
           securityContext:
+            # The dynamo runtime image defaults to the non-root dynamo user.
+            # FlashInfer downloads missing cubins into its installed
+            # flashinfer-cubin package directory under root-owned
+            # site-packages, which fails with EACCES and kills the worker
+            # during EngineCore init. See README "Debugging".
+            runAsUser: 0
             capabilities:
               add:
               - IPC_LOCK

--- a/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/vllm-single-node-disaggregated.yaml
@@ -136,6 +136,12 @@ spec:
         mainContainer:
           image: <your-registry>/modelexpress-vllm-runtime:latest
           securityContext:
+            # The dynamo runtime image defaults to the non-root dynamo user.
+            # FlashInfer downloads missing cubins into its installed
+            # flashinfer-cubin package directory under root-owned
+            # site-packages, which fails with EACCES and kills the worker
+            # during EngineCore init. See README "Debugging".
+            runAsUser: 0
             capabilities:
               add:
               - IPC_LOCK
@@ -216,6 +222,12 @@ spec:
         mainContainer:
           image: <your-registry>/modelexpress-vllm-runtime:latest
           securityContext:
+            # The dynamo runtime image defaults to the non-root dynamo user.
+            # FlashInfer downloads missing cubins into its installed
+            # flashinfer-cubin package directory under root-owned
+            # site-packages, which fails with EACCES and kills the worker
+            # during EngineCore init. See README "Debugging".
+            runAsUser: 0
             capabilities:
               add:
               - IPC_LOCK


### PR DESCRIPTION
## Problem

The `examples/dynamo_p2p_transfer_k8s` manifests declare a worker `securityContext` with only `capabilities.add: [IPC_LOCK]` and no `runAsUser`, so containers inherit the dynamo vllm-runtime image default, which is the non-root `dynamo` user.

FlashInfer resolves its cubin directory (`flashinfer/jit/env.py::_get_cubin_dir`) to the installed `flashinfer-cubin` package under root-owned `site-packages`, and `cubin_loader.get_cubin` downloads any cubin that is missing for the current GPU architecture back into that same directory. On a non-root worker that write fails:

```
[Errno 13] Permission denied:
  '/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer'
```

vLLM treats the dead worker as fatal (`multiproc_executor.py:284`), `EngineCore` initialization fails, the pod restarts in a loop, and the DynamoGraphDeployment stays at `state=pending`. FP8 MoE models select the FlashInfer backend by default, so the DeepSeek-family models these examples advertise take this path on every start.

Reproduced on GB200 with a deepseek_v3 FP8 MoE model, vLLM 0.23.0, `--load-format modelexpress`, TP=4/PP=2, multinode nodeCount=2. Adding only `runAsUser: 0` takes the same deployment from restart-looping to `state=successful` with both workers `1/1`.

## Change

- `runAsUser: 0` on the aggregated worker container and on both disaggregated services (prefill and decode), matching the existing trtllm examples.
- README "Debugging" entry describing the failure signature, plus the non-root alternative (`FLASHINFER_CUBIN_DIR` pointed at a writable path) and its caveat: setting it bypasses the `flashinfer-cubin` package entirely, so every cubin is re-downloaded at startup and the pod needs network access to the FlashInfer artifact host.

`examples/p2p_transfer_k8s` is unaffected - it builds `FROM vllm/vllm-openai`, which already runs as root.

## Test

Manifest-only change, validated with `pre-commit run` (check yaml passed). Behavior verified on the cluster run described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented vLLM workers from failing during startup because of FlashInfer cubin permission errors.
  * Updated Kubernetes deployment settings so aggregated and disaggregated workers can initialize successfully.

* **Documentation**
  * Added troubleshooting guidance for FlashInfer cubin permission issues, including root and non-root configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->