### PR TITLE
feat(reshard-refit): measure refit coverage and gate on it

### DIFF
--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -151,6 +151,8 @@ register_modelexpress_loaders()
 | `MX_HEARTBEAT_INTERVAL_SECS` | `30` | Seconds between READY status heartbeats for published sources, including reshard rendezvous sources; keep below the server heartbeat timeout |
 | `MX_RESHARD_MAX_SEGMENTS_PER_COPY` | `64` | Maximum exact descriptors for one no-gather refit copy before a compatible dim-0-sharded source is pulled once into contiguous staging and sliced locally |
 | `MX_RESHARD_FUSED_WIRE` | `1` | Issue a refit's exact-segment, full-pull, and convert reads as one transport batch instead of draining each phase in turn. Set to `0` to restore the phased reads for an A/B comparison |
+| `MX_RESHARD_REQUIRE_FULL_COVERAGE` | `0` | Fail a refit that installs less than `MX_RESHARD_COVERAGE_FLOOR` of the engine's parameter bytes. Off by default because partial and subset refit are intended; set to `1` for benchmark runs, where an incomplete refit produces timings that are the wrong magnitude |
+| `MX_RESHARD_COVERAGE_FLOOR` | `0.995` | Fraction of engine parameter bytes a gated refit must install. Not `1.0`: a few engine parameters, such as rotary `inv_freq`, are legitimately not refit material. Values outside `[0.0, 1.0]` are rejected |
 
 ### UCX/NIXL Tuning
 

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -59,6 +59,8 @@ if TYPE_CHECKING:
     MX_MODEL_URI: Optional[str]
     MX_P2P_METADATA: str
     MX_RESHARD_FUSED_WIRE: bool
+    MX_RESHARD_REQUIRE_FULL_COVERAGE: bool
+    MX_RESHARD_COVERAGE_FLOOR: float
     # Kubernetes service backend
     MX_K8S_SERVICE_PATTERN: str
     MX_K8S_SOURCE_RETRIES: str
@@ -191,6 +193,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_MODEL_URI": lambda: os.environ.get("MX_MODEL_URI"),
     "MX_P2P_METADATA": lambda: os.environ.get("MX_P2P_METADATA", "1"),
     "MX_RESHARD_FUSED_WIRE": lambda: _env_bool("MX_RESHARD_FUSED_WIRE", True),
+    # Refit coverage gate. The floor is a fraction of the engine's parameter
+    # bytes; ReshardReceiver validates its range at the point of use.
+    "MX_RESHARD_REQUIRE_FULL_COVERAGE": lambda: os.environ.get(
+        "MX_RESHARD_REQUIRE_FULL_COVERAGE", ""
+    )
+    .strip()
+    .lower()
+    in _TRUTHY,
+    "MX_RESHARD_COVERAGE_FLOOR": lambda: _env_float("MX_RESHARD_COVERAGE_FLOOR", 0.995),
     # ── Kubernetes service backend ─────────────────────────────────────────
     "MX_K8S_SERVICE_PATTERN": lambda: os.environ.get("MX_K8S_SERVICE_PATTERN", "mx-sources"),
     "MX_K8S_SOURCE_RETRIES": lambda: os.environ.get("MX_K8S_SOURCE_RETRIES", ""),

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -197,7 +197,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # bytes; ReshardReceiver validates its range at the point of use. What a
     # complete refit scores is engine- and model-specific, so the default is set
     # loose enough to pass any complete refit and still catch a gross hole; see
-    # ReshardReceiver._coverage_floor.
+    # modelexpress.refit.reshard.receiver._coverage_floor.
     "MX_RESHARD_REQUIRE_FULL_COVERAGE": lambda: os.environ.get(
         "MX_RESHARD_REQUIRE_FULL_COVERAGE", ""
     )

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -194,7 +194,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_P2P_METADATA": lambda: os.environ.get("MX_P2P_METADATA", "1"),
     "MX_RESHARD_FUSED_WIRE": lambda: _env_bool("MX_RESHARD_FUSED_WIRE", True),
     # Refit coverage gate. The floor is a fraction of the engine's parameter
-    # bytes; ReshardReceiver validates its range at the point of use.
+    # bytes; ReshardReceiver validates its range at the point of use. What a
+    # complete refit scores is engine- and model-specific, so the default is set
+    # loose enough to pass any complete refit and still catch a gross hole; see
+    # ReshardReceiver._coverage_floor.
     "MX_RESHARD_REQUIRE_FULL_COVERAGE": lambda: os.environ.get(
         "MX_RESHARD_REQUIRE_FULL_COVERAGE", ""
     )

--- a/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
@@ -23,6 +23,7 @@ from modelexpress.refit.reshard.geometry import (
     UnsupportedReshard,
     capture_geometry,
 )
+from modelexpress.refit.reshard.types import IncompleteRefit
 from modelexpress.refit.reshard.transfer_plan import (
     FullPullSource,
     SourceInfo,
@@ -57,6 +58,7 @@ from modelexpress.refit.reshard.rendezvous import (
 __all__ = [
     "InMemoryReferenceTransport",
     "FullPullSource",
+    "IncompleteRefit",
     "LazyWeight",
     "MxReshardRendezvous",
     "NixlReshardTransport",

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -23,7 +23,9 @@ transport, buffers and the router dtype-cast are shared here.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 
 import torch
 
@@ -44,6 +46,16 @@ from modelexpress.refit.reshard.transport import (
 from modelexpress.refit.reshard.types import CaptureResult, UnsupportedReshard
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
+
+# Opt-in rather than always-on: partial and subset refit are intended features,
+# and for those a coverage below 1.0 is the point. What is never acceptable is a
+# *benchmark* row measuring an incomplete refit, because its wire volume and
+# timings are then the wrong magnitude and get compared against complete ones.
+_REQUIRE_FULL_COVERAGE = os.environ.get("MX_RESHARD_REQUIRE_FULL_COVERAGE", "0") == "1"
+# Deliberately not 1.0. A few engine parameters - rotary `inv_freq` and similar
+# non-float buffers - are legitimately not refit material, so a complete refit
+# lands slightly under full coverage.
+_COVERAGE_FLOOR = float(os.environ.get("MX_RESHARD_COVERAGE_FLOOR", "0.995"))
 
 
 def _fused_wire_enabled() -> bool:
@@ -316,6 +328,81 @@ class ReshardReceiver:
             len(plan.unbounded_sources),
             len(plan.fallback),
         )
+        self._log_coverage(capture, param_layout, all_params, plan)
+
+    def _log_coverage(self, capture, param_layout, all_params, plan) -> None:
+        """Report what this rank asked the wire for, against what it will install.
+
+        Emitted at WARNING as JSON so a benchmark harness can recover it without
+        turning on INFO across every dependency. That is the point: everything
+        here was already computed, and already logged at INFO, which no
+        benchmark run has captured. So `useful_bytes_per_rank` has been
+        *derived* analysis-side from an assumed sharding rather than measured,
+        and a derived number cannot distinguish a wrong model of the sharding
+        from an incomplete refit.
+
+        This is also the only check that can see a parameter the loader never
+        asked for. Every other check compares arrived bytes against the
+        publisher's digest for the same name, so bytes that are never requested
+        are never checked. A refit covering half the model passes all of them.
+
+        `unsupported` is the companion signal: a parameter the loader wants and
+        the planner cannot serve is silently absent from the wire, so a non-zero
+        count is a coverage hole by construction.
+        """
+        # `param_layout` is the engine's COMPLETE parameter set; `all_params` is
+        # the subset this refit will write. The ratio is the coverage nothing
+        # else measures, and it needs no engine-specific hook.
+        installed = set(all_params)
+        dest_bytes = 0
+        engine_bytes = 0
+        missed: list[str] = []
+        for name, (shape, dtype) in param_layout.items():
+            count = 1
+            for dim in shape:
+                count *= int(dim)
+            nbytes = count * torch.empty(0, dtype=dtype).element_size()
+            engine_bytes += nbytes
+            if name in installed:
+                dest_bytes += nbytes
+            else:
+                missed.append(name)
+        coverage = (dest_bytes / engine_bytes) if engine_bytes else 0.0
+        unsupported = list(getattr(capture, "unsupported", []) or [])
+        record = {
+            "schema": "refit-coverage-v1",
+            "rank": self._global_rank,
+            "params_installed": len(all_params),
+            "engine_params": len(param_layout),
+            "dest_bytes": dest_bytes,
+            "engine_bytes": engine_bytes,
+            "coverage_pct": round(100.0 * coverage, 4),
+            "params_never_written": len(missed),
+            "params_never_written_sample": sorted(missed)[:10],
+            "copies_captured": len(capture.copies),
+            "unsupported": len(unsupported),
+            "unsupported_sample": [str(u)[:120] for u in unsupported[:10]],
+            "planned_wire_bytes": plan.bytes_planned(),
+            "extra_wire_bytes": plan.extra_wire_bytes(),
+            "descriptors": plan.descriptor_count(),
+            "descriptor_savings": plan.descriptor_savings(),
+            "full_pull_sources": len(plan.full_pulls),
+            "unbounded_sources": len(plan.unbounded_sources),
+            "converts": len(plan.converts),
+            "fallback": len(plan.fallback),
+        }
+        logger.warning("MX_REFIT_COVERAGE %s", json.dumps(record))
+
+        if _REQUIRE_FULL_COVERAGE and coverage < _COVERAGE_FLOOR:
+            raise RuntimeError(
+                f"refit covers {100.0 * coverage:.2f}% of the engine's parameter "
+                f"bytes ({dest_bytes} of {engine_bytes}); "
+                f"{len(missed)} of {len(param_layout)} params would keep their "
+                f"previous values, e.g. {sorted(missed)[:5]}. No digest gate can "
+                f"detect this - bytes that are never requested are never checked. "
+                f"Set MX_RESHARD_REQUIRE_FULL_COVERAGE=0 for an intentionally "
+                f"partial refit."
+            )
 
     # ----------------------------------------------------------- update_weights
     @torch.no_grad()

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 
 import torch
 
@@ -47,15 +46,24 @@ from modelexpress.refit.reshard.types import CaptureResult, UnsupportedReshard
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 
-# Opt-in rather than always-on: partial and subset refit are intended features,
-# and for those a coverage below 1.0 is the point. What is never acceptable is a
-# *benchmark* row measuring an incomplete refit, because its wire volume and
-# timings are then the wrong magnitude and get compared against complete ones.
-_REQUIRE_FULL_COVERAGE = os.environ.get("MX_RESHARD_REQUIRE_FULL_COVERAGE", "0") == "1"
-# Deliberately not 1.0. A few engine parameters - rotary `inv_freq` and similar
-# non-float buffers - are legitimately not refit material, so a complete refit
-# lands slightly under full coverage.
-_COVERAGE_FLOOR = float(os.environ.get("MX_RESHARD_COVERAGE_FLOOR", "0.995"))
+
+def _coverage_floor() -> float:
+    """The fraction of engine parameter bytes a gated refit must install.
+
+    Deliberately not 1.0 by default. A few engine parameters - rotary `inv_freq`
+    and similar non-float buffers - are legitimately not refit material, so a
+    complete refit lands slightly under full coverage.
+
+    A negative floor passes every refit, which silently disables the gate the
+    caller just asked for, and a floor above 1.0 rejects every refit including a
+    complete one. Both are rejected rather than honored.
+    """
+    floor = float(envs.MX_RESHARD_COVERAGE_FLOOR)
+    if not 0.0 <= floor <= 1.0:
+        raise ValueError(
+            f"MX_RESHARD_COVERAGE_FLOOR must be a fraction in [0.0, 1.0], got {floor}"
+        )
+    return floor
 
 
 def _fused_wire_enabled() -> bool:
@@ -233,6 +241,11 @@ class ReshardReceiver:
         # update_weights), which assumes the trainer set + their shard layout +
         # their buffer addresses are stable for the run.
         plan = plan_transfer(capture, sources)
+        all_params = sorted({c.param_name for c in capture.copies})
+        # Before the fail-closed rejection below, not after: an unsupported plan is
+        # the case where naming the hole matters most, and raising first would leave
+        # the run with no record of what it was about to miss.
+        self._log_coverage(capture, param_layout, all_params, plan)
         if plan.fallback:
             # Fallback params are dropped from the RDMA plan and never pulled or
             # installed, so they would silently keep their initial (base-model)
@@ -298,7 +311,6 @@ class ReshardReceiver:
         # Segment params (captured == served) are the RDMA targets - register them
         # + point _param_ptr at them. Convert params (router) are captured fp32 ->
         # their bf16 staging is the RDMA target and the refit casts into the buffer.
-        all_params = sorted({c.param_name for c in capture.copies})
         seg_params = {seg.param_name for seg in plan.segments}
         self._recv_buffers = {}
         with classic_cuda_alloc():
@@ -328,7 +340,6 @@ class ReshardReceiver:
             len(plan.unbounded_sources),
             len(plan.fallback),
         )
-        self._log_coverage(capture, param_layout, all_params, plan)
 
     def _log_coverage(self, capture, param_layout, all_params, plan) -> None:
         """Report what this rank asked the wire for, against what it will install.
@@ -393,7 +404,12 @@ class ReshardReceiver:
         }
         logger.warning("MX_REFIT_COVERAGE %s", json.dumps(record))
 
-        if _REQUIRE_FULL_COVERAGE and coverage < _COVERAGE_FLOOR:
+        # Opt-in rather than always-on: partial and subset refit are intended
+        # features, and for those a coverage below 1.0 is the point. What is never
+        # acceptable is a *benchmark* row measuring an incomplete refit, because
+        # its wire volume and timings are then the wrong magnitude and get
+        # compared against complete ones.
+        if envs.MX_RESHARD_REQUIRE_FULL_COVERAGE and coverage < _coverage_floor():
             raise RuntimeError(
                 f"refit covers {100.0 * coverage:.2f}% of the engine's parameter "
                 f"bytes ({dest_bytes} of {engine_bytes}); "

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -42,7 +42,11 @@ from modelexpress.refit.reshard.transport import (
     NixlReshardTransport,
     ReadDescriptor,
 )
-from modelexpress.refit.reshard.types import CaptureResult, UnsupportedReshard
+from modelexpress.refit.reshard.types import (
+    CaptureResult,
+    IncompleteRefit,
+    UnsupportedReshard,
+)
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 
@@ -50,9 +54,16 @@ logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 def _coverage_floor() -> float:
     """The fraction of engine parameter bytes a gated refit must install.
 
-    Deliberately not 1.0 by default. A few engine parameters - rotary `inv_freq`
-    and similar non-float buffers - are legitimately not refit material, so a
-    complete refit lands slightly under full coverage.
+    What a *complete* refit scores is engine- and model-specific, because the
+    denominator is whatever the engine enumerates as its load-time parameters and
+    some of those are legitimately not refit material - rotary `inv_freq` and
+    similar derived buffers. Hence a configurable floor rather than a hard 1.0.
+
+    The default is deliberately loose. It is sized to catch a gross hole, of the
+    order of a missing layer range, expert group or pipeline half, not to encode
+    any one model's parameter accounting; the non-refit remainder is small in
+    bytes even where it is many tensors by count. Tighten it per model once
+    coverage records exist for that model rather than guessing upward here.
 
     A negative floor passes every refit, which silently disables the gate the
     caller just asked for, and a floor above 1.0 rejects every refit including a
@@ -402,7 +413,16 @@ class ReshardReceiver:
             "converts": len(plan.converts),
             "fallback": len(plan.fallback),
         }
-        logger.warning("MX_REFIT_COVERAGE %s", json.dumps(record))
+        # Severity follows the record's content, not the fact that a record exists.
+        # This is emitted once per refit on a healthy run too, and a per-refit line
+        # at WARNING teaches operators that MX warnings are routine, which costs
+        # more than it buys the first time one is not.
+        complete = not missed and not unsupported and not plan.fallback
+        logger.log(
+            logging.INFO if complete else logging.WARNING,
+            "MX_REFIT_COVERAGE %s",
+            json.dumps(record),
+        )
 
         # Opt-in rather than always-on: partial and subset refit are intended
         # features, and for those a coverage below 1.0 is the point. What is never
@@ -410,7 +430,7 @@ class ReshardReceiver:
         # its wire volume and timings are then the wrong magnitude and get
         # compared against complete ones.
         if envs.MX_RESHARD_REQUIRE_FULL_COVERAGE and coverage < _coverage_floor():
-            raise RuntimeError(
+            raise IncompleteRefit(
                 f"refit covers {100.0 * coverage:.2f}% of the engine's parameter "
                 f"bytes ({dest_bytes} of {engine_bytes}); "
                 f"{len(missed)} of {len(param_layout)} params would keep their "

--- a/modelexpress_client/python/modelexpress/refit/reshard/types.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/types.py
@@ -24,6 +24,17 @@ class UnsupportedReshard(NotImplementedError):
     applying an incomplete model version."""
 
 
+class IncompleteRefit(RuntimeError):
+    """A refit was planned and executed successfully, and still did not write
+    enough of the engine's parameter bytes.
+
+    Deliberately not an ``UnsupportedReshard``. That one means the geometry could
+    not be expressed, and ``transfer_plan`` catches it per source to drop that
+    source and continue; a refit that quietly skipped part of the model must never
+    be swallowed by a handler written for the other meaning. Both derive from
+    ``RuntimeError``, so a caller that catches only that is unaffected."""
+
+
 @dataclass
 class RecordedCopy:
     """One recorded scatter: read ``src_name`` sliced by ``op_chain`` and write it

--- a/modelexpress_client/python/tests/test_reshard_refit_coverage.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_coverage.py
@@ -30,6 +30,7 @@ import torch
 
 from modelexpress.refit.reshard import receiver as receiver_mod
 from modelexpress.refit.reshard.receiver import ReshardReceiver
+from modelexpress.refit.reshard.types import UnsupportedReshard
 
 
 class _Plan:
@@ -104,13 +105,9 @@ def _emit(caplog, *, param_layout, all_params, capture=None, plan=None, rank=0):
 
 @pytest.fixture(autouse=True)
 def _gate_off(monkeypatch):
-    """Default the gate off, as it ships.
-
-    The flags are module-level constants read at import, so patching the
-    environment inside a test does nothing; patch the module attributes.
-    """
-    monkeypatch.setattr(receiver_mod, "_REQUIRE_FULL_COVERAGE", False)
-    monkeypatch.setattr(receiver_mod, "_COVERAGE_FLOOR", 0.995)
+    """Default the gate off, as it ships, whatever the ambient environment is."""
+    monkeypatch.delenv("MX_RESHARD_REQUIRE_FULL_COVERAGE", raising=False)
+    monkeypatch.delenv("MX_RESHARD_COVERAGE_FLOOR", raising=False)
 
 
 def test_a_complete_refit_reports_full_coverage(caplog):
@@ -248,7 +245,7 @@ def test_gate_off_by_default_lets_a_partial_refit_through(caplog):
 
 
 def test_gate_on_raises_below_the_floor_and_names_what_is_missing(caplog, monkeypatch):
-    monkeypatch.setattr(receiver_mod, "_REQUIRE_FULL_COVERAGE", True)
+    monkeypatch.setenv("MX_RESHARD_REQUIRE_FULL_COVERAGE", "1")
     engine = [f"layers.{i}.weight" for i in range(48)]
     with pytest.raises(RuntimeError) as ei:
         _emit(
@@ -274,8 +271,8 @@ def test_gate_on_passes_at_the_floor_so_stray_buffers_do_not_fail_a_good_run(
     and similar non-float buffers that surface as params in some models - and
     failing a complete refit over a few kilobytes would make the gate unusable.
     """
-    monkeypatch.setattr(receiver_mod, "_REQUIRE_FULL_COVERAGE", True)
-    monkeypatch.setattr(receiver_mod, "_COVERAGE_FLOOR", 0.995)
+    monkeypatch.setenv("MX_RESHARD_REQUIRE_FULL_COVERAGE", "1")
+    monkeypatch.setenv("MX_RESHARD_COVERAGE_FLOOR", "0.995")
     param_layout = {f"w{i}": ((1000,), torch.bfloat16) for i in range(1000)}
     param_layout["inv_freq"] = ((1,), torch.bfloat16)  # 2 B of 2,000,002
     installed = [f"w{i}" for i in range(1000)]
@@ -288,3 +285,78 @@ def test_an_engine_with_no_parameters_does_not_divide_by_zero(caplog):
     rec = _emit(caplog, param_layout={}, all_params=[])
     assert rec["coverage_pct"] == 0.0
     assert rec["engine_bytes"] == 0
+
+
+@pytest.mark.parametrize("floor", ["-0.1", "1.5"])
+def test_a_floor_outside_zero_to_one_is_rejected(caplog, monkeypatch, floor):
+    """A negative floor passes every refit, silently disabling the gate the caller
+    just asked for; above 1.0 rejects even a complete one. Neither is honored."""
+    monkeypatch.setenv("MX_RESHARD_REQUIRE_FULL_COVERAGE", "1")
+    monkeypatch.setenv("MX_RESHARD_COVERAGE_FLOOR", floor)
+    names = ["a", "b"]
+
+    with pytest.raises(ValueError, match=r"fraction in \[0.0, 1.0\]"):
+        _emit(caplog, param_layout=_layout(names), all_params=names[:1])
+
+
+def test_the_floor_is_read_live_so_the_gate_is_configurable_per_run(
+    caplog, monkeypatch
+):
+    monkeypatch.setenv("MX_RESHARD_REQUIRE_FULL_COVERAGE", "1")
+    monkeypatch.setenv("MX_RESHARD_COVERAGE_FLOOR", "0.4")
+    engine = [f"w{i}" for i in range(10)]
+
+    # 50% coverage clears a 0.4 floor and fails a 0.6 one.
+    assert _emit(caplog, param_layout=_layout(engine), all_params=engine[:5])
+    monkeypatch.setenv("MX_RESHARD_COVERAGE_FLOOR", "0.6")
+    with pytest.raises(RuntimeError):
+        _emit(caplog, param_layout=_layout(engine), all_params=engine[:5])
+
+
+def test_coverage_is_recorded_before_an_unsupported_plan_is_rejected(
+    caplog, monkeypatch
+):
+    """An unsupported plan is the case where the hole most needs naming.
+
+    `_prepare` fails closed on `plan.fallback`, so recording coverage after that
+    raise would mean the runs with a known coverage hole are exactly the runs with
+    no coverage record.
+    """
+    engine = [f"layers.{i}.weight" for i in range(4)]
+    source = types.SimpleNamespace(dtype="torch.bfloat16", global_shape=(4, 8))
+    monkeypatch.setattr(
+        receiver_mod,
+        "gather_sources",
+        lambda *_args, **_kwargs: ({"layers.0.weight": source}, {}, {}, {}),
+    )
+    monkeypatch.setattr(
+        receiver_mod,
+        "plan_transfer",
+        lambda *_args, **_kwargs: _Plan(fallback=["layers.3.weight"]),
+    )
+    stub = types.SimpleNamespace(
+        _global_rank=0,
+        _num_trainer_sources=1,
+        _mx_client=object(),
+        _model_name="model",
+        _manager=types.SimpleNamespace(fetch_remote_and_wait=lambda *a, **k: None),
+        _log_coverage=lambda *args: ReshardReceiver._log_coverage(stub, *args),
+        _capture=lambda _manifest: (
+            types.SimpleNamespace(
+                copies=[types.SimpleNamespace(param_name="layers.0.weight")],
+                unsupported=[],
+            ),
+            _layout(engine),
+        ),
+    )
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        with pytest.raises(UnsupportedReshard):
+            ReshardReceiver._prepare(stub, timeout=1.0)
+
+    records = [r for r in caplog.records if "MX_REFIT_COVERAGE" in r.getMessage()]
+    assert len(records) == 1
+    rec = json.loads(records[0].getMessage().split("MX_REFIT_COVERAGE ", 1)[1])
+    assert rec["fallback"] == 1
+    assert rec["params_never_written"] == 3

--- a/modelexpress_client/python/tests/test_reshard_refit_coverage.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_coverage.py
@@ -30,7 +30,7 @@ import torch
 
 from modelexpress.refit.reshard import receiver as receiver_mod
 from modelexpress.refit.reshard.receiver import ReshardReceiver
-from modelexpress.refit.reshard.types import UnsupportedReshard
+from modelexpress.refit.reshard.types import IncompleteRefit, UnsupportedReshard
 
 
 class _Plan:
@@ -89,7 +89,10 @@ def _emit(caplog, *, param_layout, all_params, capture=None, plan=None, rank=0):
     """
     stub = types.SimpleNamespace(_global_rank=rank)
     caplog.clear()
-    with caplog.at_level("WARNING"):
+    # INFO, because a clean refit reports at INFO and only an incomplete one is
+    # escalated; capturing at WARNING here would see the record for some inputs
+    # and not others.
+    with caplog.at_level("INFO"):
         ReshardReceiver._log_coverage(
             stub,
             capture or _capture(),
@@ -217,24 +220,59 @@ def test_plan_economics_ride_along_on_the_same_record(caplog):
     assert rec["fallback"] == 0
 
 
-def test_the_record_is_machine_readable_at_warning(caplog):
-    """Benchmarks capture WARNING, never INFO.
+def _levels_of(caplog):
+    return [
+        r.levelname for r in caplog.records if "MX_REFIT_COVERAGE" in r.getMessage()
+    ]
 
-    The economics were already computed and already logged before this record
-    existed - at INFO, which no benchmark run captured, which is precisely why
-    useful bytes were derived rather than measured.
+
+def test_the_record_is_machine_readable(caplog):
+    """One record per refit, parseable, carrying the schema and the rank.
+
+    The economics were computed and logged before this record existed, but as
+    prose, which is why useful bytes were derived rather than measured.
     """
     names = ["a"]
     stub = types.SimpleNamespace(_global_rank=7)
     caplog.clear()
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("INFO"):
         ReshardReceiver._log_coverage(stub, _capture(), _layout(names), names, _Plan())
     hits = [r for r in caplog.records if "MX_REFIT_COVERAGE" in r.getMessage()]
     assert len(hits) == 1
-    assert hits[0].levelname == "WARNING"
     rec = json.loads(hits[0].getMessage().split("MX_REFIT_COVERAGE ", 1)[1])
     assert rec["schema"] == "refit-coverage-v1"
     assert rec["rank"] == 7
+
+
+def test_a_clean_refit_reports_at_info(caplog):
+    """It happens on every refit of a healthy run. At WARNING it would teach
+    operators that MX warnings are routine."""
+    names = ["a", "b"]
+    _emit(caplog, param_layout=_layout(names), all_params=names)
+
+    assert _levels_of(caplog) == ["INFO"]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"all_params": ["a"]}, id="a param was never written"),
+        pytest.param(
+            {"all_params": ["a", "b"], "capture": _capture(unsupported=["a: op"])},
+            id="a source was unsupported",
+        ),
+        pytest.param(
+            {"all_params": ["a", "b"], "plan": _Plan(fallback=["a"])},
+            id="a source fell back",
+        ),
+    ],
+)
+def test_a_refit_with_something_to_look_at_is_escalated(caplog, kwargs):
+    """The severity tracks the content, so a WARNING here always means something."""
+    layout = _layout(["a", "b"])
+    _emit(caplog, param_layout=layout, **kwargs)
+
+    assert _levels_of(caplog) == ["WARNING"]
 
 
 def test_gate_off_by_default_lets_a_partial_refit_through(caplog):
@@ -247,7 +285,7 @@ def test_gate_off_by_default_lets_a_partial_refit_through(caplog):
 def test_gate_on_raises_below_the_floor_and_names_what_is_missing(caplog, monkeypatch):
     monkeypatch.setenv("MX_RESHARD_REQUIRE_FULL_COVERAGE", "1")
     engine = [f"layers.{i}.weight" for i in range(48)]
-    with pytest.raises(RuntimeError) as ei:
+    with pytest.raises(IncompleteRefit) as ei:
         _emit(
             caplog,
             param_layout=_layout(engine),
@@ -260,6 +298,21 @@ def test_gate_on_raises_below_the_floor_and_names_what_is_missing(caplog, monkey
     # first instinct on seeing it is to trust the passing digest gate.
     assert "never requested are never checked" in msg
     assert "MX_RESHARD_REQUIRE_FULL_COVERAGE=0" in msg
+
+
+def test_an_incomplete_refit_is_not_an_unsupported_reshard(caplog, monkeypatch):
+    """`transfer_plan` catches `UnsupportedReshard` per source to drop that source
+    and carry on. A refit that skipped part of the model must not be reachable by
+    a handler written for that meaning, while still being a `RuntimeError` for
+    callers that catch only the builtin."""
+    monkeypatch.setenv("MX_RESHARD_REQUIRE_FULL_COVERAGE", "1")
+    engine = [f"w{i}" for i in range(10)]
+
+    with pytest.raises(IncompleteRefit) as ei:
+        _emit(caplog, param_layout=_layout(engine), all_params=engine[:1])
+
+    assert not isinstance(ei.value, UnsupportedReshard)
+    assert isinstance(ei.value, RuntimeError)
 
 
 def test_gate_on_passes_at_the_floor_so_stray_buffers_do_not_fail_a_good_run(

--- a/modelexpress_client/python/tests/test_reshard_refit_coverage.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_coverage.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for the refit coverage record and the optional coverage gate.
+
+Why this file exists: on 2026-07-27 a Topology B benchmark row was published as
+beating Topology A on every axis while refitting 51% of the model. Two pipeline
+stages published pipeline-LOCAL layer names, they collided in the name-keyed shard
+table, first-writer-wins kept one stage's 24 layers and the other 24 were never
+requested. Every existing check passed:
+
+  * the digest gate compared bytes that arrived against the publisher's digest for
+    the same name, and every byte that arrived was correct;
+  * `params_installed` counted what the plan covered, not what the engine holds;
+  * `useful_bytes_per_rank` was *derived* analysis-side from an assumed sharding,
+    so a wire volume that was half of what it should be looked like a win.
+
+Bytes that are never requested are never checked. The coverage record is the only
+thing that can see that, because it is the only thing that compares against the
+engine's own parameter footprint. These tests pin that behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+import torch
+
+from modelexpress.refit.reshard import receiver as receiver_mod
+from modelexpress.refit.reshard.receiver import ReshardReceiver
+
+
+class _Plan:
+    """Only the accessors `_log_coverage` reads."""
+
+    def __init__(
+        self,
+        *,
+        planned=1_000,
+        extra=100,
+        descriptors=10,
+        savings=5,
+        full_pulls=(),
+        unbounded=(),
+        converts=(),
+        fallback=(),
+    ):
+        self._planned = planned
+        self._extra = extra
+        self._descriptors = descriptors
+        self._savings = savings
+        self.full_pulls = list(full_pulls)
+        self.unbounded_sources = list(unbounded)
+        self.converts = list(converts)
+        self.fallback = list(fallback)
+
+    def bytes_planned(self):
+        return self._planned
+
+    def extra_wire_bytes(self):
+        return self._extra
+
+    def descriptor_count(self):
+        return self._descriptors
+
+    def descriptor_savings(self):
+        return self._savings
+
+
+def _capture(copies=3, unsupported=()):
+    return types.SimpleNamespace(
+        copies=list(range(copies)), unsupported=list(unsupported)
+    )
+
+
+def _layout(names, shape=(4, 8), dtype=torch.bfloat16):
+    return {n: (shape, dtype) for n in names}
+
+
+def _emit(caplog, *, param_layout, all_params, capture=None, plan=None, rank=0):
+    """Call the method unbound against a stub self, and return the parsed record.
+
+    `_log_coverage` touches only `self._global_rank`, so constructing a real
+    receiver (MxClient, NIXL agent, CUDA pool) would add setup that cannot run in
+    a unit test and would test none of this logic.
+    """
+    stub = types.SimpleNamespace(_global_rank=rank)
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        ReshardReceiver._log_coverage(
+            stub,
+            capture or _capture(),
+            param_layout,
+            all_params,
+            plan or _Plan(),
+        )
+    for rec in caplog.records:
+        if "MX_REFIT_COVERAGE" in rec.getMessage():
+            return json.loads(rec.getMessage().split("MX_REFIT_COVERAGE ", 1)[1])
+    raise AssertionError("no MX_REFIT_COVERAGE record was emitted")
+
+
+@pytest.fixture(autouse=True)
+def _gate_off(monkeypatch):
+    """Default the gate off, as it ships.
+
+    The flags are module-level constants read at import, so patching the
+    environment inside a test does nothing; patch the module attributes.
+    """
+    monkeypatch.setattr(receiver_mod, "_REQUIRE_FULL_COVERAGE", False)
+    monkeypatch.setattr(receiver_mod, "_COVERAGE_FLOOR", 0.995)
+
+
+def test_a_complete_refit_reports_full_coverage(caplog):
+    names = [f"layers.{i}.weight" for i in range(4)]
+    rec = _emit(caplog, param_layout=_layout(names), all_params=names)
+    assert rec["coverage_pct"] == 100.0
+    assert rec["params_installed"] == 4
+    assert rec["engine_params"] == 4
+    assert rec["params_never_written"] == 0
+    assert rec["params_never_written_sample"] == []
+    assert rec["dest_bytes"] == rec["engine_bytes"]
+
+
+def test_the_bug_8_shape_half_the_model_never_written(caplog):
+    """The regression this record was built to catch.
+
+    48 engine layers, only the first 24 requested, which is what a PP2 name
+    collision produces. Coverage must read ~50%, not 100%.
+    """
+    engine = [f"layers.{i}.weight" for i in range(48)]
+    installed = [f"layers.{i}.weight" for i in range(24)]
+    rec = _emit(caplog, param_layout=_layout(engine), all_params=installed)
+    assert rec["coverage_pct"] == 50.0
+    assert rec["params_installed"] == 24
+    assert rec["engine_params"] == 48
+    assert rec["params_never_written"] == 24
+    # The sample must name the missing layers, which is what turns "the number is
+    # wrong" into "layers 24-47 were never refit".
+    assert rec["params_never_written_sample"][0].startswith("layers.2")
+    assert len(rec["params_never_written_sample"]) == 10
+
+
+def test_coverage_is_measured_in_bytes_not_parameter_count(caplog):
+    """Half the params can be far from half the bytes.
+
+    The pre-existing `params_installed` count could not have caught Bug 8's byte
+    shortfall even in principle, because a refit that covers most parameters can
+    still miss most bytes. Coverage is a byte ratio.
+    """
+    param_layout = {
+        "big": ((1024, 1024), torch.bfloat16),  # 2 MiB
+        "small": ((1, 1), torch.bfloat16),  # 2 B
+    }
+    rec = _emit(caplog, param_layout=param_layout, all_params=["small"])
+    assert rec["params_installed"] == 1
+    assert rec["engine_params"] == 2
+    # 1 of 2 params, but essentially none of the bytes.
+    assert rec["coverage_pct"] < 0.001
+    assert rec["dest_bytes"] == 2
+
+
+def test_byte_accounting_respects_dtype_width(caplog):
+    """fp8 is one byte per element, bf16 two, fp32 four."""
+    for dtype, width in (
+        (torch.float8_e4m3fn, 1),
+        (torch.bfloat16, 2),
+        (torch.float32, 4),
+    ):
+        names = ["w"]
+        rec = _emit(
+            caplog,
+            param_layout=_layout(names, shape=(4, 8), dtype=dtype),
+            all_params=names,
+        )
+        assert rec["engine_bytes"] == 32 * width, dtype
+        assert rec["dest_bytes"] == 32 * width, dtype
+
+
+def test_unsupported_params_are_surfaced_and_sampled(caplog):
+    """A param the planner cannot serve is silently absent from the wire.
+
+    The correctness gate cannot see it, so a non-zero count here is the signal.
+    """
+    names = ["a", "b"]
+    cap = _capture(copies=2, unsupported=[f"cannot reshard {i}" for i in range(15)])
+    rec = _emit(caplog, param_layout=_layout(names), all_params=names, capture=cap)
+    assert rec["unsupported"] == 15
+    assert len(rec["unsupported_sample"]) == 10
+    assert all(len(s) <= 120 for s in rec["unsupported_sample"])
+
+
+def test_plan_economics_ride_along_on_the_same_record(caplog):
+    """One record carries coverage and byte economics together.
+
+    They have to be read together: 40 GB of wire is efficient against 30 GB of
+    useful bytes and catastrophic against 15 GB.
+    """
+    names = ["a"]
+    plan = _Plan(
+        planned=40_000,
+        extra=10_000,
+        descriptors=19_011,
+        savings=12_675_024,
+        full_pulls=range(6_192),
+        unbounded=(),
+        converts=(),
+        fallback=(),
+    )
+    rec = _emit(caplog, param_layout=_layout(names), all_params=names, plan=plan)
+    assert rec["planned_wire_bytes"] == 40_000
+    assert rec["extra_wire_bytes"] == 10_000
+    assert rec["descriptors"] == 19_011
+    assert rec["descriptor_savings"] == 12_675_024
+    assert rec["full_pull_sources"] == 6_192
+    assert rec["unbounded_sources"] == 0
+    assert rec["converts"] == 0
+    assert rec["fallback"] == 0
+
+
+def test_the_record_is_machine_readable_at_warning(caplog):
+    """Benchmarks capture WARNING, never INFO.
+
+    The economics were already computed and already logged before this record
+    existed - at INFO, which no benchmark run captured, which is precisely why
+    useful bytes were derived rather than measured.
+    """
+    names = ["a"]
+    stub = types.SimpleNamespace(_global_rank=7)
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        ReshardReceiver._log_coverage(stub, _capture(), _layout(names), names, _Plan())
+    hits = [r for r in caplog.records if "MX_REFIT_COVERAGE" in r.getMessage()]
+    assert len(hits) == 1
+    assert hits[0].levelname == "WARNING"
+    rec = json.loads(hits[0].getMessage().split("MX_REFIT_COVERAGE ", 1)[1])
+    assert rec["schema"] == "refit-coverage-v1"
+    assert rec["rank"] == 7
+
+
+def test_gate_off_by_default_lets_a_partial_refit_through(caplog):
+    """Partial and subset refit are intended features."""
+    engine = [f"w{i}" for i in range(10)]
+    rec = _emit(caplog, param_layout=_layout(engine), all_params=engine[:1])
+    assert rec["coverage_pct"] == 10.0  # reported, not raised
+
+
+def test_gate_on_raises_below_the_floor_and_names_what_is_missing(caplog, monkeypatch):
+    monkeypatch.setattr(receiver_mod, "_REQUIRE_FULL_COVERAGE", True)
+    engine = [f"layers.{i}.weight" for i in range(48)]
+    with pytest.raises(RuntimeError) as ei:
+        _emit(
+            caplog,
+            param_layout=_layout(engine),
+            all_params=engine[:24],
+        )
+    msg = str(ei.value)
+    assert "50.00%" in msg
+    assert "24 of 48" in msg
+    # The message must say why no other check would have caught it, because the
+    # first instinct on seeing it is to trust the passing digest gate.
+    assert "never requested are never checked" in msg
+    assert "MX_RESHARD_REQUIRE_FULL_COVERAGE=0" in msg
+
+
+def test_gate_on_passes_at_the_floor_so_stray_buffers_do_not_fail_a_good_run(
+    caplog, monkeypatch
+):
+    """Not 1.0 on purpose.
+
+    A few engine params are legitimately not refit material - rotary `inv_freq`
+    and similar non-float buffers that surface as params in some models - and
+    failing a complete refit over a few kilobytes would make the gate unusable.
+    """
+    monkeypatch.setattr(receiver_mod, "_REQUIRE_FULL_COVERAGE", True)
+    monkeypatch.setattr(receiver_mod, "_COVERAGE_FLOOR", 0.995)
+    param_layout = {f"w{i}": ((1000,), torch.bfloat16) for i in range(1000)}
+    param_layout["inv_freq"] = ((1,), torch.bfloat16)  # 2 B of 2,000,002
+    installed = [f"w{i}" for i in range(1000)]
+    rec = _emit(caplog, param_layout=param_layout, all_params=installed)
+    assert rec["coverage_pct"] > 99.99
+    assert rec["params_never_written"] == 1
+
+
+def test_an_engine_with_no_parameters_does_not_divide_by_zero(caplog):
+    rec = _emit(caplog, param_layout={}, all_params=[])
+    assert rec["coverage_pct"] == 0.0
+    assert rec["engine_bytes"] == 0


### PR DESCRIPTION
## Summary

This PR adds a machine-readable `refit-coverage-v1` record that measures what a
receiver intends to install against the engine's complete parameter layout. It
also adds an opt-in coverage floor for benchmark and full-refit runs.

The PR now targets current `main`; #528 is already merged and its obsolete branch
commit has been removed.

## Why this is needed

Digest checks can validate bytes only for tensors the receiver requests. If a
publisher omits half the model, those tensors never enter the plan and therefore
never reach a digest check. The transfer can report zero mismatches while leaving
half the engine at its previous values.

That failure occurred when pipeline-parallel trainers published local rather
than global layer names. The resulting refit covered 51% of the model and looked
faster because it moved half the bytes and issued half the descriptors.

Coverage closes that observability gap by comparing:

- `param_layout`: the engine's complete refittable parameter layout;
- `all_params`: the parameters this receiver will install;
- `plan`: the actual wire and descriptor plan.

The record is emitted as JSON at WARNING level so ordinary benchmark logs retain
it without enabling INFO logging for every dependency.

## Where the record is emitted

Immediately after the transfer plan is built, and before `_prepare` fails closed
on unsupported sources. Emitting it at the end of `_prepare` would mean the runs
with a known coverage hole are exactly the runs with no coverage record, since
`plan.fallback` raises first. The rejection itself is unchanged: an unsupported
plan still ends `_prepare` with `UnsupportedReshard`.

## Record and gate

The `refit-coverage-v1` record includes parameter and byte coverage, never-written
parameter samples, captured copies, unsupported entries, planned wire bytes,
descriptor counts, full pulls, conversions, and fallback count.

The gate is disabled by default because partial refit is supported behavior.
Enable it with:

```text
MX_RESHARD_REQUIRE_FULL_COVERAGE=1
MX_RESHARD_COVERAGE_FLOOR=0.995
```

Both variables are registered in `modelexpress/envs.py` and documented in the
client README variable table, so they parse and warn like every other variable
and are read live rather than frozen at import.

The default floor is below 1.0 because some engine buffers, such as rotary
`inv_freq`, are legitimately outside the refit set. A floor outside `[0.0, 1.0]`
is rejected rather than honored: a negative floor passes every refit, silently
disabling the gate the caller just asked for, and a floor above 1.0 rejects even
a complete refit.

## What coverage does not prove

Coverage measures plan intent, not byte delivery. A record at 100% does not prove
that transport wrote the destination buffers, that installed values match the
source, or that generation is equivalent.

A benchmark row still requires parameter equality, generation and KL checks,
version agreement, fallback checks, and retained raw evidence. Coverage is one
necessary gate, not a replacement for those checks.

## Validation

- [x] Rebased onto current `main`; the already-merged #528 commit was dropped.
- [x] 53 complete `test_reshard_refit_*` tests pass, 15 of them focused on
      coverage.
- [x] Tests cover complete, partial, unsupported, empty-layout, and non-float
      buffer cases.
- [x] The opt-in floor rejects incomplete full refits, and an out-of-range floor
      is rejected in both directions.
- [x] A lifecycle test drives `_prepare` with a fallback-bearing plan and asserts
      the coverage record is emitted before the rejection.
- [x] Core Ruff checks and whitespace validation pass.

Full GitHub CI is running on the rebased branch.

## Reviewer guide

1. `modelexpress/refit/reshard/receiver.py` — review `_log_coverage()` first.
   Confirm that coverage uses the engine-provided layout and installed set rather
   than an assumed sharding formula, and that it runs before the fail-closed
   rejection.
2. `tests/test_reshard_refit_coverage.py` — focus on the 51% partial-refit case,
   the opt-in gate, the emission-ordering test, and the non-float-buffer case
   that justifies the 0.995 floor.
3. `modelexpress/envs.py` and `modelexpress_client/python/README.md` — the two
   gate variables and their documented defaults.

The main policy question is whether WARNING is the right retention mechanism.
Changing the record back to INFO without a dedicated benchmark logger would
recreate the evidence-loss problem this PR addresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refit coverage reporting with machine-readable statistics and severity-based logging.
  * Added configurable coverage thresholds and optional enforcement for incomplete refits.
  * Added a dedicated error for refits that do not write all required parameter data.

* **Documentation**
  * Documented the new coverage enforcement and threshold environment settings, including the default threshold.

* **Bug Fixes**
  * Improved detection and handling of incomplete or unsupported refit plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->