### PR TITLE
feat(reshard-refit): Megatron target lowering and zero-copy HF aliasing

### DIFF
--- a/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
@@ -47,6 +47,21 @@ from modelexpress.refit.reshard.transport import (
 )
 from modelexpress.refit.reshard.cuda_pool import classic_cuda_alloc
 from modelexpress.refit.reshard.receiver import ReshardReceiver
+from modelexpress.refit.reshard.megatron import (
+    MegatronTargetLayout,
+    MegatronTargetSpec,
+    lower_megatron_target,
+)
+from modelexpress.refit.reshard.megatron_receiver import MegatronReshardReceiver
+from modelexpress.refit.reshard.megatron_aliases import (
+    MegatronAliasInput,
+    build_hf_aliases,
+)
+from modelexpress.refit.reshard.megatron_publisher import (
+    MegatronPublishedTensorSpec,
+    publish_megatron_reshard_view,
+    publish_registered_shard_table,
+)
 from modelexpress.refit.reshard.rendezvous import (
     MxReshardRendezvous,
     PublishedShard,
@@ -60,6 +75,11 @@ __all__ = [
     "FullPullSource",
     "IncompleteRefit",
     "LazyWeight",
+    "MegatronAliasInput",
+    "MegatronPublishedTensorSpec",
+    "MegatronReshardReceiver",
+    "MegatronTargetLayout",
+    "MegatronTargetSpec",
     "MxReshardRendezvous",
     "NixlReshardTransport",
     "OpChain",
@@ -74,14 +94,18 @@ __all__ = [
     "Transport",
     "TransferPlan",
     "UnsupportedReshard",
+    "build_hf_aliases",
     "capture_geometry",
     "classic_cuda_alloc",
     "execute_transfer",
     "gather_sources",
     "intersect",
+    "lower_megatron_target",
     "op_chain_to_box",
     "paired_runs",
     "plan_pull",
     "plan_transfer",
+    "publish_megatron_reshard_view",
+    "publish_registered_shard_table",
     "wrap_rendezvous_blob",
 ]

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Lower native Megatron tensor geometry into the #496 transfer planner.
+
+Megatron publishes rank-local tensors in its native fused representation.
+Translation into HF/vLLM names therefore happens after transfer, but transfer
+planning must still use the inference rank's destination TP slice. This module
+creates the same ``RecordedCopy`` contract produced by loader capture, targeting
+native staging buffers that the Megatron translator consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from modelexpress.refit.reshard.slice_plan import _row_major_strides
+from modelexpress.refit.reshard.types import CaptureResult, RecordedCopy
+
+REPLICATED = "replicated"
+COLUMN_ROLES = frozenset(
+    {
+        "column",
+        "qkv_column",
+        "gated_mlp_column",
+        "vocab_parallel",
+        "expert_column",
+    }
+)
+ROW_ROLES = frozenset({"row", "expert_row"})
+SUPPORTED_ROLES = COLUMN_ROLES | ROW_ROLES | {REPLICATED}
+
+
+@dataclass(frozen=True)
+class MegatronTargetSpec:
+    """One native Megatron tensor requested by an inference TP rank."""
+
+    source_name: str
+    role: str
+    global_shape: tuple[int, ...]
+    dtype: Any
+    shard_axis: int | None = None
+    staging_name: str | None = None
+    descriptor_extras: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.role not in SUPPORTED_ROLES:
+            raise ValueError(f"unsupported Megatron role {self.role!r}")
+        if not self.global_shape or any(
+            int(extent) <= 0 for extent in self.global_shape
+        ):
+            raise ValueError(
+                f"{self.source_name}: global_shape must contain positive extents"
+            )
+
+
+@dataclass(frozen=True)
+class MegatronTargetLayout:
+    tp_size: int
+    tp_rank: int
+
+    def __post_init__(self) -> None:
+        if self.tp_size < 1:
+            raise ValueError("tp_size must be at least 1")
+        if not 0 <= self.tp_rank < self.tp_size:
+            raise ValueError(f"tp_rank {self.tp_rank} is outside [0, {self.tp_size})")
+
+
+def _role_axis(spec: MegatronTargetSpec) -> int | None:
+    if spec.role == REPLICATED:
+        if spec.shard_axis is not None:
+            raise ValueError(
+                f"{spec.source_name}: replicated tensor cannot set shard_axis"
+            )
+        return None
+    if spec.shard_axis is not None:
+        axis = int(spec.shard_axis)
+    elif spec.role == "expert_column":
+        axis = 1 if spec.descriptor_extras.get("expert_layout") == "leading_axis" else 0
+    elif spec.role == "expert_row":
+        axis = 2 if spec.descriptor_extras.get("expert_layout") == "leading_axis" else 1
+    elif spec.role in COLUMN_ROLES:
+        axis = 0
+    else:
+        axis = 1
+    if not 0 <= axis < len(spec.global_shape):
+        raise ValueError(
+            f"{spec.source_name}: shard axis {axis} is invalid for "
+            f"shape {spec.global_shape}"
+        )
+    return axis
+
+
+def _partition(extent: int, layout: MegatronTargetLayout) -> tuple[int, int]:
+    """Return the exact equal Megatron TP partition for this target rank."""
+
+    if extent % layout.tp_size:
+        raise ValueError(
+            f"extent {extent} is not divisible by target TP {layout.tp_size}; "
+            "explicit padded geometry is required"
+        )
+    width = extent // layout.tp_size
+    lo = layout.tp_rank * width
+    return lo, lo + width
+
+
+def lower_megatron_target(
+    specs: list[MegatronTargetSpec],
+    layout: MegatronTargetLayout,
+) -> tuple[CaptureResult, dict[str, tuple[tuple[int, ...], Any]]]:
+    """Create #496 capture records and native staging layouts for one TP rank.
+
+    Each copy describes a destination-owned narrow of the global native
+    Megatron tensor. ``plan_transfer`` then intersects that narrow with the
+    trainer's published TP/PP/EP shards and emits only the required reads.
+    """
+
+    copies: list[RecordedCopy] = []
+    param_layout: dict[str, tuple[tuple[int, ...], Any]] = {}
+    staging_sources: dict[str, str] = {}
+    for spec in specs:
+        staging_name = spec.staging_name or spec.source_name
+        previous_source = staging_sources.get(staging_name)
+        if previous_source is not None:
+            raise ValueError(
+                f"duplicate staging_name {staging_name!r} for "
+                f"{previous_source!r} and {spec.source_name!r}"
+            )
+        staging_sources[staging_name] = spec.source_name
+
+        axis = _role_axis(spec)
+        local_shape = list(spec.global_shape)
+        op_chain: tuple = ()
+        if axis is not None and layout.tp_size > 1:
+            lo, hi = _partition(int(spec.global_shape[axis]), layout)
+            local_shape[axis] = hi - lo
+            op_chain = (("narrow", (axis, lo, hi - lo), ()),)
+
+        local_shape_tuple = tuple(local_shape)
+        copies.append(
+            RecordedCopy(
+                src_name=spec.source_name,
+                op_chain=op_chain,
+                param_name=staging_name,
+                dest_offset=0,
+                dest_shape=local_shape_tuple,
+                dest_stride=tuple(_row_major_strides(local_shape_tuple)),
+                dest_dtype=spec.dtype,
+            )
+        )
+        param_layout[staging_name] = (local_shape_tuple, spec.dtype)
+
+    return CaptureResult(copies=copies), param_layout
+
+
+__all__ = [
+    "MegatronTargetLayout",
+    "MegatronTargetSpec",
+    "lower_megatron_target",
+]

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Lower native Megatron tensor geometry into the #496 transfer planner.
+"""Lower native Megatron tensor geometry into the reshard transfer planner.
 
 Megatron publishes rank-local tensors in its native fused representation.
 Translation into HF/vLLM names therefore happens after transfer, but transfer
@@ -108,7 +108,7 @@ def lower_megatron_target(
     specs: list[MegatronTargetSpec],
     layout: MegatronTargetLayout,
 ) -> tuple[CaptureResult, dict[str, tuple[tuple[int, ...], Any]]]:
-    """Create #496 capture records and native staging layouts for one TP rank.
+    """Create reshard capture records and native staging layouts for one TP rank.
 
     Each copy describes a destination-owned narrow of the global native
     Megatron tensor. ``plan_transfer`` then intersects that narrow with the

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
@@ -75,11 +75,25 @@ def _one_shard(
     )
 
 
+GATE_THEN_UP = "gate_then_up"
+
+
 def _build_gated_aliases(
     item: MegatronAliasInput, agent_name: str
 ) -> list[PublishedTensor]:
     if len(item.hf_names) != 2:
         raise ValueError(f"{item.name}: gated tensor requires gate/up HF names")
+    # The halves are assigned to hf_names positionally, so the storage order is
+    # what decides which HF tensor each half becomes. Getting it wrong publishes
+    # the gate projection's bytes under the up projection's name, which no digest
+    # gate can see: both names receive the bytes their publisher advertised. The
+    # order is therefore required rather than assumed.
+    order = item.extras.get("gated_mlp_order")
+    if order != GATE_THEN_UP:
+        raise ValueError(
+            f"{item.name}: fused gate/up aliasing requires extras"
+            f"['gated_mlp_order'] == {GATE_THEN_UP!r}, got {order!r}"
+        )
     axis = int(item.shard_axis if item.shard_axis is not None else 0)
     local_extent = int(item.tensor.shape[axis])
     if local_extent % 2:

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Expose native Megatron storage as HF-canonical #496 source shards."""
+"""Expose native Megatron storage as HF-canonical reshard source shards."""
 
 from __future__ import annotations
 
@@ -31,6 +31,15 @@ def _source_rank_and_size(item: MegatronAliasInput, axis: int) -> tuple[int, int
     if item.local_shard_range is None:
         raise ValueError(f"{item.name}: SHARD has no local range")
     lo, hi = (int(value) for value in item.local_shard_range)
+    # A range can pass every check below and still lie outside the tensor it
+    # claims part of: (16, 24) against a global extent of 16 has the right width,
+    # divides evenly, and yields source rank 2 of a 2-rank group. The alias that
+    # follows would then address bytes the full tensor does not have.
+    if not 0 <= lo < hi <= global_extent:
+        raise ValueError(
+            f"{item.name}: source shard range {(lo, hi)} is outside the global "
+            f"extent {global_extent} on axis {axis}"
+        )
     if hi - lo != local_extent or global_extent % local_extent:
         raise ValueError(f"{item.name}: inconsistent source shard geometry")
     if lo % local_extent:
@@ -187,6 +196,16 @@ def build_hf_aliases(
 
     aliases = []
     for item in items:
+        # Every alias published below is a base address plus a shape, which tells
+        # a reader the bytes run contiguously from that address. A strided view
+        # satisfies neither, and nothing downstream can detect it: the read simply
+        # lands on whatever sits between the elements the view meant to select.
+        if not item.tensor.is_contiguous():
+            raise ValueError(
+                f"{item.name}: aliasing publishes an address and a shape, which "
+                f"requires contiguous storage; got a non-contiguous tensor of "
+                f"shape {tuple(int(dim) for dim in item.tensor.shape)}"
+            )
         if item.role == "qkv_column":
             aliases.extend(_build_qkv_aliases(item, agent_name))
             continue

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Expose native Megatron storage as HF-canonical #496 source shards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from modelexpress.refit.reshard.rendezvous import PublishedShard, PublishedTensor
+
+
+@dataclass(frozen=True)
+class MegatronAliasInput:
+    name: str
+    tensor: Any
+    role: str
+    hf_names: tuple[str, ...]
+    global_shape: tuple[int, ...]
+    placement_kind: str
+    shard_axis: int | None
+    local_shard_range: tuple[int, int] | None
+    extras: dict[str, str] = field(default_factory=dict)
+
+
+def _source_rank_and_size(item: MegatronAliasInput, axis: int) -> tuple[int, int]:
+    local_extent = int(item.tensor.shape[axis])
+    global_extent = int(item.global_shape[axis])
+    if item.placement_kind != "SHARD":
+        return 0, 1
+    if item.local_shard_range is None:
+        raise ValueError(f"{item.name}: SHARD has no local range")
+    lo, hi = (int(value) for value in item.local_shard_range)
+    if hi - lo != local_extent or global_extent % local_extent:
+        raise ValueError(f"{item.name}: inconsistent source shard geometry")
+    if lo % local_extent:
+        raise ValueError(f"{item.name}: non-uniform source shard is unsupported")
+    return lo // local_extent, global_extent // local_extent
+
+
+def _one_shard(
+    *,
+    name: str,
+    tensor: Any,
+    full_shape: tuple[int, ...],
+    agent_name: str,
+    shard_axis: int | None,
+    shard_range: tuple[int, int] | None,
+) -> PublishedTensor:
+    local_shape = tuple(int(dim) for dim in tensor.shape)
+    offset = [0] * len(local_shape)
+    if shard_axis is not None:
+        if shard_range is None:
+            raise ValueError(f"{name}: shard axis has no range")
+        lo, hi = shard_range
+        if hi - lo != local_shape[shard_axis]:
+            raise ValueError(f"{name}: shard range does not match local shape")
+        offset[shard_axis] = lo
+    elif local_shape != full_shape:
+        raise ValueError(f"{name}: replicated shape mismatch")
+    return PublishedTensor(
+        name=name,
+        dtype=str(tensor.dtype),
+        elsize=int(tensor.element_size()),
+        full_shape=full_shape,
+        shards=[
+            PublishedShard(
+                agent_name=agent_name,
+                device_id=int(tensor.device.index or 0),
+                addr=int(tensor.data_ptr()),
+                shard_offset=tuple(offset),
+                shape=local_shape,
+            )
+        ],
+    )
+
+
+def _build_gated_aliases(
+    item: MegatronAliasInput, agent_name: str
+) -> list[PublishedTensor]:
+    if len(item.hf_names) != 2:
+        raise ValueError(f"{item.name}: gated tensor requires gate/up HF names")
+    axis = int(item.shard_axis if item.shard_axis is not None else 0)
+    local_extent = int(item.tensor.shape[axis])
+    if local_extent % 2:
+        raise ValueError(f"{item.name}: fused gate/up extent must be even")
+    half = local_extent // 2
+    gate = item.tensor.narrow(axis, 0, half)
+    up = item.tensor.narrow(axis, half, half)
+    if not gate.is_contiguous() or not up.is_contiguous():
+        raise ValueError(
+            f"{item.name}: fused gate/up aliases are not contiguous on axis {axis}"
+        )
+    source_rank, source_size = _source_rank_and_size(item, axis)
+    full_shape = list(item.tensor.shape)
+    full_shape[axis] = half * source_size
+    shard_range = (
+        (source_rank * half, (source_rank + 1) * half) if source_size > 1 else None
+    )
+    return [
+        _one_shard(
+            name=hf_name,
+            tensor=tensor,
+            full_shape=tuple(int(dim) for dim in full_shape),
+            agent_name=agent_name,
+            shard_axis=axis if shard_range is not None else None,
+            shard_range=shard_range,
+        )
+        for hf_name, tensor in zip(item.hf_names, (gate, up), strict=True)
+    ]
+
+
+def _build_qkv_aliases(
+    item: MegatronAliasInput, agent_name: str
+) -> list[PublishedTensor]:
+    if len(item.hf_names) != 3 or item.tensor.ndim != 2:
+        raise ValueError(f"{item.name}: QKV aliasing requires 2D q/k/v weights")
+    head_dim = int(item.extras["head_dim"])
+    q_heads_local = int(item.extras["num_heads_local"])
+    kv_heads_local = int(item.extras["num_kv_heads_local"])
+    if kv_heads_local < 1 or q_heads_local % kv_heads_local:
+        raise ValueError(f"{item.name}: invalid local Q/KV head geometry")
+    rows_per_group = (q_heads_local // kv_heads_local + 2) * head_dim
+    if rows_per_group * kv_heads_local != int(item.tensor.shape[0]):
+        raise ValueError(f"{item.name}: QKV rows disagree with head metadata")
+    source_rank, source_size = _source_rank_and_size(item, 0)
+    hidden = int(item.tensor.shape[1])
+    q_heads_per_group = q_heads_local // kv_heads_local
+    q_shards = []
+    k_shards = []
+    v_shards = []
+    for local_group in range(kv_heads_local):
+        group = item.tensor.narrow(0, local_group * rows_per_group, rows_per_group)
+        q_rows = q_heads_per_group * head_dim
+        q = group.narrow(0, 0, q_rows)
+        k = group.narrow(0, q_rows, head_dim)
+        v = group.narrow(0, q_rows + head_dim, head_dim)
+        global_group = source_rank * kv_heads_local + local_group
+        for tensor, shards, start in (
+            (q, q_shards, global_group * q_rows),
+            (k, k_shards, global_group * head_dim),
+            (v, v_shards, global_group * head_dim),
+        ):
+            shards.append(
+                PublishedShard(
+                    agent_name=agent_name,
+                    device_id=int(tensor.device.index or 0),
+                    addr=int(tensor.data_ptr()),
+                    shard_offset=(start, 0),
+                    shape=tuple(int(dim) for dim in tensor.shape),
+                )
+            )
+    return [
+        PublishedTensor(
+            name=name,
+            dtype=str(item.tensor.dtype),
+            elsize=int(item.tensor.element_size()),
+            full_shape=(rows, hidden),
+            shards=shards,
+        )
+        for name, rows, shards in (
+            (item.hf_names[0], q_heads_local * source_size * head_dim, q_shards),
+            (item.hf_names[1], kv_heads_local * source_size * head_dim, k_shards),
+            (item.hf_names[2], kv_heads_local * source_size * head_dim, v_shards),
+        )
+    ]
+
+
+def build_hf_aliases(
+    items: list[MegatronAliasInput], *, agent_name: str
+) -> list[PublishedTensor]:
+    """Build zero-copy HF aliases whose addresses remain in registered storage."""
+
+    aliases = []
+    for item in items:
+        if item.role == "qkv_column":
+            aliases.extend(_build_qkv_aliases(item, agent_name))
+            continue
+        if (
+            item.role in {"gated_mlp_column", "expert_column"}
+            and len(item.hf_names) == 2
+        ):
+            aliases.extend(_build_gated_aliases(item, agent_name))
+            continue
+        if len(item.hf_names) != 1:
+            raise ValueError(
+                f"{item.name}: role {item.role!r} cannot map to "
+                f"{len(item.hf_names)} HF tensors"
+            )
+        aliases.append(
+            _one_shard(
+                name=item.hf_names[0],
+                tensor=item.tensor,
+                full_shape=tuple(item.global_shape),
+                agent_name=agent_name,
+                shard_axis=(
+                    int(item.shard_axis) if item.placement_kind == "SHARD" else None
+                ),
+                shard_range=(
+                    tuple(item.local_shard_range)
+                    if item.placement_kind == "SHARD"
+                    and item.local_shard_range is not None
+                    else None
+                ),
+            )
+        )
+    return aliases
+
+
+__all__ = ["MegatronAliasInput", "build_hf_aliases"]

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Publish registered native Megatron tensors through #496 rendezvous."""
+"""Publish registered native Megatron tensors through the reshard rendezvous."""
 
 from __future__ import annotations
 
@@ -39,11 +39,11 @@ def publish_megatron_reshard_view(
     specs: list[MegatronPublishedTensorSpec],
     metadata_endpoint: str,
 ) -> str:
-    """Publish a #496 shard table over an existing NIXL registration.
+    """Publish a reshard shard table over an existing NIXL registration.
 
     The framework's normal publisher owns tensor lifetime, registration, and
     listen thread. This seam only describes those same stable addresses in the
-    #496 rendezvous format, avoiding a duplicate NIXL agent or second tensor
+    reshard rendezvous format, avoiding a duplicate NIXL agent or second tensor
     allocation.
     """
 
@@ -74,7 +74,7 @@ def publish_megatron_reshard_view(
         tensor = tensors[name]
         spec = by_name[name]
         if not tensor.is_contiguous():
-            raise ValueError(f"{name}: #496 publication requires contiguous storage")
+            raise ValueError(f"{name}: reshard publication requires contiguous storage")
         local_shape = tuple(int(dim) for dim in tensor.shape)
         if len(local_shape) != len(spec.global_shape):
             raise ValueError(

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
@@ -34,10 +34,7 @@ class MegatronPublishedTensorSpec:
 def publish_megatron_reshard_view(
     *,
     manager: Any,
-    client: Any,
-    model_name: str,
-    worker_rank: int,
-    worker_id: str,
+    rendezvous: MxReshardRendezvous,
     tensors: dict[str, Any],
     specs: list[MegatronPublishedTensorSpec],
     metadata_endpoint: str,
@@ -54,7 +51,15 @@ def publish_megatron_reshard_view(
         raise ValueError(
             "metadata_endpoint must be an explicit host:port reachable by receivers"
         )
-    by_name = {spec.name: spec for spec in specs}
+    by_name: dict[str, MegatronPublishedTensorSpec] = {}
+    for spec in specs:
+        # Last-writer-wins here would publish one spec's shard description under a
+        # name the other spec owns, and the missing/extra check below compares key
+        # sets, so it cannot see it. lower_megatron_target rejects the analogous
+        # duplicate staging_name for the same reason.
+        if spec.name in by_name:
+            raise ValueError(f"duplicate Megatron publish spec for {spec.name!r}")
+        by_name[spec.name] = spec
     missing = sorted(set(by_name).difference(tensors))
     extra = sorted(set(tensors).difference(by_name))
     if missing or extra:
@@ -114,10 +119,7 @@ def publish_megatron_reshard_view(
 
     return publish_registered_shard_table(
         manager=manager,
-        client=client,
-        model_name=model_name,
-        worker_rank=worker_rank,
-        worker_id=worker_id,
+        rendezvous=rendezvous,
         published=published,
         metadata_endpoint=metadata_endpoint,
     )
@@ -126,14 +128,17 @@ def publish_megatron_reshard_view(
 def publish_registered_shard_table(
     *,
     manager: Any,
-    client: Any,
-    model_name: str,
-    worker_rank: int,
-    worker_id: str,
+    rendezvous: MxReshardRendezvous,
     published: list[PublishedTensor],
     metadata_endpoint: str,
 ) -> str:
-    """Publish a validated alias table over already-registered storage."""
+    """Publish a validated alias table over already-registered storage.
+
+    The caller supplies the rendezvous and keeps it for the lifetime of the
+    publication: publishing starts the source's READY heartbeat thread, and only
+    the owner of the rendezvous can stop it and mark the source stale on shutdown.
+    Constructing one here would leave a heartbeat running with no handle to it.
+    """
 
     if not metadata_endpoint or ":" not in metadata_endpoint:
         raise ValueError(
@@ -158,13 +163,6 @@ def publish_registered_shard_table(
         agent_name,
         metadata_endpoint,
         published,
-    )
-    rendezvous = MxReshardRendezvous(
-        client,
-        role="trainer",
-        rank=int(worker_rank),
-        model_name=model_name,
-        worker_id=worker_id,
     )
     return rendezvous.publish(blob)
 

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Publish registered native Megatron tensors through #496 rendezvous."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from modelexpress.refit.reshard.rendezvous import (
+    MxReshardRendezvous,
+    PublishedShard,
+    PublishedTensor,
+    wrap_rendezvous_blob,
+)
+
+
+@dataclass(frozen=True)
+class MegatronPublishedTensorSpec:
+    name: str
+    global_shape: tuple[int, ...]
+    shard_axis: int | None = None
+    local_shard_range: tuple[int, int] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.global_shape or any(int(dim) <= 0 for dim in self.global_shape):
+            raise ValueError(f"{self.name}: invalid global shape {self.global_shape}")
+        if (self.shard_axis is None) != (self.local_shard_range is None):
+            raise ValueError(
+                f"{self.name}: shard_axis and local_shard_range must be set together"
+            )
+
+
+def publish_megatron_reshard_view(
+    *,
+    manager: Any,
+    client: Any,
+    model_name: str,
+    worker_rank: int,
+    worker_id: str,
+    tensors: dict[str, Any],
+    specs: list[MegatronPublishedTensorSpec],
+    metadata_endpoint: str,
+) -> str:
+    """Publish a #496 shard table over an existing NIXL registration.
+
+    The framework's normal publisher owns tensor lifetime, registration, and
+    listen thread. This seam only describes those same stable addresses in the
+    #496 rendezvous format, avoiding a duplicate NIXL agent or second tensor
+    allocation.
+    """
+
+    if not metadata_endpoint or ":" not in metadata_endpoint:
+        raise ValueError(
+            "metadata_endpoint must be an explicit host:port reachable by receivers"
+        )
+    by_name = {spec.name: spec for spec in specs}
+    missing = sorted(set(by_name).difference(tensors))
+    extra = sorted(set(tensors).difference(by_name))
+    if missing or extra:
+        raise ValueError(
+            f"Megatron shard table/tensor mismatch: missing={missing[:10]} "
+            f"extra={extra[:10]}"
+        )
+
+    agent_name = str(manager.agent_name)
+    published = []
+    for name in sorted(by_name):
+        tensor = tensors[name]
+        spec = by_name[name]
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name}: #496 publication requires contiguous storage")
+        local_shape = tuple(int(dim) for dim in tensor.shape)
+        if len(local_shape) != len(spec.global_shape):
+            raise ValueError(
+                f"{name}: local rank {len(local_shape)} != global rank "
+                f"{len(spec.global_shape)}"
+            )
+        offset = [0] * len(local_shape)
+        if spec.shard_axis is not None:
+            axis = int(spec.shard_axis)
+            if not 0 <= axis < len(local_shape):
+                raise ValueError(f"{name}: invalid shard axis {axis}")
+            assert spec.local_shard_range is not None
+            lo, hi = (int(value) for value in spec.local_shard_range)
+            if hi - lo != local_shape[axis] or hi > int(spec.global_shape[axis]):
+                raise ValueError(
+                    f"{name}: local shape {local_shape} disagrees with shard "
+                    f"range {(lo, hi)} in global shape {spec.global_shape}"
+                )
+            offset[axis] = lo
+        elif local_shape != tuple(spec.global_shape):
+            raise ValueError(
+                f"{name}: replicated local shape {local_shape} != "
+                f"global shape {spec.global_shape}"
+            )
+        published.append(
+            PublishedTensor(
+                name=name,
+                dtype=str(tensor.dtype),
+                elsize=int(tensor.element_size()),
+                full_shape=tuple(spec.global_shape),
+                shards=[
+                    PublishedShard(
+                        agent_name=agent_name,
+                        device_id=int(tensor.device.index or 0),
+                        addr=int(tensor.data_ptr()),
+                        shard_offset=tuple(offset),
+                        shape=local_shape,
+                    )
+                ],
+            )
+        )
+
+    return publish_registered_shard_table(
+        manager=manager,
+        client=client,
+        model_name=model_name,
+        worker_rank=worker_rank,
+        worker_id=worker_id,
+        published=published,
+        metadata_endpoint=metadata_endpoint,
+    )
+
+
+def publish_registered_shard_table(
+    *,
+    manager: Any,
+    client: Any,
+    model_name: str,
+    worker_rank: int,
+    worker_id: str,
+    published: list[PublishedTensor],
+    metadata_endpoint: str,
+) -> str:
+    """Publish a validated alias table over already-registered storage."""
+
+    if not metadata_endpoint or ":" not in metadata_endpoint:
+        raise ValueError(
+            "metadata_endpoint must be an explicit host:port reachable by receivers"
+        )
+    if not published:
+        raise ValueError("published shard table must not be empty")
+    agent_name = str(manager.agent_name)
+    for tensor in published:
+        if not tensor.shards:
+            raise ValueError(f"{tensor.name}: no shards were published")
+        for shard in tensor.shards:
+            if shard.agent_name != agent_name:
+                raise ValueError(
+                    f"{tensor.name}: shard agent {shard.agent_name!r} does not "
+                    f"match manager agent {agent_name!r}"
+                )
+            if shard.addr <= 0:
+                raise ValueError(f"{tensor.name}: shard has invalid address")
+    blob = wrap_rendezvous_blob(
+        manager.nixl_metadata,
+        agent_name,
+        metadata_endpoint,
+        published,
+    )
+    rendezvous = MxReshardRendezvous(
+        client,
+        role="trainer",
+        rank=int(worker_rank),
+        model_name=model_name,
+        worker_id=worker_id,
+    )
+    return rendezvous.publish(blob)
+
+
+__all__ = [
+    "MegatronPublishedTensorSpec",
+    "publish_megatron_reshard_view",
+    "publish_registered_shard_table",
+]

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_receiver.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""#496 receiver seam for native Megatron staging and translation."""
+"""Reshard receiver seam for native Megatron staging and translation."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ def _dtype_label(dtype: Any) -> str:
 class MegatronReshardReceiver(ReshardReceiver):
     """Pull destination-owned native tensors, then invoke framework translation.
 
-    The generic #496 receiver owns discovery, exact segment planning, NIXL reads,
+    The generic reshard receiver owns discovery, exact segment planning, NIXL reads,
     and persistent buffers. This subclass replaces vLLM loader capture with
     native Megatron target geometry; its install callback translates those
     target-local native buffers into the engine's parameter representation.

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_receiver.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""#496 receiver seam for native Megatron staging and translation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from modelexpress.refit.reshard.megatron import (
+    MegatronTargetLayout,
+    MegatronTargetSpec,
+    lower_megatron_target,
+)
+from modelexpress.refit.reshard.receiver import ReshardReceiver
+
+
+def _dtype_label(dtype: Any) -> str:
+    return str(dtype).removeprefix("torch.")
+
+
+class MegatronReshardReceiver(ReshardReceiver):
+    """Pull destination-owned native tensors, then invoke framework translation.
+
+    The generic #496 receiver owns discovery, exact segment planning, NIXL reads,
+    and persistent buffers. This subclass replaces vLLM loader capture with
+    native Megatron target geometry; its install callback translates those
+    target-local native buffers into the engine's parameter representation.
+    """
+
+    def __init__(
+        self,
+        *,
+        target_specs: list[MegatronTargetSpec],
+        target_layout: MegatronTargetLayout,
+        install_native: Callable[[dict[str, Any]], None],
+        **base_kwargs: Any,
+    ) -> None:
+        if not target_specs:
+            raise ValueError("target_specs must not be empty")
+        self._target_specs = list(target_specs)
+        self._target_layout = target_layout
+        self._install_native = install_native
+        super().__init__(**base_kwargs)
+
+    def _capture(self, manifest: list) -> tuple:
+        published = {
+            name: (_dtype_label(dtype), tuple(int(dim) for dim in shape))
+            for name, dtype, shape in manifest
+        }
+        missing = [
+            spec.source_name
+            for spec in self._target_specs
+            if spec.source_name not in published
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Megatron target plan references {len(missing)} unpublished "
+                f"tensor(s): {missing[:10]}"
+            )
+        mismatched = []
+        for spec in self._target_specs:
+            dtype, shape = published[spec.source_name]
+            if shape != tuple(spec.global_shape) or dtype != _dtype_label(spec.dtype):
+                mismatched.append(
+                    (
+                        spec.source_name,
+                        (shape, dtype),
+                        (tuple(spec.global_shape), _dtype_label(spec.dtype)),
+                    )
+                )
+        if mismatched:
+            raise RuntimeError(
+                "Megatron source manifest disagrees with target geometry: "
+                f"{mismatched[:5]}"
+            )
+        return lower_megatron_target(self._target_specs, self._target_layout)
+
+    def _install(self, recv_buffers: dict) -> None:
+        self._install_native(recv_buffers)
+
+
+__all__ = ["MegatronReshardReceiver"]

--- a/modelexpress_client/python/tests/test_reshard_megatron.py
+++ b/modelexpress_client/python/tests/test_reshard_megatron.py
@@ -9,7 +9,6 @@ from modelexpress.refit.reshard.megatron import (
     MegatronTargetSpec,
     lower_megatron_target,
 )
-from modelexpress.refit.reshard.megatron_receiver import MegatronReshardReceiver
 from modelexpress.refit.reshard.megatron_aliases import (
     MegatronAliasInput,
     build_hf_aliases,
@@ -18,6 +17,7 @@ from modelexpress.refit.reshard.megatron_publisher import (
     MegatronPublishedTensorSpec,
     publish_megatron_reshard_view,
 )
+from modelexpress.refit.reshard.megatron_receiver import MegatronReshardReceiver
 from modelexpress.refit.reshard.rendezvous import unwrap_rendezvous_blob
 from modelexpress.refit.reshard.slice_plan import Shard
 from modelexpress.refit.reshard.transfer_plan import SourceInfo, plan_transfer

--- a/modelexpress_client/python/tests/test_reshard_megatron.py
+++ b/modelexpress_client/python/tests/test_reshard_megatron.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from modelexpress import p2p_pb2
 from modelexpress.refit.reshard.megatron import (
     MegatronTargetLayout,
     MegatronTargetSpec,
@@ -18,7 +19,10 @@ from modelexpress.refit.reshard.megatron_publisher import (
     publish_megatron_reshard_view,
 )
 from modelexpress.refit.reshard.megatron_receiver import MegatronReshardReceiver
-from modelexpress.refit.reshard.rendezvous import unwrap_rendezvous_blob
+from modelexpress.refit.reshard.rendezvous import (
+    MxReshardRendezvous,
+    unwrap_rendezvous_blob,
+)
 from modelexpress.refit.reshard.slice_plan import Shard
 from modelexpress.refit.reshard.transfer_plan import SourceInfo, plan_transfer
 
@@ -190,39 +194,56 @@ def test_receiver_seam_rejects_stale_manifest_geometry():
         )
 
 
+class _PublishClient:
+    """Records the published worker record and accepts heartbeat status updates."""
+
+    def __init__(self):
+        self.worker = None
+        self.status_updates = []
+
+    def publish_metadata(self, _identity, worker, _worker_id):
+        self.worker = worker
+        return "source-id"
+
+    def update_status(self, **kwargs):
+        self.status_updates.append(kwargs)
+        return True
+
+
+class _Manager:
+    agent_name = "trainer-r3"
+    nixl_metadata = b"agent-metadata"
+
+
+def _trainer_rendezvous(client):
+    return MxReshardRendezvous(
+        client, role="trainer", rank=3, model_name="model", worker_id="worker-3"
+    )
+
+
 def test_publisher_seam_reuses_registered_tensor_addresses():
-    class Manager:
-        agent_name = "trainer-r3"
-        nixl_metadata = b"agent-metadata"
-
-    class Client:
-        def __init__(self):
-            self.worker = None
-
-        def publish_metadata(self, _identity, worker, _worker_id):
-            self.worker = worker
-            return "source-id"
-
-    client = Client()
+    client = _PublishClient()
+    rendezvous = _trainer_rendezvous(client)
     tensor = torch.zeros((8, 8), dtype=torch.bfloat16)
 
-    source_id = publish_megatron_reshard_view(
-        manager=Manager(),
-        client=client,
-        model_name="model",
-        worker_rank=3,
-        worker_id="worker-3",
-        tensors={"column": tensor},
-        specs=[
-            MegatronPublishedTensorSpec(
-                name="column",
-                global_shape=(16, 8),
-                shard_axis=0,
-                local_shard_range=(8, 16),
-            )
-        ],
-        metadata_endpoint="10.0.0.3:19003",
-    )
+    try:
+        source_id = publish_megatron_reshard_view(
+            manager=_Manager(),
+            rendezvous=rendezvous,
+            tensors={"column": tensor},
+            specs=[
+                MegatronPublishedTensorSpec(
+                    name="column",
+                    global_shape=(16, 8),
+                    shard_axis=0,
+                    local_shard_range=(8, 16),
+                )
+            ],
+            metadata_endpoint="10.0.0.3:19003",
+        )
+    finally:
+        # The caller owns the rendezvous precisely so its heartbeat can be stopped.
+        rendezvous.close()
 
     assert source_id == "source-id"
     assert client.worker.status > 0
@@ -236,6 +257,46 @@ def test_publisher_seam_reuses_registered_tensor_addresses():
     )
     assert published[0].shards[0].addr == tensor.data_ptr()
     assert published[0].shards[0].shard_offset == (8, 0)
+
+
+def test_publishing_leaves_the_heartbeat_with_its_owner():
+    """Publishing starts the source's READY heartbeat. A rendezvous built inside the
+    seam would leave that thread running with no handle to stop it, so the source
+    would only be marked stale at interpreter exit."""
+    client = _PublishClient()
+    rendezvous = _trainer_rendezvous(client)
+
+    publish_megatron_reshard_view(
+        manager=_Manager(),
+        rendezvous=rendezvous,
+        tensors={"column": torch.zeros((8, 8), dtype=torch.bfloat16)},
+        specs=[MegatronPublishedTensorSpec(name="column", global_shape=(8, 8))],
+        metadata_endpoint="10.0.0.3:19003",
+    )
+    rendezvous.close()
+
+    assert client.status_updates[-1]["status"] == p2p_pb2.SOURCE_STATUS_STALE
+    assert client.status_updates[-1]["worker_id"] == "worker-3"
+
+
+def test_publisher_seam_rejects_duplicate_spec_names():
+    """Last-writer-wins would publish one spec's shard description under a name the
+    other spec owns, and comparing key sets against the tensors cannot see it."""
+
+    class Client:
+        def publish_metadata(self, *_args, **_kwargs):
+            raise AssertionError("publication must not run")
+
+    spec = MegatronPublishedTensorSpec(name="column", global_shape=(8, 8))
+
+    with pytest.raises(ValueError, match="duplicate Megatron publish spec"):
+        publish_megatron_reshard_view(
+            manager=_Manager(),
+            rendezvous=_trainer_rendezvous(Client()),
+            tensors={"column": torch.zeros((8, 8), dtype=torch.bfloat16)},
+            specs=[spec, spec],
+            metadata_endpoint="10.0.0.3:19003",
+        )
 
 
 def test_gated_aliases_split_each_tp_shard_into_hf_gate_and_up():
@@ -263,6 +324,53 @@ def test_gated_aliases_split_each_tp_shard_into_hf_gate_and_up():
     assert gate.shards[0].shard_offset == up.shards[0].shard_offset == (4, 0)
     assert gate.shards[0].addr == fused.data_ptr()
     assert up.shards[0].addr == fused[4:].data_ptr()
+
+
+def test_an_unknown_fused_gate_up_order_is_rejected():
+    """The halves map to `hf_names` positionally, so an up-then-gate layout would
+    publish the gate projection's bytes under the up projection's name. No digest
+    gate can see that: both names receive the bytes their publisher advertised."""
+    fused = torch.arange(32, dtype=torch.bfloat16).reshape(8, 4)
+
+    with pytest.raises(ValueError, match="gated_mlp_order"):
+        build_hf_aliases(
+            [
+                MegatronAliasInput(
+                    name="linear_fc1.weight",
+                    tensor=fused,
+                    role="gated_mlp_column",
+                    hf_names=("gate_proj.weight", "up_proj.weight"),
+                    global_shape=(16, 4),
+                    placement_kind="SHARD",
+                    shard_axis=0,
+                    local_shard_range=(8, 16),
+                    extras={"gated_mlp_order": "up_then_gate"},
+                )
+            ],
+            agent_name="trainer-tp1",
+        )
+
+
+def test_a_missing_fused_gate_up_order_is_rejected():
+    """Absent metadata is not evidence of gate-then-up storage."""
+    fused = torch.arange(32, dtype=torch.bfloat16).reshape(8, 4)
+
+    with pytest.raises(ValueError, match="gated_mlp_order"):
+        build_hf_aliases(
+            [
+                MegatronAliasInput(
+                    name="linear_fc1.weight",
+                    tensor=fused,
+                    role="gated_mlp_column",
+                    hf_names=("gate_proj.weight", "up_proj.weight"),
+                    global_shape=(16, 4),
+                    placement_kind="SHARD",
+                    shard_axis=0,
+                    local_shard_range=(8, 16),
+                )
+            ],
+            agent_name="trainer-tp1",
+        )
 
 
 def test_qkv_aliases_expose_hf_head_ranges_without_copy():

--- a/modelexpress_client/python/tests/test_reshard_megatron.py
+++ b/modelexpress_client/python/tests/test_reshard_megatron.py
@@ -406,3 +406,82 @@ def test_qkv_aliases_expose_hf_head_ranges_without_copy():
     assert q.shards[0].addr == qkv.data_ptr()
     assert k.shards[0].addr == qkv[8:].data_ptr()
     assert v.shards[0].addr == qkv[10:].data_ptr()
+
+
+def test_a_shard_range_beyond_the_global_extent_is_rejected():
+    """A range of (16, 24) against a global extent of 16 clears every other
+    check: it is the right width, it divides evenly, and it yields source rank 2
+    of a 2-rank group. The alias would then describe bytes past the end of the
+    tensor it claims to be part of."""
+    fused = torch.arange(32, dtype=torch.bfloat16).reshape(8, 4)
+
+    with pytest.raises(ValueError, match="outside the global extent"):
+        build_hf_aliases(
+            [
+                MegatronAliasInput(
+                    name="linear_fc1.weight",
+                    tensor=fused,
+                    role="gated_mlp_column",
+                    hf_names=("gate_proj.weight", "up_proj.weight"),
+                    global_shape=(16, 4),
+                    placement_kind="SHARD",
+                    shard_axis=0,
+                    local_shard_range=(16, 24),
+                    extras={"gated_mlp_order": "gate_then_up"},
+                )
+            ],
+            agent_name="trainer-tp1",
+        )
+
+
+def test_a_non_contiguous_qkv_tensor_is_rejected():
+    """A shard is published as one address plus a shape, so a strided view would
+    advertise bytes that belong to the columns it skipped."""
+    strided = torch.arange(96, dtype=torch.bfloat16).reshape(12, 8)[:, :4]
+    assert not strided.is_contiguous()
+
+    with pytest.raises(ValueError, match="requires contiguous storage"):
+        build_hf_aliases(
+            [
+                MegatronAliasInput(
+                    name="linear_qkv.weight",
+                    tensor=strided,
+                    role="qkv_column",
+                    hf_names=("q_proj.weight", "k_proj.weight", "v_proj.weight"),
+                    global_shape=(24, 4),
+                    placement_kind="SHARD",
+                    shard_axis=0,
+                    local_shard_range=(12, 24),
+                    extras={
+                        "num_heads_local": "4",
+                        "num_kv_heads_local": "1",
+                        "head_dim": "2",
+                    },
+                )
+            ],
+            agent_name="trainer-tp1",
+        )
+
+
+def test_a_non_contiguous_ordinary_alias_is_rejected():
+    """The single-name path publishes the tensor's own address, so a transpose
+    would hand a reader the untransposed bytes."""
+    transposed = torch.arange(32, dtype=torch.bfloat16).reshape(4, 8).t()
+    assert not transposed.is_contiguous()
+
+    with pytest.raises(ValueError, match="requires contiguous storage"):
+        build_hf_aliases(
+            [
+                MegatronAliasInput(
+                    name="linear_fc2.weight",
+                    tensor=transposed,
+                    role="row",
+                    hf_names=("down_proj.weight",),
+                    global_shape=(8, 4),
+                    placement_kind="REPLICATE",
+                    shard_axis=None,
+                    local_shard_range=None,
+                )
+            ],
+            agent_name="trainer-tp1",
+        )

--- a/modelexpress_client/python/tests/test_reshard_megatron.py
+++ b/modelexpress_client/python/tests/test_reshard_megatron.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from modelexpress.refit.reshard.megatron import (
+    MegatronTargetLayout,
+    MegatronTargetSpec,
+    lower_megatron_target,
+)
+from modelexpress.refit.reshard.megatron_receiver import MegatronReshardReceiver
+from modelexpress.refit.reshard.megatron_aliases import (
+    MegatronAliasInput,
+    build_hf_aliases,
+)
+from modelexpress.refit.reshard.megatron_publisher import (
+    MegatronPublishedTensorSpec,
+    publish_megatron_reshard_view,
+)
+from modelexpress.refit.reshard.rendezvous import unwrap_rendezvous_blob
+from modelexpress.refit.reshard.slice_plan import Shard
+from modelexpress.refit.reshard.transfer_plan import SourceInfo, plan_transfer
+
+
+def _bf16_sources() -> tuple[dict[str, SourceInfo], list[torch.Tensor]]:
+    tensors = [
+        torch.zeros((8, 8), dtype=torch.bfloat16),
+        torch.zeros((8, 8), dtype=torch.bfloat16),
+        torch.zeros((8, 8), dtype=torch.bfloat16),
+        torch.zeros((8, 8), dtype=torch.bfloat16),
+        torch.zeros((8,), dtype=torch.bfloat16),
+    ]
+    sources = {
+        "expert_fc1": SourceInfo(
+            (16, 8),
+            torch.bfloat16,
+            2,
+            [
+                Shard((0, 0), (8, 8), "tp0", tensors[0].data_ptr(), 2),
+                Shard((8, 0), (8, 8), "tp1", tensors[1].data_ptr(), 2),
+            ],
+        ),
+        "expert_fc2": SourceInfo(
+            (8, 16),
+            torch.bfloat16,
+            2,
+            [
+                Shard((0, 0), (8, 8), "tp0", tensors[2].data_ptr(), 2),
+                Shard((0, 8), (8, 8), "tp1", tensors[3].data_ptr(), 2),
+            ],
+        ),
+        "norm": SourceInfo(
+            (8,),
+            torch.bfloat16,
+            2,
+            [Shard((0,), (8,), "tp0", tensors[4].data_ptr(), 2)],
+        ),
+    }
+    return sources, tensors
+
+
+def _specs() -> list[MegatronTargetSpec]:
+    return [
+        MegatronTargetSpec(
+            "expert_fc1",
+            "expert_column",
+            (16, 8),
+            torch.bfloat16,
+            shard_axis=0,
+            descriptor_extras={"expert_layout": "grouped"},
+        ),
+        MegatronTargetSpec(
+            "expert_fc2",
+            "expert_row",
+            (8, 16),
+            torch.bfloat16,
+            shard_axis=1,
+            descriptor_extras={"expert_layout": "grouped"},
+        ),
+        MegatronTargetSpec("norm", "replicated", (8,), torch.bfloat16),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "tp_rank", "expected_bytes", "expected_segments"),
+    [(2, 1, 272, 3), (4, 2, 144, 10)],
+)
+def test_megatron_target_lowers_to_destination_owned_bytes(
+    tp_size: int,
+    tp_rank: int,
+    expected_bytes: int,
+    expected_segments: int,
+):
+    sources, keepalive = _bf16_sources()
+    capture, layouts = lower_megatron_target(
+        _specs(), MegatronTargetLayout(tp_size=tp_size, tp_rank=tp_rank)
+    )
+
+    plan = plan_transfer(capture, sources)
+
+    assert plan.fallback == []
+    assert plan.bytes_planned() == expected_bytes
+    assert len(plan.segments) == expected_segments
+    assert layouts["expert_fc1"][0] == (16 // tp_size, 8)
+    assert layouts["expert_fc2"][0] == (8, 16 // tp_size)
+    assert layouts["norm"][0] == (8,)
+    assert all(tensor.data_ptr() for tensor in keepalive)
+
+
+def test_leading_axis_experts_preserve_expert_dimension():
+    capture, layouts = lower_megatron_target(
+        [
+            MegatronTargetSpec(
+                "fc1",
+                "expert_column",
+                (4, 16, 8),
+                torch.bfloat16,
+                descriptor_extras={"expert_layout": "leading_axis"},
+            ),
+            MegatronTargetSpec(
+                "fc2",
+                "expert_row",
+                (4, 8, 16),
+                torch.bfloat16,
+                descriptor_extras={"expert_layout": "leading_axis"},
+            ),
+        ],
+        MegatronTargetLayout(tp_size=4, tp_rank=3),
+    )
+
+    assert layouts == {
+        "fc1": ((4, 4, 8), torch.bfloat16),
+        "fc2": ((4, 8, 4), torch.bfloat16),
+    }
+    assert capture.copies[0].op_chain == (("narrow", (1, 12, 4), ()),)
+    assert capture.copies[1].op_chain == (("narrow", (2, 12, 4), ()),)
+
+
+def test_non_divisible_target_geometry_fails_closed():
+    with pytest.raises(ValueError, match="not divisible"):
+        lower_megatron_target(
+            [
+                MegatronTargetSpec(
+                    "column",
+                    "column",
+                    (10, 8),
+                    torch.bfloat16,
+                )
+            ],
+            MegatronTargetLayout(tp_size=4, tp_rank=0),
+        )
+
+
+def test_receiver_seam_validates_manifest_and_invokes_installer():
+    installed = []
+    receiver = object.__new__(MegatronReshardReceiver)
+    receiver._target_specs = _specs()
+    receiver._target_layout = MegatronTargetLayout(tp_size=4, tp_rank=0)
+    receiver._install_native = installed.append
+    manifest = [
+        ("expert_fc1", torch.bfloat16, (16, 8)),
+        ("expert_fc2", torch.bfloat16, (8, 16)),
+        ("norm", torch.bfloat16, (8,)),
+    ]
+
+    capture, layouts = receiver._capture(manifest)
+    buffers = {
+        name: torch.empty(shape, dtype=dtype)
+        for name, (shape, dtype) in layouts.items()
+    }
+    receiver._install(buffers)
+
+    assert len(capture.copies) == 3
+    assert installed == [buffers]
+
+
+def test_receiver_seam_rejects_stale_manifest_geometry():
+    receiver = object.__new__(MegatronReshardReceiver)
+    receiver._target_specs = _specs()
+    receiver._target_layout = MegatronTargetLayout(tp_size=2, tp_rank=0)
+
+    with pytest.raises(RuntimeError, match="disagrees"):
+        receiver._capture(
+            [
+                ("expert_fc1", torch.bfloat16, (8, 8)),
+                ("expert_fc2", torch.bfloat16, (8, 16)),
+                ("norm", torch.bfloat16, (8,)),
+            ]
+        )
+
+
+def test_publisher_seam_reuses_registered_tensor_addresses():
+    class Manager:
+        agent_name = "trainer-r3"
+        nixl_metadata = b"agent-metadata"
+
+    class Client:
+        def __init__(self):
+            self.worker = None
+
+        def publish_metadata(self, _identity, worker, _worker_id):
+            self.worker = worker
+            return "source-id"
+
+    client = Client()
+    tensor = torch.zeros((8, 8), dtype=torch.bfloat16)
+
+    source_id = publish_megatron_reshard_view(
+        manager=Manager(),
+        client=client,
+        model_name="model",
+        worker_rank=3,
+        worker_id="worker-3",
+        tensors={"column": tensor},
+        specs=[
+            MegatronPublishedTensorSpec(
+                name="column",
+                global_shape=(16, 8),
+                shard_axis=0,
+                local_shard_range=(8, 16),
+            )
+        ],
+        metadata_endpoint="10.0.0.3:19003",
+    )
+
+    assert source_id == "source-id"
+    assert client.worker.status > 0
+    agent_metadata, agent_name, endpoint, published = unwrap_rendezvous_blob(
+        client.worker.nixl_metadata
+    )
+    assert (agent_metadata, agent_name, endpoint) == (
+        b"agent-metadata",
+        "trainer-r3",
+        "10.0.0.3:19003",
+    )
+    assert published[0].shards[0].addr == tensor.data_ptr()
+    assert published[0].shards[0].shard_offset == (8, 0)
+
+
+def test_gated_aliases_split_each_tp_shard_into_hf_gate_and_up():
+    fused = torch.arange(32, dtype=torch.bfloat16).reshape(8, 4)
+
+    gate, up = build_hf_aliases(
+        [
+            MegatronAliasInput(
+                name="linear_fc1.weight",
+                tensor=fused,
+                role="gated_mlp_column",
+                hf_names=("gate_proj.weight", "up_proj.weight"),
+                global_shape=(16, 4),
+                placement_kind="SHARD",
+                shard_axis=0,
+                local_shard_range=(8, 16),
+                extras={"gated_mlp_order": "gate_then_up"},
+            )
+        ],
+        agent_name="trainer-tp1",
+    )
+
+    assert gate.full_shape == up.full_shape == (8, 4)
+    assert gate.shards[0].shape == up.shards[0].shape == (4, 4)
+    assert gate.shards[0].shard_offset == up.shards[0].shard_offset == (4, 0)
+    assert gate.shards[0].addr == fused.data_ptr()
+    assert up.shards[0].addr == fused[4:].data_ptr()
+
+
+def test_qkv_aliases_expose_hf_head_ranges_without_copy():
+    qkv = torch.arange(48, dtype=torch.bfloat16).reshape(12, 4)
+
+    q, k, v = build_hf_aliases(
+        [
+            MegatronAliasInput(
+                name="linear_qkv.weight",
+                tensor=qkv,
+                role="qkv_column",
+                hf_names=("q_proj.weight", "k_proj.weight", "v_proj.weight"),
+                global_shape=(24, 4),
+                placement_kind="SHARD",
+                shard_axis=0,
+                local_shard_range=(12, 24),
+                extras={
+                    "num_heads_local": "4",
+                    "num_kv_heads_local": "1",
+                    "head_dim": "2",
+                },
+            )
+        ],
+        agent_name="trainer-tp1",
+    )
+
+    assert q.full_shape == (16, 4)
+    assert k.full_shape == v.full_shape == (4, 4)
+    assert q.shards[0].shape == (8, 4)
+    assert k.shards[0].shape == v.shards[0].shape == (2, 4)
+    assert q.shards[0].shard_offset == (8, 0)
+    assert k.shards[0].shard_offset == v.shards[0].shard_offset == (2, 0)
+    assert q.shards[0].addr == qkv.data_ptr()
+    assert k.shards[0].addr == qkv[8:].data_ptr()
+    assert v.shards[0].addr == qkv[10:].data_ptr()


### PR DESCRIPTION
## Summary

This PR maps native Megatron tensor geometry into the existing reshard transfer
planner and publishes zero-copy Hugging Face aliases for fused Megatron storage.
It allows an inference receiver to request canonical tensor names without making
the trainer unfuse and copy the model first.

The PR now targets current `main`; #536 is already merged and its former base
commits have been removed.

## Why this is needed

Inference loaders request Hugging Face-style tensor names. Megatron stores many
weights in rank-local fused representations:

- query, key, and value projections share one QKV tensor;
- gate and up projections share one gated-MLP tensor;
- expert layouts have their own tensor-parallel shard axes.

Copying and unfusing those tensors before every publication would add a model-size
allocation and copy on the trainer. Instead, this PR describes canonical aliases
as offsets into storage that is already registered for transfer.

## Design

### Target lowering

`lower_megatron_target()` converts explicit Megatron roles into the planner's
`CaptureResult` and destination layout contracts. Supported roles are closed and
validated: column-like, row-like, expert, vocabulary-parallel, and replicated.
Unknown roles raise instead of defaulting to a plausible but incorrect shard
axis.

The lowering uses the receiving tensor-parallel rank's destination slice. Name
translation remains after transfer, while planning still moves only the bytes
owned by that destination rank.

### Zero-copy aliases

`build_hf_aliases()` exposes fused QKV and gated-MLP storage under canonical names
by calculating addresses and shapes within the original registered tensor. It
does not allocate, copy, or register a second buffer.

Alias construction fails closed when a role/name combination has no supported
mapping. A valid-looking partial alias set would be more dangerous than an
explicit error because it could install wrong bytes from a valid address.

For the same reason, the fused gate/up split requires the publisher to state its
storage order as `extras["gated_mlp_order"] == "gate_then_up"`. The two halves are
assigned to `hf_names` positionally, so an up-then-gate layout would publish the
gate projection's bytes under the up projection's name, and no digest check can
see that: each name receives exactly the bytes its publisher advertised for it.
Megatron stores `linear_fc1` gate-then-up, and there is no verified up-then-gate
publisher to test a swap against, so any other value - including an absent one -
is rejected rather than assumed.

### Publication and receiver

`publish_megatron_reshard_view()` packages aliases into the existing rendezvous
format. The caller supplies the `MxReshardRendezvous` and owns its lifetime:
publishing starts the source's READY heartbeat thread, so constructing a
rendezvous inside the publish seam would leave that thread running with no handle
to stop it and no way to mark the source stale on shutdown. Duplicate publish
spec names are rejected, since collapsing them would publish one spec's shard
description under a name the other spec owns and the missing/extra check compares
key sets and cannot see it.

That rendezvous ownership change is worth more of a reviewer's attention than its
size suggests, because there is now hardware evidence for what the leak costs. On a
pre-#536 tree carrying the older bespoke heartbeat, which re-published the entire
blob on every beat rather than only refreshing status, creating a rendezvous per
refit accumulated threads that kept re-asserting an earlier step's shard table.
Two runs aborted reporting corrupt weights. The delivered bytes were correct in
both: the receiver was comparing them against digests from a table a step behind,
which a background thread had put back.

On current `main` that exact mechanism is already gone, since #536 replaced the
bespoke heartbeat with `PublisherThread`, which only sends `UpdateStatus` and never
re-publishes the table. What survives on `main` is narrower and still worth
closing: several threads advertising READY for one source means stopping one marks
it stale and another's next tick puts it back. Caller-owned lifetime removes the
accumulation that makes either failure reachable.

`MegatronReshardReceiver` supplies native target capture and framework translation
while reusing discovery, planning, transport, and buffer management from
`ReshardReceiver`.

## Scope and limits

This PR establishes the Megatron publish and target-lowering path. It does not:

- add digest production or destination verification;
- prove end-to-end refit correctness on a real model;
- canonicalize collective participant ordering for NCCL M2N;
- infer roles from framework parameter names;
- change transport or installation performance.

The tests use synthetic tensor geometry. They validate lowering and alias address
arithmetic, but they are not end-to-end model evidence.

## Validation

- [x] Rebased onto current `main`; merged #536 base commits were dropped.
- [x] 51 reshard tests pass, including 13 focused Megatron tests.
- [x] Tests cover destination TP partitioning, unsupported roles, fused QKV,
      gated MLP, expert aliases, publication, and receiver integration.
- [x] Tests cover the rejected gate/up orders, duplicate publish spec names, and
      the heartbeat being stoppable by the rendezvous owner.
- [x] Core Ruff checks and whitespace validation pass.

Full GitHub CI is running on the rebased branch.

## Reviewer guide

1. `refit/reshard/megatron.py` — review role-to-axis selection and destination TP
   partitioning first.
2. `refit/reshard/megatron_aliases.py` — verify QKV, gated-MLP, and expert offset
   arithmetic remains inside registered storage, and the required storage-order
   metadata.
3. `refit/reshard/megatron_publisher.py` — verify aliases are published with
   stable names and the original registered addresses, and that rendezvous
   ownership stays with the caller.
4. `refit/reshard/megatron_receiver.py` — confirm the subclass changes only
   Megatron-specific capture and translation boundaries.
5. `tests/test_reshard_megatron.py` — use the alias-offset tests as the reference
   for the intended layouts.
6. `refit/reshard/__init__.py` — compatibility exports only.

Publish ordering is sufficient for independent NIXL reads. Canonical ordering
across collective participants remains a separate prerequisite for NCCL M2N.

