### PR TITLE
feat(reshard-refit): record refit stages and refuse impossible wire rates

### DIFF
--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -160,6 +160,8 @@ register_modelexpress_loaders()
 | `MX_RESHARD_HANDSHAKE_TIMEOUT_S` | `900` | Budget for the whole P2P metadata handshake, across every trainer peer and every retry. Bounds the handshake independently of the refit timeout, so one unreachable publisher cannot consume the entire refit |
 | `MX_RESHARD_HANDSHAKE_ATTEMPT_S` | `20` | Ceiling on a single peer dial. A reachable peer answers in well under a second, so a short attempt frees the budget to try a different peer rather than block on one |
 | `MX_RESHARD_HANDSHAKE_BACKOFF_S` | `2` | Pause after a full pass over the pending peers makes no progress, so a transient stall is waited out rather than hammered |
+| `MX_REFIT_STAGE_RECORD` | `1` | Emit one `refit-stage-v2` JSON record per refit, giving a benchmark harness the per-stage timings without parsing logs. Set to `0` to silence it |
+| `MX_RESHARD_MAX_GBPS` | `0` | Per-rank fabric ceiling in Gbps. A measured wire rate above it means the timing is wrong rather than the transfer being fast, so the refit is rejected. `0` disables the check, since only the operator knows the real per-rank limit |
 
 ### UCX/NIXL Tuning
 

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -65,6 +65,8 @@ if TYPE_CHECKING:
     MX_RESHARD_HANDSHAKE_TIMEOUT_S: float
     MX_RESHARD_HANDSHAKE_ATTEMPT_S: float
     MX_RESHARD_HANDSHAKE_BACKOFF_S: float
+    MX_REFIT_STAGE_RECORD: bool
+    MX_RESHARD_MAX_GBPS: float
     # Kubernetes service backend
     MX_K8S_SERVICE_PATTERN: str
     MX_K8S_SOURCE_RETRIES: str
@@ -259,6 +261,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_RESHARD_HANDSHAKE_BACKOFF_S": lambda: _env_positive_float(
         "MX_RESHARD_HANDSHAKE_BACKOFF_S", 2.0
     ),
+    # One JSON stage record per refit. On by default: the timings are already
+    # computed, and at INFO they were never captured by a benchmark run.
+    "MX_REFIT_STAGE_RECORD": lambda: _env_bool("MX_REFIT_STAGE_RECORD", True),
+    # Per-rank fabric ceiling in Gbps used to reject impossible wire rates. Zero
+    # disables the check, and is the default because only the operator knows the
+    # real per-rank limit for their fabric.
+    "MX_RESHARD_MAX_GBPS": lambda: _env_float("MX_RESHARD_MAX_GBPS", 0.0),
     # ── Kubernetes service backend ─────────────────────────────────────────
     "MX_K8S_SERVICE_PATTERN": lambda: os.environ.get("MX_K8S_SERVICE_PATTERN", "mx-sources"),
     "MX_K8S_SOURCE_RETRIES": lambda: os.environ.get("MX_K8S_SOURCE_RETRIES", ""),

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from collections import deque
 
@@ -58,8 +59,22 @@ def _max_gbps() -> float:
 
     Read at call time so a harness can set it per run. Off unless configured
     because only the operator knows the real per-rank limit for their fabric.
+
+    A non-finite ceiling disables the check rather than being compared against.
+    ``float("nan")`` parses happily, and every comparison against NaN is False, so
+    a fat-fingered value would slip past the "is it configured" test and then fail
+    the "is the rate acceptable" test - turning the guard into a refit that always
+    aborts. Infinity is accepted by the comparison but means the same as off.
     """
-    return envs.MX_RESHARD_MAX_GBPS
+    ceiling = envs.MX_RESHARD_MAX_GBPS
+    if not math.isfinite(ceiling):
+        logger.warning(
+            "MX_RESHARD_MAX_GBPS=%r is not a finite number; the throughput ceiling "
+            "is disabled for this run",
+            ceiling,
+        )
+        return 0.0
+    return ceiling
 
 
 def handshake_endpoints_for_plan(
@@ -724,13 +739,25 @@ class ReshardReceiver:
             self._transport.read(descriptors + full_descriptors + convert_descriptors)
             stages["wire_fused_s"] = time.perf_counter() - _t
         else:
-            _t = time.perf_counter()
-            stats = execute_transfer(
-                self._plan,
-                resolve_param_ptr=lambda name: self._param_ptr[name],
-                transport=self._transport,
-            )
-            stages["wire_exact_s"] = time.perf_counter() - _t
+            # A plan can be all converts or all full pulls. Timing an exact phase
+            # that moved nothing records a duration that is not a wire duration: it
+            # inflates accounted_s, and because the phased implied rate divides the
+            # bytes by the summed wire stages, it drags that rate down and makes the
+            # throughput ceiling less likely to catch a run that deserves it.
+            if self._plan.exact_descriptor_count:
+                _t = time.perf_counter()
+                stats = execute_transfer(
+                    self._plan,
+                    resolve_param_ptr=lambda name: self._param_ptr[name],
+                    transport=self._transport,
+                )
+                stages["wire_exact_s"] = time.perf_counter() - _t
+            else:
+                stats = {
+                    "segments": 0,
+                    "bytes": 0,
+                    "fallback": list(self._plan.fallback),
+                }
             if full_descriptors:
                 _t = time.perf_counter()
                 self._transport.read(full_descriptors)
@@ -822,6 +849,10 @@ class ReshardReceiver:
         if envs.MX_REFIT_STAGE_RECORD:
             record = {
                 "schema": "refit-stage-v2",
+                # Every rank emits its own line, so without this a fleet-wide
+                # capture cannot tell them apart - and the number that matters for
+                # a refit is the slowest rank, not the average of an anonymous pile.
+                "rank": self._global_rank,
                 "step": step,
                 "bytes": stats["bytes"],
                 "segments": stats["segments"],
@@ -895,6 +926,9 @@ class ReshardReceiver:
             return
         detail = {
             "schema": "refit-impossible-throughput-v1",
+            # Which rank saw the impossible rate. One rank's adapters being
+            # misselected is a different diagnosis from the whole pod's.
+            "rank": self._global_rank,
             "step": step,
             "wire_bytes": wire_bytes,
             "wire_s": round(wire_s, 6),

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from collections import deque
 
@@ -53,10 +52,6 @@ from modelexpress.refit.reshard.types import (
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
 
-# Emit one JSON stage record per refit. On by default: the timings are already
-# computed, and at INFO they were never captured by a benchmark run.
-_STAGE_RECORD = os.environ.get("MX_REFIT_STAGE_RECORD", "1") == "1"
-
 
 def _max_gbps() -> float:
     """Per-rank fabric ceiling in Gbps; 0 disables the check.
@@ -64,10 +59,7 @@ def _max_gbps() -> float:
     Read at call time so a harness can set it per run. Off unless configured
     because only the operator knows the real per-rank limit for their fabric.
     """
-    try:
-        return float(os.environ.get("MX_RESHARD_MAX_GBPS", "0") or 0)
-    except ValueError:
-        return 0.0
+    return envs.MX_RESHARD_MAX_GBPS
 
 
 def handshake_endpoints_for_plan(
@@ -820,7 +812,7 @@ class ReshardReceiver:
             len(stats["fallback"]),
         )
         metrics.update({k: round(v, 6) for k, v in stages.items()})
-        if _STAGE_RECORD:
+        if envs.MX_REFIT_STAGE_RECORD:
             record = {
                 "schema": "refit-stage-v2",
                 "step": step,

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -744,7 +744,13 @@ class ReshardReceiver:
             # inflates accounted_s, and because the phased implied rate divides the
             # bytes by the summed wire stages, it drags that rate down and makes the
             # throughput ceiling less likely to catch a run that deserves it.
-            if self._plan.exact_descriptor_count:
+            #
+            # Gated on segments, not exact_descriptor_count. The latter is the
+            # pre-bounding baseline that descriptor_savings() subtracts from, and it
+            # counts every copy including the ones that became full pulls or
+            # converts, so a bounded plan can carry a nonzero count with nothing
+            # left to issue. exact_descriptors() reads segments and nothing else.
+            if self._plan.segments:
                 _t = time.perf_counter()
                 stats = execute_transfer(
                     self._plan,

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from collections import deque
 
@@ -51,6 +52,22 @@ from modelexpress.refit.reshard.types import (
 )
 
 logger = logging.getLogger("modelexpress.refit.reshard.receiver")
+
+# Emit one JSON stage record per refit. On by default: the timings are already
+# computed, and at INFO they were never captured by a benchmark run.
+_STAGE_RECORD = os.environ.get("MX_REFIT_STAGE_RECORD", "1") == "1"
+
+
+def _max_gbps() -> float:
+    """Per-rank fabric ceiling in Gbps; 0 disables the check.
+
+    Read at call time so a harness can set it per run. Off unless configured
+    because only the operator knows the real per-rank limit for their fabric.
+    """
+    try:
+        return float(os.environ.get("MX_RESHARD_MAX_GBPS", "0") or 0)
+    except ValueError:
+        return 0.0
 
 
 def handshake_endpoints_for_plan(
@@ -274,7 +291,7 @@ class ReshardReceiver:
         local_rank: int,
         global_rank: int,
         num_trainer_sources: int,
-        device: "torch.device",
+        device: torch.device,
         listen_port: int,
         timeout: float = 1200.0,
     ) -> None:
@@ -328,6 +345,10 @@ class ReshardReceiver:
         self._param_ptr: dict[
             str, int
         ] = {}  # segment param_name -> receive-buffer data_ptr
+        # One-time setup costs, measured in _prepare and reported with the first
+        # refit's stage record. Kept separate from the per-step timings so a cold
+        # first step is not read as a slow steady state.
+        self._prepare_stages: dict[str, float] = {}
 
         logger.info(
             "[reshard] receiver init: agent=%s global_rank=%d trainer_sources=%d",
@@ -337,7 +358,7 @@ class ReshardReceiver:
         )
 
     # ------------------------------------------------------------- engine hooks
-    def _capture(self, manifest: list) -> "tuple[CaptureResult, dict]":
+    def _capture(self, manifest: list) -> tuple[CaptureResult, dict]:
         """Record where each published source lands in the engine's load-time
         param layout, without moving data.
 
@@ -366,6 +387,8 @@ class ReshardReceiver:
             self._num_trainer_sources,
             timeout,
         )
+        self._prepare_stages = {}
+        _t = time.perf_counter()
         sources, session_to_agent, session_to_device, agent_endpoints = gather_sources(
             self._mx_client,
             expected_trainers=self._num_trainer_sources,
@@ -374,6 +397,7 @@ class ReshardReceiver:
             rank=self._global_rank,
             timeout=timeout,
         )
+        self._prepare_stages["prepare_discover_s"] = time.perf_counter() - _t
         logger.info(
             "[reshard] _prepare: discovered %d source(s), %d agent(s)",
             len(sources),
@@ -386,7 +410,9 @@ class ReshardReceiver:
             "[reshard] _prepare: capturing geometry over %d manifest entries",
             len(manifest),
         )
+        _t = time.perf_counter()
         capture, param_layout = self._capture(manifest)
+        self._prepare_stages["prepare_capture_s"] = time.perf_counter() - _t
         logger.info(
             "[reshard] _prepare: captured %d copies, %d unsupported",
             len(capture.copies),
@@ -398,7 +424,9 @@ class ReshardReceiver:
         # It is built once and reused every step (see the guard in
         # update_weights), which assumes the trainer set + their shard layout +
         # their buffer addresses are stable for the run.
+        _t = time.perf_counter()
         plan = plan_transfer(capture, sources)
+        self._prepare_stages["prepare_plan_s"] = time.perf_counter() - _t
         all_params = sorted({c.param_name for c in capture.copies})
         # Before the fail-closed rejection below, not after: an unsupported plan is
         # the case where naming the hole matters most, and raising first would leave
@@ -423,6 +451,10 @@ class ReshardReceiver:
         # and by here the plan says which trainers are actually read from, so peers
         # this rank never touches are not dialed. It also means an unsupported plan
         # is rejected above without spending the handshake budget first.
+        # prepare_handshake_s covers the dial, and only the peers the plan reads
+        # from. It is therefore not comparable with the same figure from a run
+        # that dialed every discovered trainer before planning.
+        _t = time.perf_counter()
         handshake_endpoints = handshake_endpoints_for_plan(
             plan, session_to_agent, agent_endpoints
         )
@@ -436,6 +468,7 @@ class ReshardReceiver:
             handshake_endpoints,
             envs.MX_RESHARD_HANDSHAKE_TIMEOUT_S,
         )
+        self._prepare_stages["prepare_handshake_s"] = time.perf_counter() - _t
 
         self._transport = NixlReshardTransport(
             self._manager, session_to_agent, session_to_device, timeout_seconds=timeout
@@ -446,9 +479,18 @@ class ReshardReceiver:
         # one persistent bf16 STAGING buffer per convert param, registered as an
         # RDMA target (classic cudaMalloc so the HCA can RDMA into it); each refit
         # we RDMA into staging then cast staging -> the (load-time) receive buffer.
+        # Allocation and registration happen in three places below (convert
+        # staging, full-pull staging, receive buffers). They are accumulated into
+        # one figure each rather than reported per buffer class, because the
+        # actionable question is how much of a cold start is cudaMalloc versus HCA
+        # registration.
+        alloc_s = 0.0
+        register_s = 0.0
+
         self._staging = {}
         self._staging_ptr = {}
         if plan.converts:
+            _t = time.perf_counter()
             with classic_cuda_alloc():
                 self._staging = {
                     c.param_name: torch.empty(
@@ -456,9 +498,12 @@ class ReshardReceiver:
                     )
                     for c in plan.converts
                 }
+            alloc_s += time.perf_counter() - _t
+            _t = time.perf_counter()
             self._manager.register_tensors(
                 {f"__stage__{n}": t for n, t in self._staging.items()}
             )
+            register_s += time.perf_counter() - _t
             self._staging_ptr = {n: t.data_ptr() for n, t in self._staging.items()}
 
         # Descriptor-heavy strided copies pull each complete source into one
@@ -467,6 +512,7 @@ class ReshardReceiver:
         self._full_staging = {}
         self._full_staging_ptr = {}
         if plan.full_pulls:
+            _t = time.perf_counter()
             with classic_cuda_alloc():
                 self._full_staging = {
                     full_pull.src_name: torch.empty(
@@ -476,12 +522,15 @@ class ReshardReceiver:
                     )
                     for full_pull in plan.full_pulls
                 }
+            alloc_s += time.perf_counter() - _t
+            _t = time.perf_counter()
             self._manager.register_tensors(
                 {
                     f"__full__{name}": tensor
                     for name, tensor in self._full_staging.items()
                 }
             )
+            register_s += time.perf_counter() - _t
             self._full_staging_ptr = {
                 name: tensor.data_ptr() for name, tensor in self._full_staging.items()
             }
@@ -494,19 +543,26 @@ class ReshardReceiver:
         # their bf16 staging is the RDMA target and the refit casts into the buffer.
         seg_params = {seg.param_name for seg in plan.segments}
         self._recv_buffers = {}
+        _t = time.perf_counter()
         with classic_cuda_alloc():
             for name in all_params:
                 shape, dtype = param_layout[name]
                 self._recv_buffers[name] = torch.empty(
                     tuple(shape), dtype=dtype, device=self._device
                 )
+        alloc_s += time.perf_counter() - _t
         self._param_ptr = {}
         if seg_params:
+            _t = time.perf_counter()
             self._manager.register_tensors(
                 {f"__recv__{n}": self._recv_buffers[n] for n in seg_params}
             )
+            register_s += time.perf_counter() - _t
             for name in seg_params:
                 self._param_ptr[name] = self._recv_buffers[name].data_ptr()
+
+        self._prepare_stages["prepare_alloc_s"] = alloc_s
+        self._prepare_stages["prepare_register_s"] = register_s
 
         logger.info(
             "[reshard] prepared: %d descriptor(s), %d full-pull source(s), "
@@ -616,6 +672,7 @@ class ReshardReceiver:
         """RDMA-pull the needed slices into the receive buffers, cast the
         dtype-mismatched ones, then install into the live params."""
         timeout = timeout if timeout is not None else self._timeout
+        stages: dict[str, float] = {}
         # TODO(re-plan on topology change): the plan is built once and cached, so
         # a mid-run change in the trainer set - a trainer restart (new buffer
         # addresses), a reshard (new shard boundaries / fan-in), or scaling the
@@ -624,6 +681,10 @@ class ReshardReceiver:
         # re-discover + rebuild if a version/epoch token or address set differs).
         if self._plan is None:
             self._prepare(timeout)
+            # Attributed to the step that paid for it, so the stage record for a
+            # cold first refit accounts for its own setup instead of leaving it
+            # unattributed.
+            stages.update(self._prepare_stages)
         assert self._plan is not None and self._transport is not None
 
         # RDMA the sliced bf16 into the receive buffers (segments) and per-param
@@ -667,17 +728,25 @@ class ReshardReceiver:
                 "bytes": sum(descriptor.nbytes for descriptor in descriptors),
                 "fallback": list(self._plan.fallback),
             }
+            _t = time.perf_counter()
             self._transport.read(descriptors + full_descriptors + convert_descriptors)
+            stages["wire_fused_s"] = time.perf_counter() - _t
         else:
+            _t = time.perf_counter()
             stats = execute_transfer(
                 self._plan,
                 resolve_param_ptr=lambda name: self._param_ptr[name],
                 transport=self._transport,
             )
+            stages["wire_exact_s"] = time.perf_counter() - _t
             if full_descriptors:
+                _t = time.perf_counter()
                 self._transport.read(full_descriptors)
+                stages["wire_full_s"] = time.perf_counter() - _t
             if convert_descriptors:
+                _t = time.perf_counter()
                 self._transport.read(convert_descriptors)
+                stages["wire_convert_s"] = time.perf_counter() - _t
 
         stats["segments"] += len(full_descriptors) + len(convert_descriptors)
         stats["bytes"] += sum(
@@ -688,26 +757,41 @@ class ReshardReceiver:
         # Local re-slice of every full-pulled source into its receive buffer, and
         # the dtype cast for every converted param. Both read staging written by
         # the reads above, so both must run after the wire completes.
-        for full_pull in self._plan.full_pulls:
-            full_tensor = self._full_staging[full_pull.src_name]
-            for copy in full_pull.copies:
-                source_view = _replay_ops(full_tensor, copy.op_chain)
-                receive_buffer = self._recv_buffers[copy.param_name]
-                destination = receive_buffer.as_strided(
-                    copy.dest_shape,
-                    copy.dest_stride,
-                    receive_buffer.storage_offset() + copy.dest_offset,
-                )
-                destination.copy_(source_view)
+        # Each GPU-side stage is followed by a synchronize so its duration is the
+        # work itself rather than the point at which a later stage happens to
+        # block. Without that, launch-bound stages read as free and whichever
+        # stage syncs first absorbs the whole queue.
+        if self._plan.full_pulls:
+            _t = time.perf_counter()
+            for full_pull in self._plan.full_pulls:
+                full_tensor = self._full_staging[full_pull.src_name]
+                for copy in full_pull.copies:
+                    source_view = _replay_ops(full_tensor, copy.op_chain)
+                    receive_buffer = self._recv_buffers[copy.param_name]
+                    destination = receive_buffer.as_strided(
+                        copy.dest_shape,
+                        copy.dest_stride,
+                        receive_buffer.storage_offset() + copy.dest_offset,
+                    )
+                    destination.copy_(source_view)
+            torch.cuda.synchronize(self._device)
+            stages["reslice_s"] = time.perf_counter() - _t
+
         # Cast the served bf16 staging into the (fp32) receive buffer - a torch
         # op, so the RDMA never crosses dtypes. _install writes the buffer.
-        for convert in self._plan.converts:
-            self._recv_buffers[convert.param_name].copy_(
-                self._staging[convert.param_name]
-            )
+        if self._plan.converts:
+            _t = time.perf_counter()
+            for convert in self._plan.converts:
+                self._recv_buffers[convert.param_name].copy_(
+                    self._staging[convert.param_name]
+                )
+            torch.cuda.synchronize(self._device)
+            stages["convert_s"] = time.perf_counter() - _t
 
+        _t = time.perf_counter()
         self._install(self._recv_buffers)
         torch.cuda.synchronize(self._device)
+        stages["install_s"] = time.perf_counter() - _t
 
         metrics = {
             "step": step,
@@ -735,4 +819,90 @@ class ReshardReceiver:
             len(self._plan.unbounded_sources),
             len(stats["fallback"]),
         )
+        metrics.update({k: round(v, 6) for k, v in stages.items()})
+        if _STAGE_RECORD:
+            record = {
+                "schema": "refit-stage-v2",
+                "step": step,
+                "bytes": stats["bytes"],
+                "segments": stats["segments"],
+                # Sum of the measured stages. Compared against the caller's own
+                # end-to-end figure it gives the unattributed remainder, which is
+                # the number that says whether this record can be trusted as a
+                # breakdown. The stages do not overlap, so summing them is valid
+                # here; that stops being true if a stage is ever made concurrent.
+                "accounted_s": round(
+                    sum(v for k, v in stages.items() if k.endswith("_s")), 6
+                ),
+                # Byte economics travel with the timings. These were INFO-only, so
+                # a harness that captured the timings still had to reconstruct the
+                # useful-byte figure after the fact. Wire minus extra is measured.
+                "extra_wire_bytes": self._plan.extra_wire_bytes(),
+                "descriptor_savings": self._plan.descriptor_savings(),
+                "exact_descriptors": self._plan.exact_descriptor_count,
+                "full_pull_sources": len(self._plan.full_pulls),
+                "unbounded_sources": len(self._plan.unbounded_sources),
+                "converts": len(self._plan.converts),
+                "fallback": len(stats["fallback"]),
+                "fused_wire": _fused_wire_enabled(),
+                **{k: round(v, 6) for k, v in stages.items()},
+            }
+            # WARNING so a benchmark harness captures it without turning on INFO
+            # across every dependency.
+            logger.warning("MX_REFIT_STAGE %s", json.dumps(record))
+        self._check_throughput_ceiling(step, stats["bytes"], stages)
         return metrics
+
+    def _check_throughput_ceiling(
+        self, step: int, wire_bytes: int, stages: dict
+    ) -> None:
+        """Refuse a wire rate the fabric cannot physically produce.
+
+        One run delivered nothing and reported the fastest refit yet measured:
+        40.61 GB in 0.84 s, an implied 387 Gbps, on a pod holding two adapters
+        worth about 191 Gbps. Coverage read 100%, fallback and unsupported were 0,
+        and the addresses and digests were stable. The only signal that dissented
+        was the parameter-equality gate, which timing runs switch off by design,
+        so without this check that run becomes the best row in the matrix.
+
+        An impossible rate is not a fast measurement, it is evidence the transport
+        reported completions it did not earn, so this aborts rather than recording
+        the number with a caveat. The record is emitted before the raise so the
+        evidence survives.
+
+        Off unless a ceiling is configured, because only the operator knows the
+        real per-rank limit for their fabric.
+        """
+        ceiling = _max_gbps()
+        if ceiling <= 0 or wire_bytes <= 0:
+            return
+        # Fused mode reports one wire span; phased mode reports up to three, and
+        # they run in turn, so summing them is the phased equivalent.
+        wire_s = stages.get("wire_fused_s")
+        if wire_s is None:
+            wire_s = sum(
+                stages.get(key, 0.0)
+                for key in ("wire_exact_s", "wire_full_s", "wire_convert_s")
+            )
+        if wire_s <= 0:
+            return
+        implied_gbps = wire_bytes * 8 / wire_s / 1e9
+        if implied_gbps <= ceiling:
+            return
+        detail = {
+            "schema": "refit-impossible-throughput-v1",
+            "step": step,
+            "wire_bytes": wire_bytes,
+            "wire_s": round(wire_s, 6),
+            "implied_gbps": round(implied_gbps, 1),
+            "ceiling_gbps": ceiling,
+        }
+        logger.warning("MX_REFIT_IMPOSSIBLE_THROUGHPUT %s", json.dumps(detail))
+        raise RuntimeError(
+            f"[reshard] step {step} moved {wire_bytes} bytes in {wire_s:.4f}s, an "
+            f"implied {implied_gbps:.1f} Gbps against a per-rank ceiling of "
+            f"{ceiling:.1f} Gbps. The fabric cannot deliver that, so the transport "
+            f"reported completions without moving the payload - one known cause is "
+            f"the fabric library selecting adapters this container does not own. "
+            f"Treat this refit as failed, not fast."
+        )

--- a/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/receiver.py
@@ -746,6 +746,13 @@ class ReshardReceiver:
             for descriptor in (*full_descriptors, *convert_descriptors)
         )
 
+        # Before anything reads the receive buffers, and well before _install
+        # commits them to live parameters. An impossible rate means the transport
+        # reported completions it did not earn, so the buffers cannot be trusted;
+        # checking after the install would document the corruption rather than
+        # prevent it. Everything the check needs is known by this point.
+        self._check_throughput_ceiling(step, stats["bytes"], stages)
+
         # Local re-slice of every full-pulled source into its receive buffer, and
         # the dtype cast for every converted param. Both read staging written by
         # the reads above, so both must run after the wire completes.
@@ -842,7 +849,6 @@ class ReshardReceiver:
             # WARNING so a benchmark harness captures it without turning on INFO
             # across every dependency.
             logger.warning("MX_REFIT_STAGE %s", json.dumps(record))
-        self._check_throughput_ceiling(step, stats["bytes"], stages)
         return metrics
 
     def _check_throughput_ceiling(
@@ -859,8 +865,14 @@ class ReshardReceiver:
 
         An impossible rate is not a fast measurement, it is evidence the transport
         reported completions it did not earn, so this aborts rather than recording
-        the number with a caveat. The record is emitted before the raise so the
-        evidence survives.
+        the number with a caveat. The impossible-throughput record below is emitted
+        before the raise so the evidence survives the abort; the ordinary stage
+        record is not reached, which is the point - the run produced no trustworthy
+        timing to file.
+
+        Called before the receive buffers are read or installed. Running it after
+        the install would leave the guard describing weights it had already let
+        through, which is the one outcome it exists to prevent.
 
         Off unless a ceiling is configured, because only the operator knows the
         real per-rank limit for their fabric.

--- a/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
@@ -22,6 +22,9 @@ import json
 import logging
 
 import pytest
+import torch
+
+from tests.test_reshard_refit_fused_wire import _build, _RecordingTransport
 
 # The observed record, verbatim.
 OBSERVED_BYTES = 40_611_246_080
@@ -138,3 +141,46 @@ def test_the_failure_is_machine_readable_before_it_raises(monkeypatch, caplog):
     assert payload["wire_bytes"] == OBSERVED_BYTES
     assert payload["ceiling_gbps"] == TWO_ADAPTER_CEILING
     assert payload["implied_gbps"] == pytest.approx(OBSERVED_IMPLIED_GBPS, abs=0.2)
+
+
+# ------------------------------------------- where the guard sits in the refit
+def _refit(monkeypatch, ceiling):
+    """A whole refit through the real update_weights, with the ceiling configured."""
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1")
+    monkeypatch.setenv("MX_RESHARD_MAX_GBPS", str(ceiling))
+    monkeypatch.delenv("MX_REFIT_STAGE_RECORD", raising=False)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    return _build(_RecordingTransport())
+
+
+def test_a_breached_ceiling_blocks_the_install(monkeypatch):
+    """The point of the guard, and the thing calling it after ``_install`` silently
+    gave up.
+
+    An impossible rate means the transport reported completions it did not earn, so
+    the receive buffers hold whatever was there before. Raising after the install
+    documents that the live parameters were overwritten with untrustworthy bytes;
+    raising before it is what actually prevents them from being.
+    """
+    # Low enough that any real rate breaches it, so the test does not depend on
+    # how fast the in-memory transport happens to be.
+    harness, keepalive = _refit(monkeypatch, 0.000001)
+
+    with pytest.raises(RuntimeError, match="failed, not fast"):
+        harness.update_weights(step=1)
+
+    assert harness._install_order == [], (
+        "the ceiling breached, so nothing should have reached live parameters"
+    )
+    assert keepalive is not None
+
+
+def test_a_rate_under_the_ceiling_still_installs(monkeypatch):
+    """The other half: a guard that blocks legitimate refits gets switched off, and
+    then protects nothing."""
+    harness, keepalive = _refit(monkeypatch, 1e9)
+
+    harness.update_weights(step=1)
+
+    assert harness._install_order == ["install"]
+    assert keepalive is not None

--- a/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
@@ -210,3 +210,28 @@ def test_a_rate_under_the_ceiling_still_installs(monkeypatch):
 
     assert harness._install_order == ["install"]
     assert keepalive is not None
+
+
+def test_a_bounded_plan_still_reaches_the_guard(monkeypatch):
+    """A bounded plan - zero segments, nonzero ``exact_descriptor_count`` - is the
+    shape that skips the exact phase entirely, and it must still be checked.
+
+    This pins reachability, not the padding effect. The phased rate divides bytes by
+    the summed wire stages, so a ``wire_exact_s`` recorded for a phase that issued
+    nothing does inflate the denominator, but in this rig that span is microseconds
+    against a ceiling set low enough to breach regardless. The padding is asserted
+    where it is observable, on the stage record itself.
+    """
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "0")
+    monkeypatch.setenv("MX_RESHARD_MAX_GBPS", "0.000001")
+    monkeypatch.delenv("MX_REFIT_STAGE_RECORD", raising=False)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    harness, keepalive = _build(_RecordingTransport())
+    harness._plan.segments = []
+
+    assert harness._plan.exact_descriptor_count, "precondition: a bounded plan"
+    with pytest.raises(RuntimeError, match="failed, not fast"):
+        harness.update_weights(step=1)
+
+    assert harness._install_order == []
+    assert keepalive is not None

--- a/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
@@ -53,6 +53,8 @@ def _receiver(monkeypatch, ceiling):
 class _Rig:
     """Just enough object to call the guard as an unbound method."""
 
+    _global_rank = 3
+
 
 def _check(mod, wire_bytes, stages, step=1):
     return mod.ReshardReceiver._check_throughput_ceiling(
@@ -101,6 +103,19 @@ def test_disabled_by_default(monkeypatch):
     assert _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S}) is None
 
 
+@pytest.mark.parametrize("value", ["nan", "NaN", "inf", "-inf"])
+def test_a_non_finite_ceiling_disables_rather_than_failing_every_refit(
+    monkeypatch, value
+):
+    """``float("nan")`` parses, and every comparison against NaN is False. So a
+    fat-fingered ceiling would pass the "is it configured" test and then fail the
+    "is this rate acceptable" test, turning the guard into a refit that always
+    aborts. A ceiling nothing can be compared against is not a ceiling."""
+    mod = _receiver(monkeypatch, value)
+
+    assert _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S}) is None
+
+
 def test_an_unparseable_ceiling_disables_rather_than_crashes(monkeypatch):
     """A typo in a harness env var must not take down every refit."""
     mod = _receiver(monkeypatch, "not-a-number")
@@ -141,6 +156,17 @@ def test_the_failure_is_machine_readable_before_it_raises(monkeypatch, caplog):
     assert payload["wire_bytes"] == OBSERVED_BYTES
     assert payload["ceiling_gbps"] == TWO_ADAPTER_CEILING
     assert payload["implied_gbps"] == pytest.approx(OBSERVED_IMPLIED_GBPS, abs=0.2)
+
+
+def test_the_failure_names_the_rank_that_saw_it(monkeypatch, caplog):
+    """One rank's adapters being misselected is a different diagnosis from the whole
+    pod's, and every rank emits its own line."""
+    mod = _receiver(monkeypatch, TWO_ADAPTER_CEILING)
+    with caplog.at_level(logging.WARNING), pytest.raises(RuntimeError):
+        _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S})
+
+    line = next(m for m in caplog.messages if "MX_REFIT_IMPOSSIBLE_THROUGHPUT" in m)
+    assert json.loads(line.split("MX_REFIT_IMPOSSIBLE_THROUGHPUT ", 1)[1])["rank"] == 3
 
 
 # ------------------------------------------- where the guard sits in the refit

--- a/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_ceiling.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Throughput-ceiling guard: refuse a wire rate the fabric cannot produce.
+
+The incident these tests are anchored to: a receiver holding two of its node's
+four network adapters reported 40.61 GB delivered in 0.84 s, an implied 387 Gbps
+against a two-adapter ceiling of about 191 Gbps, and delivered nothing. Every
+other signal called the run healthy - coverage 100%, fallback 0, addresses and
+digests stable - and only the parameter-equality gate dissented, which timing
+runs switch off by design.
+
+The numbers below are that record verbatim, so the regression is pinned to
+something that happened rather than to a constructed example. The genuine
+Topology B run is pinned alongside it, because a guard that rejects real
+measurements gets switched off and then protects nothing.
+
+Run: pytest tests/test_reshard_refit_ceiling.py
+"""
+
+import json
+import logging
+
+import pytest
+
+# The observed record, verbatim.
+OBSERVED_BYTES = 40_611_246_080
+OBSERVED_WIRE_S = 0.839641
+OBSERVED_IMPLIED_GBPS = 386.9  # bytes * 8 / s / 1e9
+FOUR_ADAPTER_CEILING = 381.6
+TWO_ADAPTER_CEILING = 190.8
+
+
+def _receiver(monkeypatch, ceiling):
+    """The receiver module with the ceiling configured.
+
+    No module reload: the ceiling is read at call time precisely so a harness can
+    set it per run, and a test that needed a reload would be testing something the
+    product does not do.
+    """
+    if ceiling is None:
+        monkeypatch.delenv("MX_RESHARD_MAX_GBPS", raising=False)
+    else:
+        monkeypatch.setenv("MX_RESHARD_MAX_GBPS", str(ceiling))
+    from modelexpress.refit.reshard import receiver
+
+    return receiver
+
+
+class _Rig:
+    """Just enough object to call the guard as an unbound method."""
+
+
+def _check(mod, wire_bytes, stages, step=1):
+    return mod.ReshardReceiver._check_throughput_ceiling(
+        _Rig(), step, wire_bytes, stages
+    )
+
+
+def test_the_impossible_run_is_rejected(monkeypatch):
+    """387 Gbps on a two-adapter pod must abort, not become the best row."""
+    mod = _receiver(monkeypatch, TWO_ADAPTER_CEILING)
+    with pytest.raises(RuntimeError) as excinfo:
+        _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S})
+    message = str(excinfo.value)
+    assert "386.9" in message
+    assert "without moving the payload" in message
+    assert "failed, not fast" in message
+
+
+def test_it_would_have_been_caught_even_at_the_four_adapter_ceiling(monkeypatch):
+    """The rate was impossible even for a fully-provisioned pod, which is what makes
+    it diagnosable from the stage record alone."""
+    mod = _receiver(monkeypatch, FOUR_ADAPTER_CEILING)
+    with pytest.raises(RuntimeError):
+        _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S})
+
+
+def test_the_real_topology_b_run_passes(monkeypatch):
+    """Same byte count, 1.273 s, 255.3 Gbps on four adapters: a genuine measurement
+    that must not be rejected."""
+    mod = _receiver(monkeypatch, FOUR_ADAPTER_CEILING)
+    assert _check(mod, OBSERVED_BYTES, {"wire_fused_s": 1.273}) is None
+
+
+def test_a_rate_exactly_at_the_ceiling_is_allowed(monkeypatch):
+    """The ceiling is attainable in principle, so the comparison must not be strict."""
+    mod = _receiver(monkeypatch, FOUR_ADAPTER_CEILING)
+    exact_s = OBSERVED_BYTES * 8 / (FOUR_ADAPTER_CEILING * 1e9)
+    assert _check(mod, OBSERVED_BYTES, {"wire_fused_s": exact_s}) is None
+
+
+def test_disabled_by_default(monkeypatch):
+    """Only the operator knows their fabric ceiling, so absent config the guard must
+    stay out of the way rather than guess one."""
+    mod = _receiver(monkeypatch, None)
+    assert mod._max_gbps() == 0
+    assert _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S}) is None
+
+
+def test_an_unparseable_ceiling_disables_rather_than_crashes(monkeypatch):
+    """A typo in a harness env var must not take down every refit."""
+    mod = _receiver(monkeypatch, "not-a-number")
+    assert mod._max_gbps() == 0
+    assert _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S}) is None
+
+
+def test_phased_mode_sums_its_three_wire_stages(monkeypatch):
+    """With the fused wire off there is no wire_fused_s, and reading one phase alone
+    would understate elapsed time and manufacture an impossible rate."""
+    mod = _receiver(monkeypatch, FOUR_ADAPTER_CEILING)
+    phased = {"wire_exact_s": 0.5, "wire_full_s": 0.5, "wire_convert_s": 0.273}
+    assert _check(mod, OBSERVED_BYTES, phased) is None
+
+    too_fast = {"wire_exact_s": 0.3, "wire_full_s": 0.3, "wire_convert_s": 0.2}
+    with pytest.raises(RuntimeError):
+        _check(mod, OBSERVED_BYTES, too_fast)
+
+
+def test_a_missing_or_zero_wire_time_is_not_an_infinite_rate(monkeypatch):
+    """A refit with nothing planned must not divide by zero or trip the guard."""
+    mod = _receiver(monkeypatch, FOUR_ADAPTER_CEILING)
+    assert _check(mod, OBSERVED_BYTES, {}) is None
+    assert _check(mod, OBSERVED_BYTES, {"wire_fused_s": 0.0}) is None
+    assert _check(mod, 0, {"wire_fused_s": 0.5}) is None
+
+
+def test_the_failure_is_machine_readable_before_it_raises(monkeypatch, caplog):
+    """The record has to survive the abort, or the guard destroys the evidence that
+    explains it."""
+    mod = _receiver(monkeypatch, TWO_ADAPTER_CEILING)
+    with caplog.at_level(logging.WARNING), pytest.raises(RuntimeError):
+        _check(mod, OBSERVED_BYTES, {"wire_fused_s": OBSERVED_WIRE_S})
+
+    line = next(m for m in caplog.messages if "MX_REFIT_IMPOSSIBLE_THROUGHPUT" in m)
+    payload = json.loads(line.split("MX_REFIT_IMPOSSIBLE_THROUGHPUT ", 1)[1])
+    assert payload["schema"] == "refit-impossible-throughput-v1"
+    assert payload["wire_bytes"] == OBSERVED_BYTES
+    assert payload["ceiling_gbps"] == TWO_ADAPTER_CEILING
+    assert payload["implied_gbps"] == pytest.approx(OBSERVED_IMPLIED_GBPS, abs=0.2)

--- a/modelexpress_client/python/tests/test_reshard_refit_fused_wire.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_fused_wire.py
@@ -60,6 +60,7 @@ class _Harness(ReshardReceiver):
         self._device = torch.device("cpu")
         self._timeout = 1.0
         self._transport = transport
+        self._global_rank = 0
         self._install_order: list[str] = []
 
     def _install(self, recv_buffers) -> None:

--- a/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""The per-refit stage record emitted by ReshardReceiver.update_weights.
+
+A refit is one number to the caller and six or more stages underneath: discovery,
+the peer handshake, geometry capture, planning, allocation and registration on the
+first step, then wire, re-slice, dtype cast and install on every step. Without a
+breakdown a regression can only be described as "refit got slower".
+
+These tests pin the properties a consumer of the record depends on:
+
+  * it is one JSON object per refit at WARNING, so a harness capturing it does not
+    have to turn on INFO across every dependency;
+  * ``accounted_s`` equals the sum of the stage durations, which is what lets a
+    caller compute the unattributed remainder and decide whether to trust the
+    breakdown at all;
+  * one-time setup costs are attributed to the step that paid them rather than
+    silently dropped, so a cold first step accounts for itself;
+  * the byte economics travel with the timings, so useful bytes are read off the
+    record instead of reconstructed from an assumed sharding afterwards.
+
+The last one is the reason this record exists in this form: a derived
+useful-bytes figure once made a half-complete refit look like the faster one.
+
+Run: pytest tests/test_reshard_refit_stage_record.py
+"""
+
+import json
+import logging
+
+import pytest
+import torch
+
+from tests.test_reshard_refit_fused_wire import _build, _RecordingTransport
+
+
+def _run(monkeypatch, caplog, *, fused=True, enabled=True):
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1" if fused else "0")
+    monkeypatch.setenv("MX_REFIT_STAGE_RECORD", "1" if enabled else "0")
+    monkeypatch.delenv("MX_RESHARD_MAX_GBPS", raising=False)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    # The module reads the stage-record flag at import, so reload it under the env
+    # the test wants rather than asserting against whatever the process started
+    # with.
+    import importlib
+
+    from modelexpress.refit.reshard import receiver
+
+    importlib.reload(receiver)
+
+    transport = _RecordingTransport()
+    harness, keepalive = _build(transport)
+    with caplog.at_level(logging.WARNING):
+        metrics = harness.update_weights(step=7)
+    return harness, metrics, keepalive
+
+
+def _record(caplog):
+    line = next(m for m in caplog.messages if "MX_REFIT_STAGE" in m)
+    return json.loads(line.split("MX_REFIT_STAGE ", 1)[1])
+
+
+def test_one_record_per_refit_at_warning(monkeypatch, caplog):
+    _h, _m, _k = _run(monkeypatch, caplog)
+    lines = [m for m in caplog.messages if "MX_REFIT_STAGE " in m]
+    assert len(lines) == 1
+    record = _record(caplog)
+    assert record["schema"] == "refit-stage-v2"
+    assert record["step"] == 7
+
+
+def test_the_record_is_off_when_disabled(monkeypatch, caplog):
+    """A caller that does not want the line must be able to silence it, since it is
+    emitted at WARNING and would otherwise be unavoidable noise."""
+    _h, _m, _k = _run(monkeypatch, caplog, enabled=False)
+    assert not [m for m in caplog.messages if "MX_REFIT_STAGE " in m]
+
+
+def test_accounted_s_is_the_sum_of_the_stages(monkeypatch, caplog):
+    """The whole point of the field: a caller subtracts it from its own end-to-end
+    figure to get the unattributed remainder."""
+    _h, _m, _k = _run(monkeypatch, caplog)
+    record = _record(caplog)
+    stage_total = sum(
+        value
+        for key, value in record.items()
+        if key.endswith("_s") and key != "accounted_s"
+    )
+    assert record["accounted_s"] == pytest.approx(stage_total, abs=1e-4)
+
+
+def test_the_wire_and_install_stages_are_present_and_positive(monkeypatch, caplog):
+    _h, _m, _k = _run(monkeypatch, caplog)
+    record = _record(caplog)
+    assert "wire_fused_s" in record
+    for stage in ("wire_fused_s", "reslice_s", "convert_s", "install_s"):
+        assert record[stage] >= 0.0, stage
+
+
+def test_phased_mode_reports_its_three_wire_stages_separately(monkeypatch, caplog):
+    """Per-phase wire attribution is only recoverable with the fused wire off, which
+    is the reason the phased path is kept."""
+    _h, _m, _k = _run(monkeypatch, caplog, fused=False)
+    record = _record(caplog)
+    assert "wire_fused_s" not in record
+    for stage in ("wire_exact_s", "wire_full_s", "wire_convert_s"):
+        assert stage in record, stage
+    assert record["fused_wire"] is False
+
+
+def test_the_byte_economics_travel_with_the_timings(monkeypatch, caplog):
+    """Useful bytes must be readable from the record. Deriving them analysis-side
+    from an assumed sharding is what let an incomplete refit look faster."""
+    _h, metrics, _k = _run(monkeypatch, caplog)
+    record = _record(caplog)
+    for field in (
+        "bytes",
+        "segments",
+        "extra_wire_bytes",
+        "descriptor_savings",
+        "exact_descriptors",
+        "full_pull_sources",
+        "unbounded_sources",
+        "converts",
+        "fallback",
+    ):
+        assert field in record, field
+    assert record["bytes"] == metrics["bytes_received"]
+    assert record["segments"] == metrics["segments"]
+    # Useful bytes are wire minus the redundancy the planner knowingly accepted.
+    assert record["bytes"] - record["extra_wire_bytes"] >= 0
+
+
+def test_the_stages_also_reach_the_returned_metrics(monkeypatch, caplog):
+    """A caller holding the metrics dict should not have to parse the log line."""
+    _h, metrics, _k = _run(monkeypatch, caplog)
+    assert "install_s" in metrics
+    assert metrics["install_s"] >= 0.0
+
+
+def test_setup_costs_land_on_the_step_that_paid_them(monkeypatch, caplog):
+    """A cold first refit runs discovery, the handshake, capture, planning and
+    registration. Those belong in that step's record, or its unattributed remainder
+    is the entire setup cost and the breakdown is useless exactly when it matters
+    most."""
+    monkeypatch.setenv("MX_REFIT_STAGE_RECORD", "1")
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1")
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    transport = _RecordingTransport()
+    harness, keepalive = _build(transport)
+
+    cold_plan = harness._plan
+    harness._plan = None
+
+    def _fake_prepare(timeout):
+        harness._plan = cold_plan
+        harness._prepare_stages = {
+            "prepare_discover_s": 1.5,
+            "prepare_handshake_s": 0.25,
+            "prepare_capture_s": 0.5,
+            "prepare_plan_s": 0.125,
+            "prepare_alloc_s": 2.0,
+            "prepare_register_s": 3.0,
+        }
+
+    harness._prepare = _fake_prepare
+    with caplog.at_level(logging.WARNING):
+        harness.update_weights(step=1)
+
+    record = _record(caplog)
+    for stage, expected in (
+        ("prepare_discover_s", 1.5),
+        ("prepare_handshake_s", 0.25),
+        ("prepare_capture_s", 0.5),
+        ("prepare_plan_s", 0.125),
+        ("prepare_alloc_s", 2.0),
+        ("prepare_register_s", 3.0),
+    ):
+        assert record[stage] == pytest.approx(expected), stage
+    assert record["accounted_s"] >= 7.375
+    assert all(t.data_ptr() for t in keepalive)
+
+
+def test_a_warm_step_carries_no_setup_stages(monkeypatch, caplog):
+    """The counterpart: setup is reported once, so a steady-state step is not
+    inflated by costs it did not pay."""
+    _h, _m, _k = _run(monkeypatch, caplog)
+    record = _record(caplog)
+    assert not [key for key in record if key.startswith("prepare_")]
+
+
+def test_a_skipped_stage_is_absent_rather_than_zero(monkeypatch, caplog):
+    """Zero would claim the stage ran and took no time. Absent says it did not run,
+    which is what a plan with no converts means."""
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1")
+    monkeypatch.setenv("MX_REFIT_STAGE_RECORD", "1")
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    transport = _RecordingTransport()
+    harness, keepalive = _build(transport)
+    harness._plan.converts = []
+    harness._plan.full_pulls = []
+
+    with caplog.at_level(logging.WARNING):
+        harness.update_weights(step=1)
+
+    record = _record(caplog)
+    assert "convert_s" not in record
+    assert "reslice_s" not in record
+    assert "install_s" in record
+    assert all(t.data_ptr() for t in keepalive)  # keep the source addresses valid

--- a/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
@@ -137,6 +137,10 @@ def test_setup_costs_land_on_the_step_that_paid_them(monkeypatch, caplog):
     most."""
     monkeypatch.setenv("MX_REFIT_STAGE_RECORD", "1")
     monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1")
+    # This test builds the harness directly rather than through _run, so it has to
+    # clear the ceiling itself; a low one inherited from the environment aborts the
+    # refit before any of the record assertions below are reached.
+    monkeypatch.delenv("MX_RESHARD_MAX_GBPS", raising=False)
     monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
     transport = _RecordingTransport()
     harness, keepalive = _build(transport)
@@ -186,6 +190,9 @@ def test_a_skipped_stage_is_absent_rather_than_zero(monkeypatch, caplog):
     which is what a plan with no converts means."""
     monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "1")
     monkeypatch.setenv("MX_REFIT_STAGE_RECORD", "1")
+    # Built directly rather than through _run, so the ceiling has to be cleared here
+    # too, for the same reason.
+    monkeypatch.delenv("MX_RESHARD_MAX_GBPS", raising=False)
     monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
     transport = _RecordingTransport()
     harness, keepalive = _build(transport)
@@ -200,3 +207,34 @@ def test_a_skipped_stage_is_absent_rather_than_zero(monkeypatch, caplog):
     assert "reslice_s" not in record
     assert "install_s" in record
     assert all(t.data_ptr() for t in keepalive)  # keep the source addresses valid
+
+
+def test_the_record_names_the_rank_that_emitted_it(monkeypatch, caplog):
+    """Every rank writes its own line into the same capture. Without a rank the
+    lines cannot be told apart, and the figure a refit is judged on is the slowest
+    rank rather than the average of an anonymous pile."""
+    _h, _m, _k = _run(monkeypatch, caplog)
+
+    assert _record(caplog)["rank"] == 0
+
+
+def test_an_exact_phase_that_moved_nothing_is_not_timed(monkeypatch, caplog):
+    """A plan can be all converts or all full pulls. A ``wire_exact_s`` for a phase
+    with no descriptors is not a wire duration: it inflates ``accounted_s``, and it
+    drags down the phased implied rate the throughput ceiling is computed from,
+    making the guard less likely to catch a run that deserves it."""
+    monkeypatch.setenv("MX_RESHARD_FUSED_WIRE", "0")
+    monkeypatch.setenv("MX_REFIT_STAGE_RECORD", "1")
+    monkeypatch.delenv("MX_RESHARD_MAX_GBPS", raising=False)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    harness, keepalive = _build(_RecordingTransport())
+    harness._plan.segments = []
+    harness._plan.exact_descriptor_count = 0
+
+    with caplog.at_level(logging.WARNING):
+        harness.update_weights(step=1)
+
+    record = _record(caplog)
+    assert "wire_exact_s" not in record
+    assert "wire_full_s" in record
+    assert all(t.data_ptr() for t in keepalive)

--- a/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
@@ -228,13 +228,18 @@ def test_an_exact_phase_that_moved_nothing_is_not_timed(monkeypatch, caplog):
     monkeypatch.delenv("MX_RESHARD_MAX_GBPS", raising=False)
     monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
     harness, keepalive = _build(_RecordingTransport())
+    # A bounded plan, which is the only way a real plan reaches zero segments:
+    # plan_transfer counts every copy into exact_descriptor_count and then moves the
+    # ones it had to bound into full_pulls, so the count stays nonzero with nothing
+    # left to issue. Zeroing it here would describe a plan plan_transfer cannot
+    # produce, and would hide a guard that reads the count instead of the segments.
     harness._plan.segments = []
-    harness._plan.exact_descriptor_count = 0
 
     with caplog.at_level(logging.WARNING):
         harness.update_weights(step=1)
 
     record = _record(caplog)
+    assert harness._plan.exact_descriptor_count, "precondition: a bounded plan"
     assert "wire_exact_s" not in record
     assert "wire_full_s" in record
     assert all(t.data_ptr() for t in keepalive)

--- a/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_stage_record.py
@@ -40,15 +40,6 @@ def _run(monkeypatch, caplog, *, fused=True, enabled=True):
     monkeypatch.setenv("MX_REFIT_STAGE_RECORD", "1" if enabled else "0")
     monkeypatch.delenv("MX_RESHARD_MAX_GBPS", raising=False)
     monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
-    # The module reads the stage-record flag at import, so reload it under the env
-    # the test wants rather than asserting against whatever the process started
-    # with.
-    import importlib
-
-    from modelexpress.refit.reshard import receiver
-
-    importlib.reload(receiver)
-
     transport = _RecordingTransport()
     harness, keepalive = _build(transport)
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Why this is needed

A refit currently returns one total duration. When that number changes, reviewers and benchmark owners cannot tell whether the time moved in discovery, peer setup, transfer, conversion, or installation.

There is also a more serious failure mode: a transfer can report an impossibly short wire time even when the destination buffers were not updated. One observed run claimed 40.61 GB in 0.84 seconds, or 386.9 Gbps, on a receiver with roughly 190.8 Gbps of usable network capacity. Most existing health signals accepted that run, so it would have appeared as the best benchmark result.

This PR makes refit measurements explainable and rejects rates the configured network cannot physically produce.

## What changes

1. Each refit can emit one structured `MX_REFIT_STAGE` record (`refit-stage-v2`). It includes the emitting rank, preparation stages, wire stages, local tensor work, installation time, bytes moved, descriptor counts, and total accounted time.
2. `MX_RESHARD_MAX_GBPS` sets an optional per-rank throughput ceiling. If the measured wire rate exceeds it, the receiver emits `MX_REFIT_IMPOSSIBLE_THROUGHPUT` and stops before untrusted receive buffers are installed into live model parameters.
3. Stages that do not run are omitted. For example, an all-convert or all-full-pull plan does not report an empty exact-transfer phase.
4. Invalid or non-finite ceiling values disable the guard with a warning instead of breaking every refit.

The ceiling is disabled by default because the correct limit depends on the GPUs, network adapters, container placement, and rank placement of the specific deployment.

## Where it sits

```mermaid
flowchart TB
    A["<b>1. Discover peers and build plan</b>"] --> B["<b>2. Read weight bytes</b>"]
    B --> C["<b>3. Record wire time and bytes</b>"]
    C --> D{"<b>4. Rate within configured ceiling?</b>"}
    D -->|Yes| E["<b>5. Re-slice and convert</b>"]
    E --> F["<b>6. Install live parameters</b>"]
    F --> G["<b>7. Emit stage record</b>"]
    D -->|No| H["<b>5. Emit failure record and abort</b>"]

    classDef trainer fill:#E3F2FD,stroke:#1565C0,stroke-width:2px,color:#0D47A1,font-size:16px;
    classDef mx fill:#E8F5E9,stroke:#2E7D32,stroke-width:2px,color:#1B5E20,font-size:16px;
    classDef receiver fill:#EDE7F6,stroke:#5E35B1,stroke-width:2px,color:#311B92,font-size:16px;
    class A,B,C mx;
    class D receiver;
    class E,F,G,H receiver;
```

The important ordering is step 4 before steps 5 and 6. An impossible rate means the transport completion cannot be trusted, so the guard must run before any receive buffer reaches live parameters.

## Stage-record contract

- Preparation costs appear only on the refit that paid for them.
- GPU stages synchronize at stage boundaries so time is charged to the work that launched it.
- `accounted_s` is the sum of non-overlapping measured stages. Callers subtract it from their own end-to-end duration to identify unattributed time.
- Fused transfer reports one wire span. Phased transfer reports only the exact, full-pull, and conversion spans that actually ran.
- Every structured record includes `rank`, because fleet-level analysis depends on the slowest rank rather than an anonymous average.

`MX_REFIT_STAGE_RECORD=0` disables the stage line. It is logged at warning level so benchmark harnesses can capture it without enabling info logs for every imported dependency.

## Scope

Included:

- stage timing and byte accounting;
- rank-aware structured records;
- the configurable throughput check;
- fail-before-install ordering;
- environment-variable documentation and tests.

Not included:

- digest verification timing, which belongs with the receiver-side verification gate;
- install batching or other performance changes;
- automatic selection of a network ceiling.

## How to review

Review the six files in this order:

1. **`modelexpress/refit/reshard/receiver.py` — required review.** Check that each timer brackets the work named by the field. Then verify that the throughput check runs after all wire spans are known but before re-slice, conversion, and installation.
2. **`tests/test_reshard_refit_ceiling.py` — required review.** Check both sides of the safety rule: impossible rates install nothing, while realistic rates still install. The bad and good rates come from observed runs rather than invented thresholds.
3. **`tests/test_reshard_refit_stage_record.py` — contract review.** Check rank attribution, setup attribution, absent stages, and `accounted_s`.
4. **`tests/test_reshard_refit_fused_wire.py` — fixture-only change.** The shared harness now carries a receiver rank for structured records.
5. **`modelexpress/envs.py` and `README.md` — configuration review.** Confirm defaults and handling of invalid, NaN, and infinite values.

Questions for reviewers:

- Does the configured ceiling fail closed at the right point, before live parameters change?
- Are fused and phased wire durations calculated from equivalent work?
- Is `accounted_s` still valid if any of these stages later become concurrent? If concurrency is introduced, the schema must change rather than silently summing overlapping spans.

## Validation

- Python tests, lint, formatting, and DCO pass in CI.
- The full local reshard and NIXL lifecycle selection passed: 158 tests.
- A regression test was run against the old ordering and failed because `_install` had already executed; it passes with the guard moved before installation.

## Benchmark status

The stage fields are the instrumentation used for the existing Topology A and B measurements. The ceiling arithmetic is pinned to both the observed invalid run and a valid Topology B run. Hardware validation of the guard itself remains pending because the bad adapter placement should not be reproduced on a shared qualification run.