### PR TITLE
fix(ci): bump vCluster control plane to 1.34 to match AKS host schema

### DIFF
--- a/.github/actions/dump-vcluster-diagnostics/action.yml
+++ b/.github/actions/dump-vcluster-diagnostics/action.yml
@@ -44,6 +44,14 @@ runs:
         # Always read from the host kubeconfig written by connect-vcluster.
         KCTL="kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-host"
 
+        echo "::group::Host cluster Kubernetes version"
+        # Captures the AKS host server version so we can correlate sudden
+        # vCluster sync regressions with host k8s auto-upgrades. Kubernetes 1.34
+        # added observedGeneration on pod conditions; a host on 1.34+ against a
+        # vCluster control plane below 1.34 stalls pod-ready propagation.
+        ${KCTL} version 2>&1 || true
+        echo "::endgroup::"
+
         echo "::group::vCluster pod summary"
         ${KCTL} get pods -n "${VCLUSTER_NAMESPACE}" -l "${SELECTOR}" \
           -o wide 2>&1 || true

--- a/.github/actions/install-vcluster-cli/action.yml
+++ b/.github/actions/install-vcluster-cli/action.yml
@@ -8,7 +8,7 @@ inputs:
   vcluster_version:
     description: 'vCluster CLI version to install'
     required: false
-    default: 'v0.33.0'
+    default: 'v0.36.0'
 
 runs:
   using: "composite"

--- a/.github/actions/setup-mx-vcluster/action.yml
+++ b/.github/actions/setup-mx-vcluster/action.yml
@@ -31,9 +31,16 @@ inputs:
     required: false
     default: 'mx-ci'
   vcluster_k8s_version:
-    description: 'Kubernetes version for the vCluster control plane'
+    description: |
+      Kubernetes version for the vCluster control plane. Must be >= the host
+      cluster's minor version. Kubernetes 1.34 added the observedGeneration
+      field on pod conditions; if the host is 1.34+ but the vCluster is 1.33 or
+      older, the vCluster API drops that field and the syncer enters an infinite
+      reconcile loop that keeps overwriting Ready=True with stale data, so pods
+      never surface as Ready (Deployment availableReplicas and Service endpoints
+      stay stuck). Keep this at or above the host minor to match schemas.
     required: false
-    default: 'v1.32.13'
+    default: 'v1.34.10'
   dynamo_ref:
     description: |
       Git ref of the ai-dynamo/dynamo repo to clone for the helm chart.
@@ -143,7 +150,8 @@ runs:
           --set 'controlPlane.statefulSet.scheduling.nodeSelector.kubernetes\.azure\.com/agentpool=system' \
           --set 'controlPlane.statefulSet.scheduling.tolerations[0].key=CriticalAddonsOnly' \
           --set 'controlPlane.statefulSet.scheduling.tolerations[0].operator=Exists' \
-          --set 'controlPlane.statefulSet.scheduling.tolerations[0].effect=NoSchedule'
+          --set 'controlPlane.statefulSet.scheduling.tolerations[0].effect=NoSchedule' \
+          --set controlPlane.coredns.deployment.image=registry.k8s.io/coredns/coredns:v1.12.0
         echo "::endgroup::"
 
     - name: Wait for vCluster pod to be ready


### PR DESCRIPTION
## Summary

CI has been failing broadly since ~July 24 with `kubectl rollout status deployment/mx-server` times out even though the server comes up in seconds, hit-or-miss across tests.

**Root cause:** the AKS host cluster auto-upgraded to Kubernetes **1.34**, which added the `observedGeneration` field on pod conditions. The vCluster control plane was on **1.33**, so the vCluster API dropped that field on sync; the syncer saw the dropped field as a new change and entered an infinite reconcile loop, continuously overwriting `Ready=True` with stale data. As a result pods never surfaced as Ready in the vCluster API, and everything derived from it stalled.

Reference: https://www.vcluster.com/docs/vcluster/troubleshoot/pod-stuck-ready-false-version-skew

## Fix

- **Bump the vCluster control plane to `v1.34.10`** so its API shares the `observedGeneration` schema with the 1.34 host. This is the load-bearing change.
- **Bump the vCluster CLI to `v0.36.0`** (supports 1.34 hosts).
- **Pull CoreDNS from `registry.k8s.io`** instead of the `dynamoci.azurecr.io` mirror, which 401s for the 1.34-era CoreDNS image on a fresh cluster.
- **Print the host Kubernetes version** in vCluster diagnostics so a future host auto-upgrade skew is caught immediately.

## Validation

On a run with this fix, `Ensure vCluster` plus all P2P tests (vllm, sglang, trt-llm, sglang-mooncake, full-manifest same/mixed-version) and both Dynamo tests pass — the entire cascade of failures is resolved by the version match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostics now include the host cluster’s Kubernetes version.
  * vCluster setup uses Kubernetes version 1.34.10 by default and pins CoreDNS to version 1.12.0.
  * The default vCluster CLI version is now v0.36.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->