### PR TITLE
docs: Update ModelExpress main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The refit path is experimental today. The goal is to remove avoidable full-model
 - **Expanded model pull providers**: NGC catalog and Google Cloud Storage in addition to Hugging Face
 - **GDS (GPUDirect Storage)**: load model weights directly from NVMe into GPU memory, bypassing the CPU/DRAM copy path
 - **Lower NIXL registration overhead** — Opt in to allocation-level pool registration or a single VMM arena registration
-- **RL weight refit (experimental)** — Receiver-driven trainer-to-rollout weight movement and resharding over NIXL; see the [RL refit design and implementation status](modelexpress_client/python/modelexpress/refit/README.md)
+- **RL weight refit (experimental) and delta weight refit (planned)** — Receiver-driven trainer-to-rollout weight movement and resharding over NIXL, with planned selectors to transfer only changed parameters or expert subsets; see the [RL refit design and implementation status](modelexpress_client/python/modelexpress/refit/README.md)
 
 ### Integrations
 
@@ -294,7 +294,7 @@ cargo bench
 ### Priorities Under Development
 
 - **DRAM and NVMe-resident shard streaming**: Stream shards across workers while keeping weights in DRAM and host local high-speed NVMe.
-- **[RL post-training refit](modelexpress_client/python/modelexpress/refit/README.md)**: Make updates receiver-driven—trainer ranks publish the shards they own, rollout workers discover and plan against their target layout, then pull, convert, reshard, and load directly over NIXL.
+- **[RL post-training refit and delta weight refit](modelexpress_client/python/modelexpress/refit/README.md)**: Make updates receiver-driven—trainer ranks publish the shards they own, rollout workers discover and plan against their target layout, then pull, convert, reshard, and load directly over NIXL. Extend the planner with parameter and expert selectors so updates can transfer only changed subsets instead of executing the full cached plan.
 - **Earlier weight availability**: Bring weights to prefill earlier; identify prefill workers that can act as strong source nodes.
 - **Multi-tier cache hierarchy**: Promote and demote models across DRAM, NVMe, and PVC tiers based on access patterns.
 - **Distributed sharded cache**: Shard large models across nodes using consistent hashing and parallel shard assembly.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ cargo bench
 | [Deployment](docs/DEPLOYMENT.md) | Server/client config, Docker, K8s, P2P |
 | [Architecture](docs/ARCHITECTURE.md) | Components, gRPC, NIXL, FP8 |
 | [Benchmarks](docs/BENCHMARKS.md) | Loading paths, NIXL registration, and artifact-transfer results |
+| [RL weight refit](modelexpress_client/python/modelexpress/refit/README.md) | Receiver-driven trainer-to-rollout resharding design and implementation status |
 | [CLI](docs/CLI.md) | Full CLI reference |
 | [Metadata](docs/metadata.md) | Redis keys, K8s CRD schema |
 | [Helm](helm/README.md) | Kubernetes configuration |
@@ -281,7 +282,7 @@ cargo bench
 ### Priorities Under Development
 
 - **DRAM and NVMe-resident shard streaming**: Stream shards across workers while keeping weights in DRAM and host local high-speed NVMe.
-- **RL post-training refit**: Make updates receiver-driven—trainer ranks publish the shards they own, rollout workers discover and plan against their target layout, then pull, convert, reshard, and load directly over NIXL.
+- **[RL post-training refit](modelexpress_client/python/modelexpress/refit/README.md)**: Make updates receiver-driven—trainer ranks publish the shards they own, rollout workers discover and plan against their target layout, then pull, convert, reshard, and load directly over NIXL.
 - **Earlier weight availability**: Bring weights to prefill earlier; identify prefill workers that can act as strong source nodes.
 - **Multi-tier cache hierarchy**: Promote and demote models across DRAM, NVMe, and PVC tiers based on access patterns.
 - **Distributed sharded cache**: Shard large models across nodes using consistent hashing and parallel shard assembly.

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ SPDX-License-Identifier: Apache-2.0
 
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
-  <a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/rust-1.90%2B-orange" alt="Rust"></a>
 </p>
 
 <h1 align="center">Dynamo ModelExpress</h1>
 
 <p align="center">
-  <strong>Move model weights into GPU memory and reusable artifacts into filesystem caches</strong> — through P2P RDMA, streaming, GPUDirect Storage, or host-staged POSIX I/O.
+  <strong>Move model weights into GPU memory and reusable artifacts into filesystem caches for inference scale-out and RL post-training refit</strong> — through P2P RDMA, streaming, GPUDirect Storage, or host-staged POSIX I/O.
 </p>
 
 <p align="center">
+  <a href="#inference">Inference</a> •
+  <a href="#rl-post-training-and-weight-refit">RL Refit</a> •
   <a href="#features">Features</a> •
   <a href="#modelexpress-architecture">Architecture</a> •
   <a href="#benchmarks">Benchmarks</a> •
@@ -32,7 +33,11 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Overview
 
-ModelExpress (MX) starts with a simple question: before loading a model, where does a compatible copy of its weights already live? Rather than treating every replica as an independent cold start, ModelExpress discovers available sources and selects the fastest supported path into GPU memory. Deploy it standalone or alongside vLLM, SGLang, NVIDIA Dynamo, and other inference runtimes.
+ModelExpress (MX) is a high-speed movement and management layer for model weights and reusable runtime artifacts across two model lifecycles: serving models efficiently in production and refreshing rollout workers as reinforcement learning (RL) post-training produces new versions.
+
+### Inference
+
+Before loading a model or rebuilding runtime artifacts, MX asks where compatible weights and caches already live. Rather than treating every replica as an independent cold start, MX discovers available sources and selects the fastest supported path into GPU memory or the runtime filesystem cache. Deploy it standalone or alongside vLLM, SGLang, NVIDIA Dynamo, and other inference runtimes.
 
 | LLM serving problem | How ModelExpress helps |
 |---------------------|------------------------|
@@ -55,6 +60,12 @@ The first applicable strategy runs. If a strategy fails before changing model st
 
 The ModelExpress control plane discovers compatible sources through Redis, Kubernetes CRDs, or the decentralized `k8s-service` backend. Weight bytes stay on the data plane and move directly between storage or source and target. For clusters with a shared disk cache, the Model Cache Service also coordinates a single download so concurrent replicas reuse one cached checkpoint instead of multiplying external ingress.
 
+### RL post-training and weight refit
+
+RL post-training repeatedly produces model versions that must move from distributed trainer ranks into rollout workers, often across different Tensor Parallelism (TP), Pipeline Parallelism (PP), and Expert Parallelism (EP) layouts. MX is extending its receiver-driven data path to make this **refit** step faster: trainer ranks publish the shards they already own, and each rollout worker discovers the sources, pulls the ranges required for its target layout, reshards during transfer, and installs the update directly over NIXL. The MX server coordinates discovery while weight bytes stay on the data plane.
+
+The refit path is experimental today. The goal is to remove avoidable full-model gathers and storage round trips from the RL critical path while keeping version barriers and rollout policy under the RL framework's control. See [ModelExpress for RL weight refit](modelexpress_client/python/modelexpress/refit/README.md) for the design, implementation status, integration contract, and current limitations.
+
 ---
 
 ## Features
@@ -71,6 +82,7 @@ The ModelExpress control plane discovers compatible sources through Redis, Kuber
 - **Expanded model pull providers**: NGC catalog and Google Cloud Storage in addition to Hugging Face
 - **GDS (GPUDirect Storage)**: load model weights directly from NVMe into GPU memory, bypassing the CPU/DRAM copy path
 - **Lower NIXL registration overhead** — Opt in to allocation-level pool registration or a single VMM arena registration
+- **RL weight refit (experimental)** — Receiver-driven trainer-to-rollout weight movement and resharding over NIXL; see the [RL refit design and implementation status](modelexpress_client/python/modelexpress/refit/README.md)
 
 ### Integrations
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -639,6 +639,10 @@ plan currently assumes a stable source cohort, shard layout, and registration
 addresses; topology-epoch invalidation is a follow-up requirement before
 elastic production use.
 
+See the [RL weight refit overview](../modelexpress_client/python/modelexpress/refit/README.md)
+for the end-to-end design, integration contract, implementation status, and
+validation requirements.
+
 ### SGLang Loader
 
 **MxModelLoader** is instantiated by SGLang's `remote_instance` loader when

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -135,6 +135,7 @@ register_modelexpress_loaders()
 |--------|-------------|
 | `modelexpress.client` | `MxClient` -- gRPC client for the ModelExpress server |
 | `modelexpress.metadata` | Metadata clients, source identity, publishing, and worker manifest serving |
+| [`modelexpress.refit`](modelexpress/refit/README.md) | Experimental RL weight-refit timing, receiver-driven resharding, and engine adapter contracts |
 | `modelexpress.engines.vllm.loader` | `MxModelLoader` -- vLLM integration |
 | `modelexpress.engines.sglang.loader` | `MxModelLoader` -- SGLang `remote_instance` integration |
 | `modelexpress.vllm_loader` | Compatibility shim for the vLLM loader |

--- a/modelexpress_client/python/modelexpress/refit/README.md
+++ b/modelexpress_client/python/modelexpress/refit/README.md
@@ -1,0 +1,300 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<h1 align="center">ModelExpress for RL Weight Refit</h1>
+
+<p align="center">
+  <strong>Move each trainer version into rollout-worker layouts without first assembling a full model on one rank.</strong>
+</p>
+
+<p align="center">
+  <a href="#overview">Overview</a> •
+  <a href="#the-design">Design</a> •
+  <a href="#implementation-status">Status</a> •
+  <a href="#integration-contract">Integration</a> •
+  <a href="#validation">Validation</a>
+</p>
+
+> [!IMPORTANT]
+> The refit package is experimental. It contains framework-neutral resharding primitives, a NIXL transport, normalized timing, and vLLM receiver/install code. It does not yet provide a turnkey integration for an RL framework, and several safety gates listed in [Implementation status](#implementation-status) remain open.
+
+## Executive summary
+
+Reinforcement Learning (RL) post-training repeatedly moves a new model version from distributed trainer ranks to rollout workers. ModelExpress (MX) extends its peer-to-peer loading model to this **refit** path: trainer ranks publish the shards they already own, and each rollout rank pulls the ranges needed for its own Tensor Parallelism (TP), Pipeline Parallelism (PP), and Expert Parallelism (EP) layout. The MX server coordinates discovery but never carries weight bytes; NVIDIA Interconnect eXchange Library (NIXL) reads move data directly between registered Graphics Processing Unit (GPU) buffers. The current code establishes this shared design and a vLLM receiver, while framework orchestration, trainer publication adapters, version-atomic discovery, and broader engine coverage remain integration work.
+
+## Overview
+
+An RL training step changes the model. Rollout workers must install that version before they generate samples against it. The time from “trainer version ready” to “required rollout workers ready” is refit latency, and it sits on the training loop's critical path.
+
+| Refit cost | Conventional path | ModelExpress design |
+|---|---|---|
+| Trainer layout | Gather or checkpoint distributed shards | Keep each rank's native shard registered |
+| Topology change | Central process reconstructs, then receivers reshard | Each receiver plans from source ownership into its own layout |
+| Data path | Trainer gather, storage, or full-payload broadcast | Direct NIXL reads from owning ranks |
+| Worker membership | Usually tied to a collective or checkpoint barrier | Receiver discovers sources and starts independently |
+| Installation | Re-run the engine's general loader | Use an engine adapter; optionally cache destination mappings |
+
+![Conventional RL refit centralizes the model before redistribution, while ModelExpress publishes existing trainer shards and lets rollout ranks pull their needed ranges](images/rl-refit-critical-path.svg)
+
+### A plain-English model
+
+Think of the trainer as a library whose book is already split across several desks. A rollout worker does not ask one desk to photocopy and bind the whole book. It brings a page list for its local edition, looks up which desk owns each page, and reads those pages directly into the right sections.
+
+That analogy maps to four MX concepts:
+
+| Term | Meaning |
+|---|---|
+| **Shard ownership** | A trainer rank owns a range of a global tensor at a registered address. |
+| **Target geometry** | The ranges and destination layout one rollout rank's real model loader expects. |
+| **Transfer plan** | Source-to-destination byte runs that intersect ownership with target geometry. |
+| **Install** | Engine-specific work that commits receive buffers into the live inference model. |
+
+The difficult part is not the network copy. Training and inference often store the same logical tensor in different layouts, with fused projections, different parallelism, quantization, or grouped Mixture-of-Experts (MoE) weights. MX separates the framework-independent range planning from the engine-specific interpretation and installation of those tensors.
+
+## The design
+
+The going-forward pattern is:
+
+> **Per-rank publish, receiver-side pull, receiver-side transform and install.**
+
+The RL framework decides when a version is ready and which rollout workers must finish. Trainer adapters describe the buffers and global ranges each rank owns. MX discovers those sources, plans direct reads, and executes the transfer. An inference adapter captures the destination layout and installs the result into the live engine.
+
+![Six-step receiver-driven refit lifecycle from trainer publication through ModelExpress discovery, planning, NIXL reads, and rollout installation](images/receiver-driven-refit.svg)
+
+### End-to-end lifecycle
+
+1. **Publish trainer ownership.** Each trainer rank registers its existing buffers with NIXL and publishes tensor shape, dtype, global shard offset, local shape, address, and endpoint metadata.
+2. **Discover a source set.** A rollout rank waits for the expected READY trainer ranks and fetches their shard tables through [`MxReshardRendezvous`](reshard/rendezvous.py).
+3. **Capture target geometry.** The inference adapter dry-runs the engine's real weight loader with zero-storage [`LazyWeight`](reshard/geometry.py) tensors. It records which source view is read and where that view lands in a destination parameter; no weight bytes move.
+4. **Build a receiver-local plan.** [`plan_transfer`](reshard/transfer_plan.py) intersects each recorded target range with the published trainer shards and emits contiguous byte runs.
+5. **Pull into registered buffers.** [`NixlReshardTransport`](reshard/transport/nixl.py) groups reads by source session and issues batched one-sided Remote Direct Memory Access (RDMA) reads.
+6. **Transform and install.** The receiver casts dtype-mismatched staging buffers when supported, then calls the engine adapter to update live model storage and derived state.
+
+The first update performs discovery, geometry capture, plan construction, allocation, and memory registration. Later updates reuse the plan and buffers while source topology, shard boundaries, and addresses remain unchanged.
+
+### Resharding during transfer
+
+Source and target layouts are expressed in one global tensor coordinate system. A trainer rank might publish “rows 0–3,” while a rollout rank requests “columns 3–4 across every row.” The planner intersects the request with each owning shard and emits reads that reconstruct the rollout parameter directly.
+
+![A rollout rank requests a column slice crossing two row-sharded trainer ranks; ModelExpress plans two reads that reconstruct the local destination without a full-model gather](images/reshard-while-moving.svg)
+
+Geometry capture supports pure views that can be represented as a rank-preserving, axis-aligned box, including narrowing, unit-step slicing, and dimension permutations. [`paired_runs`](reshard/slice_plan.py) preserves actual destination strides, so non-contiguous destinations become multiple correct byte runs instead of one incorrect contiguous copy.
+
+This design removes the trainer-side full-model gather. It does **not** guarantee that every tensor becomes one large network operation: a strided view can produce many short runs, and unsupported loader operations require a separate fallback strategy.
+
+### Control plane and data plane
+
+The MX server is a directory. It stores source identity and rendezvous metadata, while trainer-to-rollout weight bytes stay on the NIXL data plane.
+
+| Layer | Responsibility |
+|---|---|
+| RL framework | Select version, trigger publish/refit, wait for required workers, enforce rollout staleness policy |
+| Trainer adapter | Translate native FSDP, DTensor, or Megatron ownership into global tensor ranges |
+| MX rendezvous | Publish and discover READY ranks and their registered shard metadata |
+| MX receiver | Capture target geometry, build/reuse the plan, allocate buffers, execute reads |
+| Inference adapter | Interpret names/fusions, install parameters, refresh quantized or derived state |
+| Inference engine | Own live parameters, caches, compiled graphs, and final readiness |
+
+Fully Sharded Data Parallel (FSDP), DTensor, and Megatron integrations belong in trainer adapters; they are not hard-coded into the planner. The current rendezvous format carries shard geometry in a JSON side table because the public protobuf does not yet have typed multidimensional ownership fields.
+
+### Transport and installation are separate
+
+Refit has two independent optimization surfaces:
+
+1. **Move fewer and better-shaped bytes.** The reshard planner selects source ranges and NIXL reads them into receiver buffers.
+2. **Commit those bytes with less loader overhead.** The inference adapter updates live model storage, quantization scales, fused parameters, and derived tensors.
+
+[`VllmReshardReceiver`](../engines/vllm/refit/receiver.py) implements the receiver hooks for vLLM. It captures load-time geometry on an unquantized meta-model twin and uses vLLM's layerwise reload path to preserve storage referenced by compiled Compute Unified Device Architecture (CUDA) graphs.
+
+[`MdlLoader`](../engines/vllm/refit/installer.py) is a separate experimental vLLM installer called Mapped Direct Load (MDL). It caches direct, fused, and expert destination views so warm updates can copy into known slots instead of repeating general loader dispatch. MDL can consume partial input batches, but the reshard transport in this package does not yet expose a selector that reduces wire bytes for partial updates. The two features must not be treated as one end-to-end partial-refit path until that selector is wired and validated.
+
+## Integration contract
+
+The shared receiver has two engine-specific hooks:
+
+```python
+from modelexpress.refit.reshard import ReshardReceiver
+
+
+class RuntimeReceiver(ReshardReceiver):
+    def _capture(self, manifest):
+        # Dry-run the runtime's loader and return:
+        # (CaptureResult, {parameter_name: (load_time_shape, load_time_dtype)})
+        ...
+
+    def _install(self, receive_buffers):
+        # Commit buffers into live model storage and refresh derived state.
+        ...
+```
+
+The framework constructs one receiver per rollout rank and calls `update_weights(step)` when its version barrier permits the update. A trainer-side adapter must build [`PublishedTensor`](reshard/rendezvous.py) records, wrap them with NIXL endpoint metadata, and publish one READY record per trainer rank.
+
+This is an adapter contract, not a complete quick start. The repository does not currently include the RL framework lifecycle hooks or a general trainer publisher that derives ownership from arbitrary training backends.
+
+### Stable-plan assumption
+
+The receiver caches its first discovery and transfer plan. Every later call reuses the original trainer addresses and shard boundaries.
+
+This is valid only when:
+
+- trainer rank membership is stable;
+- registered buffer addresses stay stable;
+- tensor names, shapes, dtypes, and ownership do not change;
+- the receiver's load-time layout stays stable.
+
+A trainer restart, reshard, scale event, or buffer replacement requires rediscovery and replanning. The current receiver does not detect those changes.
+
+## Implementation status
+
+### Implemented in this repository
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Loader-driven geometry capture | Implemented | [`geometry.py`](reshard/geometry.py), [`test_reshard_refit_geometry.py`](../../tests/test_reshard_refit_geometry.py) |
+| Multidimensional shard intersection | Implemented | [`slice_plan.py`](reshard/slice_plan.py), [`test_reshard_refit_slice_plan.py`](../../tests/test_reshard_refit_slice_plan.py) |
+| Strided destination reconstruction | Implemented in reference tests | [`test_reshard_refit_transfer.py`](../../tests/test_reshard_refit_transfer.py) |
+| Multi-rank shard rendezvous | Implemented with temporary JSON metadata | [`rendezvous.py`](reshard/rendezvous.py) |
+| Per-source batched NIXL reads | Implemented | [`transport/nixl.py`](reshard/transport/nixl.py), [`test_reshard_refit_nixl_transport.py`](../../tests/test_reshard_refit_nixl_transport.py) |
+| Same-shape dtype conversion | Implemented through staging buffers | [`receiver.py`](reshard/receiver.py) |
+| Stable-topology plan and buffer reuse | Implemented | [`ReshardReceiver`](reshard/receiver.py) |
+| vLLM geometry capture and layerwise install | Implemented adapter code | [`engines/vllm/refit/receiver.py`](../engines/vllm/refit/receiver.py) |
+| vLLM mapped direct install | Implemented as a separate opt-in installer | [`engines/vllm/refit/installer.py`](../engines/vllm/refit/installer.py) |
+| Normalized refit timing schema | Implemented | [`timing.py`](timing.py), [`test_refit_timing.py`](../../tests/test_refit_timing.py) |
+
+“Implemented” means the code and focused tests are present. It does not by itself mean a framework/model/topology combination has passed distributed end-to-end validation.
+
+### Not yet provided as a general guarantee
+
+| Gap | Current behavior |
+|---|---|
+| Full-pull fallback | The planner identifies unsupported tensors, but `ReshardReceiver` fails closed because its full-pull/install fallback is not implemented. |
+| Complete coverage gate | The planner does not yet prove that published overlaps cover every requested element before transfer. |
+| Version-atomic multi-rank manifest | Discovery waits for a rank count but does not commit and pin one atomic version across all trainer records. |
+| Topology-change handling | The cached plan is not invalidated after trainer restart, reshard, scaling, or address change. |
+| Partial/subset wire filtering | MDL accepts subset batches, but the reshard receiver currently executes its full cached plan on each update. |
+| Expert-aware wire filtering | Expert destination mapping exists in MDL; the reshard planner has no receiver-owned expert selector. |
+| Descriptor bound for strided slices | Correct strided runs can become too numerous; promotion to a bounded full-tensor pull is not implemented on this branch. |
+| Parameter digest verification | The package has reference equality tests but no distributed source-to-destination digest gate in the live receiver. |
+| Inference-to-inference fan-out | Rollout workers do not republish installed refit buffers through this package. |
+| General engine support | The shared core is engine-neutral, but only a vLLM receiver adapter is present. |
+| General trainer support | Framework-specific FSDP, DTensor, and Megatron publisher adapters are not present here. |
+| Transport-neutral receiver | A transport protocol exists for planning tests, but `ReshardReceiver` setup and handshake are currently NIXL-bound. |
+
+## Timing and configuration
+
+[`RefitTimingRecorder`](timing.py) defines a shared stage vocabulary so transport and installer changes can be compared without conflating wire time with end-to-end readiness:
+
+1. control discovery;
+2. source preparation;
+3. setup and registration;
+4. transfer planning;
+5. wire transfer;
+6. receive synchronization;
+7. transformation;
+8. installation;
+9. post-install work;
+10. rollout readiness.
+
+Set `MX_REFIT_TIMING_STDOUT=1` when a benchmark harness must collect the normalized `MX_REFIT_TIMING` JSON record from worker stdout. Lower layers add spans only when a recorder is active.
+
+vLLM's separate MDL path uses these controls:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MX_LOAD_MODE` | `stock` | Set `direct` to enable mapped direct installation. |
+| `MX_FP8_LOADERLESS` | automatic | `1` forces loaderless 8-bit floating-point (FP8) installation; `0` disables the guard. |
+| `MX_LOAD_LAYOUT_VERSION` | empty | Explicitly invalidates cached destination mappings after a layout change. |
+
+## Validation
+
+### Focused tests
+
+Run the framework-neutral refit tests from `modelexpress_client/python`:
+
+```bash
+pytest \
+  tests/test_reshard_refit_geometry.py \
+  tests/test_reshard_refit_slice_plan.py \
+  tests/test_reshard_refit_transfer.py \
+  tests/test_reshard_refit_rendezvous.py \
+  tests/test_reshard_refit_nixl_transport.py \
+  tests/test_refit_timing.py
+```
+
+The strongest local test reconstructs destination parameters from sharded source buffers through capture, planning, and the in-memory reference transport, then compares them byte-for-byte with the engine loader's ground truth. NIXL dispatch tests verify descriptor grouping and address/device mapping without requiring a GPU.
+
+### Distributed acceptance criteria
+
+A distributed integration should not claim a passing refit based on transfer completion alone. At minimum it should verify:
+
+- one pinned model version across every trainer rank;
+- complete requested-byte coverage with no silent fallback;
+- parameter equality after installation;
+- generation parity after the refit;
+- correct TP, PP, EP, and replica placement;
+- explicit source, wire, transform, install, and rollout-ready timings;
+- bounded behavior after worker restart, late join, and timeout.
+
+Performance claims must identify the exact implementation path. Reference transport, sliced NIXL resharding, full-tensor NIXL transfer, MDL installation, and framework collective paths measure different work and should be reported separately.
+
+## Tradeoffs and failure modes
+
+- **Receiver-driven pull vs. trainer-driven push:** pull lets workers join independently and avoids maintaining a receiver list on trainers. It requires source buffers and registrations to remain alive until receivers finish.
+- **Exact slices vs. descriptor count:** exact slicing reduces bytes but can create many short reads. A practical planner needs a bound that chooses a larger contiguous pull when descriptor overhead dominates.
+- **Cached plan vs. elasticity:** plan reuse removes repeated setup from warm updates. It is unsafe after source membership, ownership, or addresses change unless the receiver detects and rebuilds.
+- **Generic capture vs. explicit adapters:** dry-running the real loader avoids a hand-written reshard specification for every model pair. Unsupported arithmetic, materializing reshapes, and model-specific derived state still require engine adapter work.
+- **Fail closed vs. fallback:** failing on unsupported tensors prevents silently serving mixed model versions. A production fallback must materialize and install those tensors without weakening version and coverage checks.
+
+## Open questions
+
+- **Version commit:** Which component publishes the atomic manifest that pins all trainer ranks to one version?
+- **Plan invalidation:** What stable topology and address digest should trigger rediscovery?
+- **Partial refit:** Should the selector be expressed as layers, parameter names, expert IDs, or a framework-supplied predicate?
+- **Source lifetime:** How does the orchestrator acknowledge completion before trainers release old buffers?
+- **Contention:** How should several rollout ranks distribute reads across replicated trainer sources?
+- **Installation contract:** Which inference-engine API owns derived tensors, quantization, and compiled-graph storage stability?
+
+## Roadmap
+
+### Near term
+
+- Add complete coverage and version-consistency gates.
+- Implement bounded full-pull fallback for unsupported or descriptor-heavy tensors.
+- Rebuild plans when source topology or registered addresses change.
+- Add a public trainer publisher contract with typed shard geometry.
+
+### Mid term
+
+- Wire partial parameter and expert selectors through planning and transport.
+- Validate the shared receiver contract with additional inference engines.
+- Add load-aware source selection and rollout-to-rollout fan-out.
+- Unify reshard transport and MDL installation under explicit, measured integration paths.
+
+### Longer term
+
+- Support planner decisions across several receivers instead of independent local plans.
+- Retain and release versions through an orchestrator-visible completion contract.
+- Feed rollout-readiness and fabric contention into topology and source selection.
+
+## Package map
+
+| Path | Role |
+|---|---|
+| [`timing.py`](timing.py) | Normalized timing stages and context propagation |
+| [`reshard/geometry.py`](reshard/geometry.py) | Record the engine loader's source views and destination writes |
+| [`reshard/slice_plan.py`](reshard/slice_plan.py) | Resolve views, intersect shard boxes, emit contiguous runs |
+| [`reshard/transfer_plan.py`](reshard/transfer_plan.py) | Build and execute receiver-local plans |
+| [`reshard/rendezvous.py`](reshard/rendezvous.py) | Publish/discover shard ownership and NIXL endpoints |
+| [`reshard/receiver.py`](reshard/receiver.py) | Shared receiver lifecycle, buffers, staging, and install hooks |
+| [`reshard/transport/`](reshard/transport/) | Reference and NIXL transport adapters |
+| [`engines/vllm/refit/receiver.py`](../engines/vllm/refit/receiver.py) | vLLM geometry capture and graph-safe layerwise install |
+| [`engines/vllm/refit/installer.py`](../engines/vllm/refit/installer.py) | Optional vLLM mapped direct installer |
+
+## Related documentation
+
+- [ModelExpress overview](../../../../README.md)
+- [Python client](../../README.md)
+- [ModelExpress architecture](../../../../docs/ARCHITECTURE.md)
+- [Deployment and NIXL configuration](../../../../docs/DEPLOYMENT.md)

--- a/modelexpress_client/python/modelexpress/refit/images/receiver-driven-refit.svg
+++ b/modelexpress_client/python/modelexpress/refit/images/receiver-driven-refit.svg
@@ -1,0 +1,96 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1040" viewBox="0 0 1200 1040"
+     role="img" aria-labelledby="title desc">
+  <title id="title">Receiver-driven ModelExpress refit lifecycle</title>
+  <desc id="desc">A six-step vertical sequence shows trainer ranks publishing shard ownership, the ModelExpress catalog returning metadata, a rollout rank capturing its loader geometry, planning exact reads, pulling with NIXL, and installing into the live inference model.</desc>
+  <defs>
+    <marker id="arrow-blue" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1565C0"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2E7D32"/>
+    </marker>
+    <marker id="arrow-purple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#5E35B1"/>
+    </marker>
+    <style>
+      .title { font: 700 30px system-ui, sans-serif; fill: #1f2937; }
+      .subtitle { font: 500 17px system-ui, sans-serif; fill: #4b5563; }
+      .column { font: 700 21px system-ui, sans-serif; }
+      .node-title { font: 700 17px system-ui, sans-serif; fill: #111827; }
+      .node-text { font: 500 16px system-ui, sans-serif; fill: #374151; }
+      .step { font: 700 16px system-ui, sans-serif; fill: white; }
+      .edge-label { font: 600 16px system-ui, sans-serif; fill: #374151; }
+      .edge { fill: none; stroke-width: 3; }
+      .life { stroke: #cbd5e1; stroke-width: 3; stroke-dasharray: 8 8; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="1040" rx="24" fill="#f8fafc"/>
+  <text x="600" y="52" text-anchor="middle" class="title">Receiver-driven refit lifecycle</text>
+  <text x="600" y="82" text-anchor="middle" class="subtitle">The RL framework triggers the cycle; ModelExpress discovers, plans, and moves the weight ranges</text>
+
+  <rect x="55" y="115" width="300" height="850" rx="20" fill="#eff6ff" stroke="#64B5F6" stroke-width="2"/>
+  <rect x="450" y="115" width="300" height="850" rx="20" fill="#ecfdf5" stroke="#81C784" stroke-width="2"/>
+  <rect x="845" y="115" width="300" height="850" rx="20" fill="#f5f3ff" stroke="#B39DDB" stroke-width="2"/>
+
+  <text x="205" y="155" text-anchor="middle" class="column" fill="#1565C0">Trainer ranks</text>
+  <text x="600" y="155" text-anchor="middle" class="column" fill="#2E7D32">MX control plane</text>
+  <text x="995" y="155" text-anchor="middle" class="column" fill="#5E35B1">Rollout rank</text>
+
+  <line x1="205" y1="180" x2="205" y2="925" class="life"/>
+  <line x1="600" y1="180" x2="600" y2="925" class="life"/>
+  <line x1="995" y1="180" x2="995" y2="925" class="life"/>
+
+  <!-- Step 1 -->
+  <circle cx="90" cy="225" r="20" fill="#1565C0"/><text x="90" y="231" text-anchor="middle" class="step">1</text>
+  <rect x="105" y="190" width="200" height="70" rx="13" fill="#dbeafe" stroke="#1565C0" stroke-width="2"/>
+  <text x="205" y="219" text-anchor="middle" class="node-title">Register local shards</text>
+  <text x="205" y="243" text-anchor="middle" class="node-text">Keep native layout</text>
+  <path d="M305 225 H490" class="edge" stroke="#1565C0" marker-end="url(#arrow-blue)"/>
+  <text x="405" y="211" text-anchor="middle" class="edge-label">ownership + address</text>
+
+  <!-- Step 2 -->
+  <circle cx="465" cy="350" r="20" fill="#2E7D32"/><text x="465" y="356" text-anchor="middle" class="step">2</text>
+  <rect x="490" y="315" width="220" height="70" rx="13" fill="#dcfce7" stroke="#2E7D32" stroke-width="2"/>
+  <text x="600" y="344" text-anchor="middle" class="node-title">Catalog READY ranks</text>
+  <text x="600" y="368" text-anchor="middle" class="node-text">Metadata only</text>
+  <path d="M875 350 H710" class="edge" stroke="#5E35B1" marker-end="url(#arrow-purple)"/>
+  <text x="802" y="336" text-anchor="middle" class="edge-label">discover trainers</text>
+
+  <!-- Step 3 -->
+  <circle cx="850" cy="475" r="20" fill="#5E35B1"/><text x="850" y="481" text-anchor="middle" class="step">3</text>
+  <rect x="875" y="430" width="240" height="90" rx="13" fill="#ede9fe" stroke="#5E35B1" stroke-width="2"/>
+  <text x="995" y="463" text-anchor="middle" class="node-title">Capture target layout</text>
+  <text x="995" y="487" text-anchor="middle" class="node-text">Dry-run engine loader</text>
+  <text x="995" y="509" text-anchor="middle" class="node-text">No weight bytes move</text>
+
+  <!-- Step 4 -->
+  <circle cx="850" cy="610" r="20" fill="#5E35B1"/><text x="850" y="616" text-anchor="middle" class="step">4</text>
+  <rect x="875" y="565" width="240" height="90" rx="13" fill="#ede9fe" stroke="#5E35B1" stroke-width="2"/>
+  <text x="995" y="598" text-anchor="middle" class="node-title">Build transfer plan</text>
+  <text x="995" y="622" text-anchor="middle" class="node-text">Intersect needed ranges</text>
+  <text x="995" y="644" text-anchor="middle" class="node-text">Cache stable geometry</text>
+
+  <!-- Step 5 -->
+  <circle cx="850" cy="680" r="20" fill="#5E35B1"/><text x="850" y="686" text-anchor="middle" class="step">5</text>
+  <rect x="875" y="700" width="240" height="90" rx="13" fill="#ede9fe" stroke="#5E35B1" stroke-width="2"/>
+  <text x="995" y="733" text-anchor="middle" class="node-title">Pull with NIXL</text>
+  <text x="995" y="757" text-anchor="middle" class="node-text">Batched RDMA READs</text>
+  <text x="995" y="779" text-anchor="middle" class="node-text">Into receive buffers</text>
+  <path d="M305 745 H875" class="edge" stroke="#2E7D32" marker-end="url(#arrow-green)"/>
+  <text x="600" y="728" text-anchor="middle" class="edge-label">receiver initiates reads - bytes bypass the catalog</text>
+
+  <!-- Step 6 -->
+  <circle cx="850" cy="880" r="20" fill="#5E35B1"/><text x="850" y="886" text-anchor="middle" class="step">6</text>
+  <rect x="875" y="835" width="240" height="90" rx="13" fill="#ede9fe" stroke="#5E35B1" stroke-width="2"/>
+  <text x="995" y="868" text-anchor="middle" class="node-title">Transform and install</text>
+  <text x="995" y="892" text-anchor="middle" class="node-text">Preserve live storage</text>
+  <text x="995" y="914" text-anchor="middle" class="node-text">Report rollout ready</text>
+
+  <rect x="100" y="975" width="1000" height="42" rx="12" fill="#ffffff" stroke="#9E9E9E" stroke-width="2"/>
+  <text x="600" y="1002" text-anchor="middle" class="node-text">RL framework owns version timing and barriers - MX owns discovery, coverage planning, transport, and shared timing stages</text>
+</svg>

--- a/modelexpress_client/python/modelexpress/refit/images/receiver-driven-refit.svg
+++ b/modelexpress_client/python/modelexpress/refit/images/receiver-driven-refit.svg
@@ -89,7 +89,7 @@ SPDX-License-Identifier: Apache-2.0
   <rect x="875" y="835" width="240" height="90" rx="13" fill="#ede9fe" stroke="#5E35B1" stroke-width="2"/>
   <text x="995" y="868" text-anchor="middle" class="node-title">Transform and install</text>
   <text x="995" y="892" text-anchor="middle" class="node-text">Preserve live storage</text>
-  <text x="995" y="914" text-anchor="middle" class="node-text">Report rollout ready</text>
+  <text x="995" y="914" text-anchor="middle" class="node-text">Return completion</text>
 
   <rect x="100" y="975" width="1000" height="42" rx="12" fill="#ffffff" stroke="#9E9E9E" stroke-width="2"/>
   <text x="600" y="1002" text-anchor="middle" class="node-text">RL framework owns version timing and barriers - MX owns discovery, coverage planning, transport, and shared timing stages</text>

--- a/modelexpress_client/python/modelexpress/refit/images/reshard-while-moving.svg
+++ b/modelexpress_client/python/modelexpress/refit/images/reshard-while-moving.svg
@@ -1,0 +1,108 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="900" viewBox="0 0 1200 900"
+     role="img" aria-labelledby="title desc">
+  <title id="title">ModelExpress reshards weights while moving them</title>
+  <desc id="desc">A tensor is split by rows across two trainer ranks while one rollout rank needs a column slice crossing both shards. Geometry capture records the rollout slice, the planner intersects it with each trainer shard, and two NIXL reads reconstruct the local destination without a trainer-side gather.</desc>
+  <defs>
+    <marker id="arrow-green" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2E7D32"/>
+    </marker>
+    <style>
+      .title { font: 700 30px system-ui, sans-serif; fill: #1f2937; }
+      .subtitle { font: 500 17px system-ui, sans-serif; fill: #4b5563; }
+      .section { font: 700 21px system-ui, sans-serif; }
+      .node-title { font: 700 17px system-ui, sans-serif; fill: #111827; }
+      .node-text { font: 500 16px system-ui, sans-serif; fill: #374151; }
+      .cell { fill: #dbeafe; stroke: #1565C0; stroke-width: 2; }
+      .needed { fill: #bbf7d0; stroke: #2E7D32; stroke-width: 3; }
+      .target { fill: #ede9fe; stroke: #5E35B1; stroke-width: 2; }
+      .step { font: 700 16px system-ui, sans-serif; fill: white; }
+      .edge { fill: none; stroke: #2E7D32; stroke-width: 3; marker-end: url(#arrow-green); }
+    </style>
+  </defs>
+
+  <rect width="1200" height="900" rx="24" fill="#f8fafc"/>
+  <text x="600" y="52" text-anchor="middle" class="title">Reshard while the weights move</text>
+  <text x="600" y="82" text-anchor="middle" class="subtitle">The receiver requests its own layout; the planner reads overlaps from every owning trainer rank</text>
+
+  <!-- Source shards -->
+  <text x="230" y="145" text-anchor="middle" class="section" fill="#1565C0">Trainer ownership</text>
+  <circle cx="75" cy="205" r="20" fill="#1565C0"/><text x="75" y="211" text-anchor="middle" class="step">1</text>
+  <text x="230" y="185" text-anchor="middle" class="node-title">Full tensor W [8 x 8]</text>
+
+  <rect x="110" y="210" width="240" height="120" rx="8" class="cell"/>
+  <line x1="140" y1="210" x2="140" y2="330" stroke="#1565C0" stroke-width="2"/>
+  <line x1="170" y1="210" x2="170" y2="330" stroke="#1565C0" stroke-width="2"/>
+  <line x1="200" y1="210" x2="200" y2="330" stroke="#1565C0" stroke-width="2"/>
+  <line x1="230" y1="210" x2="230" y2="330" stroke="#1565C0" stroke-width="2"/>
+  <line x1="260" y1="210" x2="260" y2="330" stroke="#1565C0" stroke-width="2"/>
+  <line x1="290" y1="210" x2="290" y2="330" stroke="#1565C0" stroke-width="2"/>
+  <line x1="320" y1="210" x2="320" y2="330" stroke="#1565C0" stroke-width="2"/>
+  <rect x="200" y="210" width="60" height="120" class="needed" opacity="0.86"/>
+  <text x="230" y="270" text-anchor="middle" class="node-title">rank 0 rows 0-3</text>
+
+  <rect x="110" y="350" width="240" height="120" rx="8" class="cell"/>
+  <line x1="140" y1="350" x2="140" y2="470" stroke="#1565C0" stroke-width="2"/>
+  <line x1="170" y1="350" x2="170" y2="470" stroke="#1565C0" stroke-width="2"/>
+  <line x1="200" y1="350" x2="200" y2="470" stroke="#1565C0" stroke-width="2"/>
+  <line x1="230" y1="350" x2="230" y2="470" stroke="#1565C0" stroke-width="2"/>
+  <line x1="260" y1="350" x2="260" y2="470" stroke="#1565C0" stroke-width="2"/>
+  <line x1="290" y1="350" x2="290" y2="470" stroke="#1565C0" stroke-width="2"/>
+  <line x1="320" y1="350" x2="320" y2="470" stroke="#1565C0" stroke-width="2"/>
+  <rect x="200" y="350" width="60" height="120" class="needed" opacity="0.86"/>
+  <text x="230" y="410" text-anchor="middle" class="node-title">rank 1 rows 4-7</text>
+  <text x="230" y="505" text-anchor="middle" class="node-text">Green columns are the receiver's needed range</text>
+
+  <!-- Planner -->
+  <text x="600" y="145" text-anchor="middle" class="section" fill="#2E7D32">Receiver-local planner</text>
+  <circle cx="405" cy="230" r="20" fill="#2E7D32"/><text x="405" y="236" text-anchor="middle" class="step">2</text>
+  <rect x="430" y="190" width="340" height="80" rx="14" fill="#dcfce7" stroke="#2E7D32" stroke-width="2"/>
+  <text x="600" y="222" text-anchor="middle" class="node-title">Capture loader geometry</text>
+  <text x="600" y="246" text-anchor="middle" class="node-text">W[:, 3:5] to local param</text>
+
+  <path d="M600 270 V340" class="edge"/>
+  <circle cx="405" cy="380" r="20" fill="#2E7D32"/><text x="405" y="386" text-anchor="middle" class="step">3</text>
+  <rect x="430" y="340" width="340" height="80" rx="14" fill="#dcfce7" stroke="#2E7D32" stroke-width="2"/>
+  <text x="600" y="372" text-anchor="middle" class="node-title">Intersect ownership</text>
+  <text x="600" y="396" text-anchor="middle" class="node-text">Two source overlaps</text>
+
+  <path d="M600 420 V490" class="edge"/>
+  <circle cx="405" cy="530" r="20" fill="#2E7D32"/><text x="405" y="536" text-anchor="middle" class="step">4</text>
+  <rect x="430" y="490" width="340" height="80" rx="14" fill="#dcfce7" stroke="#2E7D32" stroke-width="2"/>
+  <text x="600" y="522" text-anchor="middle" class="node-title">Emit byte runs</text>
+  <text x="600" y="546" text-anchor="middle" class="node-text">One plan, reused per step</text>
+
+  <!-- Destination -->
+  <text x="970" y="145" text-anchor="middle" class="section" fill="#5E35B1">Rollout destination</text>
+  <circle cx="820" cy="185" r="20" fill="#5E35B1"/><text x="820" y="191" text-anchor="middle" class="step">5</text>
+  <rect x="860" y="210" width="220" height="240" rx="10" class="target"/>
+  <line x1="970" y1="210" x2="970" y2="450" stroke="#5E35B1" stroke-width="2"/>
+  <line x1="860" y1="240" x2="1080" y2="240" stroke="#5E35B1" stroke-width="2"/>
+  <line x1="860" y1="270" x2="1080" y2="270" stroke="#5E35B1" stroke-width="2"/>
+  <line x1="860" y1="300" x2="1080" y2="300" stroke="#5E35B1" stroke-width="2"/>
+  <line x1="860" y1="330" x2="1080" y2="330" stroke="#5E35B1" stroke-width="2"/>
+  <line x1="860" y1="360" x2="1080" y2="360" stroke="#5E35B1" stroke-width="2"/>
+  <line x1="860" y1="390" x2="1080" y2="390" stroke="#5E35B1" stroke-width="2"/>
+  <line x1="860" y1="420" x2="1080" y2="420" stroke="#5E35B1" stroke-width="2"/>
+  <text x="970" y="485" text-anchor="middle" class="node-title">local param [8 x 2]</text>
+  <text x="970" y="511" text-anchor="middle" class="node-text">assembled from both ranks</text>
+
+  <path d="M350 270 C390 135 790 135 860 285" class="edge"/>
+  <path d="M350 410 C390 610 800 610 860 375" class="edge"/>
+  <text x="760" y="168" text-anchor="middle" class="node-text">NIXL read A</text>
+  <text x="780" y="602" text-anchor="middle" class="node-text">NIXL read B</text>
+
+  <rect x="125" y="630" width="950" height="190" rx="18" fill="#ffffff" stroke="#9E9E9E" stroke-width="2"/>
+  <text x="600" y="670" text-anchor="middle" class="section" fill="#2E7D32">What this removes</text>
+  <text x="190" y="715" class="node-title">No full-model gather</text>
+  <text x="190" y="743" class="node-text">Trainer ranks keep their native shards.</text>
+  <text x="190" y="775" class="node-title">No catalog data hop</text>
+  <text x="190" y="803" class="node-text">Only ownership metadata uses the server.</text>
+  <text x="650" y="715" class="node-title">No pair-specific reshard spec</text>
+  <text x="650" y="743" class="node-text">The engine loader describes the target layout.</text>
+  <text x="650" y="775" class="node-title">No repeated planning</text>
+  <text x="650" y="803" class="node-text">Stable geometry and addresses reuse one plan.</text>
+</svg>

--- a/modelexpress_client/python/modelexpress/refit/images/rl-refit-critical-path.svg
+++ b/modelexpress_client/python/modelexpress/refit/images/rl-refit-critical-path.svg
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
   <path d="M905 255 V320" class="edge" stroke="#2E7D32" marker-end="url(#arrow-green)"/>
   <circle cx="685" cy="360" r="20" fill="#2E7D32"/><text x="685" y="366" text-anchor="middle" class="step">2</text>
   <rect x="725" y="325" width="360" height="70" rx="14" fill="#dcfce7" stroke="#2E7D32" stroke-width="2"/>
-  <text x="905" y="355" text-anchor="middle" class="node-title">Discover one version</text>
+  <text x="905" y="355" text-anchor="middle" class="node-title">Discover READY sources</text>
   <text x="905" y="379" text-anchor="middle" class="node-text">Catalog returns ownership metadata</text>
 
   <path d="M905 395 V460" class="edge" stroke="#2E7D32" marker-end="url(#arrow-green)"/>

--- a/modelexpress_client/python/modelexpress/refit/images/rl-refit-critical-path.svg
+++ b/modelexpress_client/python/modelexpress/refit/images/rl-refit-critical-path.svg
@@ -1,0 +1,93 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="920" viewBox="0 0 1200 920"
+     role="img" aria-labelledby="title desc">
+  <title id="title">Conventional RL weight refit compared with ModelExpress refit</title>
+  <desc id="desc">Two vertical flows compare a centralized gather or checkpoint path with receiver-driven ModelExpress resharding. ModelExpress keeps trainer shards distributed and lets each rollout rank pull the ranges needed for its own layout.</desc>
+  <defs>
+    <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#616161"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2E7D32"/>
+    </marker>
+    <style>
+      .title { font: 700 30px system-ui, sans-serif; fill: #1f2937; }
+      .subtitle { font: 500 17px system-ui, sans-serif; fill: #4b5563; }
+      .lane-title { font: 700 22px system-ui, sans-serif; }
+      .node-title { font: 700 18px system-ui, sans-serif; fill: #111827; }
+      .node-text { font: 500 16px system-ui, sans-serif; fill: #374151; }
+      .step { font: 700 17px system-ui, sans-serif; fill: white; }
+      .note { font: 600 16px system-ui, sans-serif; }
+      .edge { fill: none; stroke-width: 3; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="920" rx="24" fill="#f8fafc"/>
+  <text x="600" y="54" text-anchor="middle" class="title">Shorten the RL refit critical path</text>
+  <text x="600" y="84" text-anchor="middle" class="subtitle">Move each new trainer version into rollout layouts without first rebuilding one full model</text>
+
+  <rect x="50" y="120" width="520" height="750" rx="22" fill="#f3f4f6" stroke="#9E9E9E" stroke-width="2"/>
+  <text x="310" y="160" text-anchor="middle" class="lane-title" fill="#616161">Centralized refit path</text>
+
+  <rect x="630" y="120" width="520" height="750" rx="22" fill="#ecfdf5" stroke="#4CAF50" stroke-width="2"/>
+  <text x="890" y="160" text-anchor="middle" class="lane-title" fill="#2E7D32">ModelExpress refit</text>
+
+  <!-- Conventional path -->
+  <circle cx="105" cy="220" r="20" fill="#616161"/><text x="105" y="226" text-anchor="middle" class="step">1</text>
+  <rect x="145" y="185" width="360" height="70" rx="14" fill="#dbeafe" stroke="#1565C0" stroke-width="2"/>
+  <text x="325" y="215" text-anchor="middle" class="node-title">Distributed trainer shards</text>
+  <text x="325" y="239" text-anchor="middle" class="node-text">TP / PP / EP layout</text>
+
+  <path d="M325 255 V320" class="edge" stroke="#616161" marker-end="url(#arrow-gray)"/>
+  <circle cx="105" cy="360" r="20" fill="#616161"/><text x="105" y="366" text-anchor="middle" class="step">2</text>
+  <rect x="145" y="325" width="360" height="70" rx="14" fill="#e5e7eb" stroke="#616161" stroke-width="2"/>
+  <text x="325" y="355" text-anchor="middle" class="node-title">Centralize the model</text>
+  <text x="325" y="379" text-anchor="middle" class="node-text">Gather, merge, or save checkpoint</text>
+
+  <path d="M325 395 V460" class="edge" stroke="#616161" marker-end="url(#arrow-gray)"/>
+  <circle cx="105" cy="500" r="20" fill="#616161"/><text x="105" y="506" text-anchor="middle" class="step">3</text>
+  <rect x="145" y="465" width="360" height="70" rx="14" fill="#e5e7eb" stroke="#616161" stroke-width="2"/>
+  <text x="325" y="495" text-anchor="middle" class="node-title">Redistribute full payload</text>
+  <text x="325" y="519" text-anchor="middle" class="node-text">Broadcast or reload from storage</text>
+
+  <path d="M325 535 V600" class="edge" stroke="#616161" marker-end="url(#arrow-gray)"/>
+  <circle cx="105" cy="640" r="20" fill="#616161"/><text x="105" y="646" text-anchor="middle" class="step">4</text>
+  <rect x="145" y="605" width="360" height="70" rx="14" fill="#ede9fe" stroke="#5E35B1" stroke-width="2"/>
+  <text x="325" y="635" text-anchor="middle" class="node-title">Reshard and install</text>
+  <text x="325" y="659" text-anchor="middle" class="node-text">Build each rollout rank's layout</text>
+
+  <rect x="120" y="735" width="380" height="86" rx="14" fill="#ffffff" stroke="#9E9E9E" stroke-width="2"/>
+  <text x="310" y="770" text-anchor="middle" class="note" fill="#616161">Critical-path cost</text>
+  <text x="310" y="798" text-anchor="middle" class="node-text">gather / storage + transfer + reshard + install</text>
+
+  <!-- MX path -->
+  <circle cx="685" cy="220" r="20" fill="#2E7D32"/><text x="685" y="226" text-anchor="middle" class="step">1</text>
+  <rect x="725" y="185" width="360" height="70" rx="14" fill="#dbeafe" stroke="#1565C0" stroke-width="2"/>
+  <text x="905" y="215" text-anchor="middle" class="node-title">Publish existing shards</text>
+  <text x="905" y="239" text-anchor="middle" class="node-text">Metadata points at trainer buffers</text>
+
+  <path d="M905 255 V320" class="edge" stroke="#2E7D32" marker-end="url(#arrow-green)"/>
+  <circle cx="685" cy="360" r="20" fill="#2E7D32"/><text x="685" y="366" text-anchor="middle" class="step">2</text>
+  <rect x="725" y="325" width="360" height="70" rx="14" fill="#dcfce7" stroke="#2E7D32" stroke-width="2"/>
+  <text x="905" y="355" text-anchor="middle" class="node-title">Discover one version</text>
+  <text x="905" y="379" text-anchor="middle" class="node-text">Catalog returns ownership metadata</text>
+
+  <path d="M905 395 V460" class="edge" stroke="#2E7D32" marker-end="url(#arrow-green)"/>
+  <circle cx="685" cy="500" r="20" fill="#2E7D32"/><text x="685" y="506" text-anchor="middle" class="step">3</text>
+  <rect x="725" y="465" width="360" height="70" rx="14" fill="#dcfce7" stroke="#2E7D32" stroke-width="2"/>
+  <text x="905" y="495" text-anchor="middle" class="node-title">Plan receiver-local ranges</text>
+  <text x="905" y="519" text-anchor="middle" class="node-text">Intersect source and target layouts</text>
+
+  <path d="M905 535 V600" class="edge" stroke="#2E7D32" marker-end="url(#arrow-green)"/>
+  <circle cx="685" cy="640" r="20" fill="#2E7D32"/><text x="685" y="646" text-anchor="middle" class="step">4</text>
+  <rect x="725" y="605" width="360" height="70" rx="14" fill="#ede9fe" stroke="#5E35B1" stroke-width="2"/>
+  <text x="905" y="635" text-anchor="middle" class="node-title">Pull, transform, install</text>
+  <text x="905" y="659" text-anchor="middle" class="node-text">NIXL reads directly into GPU buffers</text>
+
+  <rect x="700" y="735" width="380" height="86" rx="14" fill="#ffffff" stroke="#4CAF50" stroke-width="2"/>
+  <text x="890" y="770" text-anchor="middle" class="note" fill="#2E7D32">Critical-path cost</text>
+  <text x="890" y="798" text-anchor="middle" class="node-text">discovery + plan + needed wire bytes + install</text>
+</svg>


### PR DESCRIPTION
## Summary

- Position the main README around two ModelExpress product paths: inference scale-out and RL post-training weight refit.
- Add delta weight refit to Features and the RL roadmap, explicitly labeled as planned work for changed-parameter or expert-subset transfers.
- Explicitly retain the artifact-transport proposition: model weights move into GPU memory while reusable artifacts move into filesystem caches.
- Remove the Rust badge from the README header.
- Link to the detailed RL refit documentation introduced by the stacked base PR.

## Why

Clarify ModelExpress's customer and product positioning, especially its role in RL weight management, while preserving artifact transport as a core part of the value proposition.

## Impact

Makes both product paths visible from the main README without overstating the maturity of the experimental RL refit path.

## Validation

- README-only diff against the stacked base
- Verified section anchors, headings, and RL refit link
- Verified artifact-transport positioning remains explicit
- Verified Rust badge is removed
- No Copilot co-author or `Co-authored-by` trailer

## Stacked PR

Base: #558 (`kavink/docs-rl-refit-readme`)
