### PR TITLE
fix(client): support protobuf 6 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,16 @@ jobs:
       run: cargo test --doc
 
   python-test:
-    name: Python Tests
+    name: Python Tests (protobuf ${{ matrix.protobuf_major }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - protobuf_major: 5
+            protobuf_spec: "protobuf==5.27.2"
+          - protobuf_major: 6
+            protobuf_spec: "protobuf>=6.30.2,<7.0.0"
 
     steps:
     - name: Checkout repository
@@ -115,7 +123,7 @@ jobs:
       working-directory: modelexpress_client/python
       run: |
         uv venv .venv --python 3.12
-        uv pip install -e ".[dev]"
+        uv pip install -e ".[dev]" '${{ matrix.protobuf_spec }}'
 
     - name: Run tests
       working-directory: modelexpress_client/python

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -15,8 +15,11 @@ pip install modelexpress
 # Editable install from source
 pip install -e .
 
-# With dev dependencies (pytest, grpcio-tools)
+# With test dependencies
 pip install -e ".[dev]"
+
+# Additionally install the pinned protobuf code generator when changing p2p.proto
+pip install -e ".[codegen]"
 ```
 
 NIXL is expected to be supplied by the runtime environment (TRT-LLM,
@@ -27,6 +30,7 @@ or `pip install nixl-cu13` separately, matching your host CUDA toolkit.
 ### Requirements
 
 - Python >= 3.10
+- protobuf >= 5.27.2 and < 7
 - NVIDIA GPUs with RDMA/InfiniBand support
 - [NIXL](https://github.com/ai-dynamo/nixl) (NVIDIA Interconnect eXchange Library)
 - A running [ModelExpress server](https://github.com/ai-dynamo/modelexpress/tree/main/modelexpress_server) (Rust gRPC service backed by Redis)

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "google-crc32c>=1.5.0",
     "huggingface_hub>=0.20.0",
     "numpy>=1.24.0",
-    "protobuf>=5.27.0,<6.0.0", # protobuf 5.x compatibility
+    "protobuf>=5.27.2,<7.0.0",
     "pydantic>=2.0.0",
     "torch>=2.6.0",
     "runai-model-streamer[s3,gcs,azure]; sys_platform == 'linux'",
@@ -37,12 +37,14 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    # Use grpcio-tools<=1.66.2 for protobuf 5.x, >=1.67.0 for protobuf 6.x
-    "grpcio-tools>=1.60.0,<=1.66.2",
     "opentelemetry-api>=1.41.1",
     "opentelemetry-sdk>=1.41.1",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+]
+codegen = [
+    # Keep generated Python stubs compatible with both protobuf 5 and 6.
+    "grpcio-tools==1.66.2",
 ]
 otel = [
     "opentelemetry-api>=1.20.0",

--- a/modelexpress_client/python/tests/test_types.py
+++ b/modelexpress_client/python/tests/test_types.py
@@ -19,8 +19,8 @@ from modelexpress.types import TensorDescriptor, WorkerMetadata, GetMetadataResp
 class TestProtobufCompatibility:
     """Guard against generated protobuf code drifting from the installed runtime."""
 
-    def test_p2p_pb2_gencode_matches_runtime_major_version(self):
-        """Regenerate p2p_pb2.py if this fails (see pyproject.toml [dev] deps)."""
+    def test_p2p_pb2_gencode_supports_runtime_major_version(self):
+        """Keep protobuf 5 gencode usable on supported 5.x and 6.x runtimes."""
         import modelexpress.p2p_pb2 as pb2
 
         with open(pb2.__file__) as f:
@@ -29,12 +29,9 @@ class TestProtobufCompatibility:
         assert m, "Could not parse gencode version from p2p_pb2.py"
         gencode_major = int(m.group(1))
         runtime_major = int(_pb_version.split(".")[0])
-        assert gencode_major == runtime_major, (
-            f"p2p_pb2.py was generated with protobuf {gencode_major}.x "
-            f"but runtime is {runtime_major}.x - regenerate with: "
-            f"python -m grpc_tools.protoc -I../../modelexpress_common/proto "
-            f"--python_out=modelexpress --grpc_python_out=modelexpress "
-            f"../../modelexpress_common/proto/p2p.proto"
+        assert gencode_major == 5, "checked-in bindings must remain protobuf 5 gencode"
+        assert runtime_major in {5, 6}, (
+            f"unsupported protobuf runtime major: {runtime_major}"
         )
 
     def test_publish_request_is_readable_by_0_4_schema(self):

--- a/modelexpress_client/python/uv.lock
+++ b/modelexpress_client/python/uv.lock
@@ -940,8 +940,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
+codegen = [
     { name = "grpcio-tools" },
+]
+dev = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "pytest" },
@@ -962,7 +964,7 @@ requires-dist = [
     { name = "cuda-python", marker = "extra == 'vmm'", specifier = ">=12.0" },
     { name = "google-crc32c", specifier = ">=1.5.0" },
     { name = "grpcio", specifier = ">=1.66.2" },
-    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60.0,<=1.66.2" },
+    { name = "grpcio-tools", marker = "extra == 'codegen'", specifier = "==1.66.2" },
     { name = "huggingface-hub", specifier = ">=0.20.0" },
     { name = "instanttensor", marker = "sys_platform == 'linux'", specifier = ">=0.1.9" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -970,14 +972,14 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.41.1" },
     { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20.0" },
-    { name = "protobuf", specifier = ">=5.27.0,<6.0.0" },
+    { name = "protobuf", specifier = ">=5.27.2,<7.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "runai-model-streamer", extras = ["s3", "gcs", "azure"], marker = "sys_platform == 'linux'" },
     { name = "torch", specifier = ">=2.6.0" },
 ]
-provides-extras = ["dev", "otel", "metrics", "vmm"]
+provides-extras = ["dev", "codegen", "otel", "metrics", "vmm"]
 
 [[package]]
 name = "mpmath"


### PR DESCRIPTION
## Summary

- widen the ModelExpress client runtime constraint to `protobuf>=5.27,<7`
- keep checked-in Python stubs generated with the pinned protobuf-5-era toolchain so they remain usable on both protobuf 5 and 6
- move `grpcio-tools` out of the test extra into an explicit `codegen` extra
- run the full Python CI suite against both protobuf 5 and protobuf 6

## Why

Current TensorRT-LLM images require protobuf 6.x, while ModelExpress declares `protobuf<6`. A normal ModelExpress install therefore conflicts with the TRT-LLM runtime or requires `--no-deps`, leaving compatibility unverified. The generated protobuf 5 bindings already run correctly on protobuf 6; the blocker is the package constraint and same-major-only test guard.

## User impact

ModelExpress can be installed normally into qualified TensorRT-LLM images without downgrading their protobuf stack. Existing protobuf 5 users remain supported. Contributors changing `p2p.proto` use `pip install -e ".[codegen]"` to preserve dual-runtime bindings.

## Validation

- 184 metadata, client, source-selection, publisher, and TRT-LLM tests passed with protobuf 5.29.6
- the same 184 tests passed with protobuf 6.33.6
- protobuf compatibility tests: 11 passed on each major
- source distribution and wheel build succeeded; wheel metadata contains `protobuf>=5.27,<7`
- `uv lock --check`
- GitHub workflow YAML parse
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Expanded supported Python protobuf runtime versions to include major versions 5 and 6.
  - Updated compatibility checks to better support generated bindings across supported runtime versions.

- **Documentation**
  - Clarified installation steps by separating development tools from optional protobuf code-generation tools.
  - Documented supported protobuf version requirements and when code-generation dependencies are needed.

- **Testing**
  - CI now validates the Python package against multiple supported protobuf versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->