### PR TITLE
fix(sglang): backport TransferEngine fallback to 0.5.0

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/sglang/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/loader.py
@@ -168,25 +168,57 @@ class MxModelLoader:
             result = ctx.adapter.load_via_native(result)
             tensors = ctx.adapter.discover_tensors(result)
         else:
-            result = ctx.adapter.before_rdma_receive(result)
-            tensors = ctx.adapter.discover_tensors(result)
-            weight_info = self._register_transfer_engine_tensors(
-                tensors,
-                transfer_engine,
-            )
-            self._receive_via_transfer_engine(
-                tensors,
-                transfer_engine,
-                source_worker,
-                ctx,
-            )
-            result = ctx.adapter.after_rdma_receive(result)
+            registered_tensors = None
+            try:
+                result = ctx.adapter.before_rdma_receive(result)
+                tensors = ctx.adapter.discover_tensors(result)
+                weight_info = self._register_transfer_engine_tensors(
+                    tensors,
+                    transfer_engine,
+                )
+                registered_tensors = tensors
+                self._receive_via_transfer_engine(
+                    tensors,
+                    transfer_engine,
+                    source_worker,
+                    ctx,
+                )
+                result = ctx.adapter.after_rdma_receive(result)
+            except Exception as exc:
+                if registered_tensors is not None:
+                    self._unregister_transfer_engine_tensors(
+                        registered_tensors,
+                        transfer_engine,
+                    )
+                logger.warning(
+                    "[Worker %s] TransferEngine load failed, falling back "
+                    "to native load: %s",
+                    ctx.global_rank,
+                    exc,
+                    exc_info=True,
+                )
+                result = ctx.adapter.reinit_for_retry(result)
+                result = ctx.adapter.load_via_native(result)
+                tensors = ctx.adapter.discover_tensors(result)
+                weight_info = None
 
         if weight_info is None:
-            weight_info = self._register_transfer_engine_tensors(
-                tensors,
-                transfer_engine,
-            )
+            try:
+                weight_info = self._register_transfer_engine_tensors(
+                    tensors,
+                    transfer_engine,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[Worker %s] TransferEngine source registration failed; "
+                    "model load will continue without source publication: %s",
+                    ctx.global_rank,
+                    exc,
+                    exc_info=True,
+                )
+                ctx.tensors = tensors
+                self.remote_instance_transfer_engine_weight_info = {}
+                return result.model.eval()
         ctx.tensors = tensors
         self.remote_instance_transfer_engine_weight_info = weight_info
         publish_ok = self._publish_transfer_engine_source(
@@ -252,6 +284,10 @@ class MxModelLoader:
                 return worker
         return None
 
+    @staticmethod
+    def _byte_size(numel: int, element_size: int) -> int:
+        return numel * element_size
+
     def _receive_via_transfer_engine(
         self,
         tensors: dict[str, torch.Tensor],
@@ -275,12 +311,14 @@ class MxModelLoader:
                     "in source metadata"
                 )
             seed_ptr, seed_size = weight_info
-            local_size = tensor.numel() * tensor.element_size()
+            local_size = self._byte_size(tensor.numel(), tensor.element_size())
             if seed_size != local_size:
                 raise RuntimeError(
                     f"ModelExpress transfer_engine: size mismatch for {name}: "
                     f"source={seed_size} bytes, local={local_size} bytes"
                 )
+            if local_size == 0:
+                continue
             seed_ptr_list.append(seed_ptr)
             client_ptr_list.append(tensor.data_ptr())
             client_len_list.append(local_size)
@@ -309,21 +347,64 @@ class MxModelLoader:
     ) -> dict[str, tuple[int, int, int]]:
         weight_info = {}
         registered_ptrs = set()
-        for name, tensor in tensors.items():
-            addr = tensor.data_ptr()
-            numel = tensor.numel()
-            element_size = tensor.element_size()
-            size = numel * element_size
-            if addr not in registered_ptrs:
-                ret = transfer_engine.register_memory(addr, size)
-                if ret != 0:
-                    raise RuntimeError(
-                        "ModelExpress transfer_engine: register_memory failed "
-                        f"for tensor {name!r}, error={ret}"
-                    )
-                registered_ptrs.add(addr)
-            weight_info[name] = (addr, numel, element_size)
+        try:
+            for name, tensor in tensors.items():
+                addr = tensor.data_ptr()
+                numel = tensor.numel()
+                element_size = tensor.element_size()
+                size = self._byte_size(numel, element_size)
+                weight_info[name] = (addr, numel, element_size)
+                if size == 0:
+                    continue
+                if addr not in registered_ptrs:
+                    ret = transfer_engine.register_memory(addr, size)
+                    if ret != 0:
+                        raise RuntimeError(
+                            "ModelExpress transfer_engine: register_memory failed "
+                            f"for tensor {name!r}, error={ret}"
+                        )
+                    registered_ptrs.add(addr)
+        except Exception:
+            self._unregister_transfer_engine_ptrs(
+                registered_ptrs,
+                transfer_engine,
+            )
+            raise
         return weight_info
+
+    def _unregister_transfer_engine_tensors(
+        self,
+        tensors: dict[str, torch.Tensor],
+        transfer_engine,
+    ) -> None:
+        registered_ptrs = {
+            tensor.data_ptr()
+            for tensor in tensors.values()
+            if self._byte_size(tensor.numel(), tensor.element_size()) > 0
+        }
+        self._unregister_transfer_engine_ptrs(registered_ptrs, transfer_engine)
+
+    def _unregister_transfer_engine_ptrs(
+        self,
+        registered_ptrs: set[int],
+        transfer_engine,
+    ) -> None:
+        for addr in registered_ptrs:
+            try:
+                ret = transfer_engine.unregister_memory(addr)
+                if ret != 0:
+                    logger.warning(
+                        "ModelExpress transfer_engine: unregister_memory failed "
+                        "for address %s, error=%s",
+                        addr,
+                        ret,
+                    )
+            except Exception:
+                logger.exception(
+                    "ModelExpress transfer_engine: unregister_memory raised "
+                    "for address %s",
+                    addr,
+                )
 
     def _publish_transfer_engine_source(
         self,
@@ -337,7 +418,7 @@ class MxModelLoader:
                 p2p_pb2.TensorDescriptor(
                     name=name,
                     addr=addr,
-                    size=numel * element_size,
+                    size=self._byte_size(numel, element_size),
                     device_id=ctx.device_id,
                 )
                 for name, (addr, numel, element_size) in weight_info.items()

--- a/modelexpress_client/python/modelexpress/tensor_utils.py
+++ b/modelexpress_client/python/modelexpress/tensor_utils.py
@@ -284,6 +284,9 @@ def collect_module_tensors(
     Multiple views into the same storage (e.g. W_UV and W_UK_T sharing
     a dequantized intermediate) are deduplicated by data_ptr so the
     storage is transferred only once.
+
+    Zero-element tensors retain their original names and bypass pointer-based
+    deduplication because distinct empty tensors can share a null data_ptr.
     """
     backend = _resolve_accelerator_backend(accelerator_backend)
     tensors: dict[str, torch.Tensor] = {}
@@ -292,6 +295,10 @@ def collect_module_tensors(
     skipped_duplicate = 0
     for name, tensor, _tensor_type in iter_module_tensors(model, backend):
         t = tensor.data if hasattr(tensor, "data") else tensor
+
+        if t.numel() == 0:
+            tensors[name] = t
+            continue
 
         if t.is_contiguous():
             ptr = t.data_ptr()

--- a/modelexpress_client/python/tests/test_sglang_loader.py
+++ b/modelexpress_client/python/tests/test_sglang_loader.py
@@ -511,6 +511,132 @@ def test_mx_model_loader_delegates_transfer_engine_transport_in_mx_package():
     )
 
 
+def test_transfer_engine_receive_failure_reinitializes_before_native_fallback():
+    transfer_engine = MagicMock()
+    transfer_engine.register_memory.return_value = 0
+    transfer_engine.batch_transfer_sync_read.return_value = -1
+    load_config = _load_config(
+        modelexpress_transport="transfer_engine",
+        remote_instance_weight_loader_transfer_engine=transfer_engine,
+        remote_instance_weight_loader_transfer_engine_session_id="target-session",
+    )
+    loader = MxModelLoader(load_config)
+    initial_model = nn.Linear(2, 2)
+    prepared_model = nn.Linear(2, 2)
+    fresh_model = nn.Linear(2, 2)
+    native_model = nn.Linear(2, 2)
+    target_tensor = torch.randn(2, 3)
+    native_tensor = torch.randn(3, 2)
+    prepared_result = SimpleNamespace(value=prepared_model, model=prepared_model)
+    fresh_result = SimpleNamespace(value=fresh_model, model=fresh_model)
+    native_result = SimpleNamespace(value=native_model, model=native_model)
+    adapter = MagicMock()
+    adapter.before_rdma_receive.return_value = prepared_result
+    adapter.discover_tensors.side_effect = [
+        {"target": target_tensor},
+        {"native": native_tensor},
+    ]
+    adapter.reinit_for_retry.return_value = fresh_result
+    adapter.load_via_native.return_value = native_result
+    ctx = SimpleNamespace(
+        global_rank=0,
+        identity=SimpleNamespace(model_name="model"),
+        adapter=adapter,
+        tensors={},
+    )
+    source_worker = p2p_pb2.WorkerMetadata(
+        transfer_engine_session_id="source-session",
+        tensors=[
+            p2p_pb2.TensorDescriptor(
+                name="target",
+                addr=1234,
+                size=target_tensor.numel() * target_tensor.element_size(),
+            )
+        ],
+    )
+
+    with patch(
+        "modelexpress.engines.sglang.loader.build_sglang_load_context",
+        return_value=ctx,
+    ), patch.object(
+        loader,
+        "_find_transfer_engine_source",
+        return_value=source_worker,
+    ), patch.object(
+        loader,
+        "_publish_transfer_engine_source",
+        return_value=True,
+    ) as publish:
+        loaded = loader._load_model_via_transfer_engine(
+            model=initial_model,
+            model_config=_model_config(),
+            device_config=_device_config(),
+        )
+
+    assert loaded is native_model
+    transfer_engine.unregister_memory.assert_called_once_with(
+        target_tensor.data_ptr()
+    )
+    adapter.reinit_for_retry.assert_called_once_with(prepared_result)
+    adapter.load_via_native.assert_called_once_with(fresh_result)
+    publish.assert_called_once()
+    assert publish.call_args.kwargs["weight_info"] == {
+        "native": (
+            native_tensor.data_ptr(),
+            native_tensor.numel(),
+            native_tensor.element_size(),
+        )
+    }
+
+
+def test_transfer_engine_source_registration_failure_keeps_native_model():
+    transfer_engine = MagicMock()
+    transfer_engine.register_memory.side_effect = [0, -1]
+    load_config = _load_config(
+        modelexpress_transport="transfer_engine",
+        remote_instance_weight_loader_transfer_engine=transfer_engine,
+        remote_instance_weight_loader_transfer_engine_session_id="source-session",
+    )
+    loader = MxModelLoader(load_config)
+    initial_model = nn.Linear(2, 2)
+    native_model = nn.Linear(2, 2)
+    first = torch.randn(2, 3)
+    second = torch.randn(3, 2)
+    native_result = SimpleNamespace(value=native_model, model=native_model)
+    adapter = MagicMock()
+    adapter.load_via_native.return_value = native_result
+    adapter.discover_tensors.return_value = {"first": first, "second": second}
+    ctx = SimpleNamespace(
+        global_rank=0,
+        identity=SimpleNamespace(model_name="model"),
+        adapter=adapter,
+        tensors={},
+    )
+
+    with patch(
+        "modelexpress.engines.sglang.loader.build_sglang_load_context",
+        return_value=ctx,
+    ), patch.object(
+        loader,
+        "_find_transfer_engine_source",
+        return_value=None,
+    ), patch.object(
+        loader,
+        "_publish_transfer_engine_source",
+    ) as publish:
+        loaded = loader._load_model_via_transfer_engine(
+            model=initial_model,
+            model_config=_model_config(),
+            device_config=_device_config(),
+        )
+
+    assert loaded is native_model
+    transfer_engine.unregister_memory.assert_called_once_with(first.data_ptr())
+    adapter.reinit_for_retry.assert_not_called()
+    adapter.load_via_native.assert_called_once()
+    publish.assert_not_called()
+
+
 def test_mx_model_loader_rejects_unknown_transport_in_mx_package():
     loader = MxModelLoader(_load_config(modelexpress_transport="unknown"))
 
@@ -529,6 +655,7 @@ def test_mx_model_loader_rejects_unknown_transport_in_mx_package():
 def test_transfer_engine_registers_discovered_tensor_map():
     loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
     tensor = torch.randn(2, 3)
+    empty = torch.empty(0)
     calls = []
 
     class FakeTransferEngine:
@@ -537,7 +664,7 @@ def test_transfer_engine_registers_discovered_tensor_map():
             return 0
 
     weight_info = loader._register_transfer_engine_tensors(
-        {"weight.__storage": tensor},
+        {"weight.__storage": tensor, "empty": empty},
         FakeTransferEngine(),
     )
 
@@ -547,13 +674,15 @@ def test_transfer_engine_registers_discovered_tensor_map():
             tensor.data_ptr(),
             tensor.numel(),
             tensor.element_size(),
-        )
+        ),
+        "empty": (empty.data_ptr(), empty.numel(), empty.element_size()),
     }
 
 
 def test_transfer_engine_receive_uses_discovered_tensor_map():
     loader = MxModelLoader(_load_config(modelexpress_transport="transfer_engine"))
     tensor = torch.randn(2, 3)
+    empty = torch.empty(0)
     ctx = SimpleNamespace(global_rank=0)
     transferred = {}
     source_worker = p2p_pb2.WorkerMetadata(
@@ -564,7 +693,8 @@ def test_transfer_engine_receive_uses_discovered_tensor_map():
                 addr=1234,
                 size=tensor.numel() * tensor.element_size(),
                 device_id=0,
-            )
+            ),
+            p2p_pb2.TensorDescriptor(name="empty", addr=0, size=0, device_id=0),
         ],
     )
 
@@ -583,7 +713,7 @@ def test_transfer_engine_receive_uses_discovered_tensor_map():
             return 0
 
     loader._receive_via_transfer_engine(
-        {"weight.__storage": tensor},
+        {"weight.__storage": tensor, "empty": empty},
         FakeTransferEngine(),
         source_worker,
         ctx,

--- a/modelexpress_client/python/tests/test_tensor_utils.py
+++ b/modelexpress_client/python/tests/test_tensor_utils.py
@@ -329,6 +329,16 @@ class TestCollectModuleTensors:
         # Only one should be collected (same data_ptr)
         assert len(tensors) == 1
 
+    def test_preserves_distinct_empty_parameters(self, mock_accelerator_backend_cls):
+        backend = mock_accelerator_backend_cls(torch_device_type="cpu")
+        model = nn.Module()
+        model.register_parameter("a", nn.Parameter(torch.empty(0)))
+        model.register_parameter("b", nn.Parameter(torch.empty(0)))
+
+        tensors = collect_module_tensors(model, backend)
+
+        assert set(tensors) == {"a", "b"}
+
     def test_non_contiguous_registered_as_storage(self, mock_accelerator_backend_cls):
         backend = mock_accelerator_backend_cls(torch_device_type="cpu")
         model = nn.Module()


### PR DESCRIPTION
## Summary

Backport the merged PR #550 fix to `release/0.5.0` as one provenance-preserving cherry-pick.

- fall back to native SGLang loading after TransferEngine receive failures
- clean up partially registered memory before retrying
- continue native loading when source registration fails
- preserve and safely skip zero-length tensors during registration and transfer

## Root cause

TransferEngine failures could escape the SGLang loader after the model had been prepared for RDMA, crashing model startup instead of reinitializing the model and continuing with the native load strategy. Zero-length tensors could also reach memory registration or batch transfer operations.

## Validation

- stable patch ID matches merged squash commit `203a8d01c6d31263356e055c227f5cfd8f89dc35`
- signed commit and DCO trailer verified
- focused changed-file tests: `59 passed`
- broader Python client suite: `607 passed, 22 skipped`; 7 unrelated pool-registration tests could not run because `cuda-bindings` has no macOS ARM wheel
- `git diff --check` passed

Backport of #550.