### PR TITLE
ci: fail early on host/vCluster k8s version skew; document CoreDNS pin

### DIFF
--- a/.github/actions/setup-mx-vcluster/action.yml
+++ b/.github/actions/setup-mx-vcluster/action.yml
@@ -139,6 +139,16 @@ runs:
         # ("untolerated taint {CriticalAddonsOnly: true}"). The matching
         # toleration below lets it schedule there. operator=Exists avoids
         # helm coercing the string value "true" into a bool.
+        #
+        # CoreDNS image override (--set controlPlane.coredns.deployment.image):
+        # the CoreDNS tag is coupled to the vCluster k8s version — bumping
+        # VCLUSTER_K8S_VERSION also moves the CoreDNS version vCluster wants
+        # (1.33 -> 1.34 pulls coredns v1.12.0). vCluster's default image path
+        # routes through the `dynamoci` ACR mirror, which 401s on this image, so
+        # CoreDNS never starts and the whole vCluster is DNS-dead. Pin to
+        # registry.k8s.io (anonymous, no mirror auth) to bypass that. Keep this
+        # tag in sync when you bump VCLUSTER_K8S_VERSION across a CoreDNS bump.
+        COREDNS_IMAGE="registry.k8s.io/coredns/coredns:v1.12.0"
         vcluster create ${VCLUSTER_NAME} \
           --namespace ${NAMESPACE} \
           --connect=false \
@@ -151,7 +161,7 @@ runs:
           --set 'controlPlane.statefulSet.scheduling.tolerations[0].key=CriticalAddonsOnly' \
           --set 'controlPlane.statefulSet.scheduling.tolerations[0].operator=Exists' \
           --set 'controlPlane.statefulSet.scheduling.tolerations[0].effect=NoSchedule' \
-          --set controlPlane.coredns.deployment.image=registry.k8s.io/coredns/coredns:v1.12.0
+          --set controlPlane.coredns.deployment.image="${COREDNS_IMAGE}"
         echo "::endgroup::"
 
     - name: Wait for vCluster pod to be ready

--- a/.github/workflows/modelexpress-ci-tests.yml
+++ b/.github/workflows/modelexpress-ci-tests.yml
@@ -290,6 +290,50 @@ jobs:
           vcluster_name: ${{ env.VCLUSTER_NAME }}
           vcluster_namespace: ${{ env.VCLUSTER_NAMESPACE }}
 
+      - name: Guard against host / vCluster version skew
+        # The control-plane version is a pinned constant (vcluster_k8s_version
+        # in setup-mx-vcluster). What broke CI once was the AKS host
+        # auto-upgrading PAST that pin: Kubernetes 1.34 added observedGeneration
+        # on pod conditions, and a vCluster minor below the host makes the
+        # syncer loop, dropping that field and overwriting Ready=True with stale
+        # data so pods never surface as Ready. setup-mx-vcluster is gated (only
+        # runs when the vCluster is absent), so a running cluster silently
+        # skewed after a host bump is never re-checked there. Compare the LIVE
+        # vCluster server minor against the host's on every run and fail loudly
+        # with the fix — so the next host bump is a red step with the answer in
+        # it instead of days of digging. Compares major.minor only (the skew is
+        # a minor-version feature; patch differences are fine). Fails closed on
+        # a confirmed skew and also when either version can't be read.
+        # Incident writeup + context: MX-429.
+        shell: bash
+        run: |
+          # `|| true`: the default GitHub bash runs with `-eo pipefail`, so a
+          # no-match grep would abort the `VAR=$(server_minor ...)` assignment
+          # before the empty-value check runs. Swallow the pipeline status and
+          # let the explicit check below produce the parse-error diagnostic.
+          server_minor() {
+            kubectl --kubeconfig="$1" version 2>/dev/null \
+              | grep -iE 'server version' | grep -oE '[0-9]+\.[0-9]+' | head -1 || true
+          }
+          HOST_MM=$(server_minor "${{ github.workspace }}/.kubeconfig-host")
+          VC_MM=$(server_minor "${{ github.workspace }}/.kubeconfig-vcluster")
+          echo "Host k8s minor: ${HOST_MM:-unknown}; vCluster k8s minor: ${VC_MM:-unknown}"
+          if [ -z "${HOST_MM}" ] || [ -z "${VC_MM}" ]; then
+            # Fail closed: reachability is already verified above, so an
+            # unreadable version means the parse broke, not connectivity. Fail
+            # loudly rather than let the guard silently stop protecting.
+            echo "::error::Could not read host and/or vCluster server version (host='${HOST_MM:-}', vCluster='${VC_MM:-}'). Fix the version parse in this step."
+            exit 1
+          fi
+          HOST_MAJOR=${HOST_MM%.*}; HOST_MINOR=${HOST_MM#*.}
+          VC_MAJOR=${VC_MM%.*};     VC_MINOR=${VC_MM#*.}
+          if [ "${VC_MAJOR}" -lt "${HOST_MAJOR}" ] \
+             || { [ "${VC_MAJOR}" -eq "${HOST_MAJOR}" ] && [ "${VC_MINOR}" -lt "${HOST_MINOR}" ]; }; then
+            echo "::error::vCluster control plane is ${VC_MM} but the AKS host is ${HOST_MM}. A vCluster minor below the host stalls pod-ready propagation (observedGeneration, added in k8s 1.34, makes the syncer overwrite Ready=True). Bump vcluster_k8s_version in .github/actions/setup-mx-vcluster to >= ${HOST_MM}, then recreate the vCluster (delete it so the gated bootstrap rebuilds at the new version)."
+            exit 1
+          fi
+          echo "No host/vCluster version skew (vCluster ${VC_MM} >= host ${HOST_MM})."
+
       - name: vCluster baseline health
         # Snapshot vCluster control-plane state before any test job runs. When
         # downstream jobs fail with "connection refused" mid-run, this baseline


### PR DESCRIPTION
## Summary

Follow-up to #559 (the AKS host / vCluster `observedGeneration` skew fix),
addressing the review comments left on that PR. Context: MX-429.

## Changes

- **Version-skew guard** in `ensure-vcluster` — the control-plane version is a
  pinned constant and `setup-mx-vcluster` is gated (only runs when the vCluster
  is absent), so a running cluster silently skewed after the *next* host
  auto-upgrade (e.g. AKS → 1.35) would never be re-checked. This step compares
  the live vCluster k8s minor version to the host's on **every** run and fails early
  with the fix ("bump `vcluster_k8s_version` and recreate"), so the next host
  bump is a red CI step with the answer in it. Compares major.minor only
  (the skew is a minor-version feature). Fails closed if a version can't be
  read — reachability is already verified by `connect-vcluster`, so an empty
  version means the parse broke, and we surface it rather than silently skip.

- **CoreDNS pin documented** — a comment explaining the CoreDNS image is coupled
  to the k8s version and is deliberately pinned to `registry.k8s.io` to bypass
  the `dynamoci` ACR mirror (which 401s on the 1.34-era CoreDNS image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a compatibility check to prevent tests from running when the virtual cluster’s Kubernetes version is older than the host cluster’s version.
  * Improved error handling when Kubernetes version information cannot be determined.

* **Chores**
  * Standardized the CoreDNS image configuration using a pinned version for more consistent virtual cluster setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->