### PR TITLE
fix(client): disconnect NIXL peers before a reader exits (cherry-pick #555)

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -205,7 +205,7 @@ stateDiagram-v2
 
 - **INITIALIZING**: Worker has published metadata but heartbeat hasn't confirmed NIXL health yet
 - **READY**: Worker is healthy and accepting RDMA connections. Heartbeat refreshes `updated_at` every `MX_HEARTBEAT_INTERVAL_SECS` (default 30s)
-- **STALE**: Worker is no longer available. Set by the client `atexit` handler on clean shutdown (SIGTERM), or by the server-side reaper when `updated_at` exceeds `MX_HEARTBEAT_TIMEOUT_SECS` (default 90s)
+- **STALE**: Worker is no longer available. Set by the client `atexit` handler on clean shutdown, by the client when its NIXL data plane fails, or by the server-side reaper when `updated_at` exceeds `MX_HEARTBEAT_TIMEOUT_SECS` (default 90s). A worker demoted for a failed data plane returns to READY on its next healthy heartbeat, so this transition is not terminal. Note that the `atexit` route covers normal interpreter exit and `SystemExit`, but CPython does not run `atexit` handlers when the default `SIGTERM` disposition terminates the process; a worker killed that way is caught by the reaper instead
 - **Deleted**: Reaper garbage-collects stale entries after `MX_GC_TIMEOUT_SECS` (default 3600s)
 
 vLLM and SGLang weight sources wait for the framework health endpoint before
@@ -547,6 +547,7 @@ The `backend_type` discriminator is persisted in storage for unambiguous deseria
 | `MX_REAPER_SCAN_INTERVAL_SECS` | `30` | Server reaper scan frequency |
 | `MX_GC_TIMEOUT_SECS` | `3600` | Time before stale entries are deleted |
 | `MX_POOL_REG` | `0` | Register each unique cudaMalloc allocation instead of each tensor (allocation-level NIXL registration) |
+| `MX_TRANSFER_TIMEOUT` | `300` on the RDMA receive path | Per-candidate budget for receiving weights from one source. Applies **per source**, not per load, so a target trying `MAX_SOURCE_RETRIES` candidates can spend this much three times before falling back to disk. Set it against your model size: the default suits a small model but is long for one that transfers in under a second. Note the RDMA path only honours this variable when it is explicitly set, and otherwise uses 300s rather than the 900s default that other transfer paths use. |
 
 ## Debugging
 

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import logging
+import math
+import os
 import time
 
 from .. import envs
@@ -36,6 +38,53 @@ from .. import p2p_pb2
 logger = logging.getLogger("modelexpress.strategy_rdma")
 
 MAX_SOURCE_RETRIES = 3
+
+# Fallback when MX_TRANSFER_TIMEOUT is unset or unusable. Matches the value this
+# path used when the timeout was hard-coded, so behaviour is unchanged by default.
+DEFAULT_RDMA_TRANSFER_TIMEOUT_S = 300.0
+
+
+def _transfer_timeout_seconds() -> float:
+    """Per-source RDMA receive budget, in seconds.
+
+    Every candidate costs this long when a source is wedged, because a wedged QP
+    produces neither a completion nor an error status - the timeout is the only
+    thing that ends the wait. With MAX_SOURCE_RETRIES candidates the worst case is
+    that multiplied by three before the target falls back to disk, so operators
+    need to be able to size it against their model rather than accept a constant.
+
+    Honours MX_TRANSFER_TIMEOUT only when it is *explicitly set*, and reads
+    os.environ directly to tell that apart from the default. This is deliberate:
+    that variable defaults to 900, so simply adopting ``envs.MX_TRANSFER_TIMEOUT``
+    would triple this path's budget from 300s to 900s and make the stall being
+    fixed three times more expensive for anyone who never configured it.
+
+    A non-positive or unparseable value falls back rather than being honoured. In
+    particular 0 must not become "no timeout": ``receive_from_source`` treats None
+    as wait-forever, which is the failure mode this exists to bound.
+    """
+    raw = os.environ.get("MX_TRANSFER_TIMEOUT")
+    if raw is None:
+        return DEFAULT_RDMA_TRANSFER_TIMEOUT_S
+    try:
+        configured = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "MX_TRANSFER_TIMEOUT=%r is not a number; using %.1fs for the RDMA "
+            "receive budget",
+            raw,
+            DEFAULT_RDMA_TRANSFER_TIMEOUT_S,
+        )
+        return DEFAULT_RDMA_TRANSFER_TIMEOUT_S
+    if not math.isfinite(configured) or configured <= 0:
+        logger.warning(
+            "MX_TRANSFER_TIMEOUT=%r is not finite and positive; using %.1fs for the RDMA "
+            "receive budget rather than waiting indefinitely",
+            raw,
+            DEFAULT_RDMA_TRANSFER_TIMEOUT_S,
+        )
+        return DEFAULT_RDMA_TRANSFER_TIMEOUT_S
+    return configured
 
 
 class RdmaStrategy(LoadStrategy):
@@ -446,7 +495,7 @@ class RdmaStrategy(LoadStrategy):
             bytes_transferred, tensor_count, _ = ctx.nixl_manager.receive_from_source(
                 source_metadata=source_worker.nixl_metadata,
                 source_tensors=source_tensors,
-                timeout_seconds=300.0,
+                timeout_seconds=_transfer_timeout_seconds(),
                 remote_agent_name=remote_agent_name_override,
             )
         except Exception as e:

--- a/modelexpress_client/python/modelexpress/metadata/publisher.py
+++ b/modelexpress_client/python/modelexpress/metadata/publisher.py
@@ -31,8 +31,9 @@ class PublisherThread:
     ``mx_source_id``. A ``ready_fn`` can gate publication until the engine has
     finished work that must happen before the source is advertised.
 
-    On clean shutdown (SIGTERM), atexit handler sends UpdateStatus(STALE)
-    for immediate detection without waiting for the reaper timeout.
+    On normal interpreter exit, an atexit handler sends UpdateStatus(STALE)
+    for immediate detection without waiting for the reaper timeout. The default
+    SIGTERM disposition does not run atexit handlers.
 
     Args:
         mx_client: gRPC client for UpdateStatus calls.
@@ -92,6 +93,9 @@ class PublisherThread:
         self._publish_started_at: float | None = None
         self._publish_given_up = False
         self._cleaned_up = False
+        # True once we have demoted this worker for an unhealthy data plane, so the
+        # demotion and its log line happen once rather than every interval.
+        self._unhealthy = False
 
         self._interval = (
             interval_secs
@@ -137,8 +141,10 @@ class PublisherThread:
         logger.info(f"[Worker {self._worker_rank}] Publisher thread stopped")
 
     def _on_exit(self) -> None:
-        """atexit handler: mark STALE on clean shutdown (SIGTERM)."""
+        """Stop the publisher before marking it STALE."""
         self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._interval + 5)
         self._mark_stale()
         self._cleanup()
 
@@ -158,6 +164,40 @@ class PublisherThread:
                     exc_info=True,
                 )
                 self._started = False
+
+    def _mark_unhealthy(self) -> None:
+        """Best-effort UpdateStatus(STALE) for a worker whose data plane is down.
+
+        Distinct from ``_mark_stale``, which is a shutdown path and clears
+        ``_started`` permanently. Here the worker is still running and may recover,
+        so ``_started`` is left alone: the next healthy tick sends READY again, and
+        this method stays quiet after the first demotion so a persistently broken
+        agent does not log once per interval forever.
+        """
+        with self._status_lock:
+            if self._stop_event.is_set() or self._unhealthy:
+                return
+            if not self._started:
+                # Never advertised READY, so no target can have selected us and
+                # there is nothing to demote. Deliberately does not latch
+                # ``_unhealthy``: if this worker later goes READY and then breaks,
+                # that is the case worth demoting.
+                return
+            reason = getattr(self._nixl_manager, "data_plane_error", None)
+            try:
+                from .. import p2p_pb2
+                self._update_status(p2p_pb2.SOURCE_STATUS_STALE)
+                self._unhealthy = True
+                logger.warning(
+                    f"[Worker {self._worker_rank}] NIXL agent unhealthy, marked "
+                    f"STALE so targets stop selecting it: {reason}"
+                )
+            except Exception:
+                logger.debug(
+                    f"[Worker {self._worker_rank}] Failed to mark STALE for "
+                    f"unhealthy agent",
+                    exc_info=True,
+                )
 
     def _update_status(self, status: int) -> None:
         """Send UpdateStatus RPC."""
@@ -256,12 +296,27 @@ class PublisherThread:
                 return
 
         if self._nixl_manager is not None and not self._nixl_manager.is_healthy():
+            # Demote rather than just skip the update. Skipping only stops
+            # refreshing updated_at, so the entry keeps its last status and stays
+            # selectable until the server's reaper times it out - 90s by default,
+            # during which every target that picks this worker pays a full
+            # transfer timeout. Saying STALE now removes it from the candidate set
+            # immediately. It is not permanent: if the agent recovers, the next
+            # tick puts it back to READY.
+            self._mark_unhealthy()
             return
 
         with self._status_lock:
             if self._stop_event.is_set():
                 return
             self._update_status(p2p_pb2.SOURCE_STATUS_READY)
+            if self._unhealthy:
+                # Recovered: allow a future failure to demote us again.
+                self._unhealthy = False
+                logger.info(
+                    f"[Worker {self._worker_rank}] NIXL agent healthy again, "
+                    f"status -> READY"
+                )
             if not self._started:
                 logger.info(
                     f"[Worker {self._worker_rank}] Status -> READY"

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -14,6 +14,7 @@ also uses the same agent for host DRAM chunk staging.
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import time
@@ -112,6 +113,22 @@ class NixlTransferManager:
         self._metadata: bytes = b""
         self._tensor_descriptors: list[TensorDescriptor] = []
         self._tensors: dict[str, torch.Tensor] = {}
+        # Remote agents this manager has loaded, so shutdown can disconnect them.
+        # Maps agent name -> (ip, port) for agents reached over the P2P socket, or
+        # None for agents loaded from a metadata blob.
+        #
+        # Tracking exists because NIXL only lets the side that *loaded* a peer
+        # disconnect from it: invalidateRemoteMD looks the peer up in
+        # remoteBackends_ and is a no-op otherwise. In P2P the target loads the
+        # source (it sends NIXLCOMM:SEND and gets back the source's metadata) but
+        # the source never loads the target, so the target is the only side that
+        # can close the pair. Leaving it to process death leaves the source with
+        # a half-open QP it has no way to invalidate.
+        self._remote_agents: dict[str, tuple[str, int] | None] = {}
+        # Last data-plane failure, used by is_healthy(). None means no failure
+        # has been observed on a transfer this manager issued.
+        self._data_plane_error: str | None = None
+        self._atexit_registered = False
 
     @property
     def agent_name(self) -> str:
@@ -181,6 +198,7 @@ class NixlTransferManager:
             else:
                 config = None
             self._agent = NixlAgent(self._agent_name, config)
+            self._register_atexit()
             logger.info(
                 f"NIXL agent '{self._agent_name}' created on device "
                 f"{self._device_id} (backend={self._backend})"
@@ -190,6 +208,13 @@ class NixlTransferManager:
                 os.environ["UCX_TLS"] = saved_ucx_tls
             elif envs.is_set("UCX_TLS"):
                 os.environ.pop("UCX_TLS")
+
+    def _register_atexit(self) -> None:
+        """Register manager-owned process teardown once."""
+        if self._atexit_registered:
+            return
+        atexit.register(self.shutdown)
+        self._atexit_registered = True
 
     def _build_tensor_descriptors(
         self, tensors: dict[str, torch.Tensor]
@@ -438,6 +463,45 @@ class NixlTransferManager:
 
         return sorted(seen.items())
 
+    def _wait_for_xfer(
+        self,
+        handle: Any,
+        timeout_seconds: float | None,
+        label: str,
+    ) -> None:
+        """Poll a NIXL transfer handle until completion or failure."""
+        if self._agent is None:
+            raise RuntimeError("NIXL agent not initialized")
+        wait_start = time.perf_counter()
+        while True:
+            if (
+                timeout_seconds is not None
+                and time.perf_counter() - wait_start >= timeout_seconds
+            ):
+                # A timeout here is a data-plane failure even though NIXL never
+                # reported one. When a QP is wedged the READ neither completes nor
+                # transitions to ERR, so the handle stays incomplete and the
+                # timeout is the only evidence that anything went wrong. Recording
+                # it is what lets is_healthy() stop advertising this agent.
+                self._data_plane_error = (
+                    f"{label} timed out after {timeout_seconds:.1f}s with no "
+                    f"completion and no error status from NIXL"
+                )
+                raise TimeoutError(f"{label} timed out")
+            status = self._agent.check_xfer_state(handle)
+            if status in ("DONE", "SUCCESS"):
+                # A completed transfer is direct proof the data plane works, so it
+                # clears any earlier failure. Without this the flag would latch for
+                # the life of the process and a worker demoted for one transient
+                # timeout could never return to READY, however healthy the fabric
+                # became.
+                self._data_plane_error = None
+                return
+            if status in ("ERR", "ERROR", "FAIL"):
+                self._data_plane_error = f"{label} failed with status {status}"
+                raise RuntimeError(f"{label} failed with status {status}")
+            time.sleep(0.001)
+
     def fetch_remote_and_wait(
         self,
         remote_agent_name: str,
@@ -470,6 +534,7 @@ class NixlTransferManager:
                     f"Remote metadata loaded for {remote_agent_name} "
                     f"({time.perf_counter() - start:.2f}s)"
                 )
+                self._remote_agents[remote_agent_name] = (ip, port)
                 return
             time.sleep(0.01)
 
@@ -483,7 +548,50 @@ class NixlTransferManager:
             remote_agent_name,
             len(source_metadata),
         )
+        self._remote_agents.setdefault(remote_agent_name, None)
         return remote_agent_name
+
+    def remove_remote_agent(self, remote_agent_name: str) -> bool:
+        """Disconnect from a remote agent and drop its cached metadata.
+
+        The counterpart to :meth:`add_remote_agent` and
+        :meth:`fetch_remote_and_wait`. NIXL's ``invalidateRemoteMD`` both frees the
+        cached metadata and disconnects the backend, so this is what returns the
+        QP pair to a clean state instead of leaving it half-open.
+
+        Returns True if NIXL accepted the removal. Never raises: this runs on
+        teardown paths where the interesting failure has usually already happened,
+        and masking it behind a cleanup error would be worse than logging it.
+        """
+        if self._agent is None:
+            return False
+        try:
+            self._agent.remove_remote_agent(remote_agent_name)
+        except Exception as exc:
+            # NOT_FOUND is expected if the peer was already invalidated, e.g. it
+            # sent us NIXLCOMM:INVL on its way out.
+            logger.warning(
+                "Failed to remove remote NIXL agent %s: %s", remote_agent_name, exc
+            )
+            self._remote_agents.pop(remote_agent_name, None)
+            return False
+        self._remote_agents.pop(remote_agent_name, None)
+        logger.info("Disconnected remote NIXL agent %s", remote_agent_name)
+        return True
+
+    def disconnect_remote_agents(self) -> int:
+        """Disconnect every remote agent this manager loaded.
+
+        Returns the number successfully disconnected. Iterates a copy because
+        :meth:`remove_remote_agent` mutates the tracking map.
+        """
+        if self._agent is None or not self._remote_agents:
+            return 0
+        removed = 0
+        for name in list(self._remote_agents):
+            if self.remove_remote_agent(name):
+                removed += 1
+        return removed
 
     def receive_from_source(
         self,
@@ -522,7 +630,7 @@ class NixlTransferManager:
 
         if remote_agent_name is None:
             add_start = time.perf_counter()
-            remote_agent_name = self._agent.add_remote_agent(source_metadata)
+            remote_agent_name = self.add_remote_agent(source_metadata)
             add_time = time.perf_counter() - add_start
             logger.info(
                 f"[TIMING] add_remote_agent: {add_time:.3f}s "
@@ -622,20 +730,10 @@ class NixlTransferManager:
         self._agent.transfer(handle)
 
         # Wait for completion
-        start_wait = time.perf_counter()
-        while True:
-            if timeout_seconds is not None and time.perf_counter() - start_wait >= timeout_seconds:
-                self._agent.release_xfer_handle(handle)
-                raise TimeoutError("Transfer timed out")
-
-            status = self._agent.check_xfer_state(handle)
-            if status in ("DONE", "SUCCESS"):
-                self._agent.release_xfer_handle(handle)
-                break
-            if status in ("ERR", "ERROR", "FAIL"):
-                self._agent.release_xfer_handle(handle)
-                raise RuntimeError(f"Transfer failed with status {status}")
-            time.sleep(0.001)
+        try:
+            self._wait_for_xfer(handle, timeout_seconds, "Transfer")
+        finally:
+            self._agent.release_xfer_handle(handle)
 
         # CRITICAL: Synchronize the device to ensure RDMA writes are visible.
         # GPUDirect RDMA writes bypass torch streams, so we must sync.
@@ -736,44 +834,41 @@ class NixlTransferManager:
             )
             self._agent.transfer(handle)
 
-            wait_start = time.perf_counter()
-            while True:
-                if (
-                    timeout_seconds is not None
-                    and time.perf_counter() - wait_start >= timeout_seconds
-                ):
-                    raise TimeoutError("NIXL DRAM transfer timed out")
-                status = self._agent.check_xfer_state(handle)
-                if status in ("DONE", "SUCCESS"):
-                    duration = time.perf_counter() - start_time
-                    logger.info(
-                        "NIXL DRAM READ complete: %.2f MiB in %.3fs",
-                        size / (1024 * 1024),
-                        duration,
-                    )
-                    return duration
-                if status in ("ERR", "ERROR", "FAIL"):
-                    raise RuntimeError(f"NIXL DRAM transfer failed with status {status}")
-                time.sleep(0.001)
+            self._wait_for_xfer(handle, timeout_seconds, "NIXL DRAM transfer")
+            duration = time.perf_counter() - start_time
+            logger.info(
+                "NIXL DRAM READ complete: %.2f MiB in %.3fs",
+                size / (1024 * 1024),
+                duration,
+            )
+            return duration
         finally:
             if handle is not None:
                 self._agent.release_xfer_handle(handle)
 
     def is_healthy(self) -> bool:
-        """Check if the NIXL agent is initialized and has registered metadata."""
-        return self._agent is not None and len(self._metadata) > 0
+        """Whether the agent is initialized and has no observed transfer failure."""
+        if self._agent is None or len(self._metadata) == 0:
+            return False
+        return self._data_plane_error is None
+
+    @property
+    def data_plane_error(self) -> str | None:
+        """Last data-plane failure observed on a transfer, or None."""
+        return self._data_plane_error
 
     def shutdown(self) -> None:
-        """Clean up NIXL resources.
-
-        Rebinds ``_tensor_descriptors`` and ``_tensors`` to fresh empty
-        containers instead of mutating in place. Belt-and-suspenders:
-        even if a future caller bypasses ``register_tensors`` and
-        aliases ``_tensors`` directly, shutdown will not mutate the
-        shared container out from under them.
-        """
+        """Disconnect remote agents before releasing local NIXL resources."""
+        if self._atexit_registered:
+            atexit.unregister(self.shutdown)
+            self._atexit_registered = False
+        disconnected = self.disconnect_remote_agents()
         self._agent = None
         self._metadata = b""
         self._tensor_descriptors = []
         self._tensors = {}
-        logger.info("NixlTransferManager shutdown complete")
+        self._remote_agents = {}
+        logger.info(
+            "NixlTransferManager shutdown complete (%d remote agent(s) disconnected)",
+            disconnected,
+        )

--- a/modelexpress_client/python/tests/test_nixl_peer_lifecycle.py
+++ b/modelexpress_client/python/tests/test_nixl_peer_lifecycle.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Peer lifecycle: a reader must disconnect from its source before it exits.
+
+Regression cover for a source wedged by a departing reader. A target pulled weights
+from a source over P2P, then was scaled to zero. Every later target stalled for the
+full transfer timeout and fell back to disk, and the source stayed wedged until it
+restarted while still heartbeating READY.
+
+The asymmetry that makes this the *reader's* job: in P2P the target sends
+``NIXLCOMM:SEND`` and the source answers with its own metadata, so only the target
+loads a remote agent. NIXL's ``invalidateRemoteMD`` disconnects by looking the peer
+up in ``remoteBackends_``, which on the source has no entry for a reader it never
+loaded. The source therefore cannot invalidate its readers, and a reader that exits
+without disconnecting leaves it holding a QP nothing can clean up.
+
+Run: pytest tests/test_nixl_peer_lifecycle.py
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from modelexpress.nixl_transfer import NixlTransferManager
+
+
+class FakeAgent:
+    """Minimal stand-in recording the lifecycle calls we care about."""
+
+    def __init__(self, fail_remove: bool = False):
+        self.removed: list[str] = []
+        self.fail_remove = fail_remove
+        self._fetched: set[str] = set()
+
+    def fetch_remote_metadata(self, name, ip, port):
+        self._fetched.add(name)
+
+    def check_remote_metadata(self, name):
+        return name in self._fetched
+
+    def add_remote_agent(self, metadata: bytes) -> str:
+        return "src-from-blob"
+
+    def remove_remote_agent(self, name: str):
+        if self.fail_remove:
+            raise RuntimeError(f"remote metadata for agent '{name}' not found")
+        self.removed.append(name)
+
+
+def _manager(agent=None, metadata=b"md", accelerator=None):
+    mgr = NixlTransferManager(
+        agent_name="tgt", device_id=0, accelerator_backend=accelerator
+    )
+    mgr._agent = agent if agent is not None else FakeAgent()
+    mgr._metadata = metadata
+    return mgr
+
+
+class TestTracksLoadedPeers:
+    def test_a_fetched_source_is_tracked_with_its_endpoint(self):
+        """The endpoint is retained because it identifies the peer we connected to."""
+        mgr = _manager()
+        mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555)
+        assert mgr._remote_agents == {"src-a": ("10.0.18.37", 5555)}
+
+    def test_a_blob_loaded_source_is_tracked_without_an_endpoint(self):
+        """Centralized mode has no socket endpoint, but still needs disconnecting."""
+        mgr = _manager()
+        name = mgr.add_remote_agent(b"some-metadata")
+        assert mgr._remote_agents == {name: None}
+
+    def test_centralized_receive_tracks_peer_for_shutdown(
+        self, mock_accelerator_backend_cls
+    ):
+        """The receive wrapper must not bypass the manager-owned inventory.
+
+        Takes the mock accelerator because ``receive_from_source`` selects a
+        device before transferring, which the real CUDA backend cannot do on a
+        CPU-only runner.
+        """
+        agent = FakeAgent()
+        mgr = _manager(agent=agent, accelerator=mock_accelerator_backend_cls())
+
+        mgr.receive_from_source(b"some-metadata", [])
+        mgr.shutdown()
+
+        assert agent.removed == ["src-from-blob"]
+
+    def test_a_failed_fetch_is_not_tracked(self):
+        """Tracking a peer we never loaded would make shutdown remove a stranger."""
+
+        class NeverReady(FakeAgent):
+            def check_remote_metadata(self, name):
+                return False
+
+        mgr = _manager(agent=NeverReady())
+        with pytest.raises(TimeoutError):
+            mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555, timeout_seconds=0.05)
+        assert mgr._remote_agents == {}
+
+
+class TestDisconnect:
+    def test_manager_registers_process_exit_teardown_once(self):
+        mgr = _manager()
+        with (
+            patch("modelexpress.nixl_transfer.atexit.register") as register,
+            patch("modelexpress.nixl_transfer.atexit.unregister") as unregister,
+        ):
+            mgr._register_atexit()
+            mgr._register_atexit()
+            register.assert_called_once_with(mgr.shutdown)
+
+            mgr.shutdown()
+            unregister.assert_called_once_with(mgr.shutdown)
+
+    def test_shutdown_disconnects_the_source_it_pulled_from(self):
+        """The bug: this is what a departing target never did."""
+        agent = FakeAgent()
+        mgr = _manager(agent=agent)
+        mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555)
+
+        mgr.shutdown()
+
+        assert agent.removed == ["src-a"], "reader exited without disconnecting"
+        assert mgr._remote_agents == {}
+
+    def test_shutdown_disconnects_every_peer(self):
+        agent = FakeAgent()
+        mgr = _manager(agent=agent)
+        mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555)
+        mgr.fetch_remote_and_wait("src-b", "10.0.18.38", 5555)
+
+        mgr.shutdown()
+
+        assert sorted(agent.removed) == ["src-a", "src-b"]
+
+    def test_disconnect_happens_before_the_agent_is_dropped(self):
+        """Ordering is the whole point: once ``_agent`` is None there is no handle
+        left to disconnect through, and the peer is stranded."""
+        agent = FakeAgent()
+        mgr = _manager(agent=agent)
+        mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555)
+
+        seen = {}
+        real_remove = agent.remove_remote_agent
+
+        def spy(name):
+            seen["agent_alive"] = mgr._agent is not None
+            return real_remove(name)
+
+        agent.remove_remote_agent = spy
+        mgr.shutdown()
+
+        assert seen["agent_alive"] is True
+        assert mgr._agent is None
+
+    def test_removing_a_peer_twice_is_harmless(self):
+        """The peer may already be gone, e.g. it sent us NIXLCOMM:INVL on exit."""
+        agent = FakeAgent()
+        mgr = _manager(agent=agent)
+        mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555)
+
+        assert mgr.remove_remote_agent("src-a") is True
+        assert mgr.remove_remote_agent("src-a") is True  # NIXL no-ops on NOT_FOUND
+        assert agent.removed == ["src-a", "src-a"]
+
+    def test_a_failing_disconnect_does_not_break_shutdown(self):
+        """Teardown runs on paths where something has usually already failed;
+        raising here would turn a clean exit into a crash."""
+        agent = FakeAgent(fail_remove=True)
+        mgr = _manager(agent=agent)
+        mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555)
+
+        assert mgr.remove_remote_agent("src-a") is False
+        mgr.shutdown()  # must not raise
+        assert mgr._agent is None
+        assert mgr._remote_agents == {}
+
+    def test_disconnect_without_an_agent_is_a_no_op(self):
+        mgr = NixlTransferManager(agent_name="tgt", device_id=0)
+        assert mgr.disconnect_remote_agents() == 0
+        assert mgr.remove_remote_agent("anything") is False
+
+    def test_disconnect_reports_how_many_peers_it_closed(self):
+        agent = FakeAgent()
+        mgr = _manager(agent=agent)
+        mgr.fetch_remote_and_wait("src-a", "10.0.18.37", 5555)
+        mgr.fetch_remote_and_wait("src-b", "10.0.18.38", 5555)
+        assert mgr.disconnect_remote_agents() == 2
+        assert mgr.disconnect_remote_agents() == 0
+
+
+class TestHealthReflectsDataPlane:
+    """A structural health check stays true through a dead data plane, which is how
+    a broken worker keeps heartbeating READY and keeps being selected."""
+
+    def test_a_fresh_manager_with_metadata_is_healthy(self):
+        assert _manager().is_healthy() is True
+
+    def test_no_agent_is_unhealthy(self):
+        mgr = _manager()
+        mgr._agent = None
+        assert mgr.is_healthy() is False
+
+    def test_no_metadata_is_unhealthy(self):
+        assert _manager(metadata=b"").is_healthy() is False
+
+    def test_a_transfer_timeout_makes_the_agent_unhealthy(self):
+        """A wedged QP yields neither a completion nor an ERR status, so the
+        timeout is the only evidence that the data plane is broken."""
+
+        class Stuck:
+            def check_xfer_state(self, handle):
+                return "PROC"
+
+        mgr = _manager(agent=Stuck())
+        with pytest.raises(TimeoutError):
+            mgr._wait_for_xfer(object(), 0.02, "Transfer")
+
+        assert mgr.is_healthy() is False
+        assert "timed out" in (mgr.data_plane_error or "")
+
+    def test_an_error_status_makes_the_agent_unhealthy(self):
+        class Failing:
+            def check_xfer_state(self, handle):
+                return "ERR"
+
+        mgr = _manager(agent=Failing())
+        with pytest.raises(RuntimeError):
+            mgr._wait_for_xfer(object(), 5.0, "Transfer")
+
+        assert mgr.is_healthy() is False
+        assert "ERR" in (mgr.data_plane_error or "")
+
+    def test_a_completed_transfer_leaves_health_untouched(self):
+        class Done:
+            def check_xfer_state(self, handle):
+                return "DONE"
+
+        mgr = _manager(agent=Done())
+        mgr._wait_for_xfer(object(), 5.0, "Transfer")
+        assert mgr.is_healthy() is True
+        assert mgr.data_plane_error is None
+
+    def test_a_later_success_clears_an_earlier_failure(self):
+        """Health must not latch. A completed transfer proves the data plane works,
+        so a worker demoted for one transient timeout has to be able to return to
+        READY - otherwise the publisher's recovery path can never fire in
+        production and one blip sidelines a worker for the life of the process."""
+
+        class Flaky:
+            def __init__(self):
+                self.state = "PROC"
+
+            def check_xfer_state(self, handle):
+                return self.state
+
+        agent = Flaky()
+        mgr = _manager(agent=agent)
+        with pytest.raises(TimeoutError):
+            mgr._wait_for_xfer(object(), 0.02, "Transfer")
+        assert mgr.is_healthy() is False
+
+        agent.state = "DONE"
+        mgr._wait_for_xfer(object(), 5.0, "Transfer")
+
+        assert mgr.is_healthy() is True
+        assert mgr.data_plane_error is None
+
+    def test_health_does_not_claim_to_catch_a_passive_source(self):
+        """Documents the limit deliberately. A pure P2P source issues no transfers -
+        the reader's one-sided READ is invisible to it - so a source wedged by a
+        departed peer has nothing to record and reports healthy. Catching that needs
+        an active probe or reader-side reporting, and this test exists so nobody
+        assumes otherwise from the fix."""
+        source = _manager()
+        assert source.data_plane_error is None
+        assert source.is_healthy() is True

--- a/modelexpress_client/python/tests/test_publisher_peer_teardown.py
+++ b/modelexpress_client/python/tests/test_publisher_peer_teardown.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publisher demotion and manager-owned teardown for a departing reader.
+
+Two related lifecycle behaviours are covered:
+
+1. A publisher marks only its own source STALE. The shared NIXL manager owns
+   process-wide remote-peer disconnection, so routine publisher replacement does
+   not invalidate peers loaded by unrelated receive or artifact paths.
+
+2. A worker whose data plane is broken must be demoted, not merely skipped.
+   Skipping the heartbeat only stops refreshing ``updated_at``, so the entry keeps
+   its last status and stays selectable until the server's reaper times it out.
+
+Run: pytest tests/test_publisher_peer_teardown.py
+"""
+
+import time
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from modelexpress.metadata.publisher import PublisherThread
+
+READY = 2
+STALE = 3
+
+
+@pytest.fixture
+def mx_client():
+    client = MagicMock()
+    client.update_status.return_value = True
+    return client
+
+
+@pytest.fixture
+def nixl_manager():
+    manager = MagicMock()
+    manager.is_healthy.return_value = True
+    manager.disconnect_remote_agents.return_value = 1
+    manager.data_plane_error = None
+    return manager
+
+
+@pytest.fixture
+def publisher(mx_client, nixl_manager):
+    with patch.dict("os.environ", {"MX_HEARTBEAT_INTERVAL_SECS": "1"}):
+        pub = PublisherThread(
+            mx_client=mx_client,
+            mx_source_id="abc123",
+            worker_id="w1",
+            worker_rank=0,
+            nixl_manager=nixl_manager,
+        )
+    yield pub
+    pub.stop()
+
+
+def _status_calls(mx_client, status):
+    return [
+        c
+        for c in mx_client.update_status.call_args_list
+        if c
+        == call(mx_source_id="abc123", worker_id="w1", worker_rank=0, status=status)
+    ]
+
+
+class TestPublisherDoesNotOwnSharedPeers:
+    def test_stop_leaves_manager_peers_connected(self, publisher, nixl_manager):
+        """Routine publisher replacement must not tear down shared receive paths."""
+        publisher.start()
+        time.sleep(1.5)
+        publisher.stop()
+        nixl_manager.disconnect_remote_agents.assert_not_called()
+
+    def test_atexit_leaves_manager_teardown_to_its_owner(
+        self, publisher, nixl_manager
+    ):
+        """The manager's later atexit hook owns process-wide peer teardown."""
+        publisher.start()
+        time.sleep(1.5)
+        publisher._on_exit()
+        nixl_manager.disconnect_remote_agents.assert_not_called()
+
+    def test_atexit_joins_before_marking_stale(self, publisher, mx_client):
+        """An in-flight tick must finish before shutdown publishes STALE."""
+        order = []
+        publisher._thread = MagicMock()
+        publisher._thread.join.side_effect = lambda **_: order.append("join")
+        publisher._started = True
+        mx_client.update_status.side_effect = lambda **kw: order.append(
+            f"status:{kw['status']}"
+        ) or True
+
+        publisher._on_exit()
+
+        assert order == ["join", f"status:{STALE}"]
+        publisher._thread.join.assert_called_once_with(timeout=publisher._interval + 5)
+
+    def test_a_publisher_without_a_nixl_manager_is_fine(self, mx_client):
+        """Not every publisher owns a NIXL agent."""
+        with patch.dict("os.environ", {"MX_HEARTBEAT_INTERVAL_SECS": "1"}):
+            pub = PublisherThread(
+                mx_client=mx_client,
+                mx_source_id="abc123",
+                worker_id="w1",
+                worker_rank=0,
+                nixl_manager=None,
+            )
+        pub.start()
+        time.sleep(1.2)
+        pub.stop()  # must not raise
+
+
+class TestDemotesUnhealthyWorker:
+    def test_an_unhealthy_worker_is_marked_stale(
+        self, publisher, mx_client, nixl_manager
+    ):
+        """Previously the tick just returned, leaving the worker READY in the
+        registry and selectable for another 90s of reaper timeout."""
+        publisher.start()
+        time.sleep(1.5)  # go READY first
+        nixl_manager.is_healthy.return_value = False
+        nixl_manager.data_plane_error = "Transfer timed out after 300.0s"
+        time.sleep(1.5)
+
+        assert _status_calls(mx_client, STALE), "unhealthy worker was not demoted"
+
+    def test_demotion_happens_once_not_every_interval(
+        self, publisher, mx_client, nixl_manager
+    ):
+        """A persistently broken agent should not log and demote on every tick."""
+        publisher.start()
+        time.sleep(1.5)
+        nixl_manager.is_healthy.return_value = False
+        time.sleep(2.5)
+        publisher.stop()
+
+        # One demotion from the unhealthy ticks; stop() adds its own shutdown STALE.
+        assert len(_status_calls(mx_client, STALE)) <= 2
+
+    def test_failed_demotion_is_retried(
+        self, publisher, mx_client, nixl_manager
+    ):
+        """A transient RPC failure must not latch the local demotion state."""
+        publisher._started = True
+        mx_client.update_status.side_effect = [RuntimeError("temporary"), True]
+
+        publisher._mark_unhealthy()
+        assert publisher._unhealthy is False
+
+        publisher._mark_unhealthy()
+        assert publisher._unhealthy is True
+        assert mx_client.update_status.call_count == 2
+
+    def test_recovery_restores_ready(self, publisher, mx_client, nixl_manager):
+        """Demotion is advisory, not terminal: a recovered agent must come back."""
+        publisher.start()
+        time.sleep(1.5)
+        nixl_manager.is_healthy.return_value = False
+        time.sleep(1.5)
+        ready_before = len(_status_calls(mx_client, READY))
+        nixl_manager.is_healthy.return_value = True
+        time.sleep(1.5)
+
+        assert len(_status_calls(mx_client, READY)) > ready_before
+
+    def test_a_worker_that_never_went_ready_is_not_demoted(
+        self, mx_client, nixl_manager
+    ):
+        """Nothing can have selected it, so STALE would be noise - and it may still
+        be INITIALIZING, which STALE would misrepresent."""
+        nixl_manager.is_healthy.return_value = False
+        with patch.dict("os.environ", {"MX_HEARTBEAT_INTERVAL_SECS": "1"}):
+            pub = PublisherThread(
+                mx_client=mx_client,
+                mx_source_id="abc123",
+                worker_id="w1",
+                worker_rank=0,
+                nixl_manager=nixl_manager,
+            )
+        pub.start()
+        time.sleep(1.5)
+        pub.stop()
+
+        assert _status_calls(mx_client, STALE) == []

--- a/modelexpress_client/python/tests/test_rdma_transfer_timeout.py
+++ b/modelexpress_client/python/tests/test_rdma_transfer_timeout.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The per-source RDMA receive budget must be configurable, without regressing.
+
+The budget was hard-coded at 300s on this path while MX_TRANSFER_TIMEOUT already
+existed for other transfer paths. When a source is wedged the transfer yields
+neither a completion nor an error status, so the timeout is the only thing that ends
+the wait, and with MAX_SOURCE_RETRIES candidates a target can burn three full
+budgets before falling back to disk.
+
+The subtlety these tests pin: MX_TRANSFER_TIMEOUT *defaults to 900*. Wiring it
+naively would have tripled this path's budget for everyone who never set it, making
+the reported stall three times worse. So it is honoured only when explicitly set.
+
+Run: pytest tests/test_rdma_transfer_timeout.py
+"""
+
+import pytest
+
+from modelexpress.load_strategy import rdma_strategy
+from modelexpress.load_strategy.rdma_strategy import (
+    DEFAULT_RDMA_TRANSFER_TIMEOUT_S,
+    MAX_SOURCE_RETRIES,
+    _transfer_timeout_seconds,
+)
+
+
+def test_unset_preserves_the_previous_hard_coded_budget(monkeypatch):
+    """Unset must not change behaviour for anyone relying on the old constant."""
+    monkeypatch.delenv("MX_TRANSFER_TIMEOUT", raising=False)
+    assert DEFAULT_RDMA_TRANSFER_TIMEOUT_S == 300.0
+    assert _transfer_timeout_seconds() == 300.0
+
+
+def test_the_900_default_of_the_env_var_is_not_inherited(monkeypatch):
+    """The regression this fix must not introduce.
+
+    ``envs.MX_TRANSFER_TIMEOUT`` reports 900 when unset. If this path adopted that,
+    a wedged source would stall a target for 900s instead of 300s, and up to 45
+    minutes across three candidates.
+    """
+    monkeypatch.delenv("MX_TRANSFER_TIMEOUT", raising=False)
+    assert rdma_strategy.envs.MX_TRANSFER_TIMEOUT == 900
+    assert _transfer_timeout_seconds() == 300.0
+
+
+def test_an_operator_can_shorten_the_budget(monkeypatch):
+    """The point of the fix: a 1.2 GB model should not cost 300s to give up on."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "30")
+    assert _transfer_timeout_seconds() == 30.0
+
+
+def test_an_operator_can_lengthen_the_budget(monkeypatch):
+    """Large models legitimately need longer than the old constant."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "1800")
+    assert _transfer_timeout_seconds() == 1800.0
+
+
+def test_an_explicit_900_is_honoured(monkeypatch):
+    """Declining the default is not the same as forbidding the value."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "900")
+    assert _transfer_timeout_seconds() == 900.0
+
+
+def test_zero_falls_back_rather_than_meaning_unbounded(monkeypatch):
+    """receive_from_source treats None as wait-forever, which is the failure mode
+    being bounded; a misconfigured 0 must not resurrect it."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "0")
+    assert _transfer_timeout_seconds() == 300.0
+
+
+def test_a_negative_value_falls_back(monkeypatch):
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "-1")
+    assert _transfer_timeout_seconds() == 300.0
+
+
+def test_a_non_numeric_value_falls_back(monkeypatch):
+    """A bad env var should degrade to the documented default, not crash a load."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "not-a-number")
+    assert _transfer_timeout_seconds() == 300.0
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+def test_a_non_finite_value_falls_back(monkeypatch, value):
+    """A non-finite budget would make the transfer wait loop unbounded."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", value)
+    assert _transfer_timeout_seconds() == 300.0
+
+
+def test_a_fractional_value_is_accepted(monkeypatch):
+    """The budget is a float; sub-second values are legitimate in tests and rigs."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "0.5")
+    assert _transfer_timeout_seconds() == 0.5
+
+
+def test_the_budget_is_per_candidate_not_per_load(monkeypatch):
+    """Documents the multiplier that made the reported 300s so expensive."""
+    monkeypatch.setenv("MX_TRANSFER_TIMEOUT", "60")
+    assert _transfer_timeout_seconds() * MAX_SOURCE_RETRIES == 180.0


### PR DESCRIPTION
Cherry-pick of #555 (merged to `main` as 746fe08) onto `release/0.5.0`.

Unlike a clean backport, this needed one conflict resolved — see **Conflict resolution** below.

## Problem

A worker that pulled weights over P2P held a loaded remote agent — and a live QP — for the source it pulled from, and exited without invalidating either. That left the source's data plane permanently unusable:

* Every subsequent reader's transfer neither completed nor reported an error, so each stalled for the full 300 s budget and fell back to disk loading.
* The source kept heartbeating `READY`, so new readers kept selecting it.
* The only source-side trace was a single UCX error at the moment the *next* reader connected: `mlx5dv_devx_obj_modify(opcode=0x503) failed ... Remote I/O error`.
* Restarting the source was the only recovery.

The reader has to be the side that cleans up. In P2P the reader drives the metadata exchange — it sends `NIXLCOMM:SEND` and the source replies with its own metadata — so only the reader calls `loadRemoteMD`. The source never loads the reader, so `invalidateRemoteMD` on the source finds no entry in `remoteSections_` or `remoteBackends_` and cannot disconnect a reader it has no record of. The source also cannot detect the departure: the comm worker treats a cleanly closed socket as "nothing to read yet".

## Change

* `NixlTransferManager` tracks the remote agents it loads, via both `fetch_remote_and_wait` (P2P) and `add_remote_agent` (centralized), and gains `remove_remote_agent()` / `disconnect_remote_agents()`.
* Peer teardown is manager-owned and process-wide: the manager registers its own `atexit` hook and disconnects tracked peers before dropping `_agent`.
* `is_healthy()` accounts for transfer timeouts and error statuses, cleared by a later success. An unhealthy worker that had reached `READY` is demoted rather than merely skipped.
* `MX_TRANSFER_TIMEOUT` applies to the RDMA receive path, but **only when explicitly set** — it defaults to 900, three times this path's historical 300, so adopting it wholesale would have made the stall worse for unconfigured deployments.

## Conflict resolution

One conflict, in `nixl_transfer.py`. `release/0.5.0` predates the extraction of the transfer-polling helpers, so it has no `_wait_for_xfer`; it inlines the polling loop in `receive_from_source` and `receive_dram_into_buffer`. The upstream change records the data-plane error inside `_wait_for_xfer`, which does not exist here.

Resolved by backporting `_wait_for_xfer` (byte-identical to the version on `main`) and delegating both inlined loops to it, rather than duplicating the flag writes in two places:

* `receive_from_source` wraps the call in `try/finally` to keep releasing the handle on every outcome, as the inlined loop did.
* `receive_dram_into_buffer` keeps its existing `finally` release.
* Both call sites pass labels (`"Transfer"`, `"NIXL DRAM transfer"`) that reproduce the previous exception messages exactly.

`_wait_for_xfers` — the batched variant that appeared in the same conflict hunk — is **not** included: it comes from an unrelated change that is not on this branch and has no caller here.

All members introduced by #555 (`remove_remote_agent`, `disconnect_remote_agents`, `_register_atexit`, `is_healthy`, `shutdown`, `data_plane_error`, `_wait_for_xfer`) are byte-identical to `main`. The other six files applied without conflict.

## Test

Focused suite plus the tests covering the refactored transfer paths: **104 passed** (`test_nixl_peer_lifecycle.py`, `test_publisher_peer_teardown.py`, `test_rdma_transfer_timeout.py`, `test_publisher.py`, `test_nixl_backend.py`, `test_pool_registration.py`, `test_accelerator_backend.py`). Pre-commit clean.

`test_artifact_transfer.py` cannot be collected in my environment (`google_crc32c` not installed); verified this also fails on the untouched base commit, so it is environmental and not caused by this change.

Carries the same hardware caveat as #555: the tests cover the client contract, not the UCX behaviour it avoids. Confirming the wedge is gone needs the original InfiniBand rig.