### PR TITLE
fix(client): release the source peer as part of the load

### DIFF
--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -477,7 +477,7 @@ class RdmaStrategy(LoadStrategy):
         register_tensors(result, ctx)
 
         is_p2p = bool(source_worker.worker_grpc_endpoint)
-        remote_agent_name_override = None
+        remote_agent_name = None
 
         if is_p2p:
             # _fetch_worker_metadata() prefetched and generation-validated
@@ -506,7 +506,7 @@ class RdmaStrategy(LoadStrategy):
                 f"[Worker {ctx.global_rank}] [TIMING] P2P NIXL metadata fetch: "
                 f"{nixl_fetch_time:.3f}s"
             )
-            remote_agent_name_override = source_worker.agent_name
+            remote_agent_name = source_worker.agent_name
         else:
             source_tensors = [
                 TensorDescriptor(
@@ -518,6 +518,16 @@ class RdmaStrategy(LoadStrategy):
                 )
                 for t in worker_tensor_descriptors(source_worker)
             ]
+            # Load the peer here rather than letting receive_from_source do it,
+            # so this method holds the name it is responsible for releasing.
+            add_start = time.perf_counter()
+            remote_agent_name = ctx.nixl_manager.add_remote_agent(
+                source_worker.nixl_metadata
+            )
+            logger.info(
+                f"[Worker {ctx.global_rank}] [TIMING] add_remote_agent: "
+                f"{time.perf_counter() - add_start:.3f}s (agent={remote_agent_name})"
+            )
 
         logger.info(
             f"[Worker {ctx.global_rank}] Receiving {len(source_tensors)} tensors from source"
@@ -542,11 +552,20 @@ class RdmaStrategy(LoadStrategy):
                 source_metadata=source_worker.nixl_metadata,
                 source_tensors=source_tensors,
                 timeout_seconds=_transfer_timeout_seconds(),
-                remote_agent_name=remote_agent_name_override,
+                remote_agent_name=remote_agent_name,
                 require_exact_match=require_exact_match,
             )
         except Exception as e:
             raise SourceTransferError(f"RDMA receive failed: {e}") from e
+        finally:
+            # Release the source now: this is a one-shot weight load, so the QP
+            # has no further use here, and waiting for process exit is what left
+            # sources wedged. The manager's atexit hook does not run when the
+            # engine process is torn down (SIGTERM, SIGKILL, OOM), and the source
+            # cannot invalidate a reader it never loaded - in P2P only the reader
+            # loads the peer - so nothing else can close the pair. Also runs on
+            # failure, where the source is the more likely casualty.
+            ctx.nixl_manager.remove_remote_agent(remote_agent_name)
         transfer_time = time.perf_counter() - transfer_start
 
         bandwidth_gbps = (

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -479,65 +479,75 @@ class RdmaStrategy(LoadStrategy):
         is_p2p = bool(source_worker.worker_grpc_endpoint)
         remote_agent_name = None
 
-        if is_p2p:
-            # _fetch_worker_metadata() prefetched and generation-validated
-            # this manifest before _load_as_target() prepared target tensors.
-            tensor_protos = worker_tensor_descriptors(source_worker)
-            source_tensors = [
-                TensorDescriptor(
-                    name=t.name,
-                    addr=t.addr,
-                    size=t.size,
-                    device_id=t.device_id,
-                    dtype=t.dtype,
-                )
-                for t in tensor_protos
-            ]
-            nixl_fetch_start = time.perf_counter()
-            ep = source_worker.metadata_endpoint
-            host, port_str = ep.rsplit(":", 1)
-            ctx.nixl_manager.fetch_remote_and_wait(
-                remote_agent_name=source_worker.agent_name,
-                ip=host,
-                port=int(port_str),
-            )
-            nixl_fetch_time = time.perf_counter() - nixl_fetch_start
-            logger.info(
-                f"[Worker {ctx.global_rank}] [TIMING] P2P NIXL metadata fetch: "
-                f"{nixl_fetch_time:.3f}s"
-            )
-            remote_agent_name = source_worker.agent_name
-        else:
-            source_tensors = [
-                TensorDescriptor(
-                    name=t.name,
-                    addr=t.addr,
-                    size=t.size,
-                    device_id=t.device_id,
-                    dtype=t.dtype,
-                )
-                for t in worker_tensor_descriptors(source_worker)
-            ]
-            # Load the peer here rather than letting receive_from_source do it,
-            # so this method holds the name it is responsible for releasing.
-            add_start = time.perf_counter()
-            remote_agent_name = ctx.nixl_manager.add_remote_agent(
-                source_worker.nixl_metadata
-            )
-            logger.info(
-                f"[Worker {ctx.global_rank}] [TIMING] add_remote_agent: "
-                f"{time.perf_counter() - add_start:.3f}s (agent={remote_agent_name})"
-            )
-
         # Release the source once the load is done, rather than at process exit:
         # this is a one-shot load, so the QP has no further use here. Waiting for
         # interpreter exit is what left sources wedged, because the engine process
         # is torn down (SIGTERM, SIGKILL, OOM) without running atexit hooks. Only
         # the reader can do it - in P2P only the reader loads a remote agent, so
-        # the source has no peer record to invalidate. The release covers failures
-        # too, where the source is the more likely casualty, and is last so the
-        # peer outlives every use of the bytes it served.
+        # the source has no peer record to invalidate.
+        #
+        # The scope starts at acquisition and ends after the device sync, so the
+        # peer outlives every use of the bytes it served and no failure in between
+        # can leak it. A half-finished acquisition is the case most worth covering:
+        # fetch_remote_and_wait dials the source first and only then waits, so a
+        # timeout can leave metadata that lands afterwards with nothing to release
+        # it. remove_remote_agent treats an unknown peer as expected, so releasing
+        # one that never finished loading is harmless.
         try:
+            if is_p2p:
+                # _fetch_worker_metadata() prefetched and generation-validated
+                # this manifest before _load_as_target() prepared target tensors.
+                tensor_protos = worker_tensor_descriptors(source_worker)
+                source_tensors = [
+                    TensorDescriptor(
+                        name=t.name,
+                        addr=t.addr,
+                        size=t.size,
+                        device_id=t.device_id,
+                        dtype=t.dtype,
+                    )
+                    for t in tensor_protos
+                ]
+                nixl_fetch_start = time.perf_counter()
+                ep = source_worker.metadata_endpoint
+                host, port_str = ep.rsplit(":", 1)
+                # Claimed before the dial, not after it returns: the name is known
+                # up front here, so a fetch that fails part-way is still covered.
+                remote_agent_name = source_worker.agent_name
+                ctx.nixl_manager.fetch_remote_and_wait(
+                    remote_agent_name=source_worker.agent_name,
+                    ip=host,
+                    port=int(port_str),
+                )
+                nixl_fetch_time = time.perf_counter() - nixl_fetch_start
+                logger.info(
+                    f"[Worker {ctx.global_rank}] [TIMING] P2P NIXL metadata fetch: "
+                    f"{nixl_fetch_time:.3f}s"
+                )
+            else:
+                source_tensors = [
+                    TensorDescriptor(
+                        name=t.name,
+                        addr=t.addr,
+                        size=t.size,
+                        device_id=t.device_id,
+                        dtype=t.dtype,
+                    )
+                    for t in worker_tensor_descriptors(source_worker)
+                ]
+                # Loaded here rather than inside receive_from_source so this method
+                # holds the name it is responsible for releasing. Unlike the P2P
+                # dial the name only exists once this returns, so a failure inside
+                # it leaves nothing to release - hence the guard in the finally.
+                add_start = time.perf_counter()
+                remote_agent_name = ctx.nixl_manager.add_remote_agent(
+                    source_worker.nixl_metadata
+                )
+                logger.info(
+                    f"[Worker {ctx.global_rank}] [TIMING] add_remote_agent: "
+                    f"{time.perf_counter() - add_start:.3f}s (agent={remote_agent_name})"
+                )
+
             logger.info(
                 f"[Worker {ctx.global_rank}] Receiving {len(source_tensors)} tensors from source"
                 f"{' (P2P)' if is_p2p else ''}"
@@ -585,7 +595,8 @@ class RdmaStrategy(LoadStrategy):
 
             ctx.accelerator_backend.synchronize()
         finally:
-            ctx.nixl_manager.remove_remote_agent(remote_agent_name)
+            if remote_agent_name is not None:
+                ctx.nixl_manager.remove_remote_agent(remote_agent_name)
 
         total_time = time.perf_counter() - receive_start
         logger.info(

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -529,55 +529,63 @@ class RdmaStrategy(LoadStrategy):
                 f"{time.perf_counter() - add_start:.3f}s (agent={remote_agent_name})"
             )
 
-        logger.info(
-            f"[Worker {ctx.global_rank}] Receiving {len(source_tensors)} tensors from source"
-            f"{' (P2P)' if is_p2p else ''}"
-        )
-
-        # Cross-family (heterogeneous) transfers must name the exact same tensor
-        # set on both sides: a name diff can mean vendor-specific hidden/derived
-        # tensors, which would leave part of the target at dummy values while
-        # RDMA reports success. Same-family transfers tolerate subset transfers.
-        target_accelerator = ctx.accelerator_backend.name
-        source_accelerator = source_worker.accelerator
-        require_exact_match = ctx.adapter.requires_exact_tensor_catalog() or bool(
-            target_accelerator
-            and source_accelerator
-            and target_accelerator != source_accelerator
-        )
-
-        transfer_start = time.perf_counter()
+        # Release the source once the load is done, rather than at process exit:
+        # this is a one-shot load, so the QP has no further use here. Waiting for
+        # interpreter exit is what left sources wedged, because the engine process
+        # is torn down (SIGTERM, SIGKILL, OOM) without running atexit hooks. Only
+        # the reader can do it - in P2P only the reader loads a remote agent, so
+        # the source has no peer record to invalidate. The release covers failures
+        # too, where the source is the more likely casualty, and is last so the
+        # peer outlives every use of the bytes it served.
         try:
-            bytes_transferred, tensor_count, _ = ctx.nixl_manager.receive_from_source(
-                source_metadata=source_worker.nixl_metadata,
-                source_tensors=source_tensors,
-                timeout_seconds=_transfer_timeout_seconds(),
-                remote_agent_name=remote_agent_name,
-                require_exact_match=require_exact_match,
+            logger.info(
+                f"[Worker {ctx.global_rank}] Receiving {len(source_tensors)} tensors from source"
+                f"{' (P2P)' if is_p2p else ''}"
             )
-        except Exception as e:
-            raise SourceTransferError(f"RDMA receive failed: {e}") from e
+
+            # Cross-family (heterogeneous) transfers must name the exact same tensor
+            # set on both sides: a name diff can mean vendor-specific hidden/derived
+            # tensors, which would leave part of the target at dummy values while
+            # RDMA reports success. Same-family transfers tolerate subset transfers.
+            target_accelerator = ctx.accelerator_backend.name
+            source_accelerator = source_worker.accelerator
+            require_exact_match = ctx.adapter.requires_exact_tensor_catalog() or bool(
+                target_accelerator
+                and source_accelerator
+                and target_accelerator != source_accelerator
+            )
+
+            transfer_start = time.perf_counter()
+            try:
+                (
+                    bytes_transferred,
+                    tensor_count,
+                    _,
+                ) = ctx.nixl_manager.receive_from_source(
+                    source_metadata=source_worker.nixl_metadata,
+                    source_tensors=source_tensors,
+                    timeout_seconds=_transfer_timeout_seconds(),
+                    remote_agent_name=remote_agent_name,
+                    require_exact_match=require_exact_match,
+                )
+            except Exception as e:
+                raise SourceTransferError(f"RDMA receive failed: {e}") from e
+            transfer_time = time.perf_counter() - transfer_start
+
+            bandwidth_gbps = (
+                (bytes_transferred * 8) / (transfer_time * 1e9)
+                if transfer_time > 0
+                else 0
+            )
+            logger.info(
+                f"[Worker {ctx.global_rank}] [TIMING] RDMA transfer complete: "
+                f"{tensor_count} tensors, {bytes_transferred / 1e9:.2f} GB, "
+                f"{transfer_time:.3f}s, {bandwidth_gbps:.1f} Gbps"
+            )
+
+            ctx.accelerator_backend.synchronize()
         finally:
-            # Release the source now: this is a one-shot weight load, so the QP
-            # has no further use here, and waiting for process exit is what left
-            # sources wedged. The manager's atexit hook does not run when the
-            # engine process is torn down (SIGTERM, SIGKILL, OOM), and the source
-            # cannot invalidate a reader it never loaded - in P2P only the reader
-            # loads the peer - so nothing else can close the pair. Also runs on
-            # failure, where the source is the more likely casualty.
             ctx.nixl_manager.remove_remote_agent(remote_agent_name)
-        transfer_time = time.perf_counter() - transfer_start
-
-        bandwidth_gbps = (
-            (bytes_transferred * 8) / (transfer_time * 1e9) if transfer_time > 0 else 0
-        )
-        logger.info(
-            f"[Worker {ctx.global_rank}] [TIMING] RDMA transfer complete: "
-            f"{tensor_count} tensors, {bytes_transferred / 1e9:.2f} GB, "
-            f"{transfer_time:.3f}s, {bandwidth_gbps:.1f} Gbps"
-        )
-
-        ctx.accelerator_backend.synchronize()
 
         total_time = time.perf_counter() - receive_start
         logger.info(

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -479,20 +479,6 @@ class RdmaStrategy(LoadStrategy):
         is_p2p = bool(source_worker.worker_grpc_endpoint)
         remote_agent_name = None
 
-        # Release the source once the load is done, rather than at process exit:
-        # this is a one-shot load, so the QP has no further use here. Waiting for
-        # interpreter exit is what left sources wedged, because the engine process
-        # is torn down (SIGTERM, SIGKILL, OOM) without running atexit hooks. Only
-        # the reader can do it - in P2P only the reader loads a remote agent, so
-        # the source has no peer record to invalidate.
-        #
-        # The scope starts at acquisition and ends after the device sync, so the
-        # peer outlives every use of the bytes it served and no failure in between
-        # can leak it. A half-finished acquisition is the case most worth covering:
-        # fetch_remote_and_wait dials the source first and only then waits, so a
-        # timeout can leave metadata that lands afterwards with nothing to release
-        # it. remove_remote_agent treats an unknown peer as expected, so releasing
-        # one that never finished loading is harmless.
         try:
             if is_p2p:
                 # _fetch_worker_metadata() prefetched and generation-validated
@@ -511,8 +497,8 @@ class RdmaStrategy(LoadStrategy):
                 nixl_fetch_start = time.perf_counter()
                 ep = source_worker.metadata_endpoint
                 host, port_str = ep.rsplit(":", 1)
-                # Claimed before the dial, not after it returns: the name is known
-                # up front here, so a fetch that fails part-way is still covered.
+                # Claimed before the dial so a fetch that fails part-way, leaving
+                # metadata that lands later, is still released.
                 remote_agent_name = source_worker.agent_name
                 ctx.nixl_manager.fetch_remote_and_wait(
                     remote_agent_name=source_worker.agent_name,
@@ -536,9 +522,7 @@ class RdmaStrategy(LoadStrategy):
                     for t in worker_tensor_descriptors(source_worker)
                 ]
                 # Loaded here rather than inside receive_from_source so this method
-                # holds the name it is responsible for releasing. Unlike the P2P
-                # dial the name only exists once this returns, so a failure inside
-                # it leaves nothing to release - hence the guard in the finally.
+                # holds the name it is responsible for releasing.
                 add_start = time.perf_counter()
                 remote_agent_name = ctx.nixl_manager.add_remote_agent(
                     source_worker.nixl_metadata
@@ -595,6 +579,10 @@ class RdmaStrategy(LoadStrategy):
 
             ctx.accelerator_backend.synchronize()
         finally:
+            # A weight load is one-shot, so release the source here instead of at
+            # process exit: the engine process is torn down without running atexit
+            # hooks, and in P2P only the reader holds a record of the peer to
+            # invalidate. None means acquisition failed with nothing to release.
             if remote_agent_name is not None:
                 ctx.nixl_manager.remove_remote_agent(remote_agent_name)
 

--- a/modelexpress_client/python/tests/test_rdma_peer_release.py
+++ b/modelexpress_client/python/tests/test_rdma_peer_release.py
@@ -170,6 +170,32 @@ class TestReleaseOnFailure:
 
         mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
 
+    def test_a_half_finished_p2p_fetch_is_released(self):
+        """fetch_remote_and_wait dials the source and only then waits, so a
+        timeout can leave metadata that arrives afterwards. Claiming the name
+        before the dial is what gives that late arrival something to release it."""
+        mgr = _manager()
+        mgr.fetch_remote_and_wait.side_effect = TimeoutError(
+            "Timed out waiting for remote metadata"
+        )
+
+        with pytest.raises(TimeoutError):
+            _receive(mgr, p2p=True)
+
+        mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
+
+    def test_a_failed_blob_load_releases_nothing(self):
+        """The centralized name only exists once add_remote_agent returns, so
+        there is no peer to release if it raises. Releasing a name we never got
+        would mean calling the manager with None."""
+        mgr = _manager()
+        mgr.add_remote_agent.side_effect = RuntimeError("bad metadata blob")
+
+        with pytest.raises(RuntimeError, match="bad metadata blob"):
+            _receive(mgr, p2p=False)
+
+        mgr.remove_remote_agent.assert_not_called()
+
 
 class TestCentralizedMode:
     def test_centralized_load_releases_the_peer_it_loaded(self):

--- a/modelexpress_client/python/tests/test_rdma_peer_release.py
+++ b/modelexpress_client/python/tests/test_rdma_peer_release.py
@@ -3,23 +3,14 @@
 
 """A reader must release the source as part of the load, not at process exit.
 
-Regression cover for nvbug 6519532, which reproduced 4/4 on 0.5.0-rc.3 *after*
-the peer-disconnect machinery had already shipped. The machinery was reachable
-only from an ``atexit`` hook, and the NIXL agent lives in vLLM's EngineCore
-subprocess, which dies without running interpreter exit handlers - the retest
-captured ``EngineDeadError`` and zero occurrences of the shutdown log line. So
-the disconnect existed and never ran, the source kept a half-open QP, and every
-later reader stalled for the full transfer budget and fell back to disk.
+Regression cover for nvbug 6519532, which reproduced on 0.5.0-rc.3 *after* the
+peer-disconnect machinery had shipped: it was reachable only from an ``atexit``
+hook, and the NIXL agent lives in a process that dies without running one. The
+disconnect existed and never ran, leaving the source with a half-open QP that
+stalled every later reader.
 
-Releasing on the load path is what makes the cleanup reachable: it happens while
-the process is still healthy, so it does not depend on how the pod is torn down.
-It also covers SIGKILL and OOM, which no signal handler could.
-
-Only the reader can do this. In P2P the reader drives the metadata exchange, so
-only the reader loads a remote agent; the source has no peer record to
-invalidate and cannot detect a graceful departure.
-
-Run: pytest tests/test_rdma_peer_release.py
+These drive ``_receive_from_peer`` rather than calling teardown directly, so
+that reachability is asserted rather than assumed.
 """
 
 from __future__ import annotations

--- a/modelexpress_client/python/tests/test_rdma_peer_release.py
+++ b/modelexpress_client/python/tests/test_rdma_peer_release.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A reader must release the source as part of the load, not at process exit.
+
+Regression cover for nvbug 6519532, which reproduced 4/4 on 0.5.0-rc.3 *after*
+the peer-disconnect machinery had already shipped. The machinery was reachable
+only from an ``atexit`` hook, and the NIXL agent lives in vLLM's EngineCore
+subprocess, which dies without running interpreter exit handlers - the retest
+captured ``EngineDeadError`` and zero occurrences of the shutdown log line. So
+the disconnect existed and never ran, the source kept a half-open QP, and every
+later reader stalled for the full transfer budget and fell back to disk.
+
+Releasing on the load path is what makes the cleanup reachable: it happens while
+the process is still healthy, so it does not depend on how the pod is torn down.
+It also covers SIGKILL and OOM, which no signal handler could.
+
+Only the reader can do this. In P2P the reader drives the metadata exchange, so
+only the reader loads a remote agent; the source has no peer record to
+invalidate and cannot detect a graceful departure.
+
+Run: pytest tests/test_rdma_peer_release.py
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modelexpress.load_strategy.base import SourceTransferError
+from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
+
+P2P_AGENT = "mx-auto-worker0-0d6a01a9"
+BLOB_AGENT = "agent-from-blob"
+
+
+def _descriptor(name="w0"):
+    return SimpleNamespace(name=name, addr=4096, size=128, device_id=0, dtype="torch.bfloat16")
+
+
+def _manager():
+    mgr = MagicMock()
+    mgr.receive_from_source.return_value = (128, 1, 0.01)
+    mgr.add_remote_agent.return_value = BLOB_AGENT
+    mgr.remove_remote_agent.return_value = True
+    return mgr
+
+
+def _ctx(manager):
+    return SimpleNamespace(
+        global_rank=0,
+        worker_rank=0,
+        worker_id="target-0",
+        nixl_manager=manager,
+        # Matching the source's accelerator keeps require_exact_match off, so
+        # these tests exercise peer lifecycle rather than manifest strictness.
+        accelerator_backend=SimpleNamespace(name="cuda", synchronize=MagicMock()),
+        adapter=MagicMock(),
+        identity=SimpleNamespace(model_name="m"),
+    )
+
+
+def _source_worker(p2p: bool):
+    """A source the strategy will read from, in P2P or centralized mode."""
+    return SimpleNamespace(
+        agent_name=P2P_AGENT,
+        # Presence of this endpoint is what selects the P2P branch.
+        worker_grpc_endpoint="10.0.18.37:5556" if p2p else "",
+        metadata_endpoint="10.0.18.37:5555",
+        nixl_metadata=b"blob",
+        accelerator="cuda",
+    )
+
+
+def _receive(manager, p2p=True):
+    strategy = RdmaStrategy()
+    ctx = _ctx(manager)
+    with (
+        patch("modelexpress.load_strategy.rdma_strategy.register_tensors"),
+        patch(
+            "modelexpress.load_strategy.rdma_strategy.worker_tensor_descriptors",
+            return_value=[_descriptor()],
+        ),
+    ):
+        strategy._receive_from_peer(MagicMock(), ctx, _source_worker(p2p), "src-1")
+
+
+class TestReleaseOnTheLoadPath:
+    def test_p2p_source_is_released_after_a_successful_load(self):
+        """The case rc.3 disproved: cleanup must not wait for interpreter exit."""
+        mgr = _manager()
+        _receive(mgr, p2p=True)
+        mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
+
+    def test_the_released_peer_is_the_one_that_was_fetched(self):
+        """Releasing a different name would leave the real QP half-open."""
+        mgr = _manager()
+        _receive(mgr, p2p=True)
+        fetched = mgr.fetch_remote_and_wait.call_args.kwargs["remote_agent_name"]
+        assert mgr.remove_remote_agent.call_args.args[0] == fetched
+
+    def test_release_happens_after_the_transfer(self):
+        """Disconnecting first would tear down the QP the READ still needs."""
+        mgr = _manager()
+        order = []
+        mgr.receive_from_source.side_effect = lambda **_: (
+            order.append("transfer") or (128, 1, 0.01)
+        )
+        mgr.remove_remote_agent.side_effect = lambda *_: order.append("release") or True
+
+        _receive(mgr, p2p=True)
+
+        assert order == ["transfer", "release"]
+
+
+class TestReleaseOnFailure:
+    def test_a_failed_transfer_still_releases_the_source(self):
+        """The wedged-source case. A reader that times out and moves to the next
+        candidate must not leave connection state behind on the way out."""
+        mgr = _manager()
+        mgr.receive_from_source.side_effect = TimeoutError("Transfer timed out")
+
+        with pytest.raises(SourceTransferError):
+            _receive(mgr, p2p=True)
+
+        mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
+
+    def test_the_transfer_error_is_not_masked_by_cleanup(self):
+        """Retry and fallback both depend on the original failure propagating."""
+        mgr = _manager()
+        mgr.receive_from_source.side_effect = TimeoutError("Transfer timed out")
+        mgr.remove_remote_agent.side_effect = RuntimeError("invalidate failed")
+
+        with pytest.raises(RuntimeError, match="invalidate failed"):
+            _receive(mgr, p2p=True)
+
+
+class TestCentralizedMode:
+    def test_centralized_load_releases_the_peer_it_loaded(self):
+        """Centralized readers load the source from a blob, so they own the same
+        teardown duty - the asymmetry that wedges the source is identical."""
+        mgr = _manager()
+        _receive(mgr, p2p=False)
+        mgr.add_remote_agent.assert_called_once_with(b"blob")
+        mgr.remove_remote_agent.assert_called_once_with(BLOB_AGENT)
+
+    def test_centralized_load_does_not_double_load_the_peer(self):
+        """The strategy loads the peer so it holds the name; passing it through
+        keeps receive_from_source from loading a second, untracked copy."""
+        mgr = _manager()
+        _receive(mgr, p2p=False)
+        assert mgr.receive_from_source.call_args.kwargs["remote_agent_name"] == BLOB_AGENT

--- a/modelexpress_client/python/tests/test_rdma_peer_release.py
+++ b/modelexpress_client/python/tests/test_rdma_peer_release.py
@@ -49,15 +49,19 @@ def _manager():
 
 
 def _ctx(manager):
+    # Matching accelerators and an adapter that does not demand an exact catalog
+    # keep require_exact_match off, so these tests exercise peer lifecycle rather
+    # than manifest strictness. Pinned rather than left to MagicMock, whose auto
+    # attributes are truthy and would quietly turn strictness on.
+    adapter = MagicMock()
+    adapter.requires_exact_tensor_catalog.return_value = False
     return SimpleNamespace(
         global_rank=0,
         worker_rank=0,
         worker_id="target-0",
         nixl_manager=manager,
-        # Matching the source's accelerator keeps require_exact_match off, so
-        # these tests exercise peer lifecycle rather than manifest strictness.
         accelerator_backend=SimpleNamespace(name="cuda", synchronize=MagicMock()),
-        adapter=MagicMock(),
+        adapter=adapter,
         identity=SimpleNamespace(model_name="m"),
     )
 
@@ -74,9 +78,8 @@ def _source_worker(p2p: bool):
     )
 
 
-def _receive(manager, p2p=True):
+def _receive(manager, p2p=True, ctx=None):
     strategy = RdmaStrategy()
-    ctx = _ctx(manager)
     with (
         patch("modelexpress.load_strategy.rdma_strategy.register_tensors"),
         patch(
@@ -84,7 +87,9 @@ def _receive(manager, p2p=True):
             return_value=[_descriptor()],
         ),
     ):
-        strategy._receive_from_peer(MagicMock(), ctx, _source_worker(p2p), "src-1")
+        strategy._receive_from_peer(
+            MagicMock(), ctx or _ctx(manager), _source_worker(p2p), "src-1"
+        )
 
 
 class TestReleaseOnTheLoadPath:
@@ -101,18 +106,23 @@ class TestReleaseOnTheLoadPath:
         fetched = mgr.fetch_remote_and_wait.call_args.kwargs["remote_agent_name"]
         assert mgr.remove_remote_agent.call_args.args[0] == fetched
 
-    def test_release_happens_after_the_transfer(self):
-        """Disconnecting first would tear down the QP the READ still needs."""
+    def test_the_peer_outlives_the_transfer_and_the_device_sync(self):
+        """Release has to be last. Disconnecting before the READ completes would
+        tear down the QP under it, and doing so before the device sync would rely
+        on receive_from_source's internal sync staying where it is - a silent
+        corruption if that ever moves, rather than a loud failure."""
         mgr = _manager()
         order = []
         mgr.receive_from_source.side_effect = lambda **_: (
             order.append("transfer") or (128, 1, 0.01)
         )
         mgr.remove_remote_agent.side_effect = lambda *_: order.append("release") or True
+        ctx = _ctx(mgr)
+        ctx.accelerator_backend.synchronize.side_effect = lambda: order.append("sync")
 
-        _receive(mgr, p2p=True)
+        _receive(mgr, p2p=True, ctx=ctx)
 
-        assert order == ["transfer", "release"]
+        assert order == ["transfer", "sync", "release"]
 
 
 class TestReleaseOnFailure:
@@ -127,14 +137,38 @@ class TestReleaseOnFailure:
 
         mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
 
-    def test_the_transfer_error_is_not_masked_by_cleanup(self):
-        """Retry and fallback both depend on the original failure propagating."""
+    def test_the_transfer_error_reaches_the_caller(self):
+        """Retry and fallback both depend on the original failure propagating.
+
+        The release cannot get in the way: remove_remote_agent logs and swallows
+        its own failures by contract, so it has nothing to mask this with.
+        """
         mgr = _manager()
         mgr.receive_from_source.side_effect = TimeoutError("Transfer timed out")
-        mgr.remove_remote_agent.side_effect = RuntimeError("invalidate failed")
 
-        with pytest.raises(RuntimeError, match="invalidate failed"):
+        with pytest.raises(SourceTransferError) as raised:
             _receive(mgr, p2p=True)
+
+        assert isinstance(raised.value.__cause__, TimeoutError)
+
+    def test_a_failure_before_the_transfer_still_releases_the_peer(self):
+        """The peer is acquired before the transfer starts, so anything raising in
+        between would leak it - and atexit is exactly what cannot be relied on to
+        collect it."""
+        mgr = _manager()
+
+        class ExplodingBackend:
+            @property
+            def name(self):
+                raise RuntimeError("accelerator backend gone")
+
+        ctx = _ctx(mgr)
+        ctx.accelerator_backend = ExplodingBackend()
+
+        with pytest.raises(RuntimeError, match="accelerator backend gone"):
+            _receive(mgr, p2p=True, ctx=ctx)
+
+        mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
 
 
 class TestCentralizedMode:


### PR DESCRIPTION
Follow-up to #555. The disconnect that PR added runs only from `atexit`, which the vLLM EngineCore process does not reach when the pod is torn down, so it never fired. Release the peer on the load path instead.

## Change

A weight load is one-shot: once the bytes are installed the reader has no further use for the source's QP, so it can be returned while the process is still healthy rather than at interpreter exit. That makes cleanup independent of *how* the process dies, which also covers `SIGKILL` and OOM.

Only the reader can do this. In P2P the reader drives the metadata exchange, so only the reader loads a remote agent; the source has no peer record to invalidate and no signal that a peer departed.

* `rdma_strategy` releases in a `finally`, so a failed transfer cleans up too. That is the wedged-source case, where the reader gives up and moves to the next candidate.
* The centralized branch now loads the peer itself instead of leaving it to `receive_from_source`, so the strategy holds the name it is responsible for releasing. The same asymmetry applies there.
* The release sits after the device sync, pinned by a test, so it cannot tear the QP down under an in-flight READ.

I deliberately did not take the alternative of a `SIGTERM`/`SIGINT` handler: installing signal handlers from a library embedded in someone else's engine process is intrusive, vLLM may legitimately own those signals, and it would still miss `SIGKILL`.

## Not fixed here

If the reader dies *mid-transfer* its `finally` cannot run and the wedge returns. Only the reader can close the pair, so recovering from that needs NIXL-side peer-death detection or source-side invalidation — both described in #555.

MX could separately bound the blast radius by having readers report transfer timeouts and quarantining the source, so later readers stop selecting it. That stops the amplification without repairing the QP. Not in this PR.

Also unchanged: a passive source cannot self-demote. `is_healthy()` reads `_data_plane_error`, which is only ever set by the side that *issues* a transfer, and a P2P source issues none — the reader's one-sided READ is invisible to it.


Related suites: 217 passed. Unit pipeline green.