### PR TITLE
feat(reshard): stamp the published shard table with its training step

### DIFF
--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -217,13 +217,31 @@ def merge_shard_tables(tables: list) -> list:
 
 
 def wrap_rendezvous_blob(
-    agent_metadata: bytes, agent_name: str, metadata_endpoint: str, tensors: list
+    agent_metadata: bytes,
+    agent_name: str,
+    metadata_endpoint: str,
+    tensors: list,
+    publisher_step: int | None = None,
 ) -> bytes:
     """Pack ``{agent_meta, agent_name, metadata_endpoint, shard_table}`` into one
     JSON blob. ``metadata_endpoint`` (``host:listen_port`` of the trainer's NIXL
     listen thread) is what the receiver's ``fetch_remote_and_wait`` connects to
     for the P2P memory-registration handshake (the central agent-metadata blob
-    alone does not make the registrations resolvable for RDMA reads)."""
+    alone does not make the registrations resolvable for RDMA reads).
+
+    ``publisher_step`` stamps the table with the training step whose weights it
+    describes. A receiver otherwise has no way to tell a current table from one
+    published a step ago, and it needs to: the shard table carries the per-shard
+    digests a receiver verifies against, so a table one step behind makes correctly
+    delivered bytes read as corruption. Inferring freshness instead - asking whether
+    any digest changed since planning - holds only when a table is wholly stale or
+    wholly current, and breaks under partial propagation across many publishers,
+    where it reports one lagging publisher's shard as a hard defect. The stamp turns
+    that inference into an observation.
+
+    The key is omitted rather than written as null when absent, so a blob from an
+    unstamped publisher is byte-identical to one an older client would have produced.
+    """
     payload = {
         "schema": _SCHEMA,
         "agent_name": agent_name,
@@ -231,6 +249,8 @@ def wrap_rendezvous_blob(
         "agent_meta_b64": base64.b64encode(agent_metadata).decode("ascii"),
         "tensors": json.loads(encode_shard_table(tensors).decode("utf-8"))["tensors"],
     }
+    if publisher_step is not None:
+        payload["publisher_step"] = int(publisher_step)
     return json.dumps(payload).encode("utf-8")
 
 
@@ -239,13 +259,21 @@ class RendezvousPayload(NamedTuple):
 
     A plain tuple until now, which read as ``payload[3]`` at the point where the
     interesting question is asked - whether this rank published any tensors. Being
-    a tuple subclass, it still unpacks and indexes as before.
+    a tuple subclass, it still indexes as before.
+
+    ``publisher_step`` is ``None`` for a publisher that does not stamp, and that
+    must be read as "unknown", never as step 0: a publisher read as step 0 looks
+    permanently behind, and a consumer that excuses lagging publishers would then
+    excuse all of its shards, going quiet instead of strict. It carries a default
+    so that reading the stamp is a new field rather than a second unwrap function,
+    which is also why unpacking must now name five values.
     """
 
     agent_metadata: bytes
     agent_name: str
     metadata_endpoint: str
     tensors: list
+    publisher_step: int | None = None
 
 
 def unwrap_rendezvous_blob(blob: bytes) -> RendezvousPayload:
@@ -259,7 +287,11 @@ def unwrap_rendezvous_blob(blob: bytes) -> RendezvousPayload:
     tensors = decode_shard_table(
         json.dumps({"schema": _SCHEMA, "tensors": payload["tensors"]}).encode("utf-8")
     )
-    return RendezvousPayload(agent_metadata, agent_name, metadata_endpoint, tensors)
+    raw_step = payload.get("publisher_step")
+    publisher_step = None if raw_step is None else int(raw_step)
+    return RendezvousPayload(
+        agent_metadata, agent_name, metadata_endpoint, tensors, publisher_step
+    )
 
 
 class MxReshardRendezvous:

--- a/modelexpress_client/python/tests/test_reshard_megatron.py
+++ b/modelexpress_client/python/tests/test_reshard_megatron.py
@@ -247,16 +247,14 @@ def test_publisher_seam_reuses_registered_tensor_addresses():
 
     assert source_id == "source-id"
     assert client.worker.status > 0
-    agent_metadata, agent_name, endpoint, published = unwrap_rendezvous_blob(
-        client.worker.nixl_metadata
-    )
-    assert (agent_metadata, agent_name, endpoint) == (
+    payload = unwrap_rendezvous_blob(client.worker.nixl_metadata)
+    assert (payload.agent_metadata, payload.agent_name, payload.metadata_endpoint) == (
         b"agent-metadata",
         "trainer-r3",
         "10.0.0.3:19003",
     )
-    assert published[0].shards[0].addr == tensor.data_ptr()
-    assert published[0].shards[0].shard_offset == (8, 0)
+    assert payload.tensors[0].shards[0].addr == tensor.data_ptr()
+    assert payload.tensors[0].shards[0].shard_offset == (8, 0)
 
 
 def test_publishing_leaves_the_heartbeat_with_its_owner():

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -134,10 +134,10 @@ def test_published_rendezvous_stays_ready_and_closes_stale(monkeypatch):
         assert client.heartbeat_seen.wait(timeout=1.0)
         assert client.publish_count == 1
         discovered = rendezvous.discover_trainers(expected_trainers=1)
-        assert [(meta, name, ep) for (meta, name, ep, _t) in discovered] == [
-            (b"nixl", "trainer-agent", "trainer:1234")
-        ]
-        assert [t.name for t in discovered[0][3]] == ["weight"]
+        assert [
+            (p.agent_metadata, p.agent_name, p.metadata_endpoint) for p in discovered
+        ] == [(b"nixl", "trainer-agent", "trainer:1234")]
+        assert [t.name for t in discovered[0].tensors] == ["weight"]
         assert client.status_filter == p2p_pb2.SOURCE_STATUS_READY
     finally:
         rendezvous.close()
@@ -208,10 +208,7 @@ def test_quorum_is_met_once_every_rank_publishes_tensors():
 
     discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
 
-    assert [name for (_meta, name, _ep, _tensors) in discovered] == [
-        "rank-0",
-        "rank-1",
-    ]
+    assert [p.agent_name for p in discovered] == ["rank-0", "rank-1"]
 
 
 def test_empty_publishers_are_excluded_from_the_returned_payloads():
@@ -227,7 +224,7 @@ def test_empty_publishers_are_excluded_from_the_returned_payloads():
 
     discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
 
-    assert "empty-rank" not in [name for (_meta, name, _ep, _t) in discovered]
+    assert "empty-rank" not in [p.agent_name for p in discovered]
     assert len(discovered) == 2
 
 
@@ -248,15 +245,19 @@ def test_only_the_requested_number_of_ranks_is_returned():
 
 
 def test_a_discovered_payload_reads_by_field_and_by_position():
-    """Named access is the point of the change; positional access is what every
-    existing caller does, so both have to keep working."""
+    """Named access is the point of the change. Positions are still stable, which is
+    what lets an optional field like the publisher step be appended without moving
+    anything a caller already reads."""
     client = _DiscoveryClient([_blob("rank-0", _one_tensor())])
 
     (payload,) = _rendezvous(client).discover_trainers(expected_trainers=1, timeout=0)
-    agent_metadata, agent_name, endpoint, tensors = payload
 
-    assert (payload.agent_name, payload.metadata_endpoint) == (agent_name, endpoint)
-    assert (payload.agent_metadata, payload.tensors) == (agent_metadata, tensors)
+    assert payload[:4] == (
+        payload.agent_metadata,
+        payload.agent_name,
+        payload.metadata_endpoint,
+        payload.tensors,
+    )
     assert payload[3] is payload.tensors
 
 

--- a/modelexpress_client/python/tests/test_reshard_refit_step_stamp.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_step_stamp.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for the publisher step stamp on the rendezvous blob.
+
+The stamp answers a question a receiver otherwise has to guess at: does the shard
+table I just discovered describe the step I am refitting, or the one before it? It
+matters because the table carries the per-shard digests a verify gate compares
+against, so a table one step behind turns correctly delivered bytes into a reported
+corruption.
+
+What is worth testing here is not that a field round-trips. It is that the stamp is
+optional in *both* directions, because a fleet is upgraded one image at a time and
+neither side may assume the other has it, and that a missing stamp reads as "unknown"
+rather than as step 0.
+"""
+
+from __future__ import annotations
+
+import json
+
+from modelexpress.refit.reshard.rendezvous import (
+    unwrap_rendezvous_blob,
+    wrap_rendezvous_blob,
+)
+
+
+def _blob(step=None, tensors=None):
+    return wrap_rendezvous_blob(b"meta", "agent-r0", "h:1", tensors or [], step)
+
+
+def test_the_stamp_round_trips():
+    assert unwrap_rendezvous_blob(_blob(step=7)).publisher_step == 7
+
+
+def test_an_unstamped_blob_reads_as_unknown_not_step_zero():
+    """The distinction a staleness check has to rest on. Read as 0, an unstamped
+    publisher looks permanently behind, and a consumer that excuses lagging
+    publishers would excuse every one of its shards."""
+    assert unwrap_rendezvous_blob(_blob()).publisher_step is None
+
+
+def test_step_zero_is_carried_not_dropped():
+    """0 is a legitimate step and must not collapse into "no stamp"."""
+    assert unwrap_rendezvous_blob(_blob(step=0)).publisher_step == 0
+
+
+def test_the_stamp_is_omitted_rather_than_nulled_when_absent():
+    """So an unstamped publisher emits the blob an older client would have."""
+    payload = json.loads(_blob().decode("utf-8"))
+
+    assert "publisher_step" not in payload
+
+
+def test_the_stamp_is_the_only_added_key():
+    """A wire-format change should be auditable by diffing the key sets."""
+    without = set(json.loads(_blob().decode("utf-8")))
+    with_step = set(json.loads(_blob(step=4).decode("utf-8")))
+
+    assert with_step - without == {"publisher_step"}
+
+
+def test_the_first_four_fields_keep_their_positions():
+    """The stamp is appended, so existing positional reads still land on the same
+    values. Unpacking now has to name five, which is the intended cost of one
+    payload type over a second unwrap function."""
+    payload = unwrap_rendezvous_blob(_blob(step=3))
+
+    assert payload[:4] == (b"meta", "agent-r0", "h:1", [])
+
+
+def test_a_new_reader_handles_an_unstamped_publishers_blob():
+    """Forward compatibility: no `publisher_step` key at all."""
+    payload = json.loads(_blob().decode("utf-8"))
+    payload.pop("publisher_step", None)
+
+    unwrapped = unwrap_rendezvous_blob(json.dumps(payload).encode("utf-8"))
+
+    assert unwrapped.publisher_step is None
+
+
+def test_an_old_reader_ignores_a_stamped_publishers_blob():
+    """Backward compatibility: the extra key must not be rejected."""
+    assert unwrap_rendezvous_blob(_blob(step=11))[1] == "agent-r0"
+
+
+def test_the_stamp_does_not_disturb_the_shard_table():
+    """The stamp describes the table; it must not alter how the table decodes."""
+    from modelexpress.refit.reshard.rendezvous import PublishedShard, PublishedTensor
+
+    tensors = [
+        PublishedTensor(
+            name="layers.0.weight",
+            dtype="torch.bfloat16",
+            elsize=2,
+            full_shape=(8, 4),
+            shards=[
+                PublishedShard(
+                    agent_name="agent-r0",
+                    device_id=0,
+                    addr=4096,
+                    shard_offset=(0, 0),
+                    shape=(4, 4),
+                )
+            ],
+        )
+    ]
+
+    stamped = unwrap_rendezvous_blob(_blob(step=5, tensors=tensors))
+    plain = unwrap_rendezvous_blob(_blob(tensors=tensors))
+
+    assert stamped[:4] == plain[:4]
+    assert stamped.tensors[0].shards[0].addr == 4096

--- a/modelexpress_client/python/tests/test_reshard_refit_step_stamp.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_step_stamp.py
@@ -79,9 +79,20 @@ def test_a_new_reader_handles_an_unstamped_publishers_blob():
     assert unwrapped.publisher_step is None
 
 
-def test_an_old_reader_ignores_a_stamped_publishers_blob():
-    """Backward compatibility: the extra key must not be rejected."""
-    assert unwrap_rendezvous_blob(_blob(step=11))[1] == "agent-r0"
+def test_stamping_leaves_every_other_field_untouched():
+    """What actually makes a stamped blob safe for a reader that predates the field.
+
+    Such a reader looks up the keys it knows and ignores the rest, so the property it
+    depends on is that the stamp is purely additive: every other key holds the same
+    value whether or not the stamp is present. Asserting that is honest about what
+    this suite can check. Running a released reader against the blob would be the
+    stronger test and is not something an in-process unit test can do, so it belongs
+    in a version-compatibility run rather than here.
+    """
+    stamped = json.loads(_blob(step=11).decode("utf-8"))
+    unstamped = json.loads(_blob().decode("utf-8"))
+
+    assert {k: v for k, v in stamped.items() if k != "publisher_step"} == unstamped
 
 
 def test_the_stamp_does_not_disturb_the_shard_table():


### PR DESCRIPTION
## Why this is needed

A receiver discovers a table that says where each published weight shard lives. The table does not currently say which training step those shards belong to.

That gap matters once shard digests are checked. If discovery returns a table from step 10 while the receiver pulls weights from step 11, the bytes can transfer correctly and still fail verification because the expected digest is one step old. With many publishers updating at slightly different times, the receiver cannot safely infer freshness from whether a digest changed.

This PR adds an explicit training-step stamp to the published table. Later verification code can compare step numbers instead of guessing whether metadata is fresh.

## What changes

- `wrap_rendezvous_blob` accepts an optional `publisher_step` and adds it to the JSON payload.
- `unwrap_rendezvous_blob` returns the stamp as `RendezvousPayload.publisher_step`.
- A missing stamp decodes to `None`, meaning “unknown.” It does not decode to step 0, because step 0 is valid.
- An unstamped publisher omits the key entirely. This preserves the previous wire payload for publishers that do not use the feature.
- Existing callers use named fields instead of unpacking a fixed four-item tuple.

## Where it sits

```mermaid
sequenceDiagram
    participant T as Trainer publisher
    participant C as MX catalog
    participant R as Refit receiver

    T->>C: 1. Publish shard table + optional step
    R->>C: 2. Discover shard table
    C-->>R: 3. Return shards + publisher_step
    alt Stamp is present
        R->>R: 4. Record the observed training step
    else Stamp is absent
        R->>R: 4. Treat freshness as unknown
    end
    Note over R: Future PR compares the observed step before digest verification
```

This PR adds the observation in step 4. It does not add the future freshness decision or the digest comparison.

## Compatibility contract

Mixed-version deployments are expected while trainer and receiver images roll out.

- New reader + old publisher: the missing key becomes `None`.
- New reader + new publisher: the integer step is available by name.
- Unstamped publication: every existing JSON field keeps the same value and no `publisher_step` key is written.
- Step 0 remains distinguishable from an unknown step.

The payload named tuple now has five fields. The first four retain their positions, but callers should use named access because fixed-length positional unpacking is brittle when optional metadata grows.

## Scope

Included:

- wire-format support for the optional step;
- decoding into the existing `RendezvousPayload` type;
- compatibility and shard-table tests.

Not included:

- wiring the current optimizer/training step into every publisher;
- rediscovery during a refit;
- rejecting or retrying stale metadata;
- digest comparison.

Those pieces should land with the consumer so the policy and the data it acts on can be reviewed together.

## How to review

Review the four files in this order:

1. **`refit/reshard/rendezvous.py` — required review.** Check the meaning of `None`, preservation of step 0, and omission of the JSON key when no stamp is supplied.
2. **`tests/test_reshard_refit_step_stamp.py` — required review.** Check the mixed-version properties and that adding a stamp leaves all other payload fields unchanged.
3. **`tests/test_reshard_refit_rendezvous.py` — mechanical review.** Existing assertions now prefer named fields; positional stability is still tested explicitly.
4. **`tests/test_reshard_megatron.py` — mechanical review.** The Megatron test reads the same payload through named fields.

Questions for reviewers:

- Is `None` the right representation for “publisher did not provide freshness”?
- Should the wire key remain optional during mixed-version rollout?
- Is extending the existing named tuple preferable to adding a second unwrap function and return type?

## Validation

- Python tests, lint, formatting, and DCO pass in CI.
- The full local reshard/refit selection passed: 119 tests.
- The focused step-stamp suite passed: 9 tests.

## Follow-up

The next consumer should rediscover metadata for the target refit, compare the observed publisher step with the requested step, and only then evaluate shard digests. A missing stamp must remain “not verified,” not “verified successfully.”