### PR TITLE
fix(client): release the source peer as part of the load (cherry-pick #577)

### DIFF
--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -449,67 +449,89 @@ class RdmaStrategy(LoadStrategy):
         register_tensors(result, ctx)
 
         is_p2p = bool(source_worker.worker_grpc_endpoint)
-        remote_agent_name_override = None
+        remote_agent_name = None
 
-        if is_p2p:
-            # _fetch_worker_metadata() prefetched and generation-validated
-            # this manifest before _load_as_target() prepared target tensors.
-            tensor_protos = worker_tensor_descriptors(source_worker)
-            source_tensors = [
-                TensorDescriptor(
-                    name=t.name, addr=t.addr, size=t.size,
-                    device_id=t.device_id, dtype=t.dtype,
-                )
-                for t in tensor_protos
-            ]
-            nixl_fetch_start = time.perf_counter()
-            ep = source_worker.metadata_endpoint
-            host, port_str = ep.rsplit(":", 1)
-            ctx.nixl_manager.fetch_remote_and_wait(
-                remote_agent_name=source_worker.agent_name,
-                ip=host,
-                port=int(port_str),
-            )
-            nixl_fetch_time = time.perf_counter() - nixl_fetch_start
-            logger.info(
-                f"[Worker {ctx.global_rank}] [TIMING] P2P NIXL metadata fetch: "
-                f"{nixl_fetch_time:.3f}s"
-            )
-            remote_agent_name_override = source_worker.agent_name
-        else:
-            source_tensors = [
-                TensorDescriptor(
-                    name=t.name, addr=t.addr, size=t.size,
-                    device_id=t.device_id, dtype=t.dtype,
-                )
-                for t in worker_tensor_descriptors(source_worker)
-            ]
-
-        logger.info(
-            f"[Worker {ctx.global_rank}] Receiving {len(source_tensors)} tensors from source"
-            f"{' (P2P)' if is_p2p else ''}"
-        )
-
-        transfer_start = time.perf_counter()
         try:
-            bytes_transferred, tensor_count, _ = ctx.nixl_manager.receive_from_source(
-                source_metadata=source_worker.nixl_metadata,
-                source_tensors=source_tensors,
-                timeout_seconds=_transfer_timeout_seconds(),
-                remote_agent_name=remote_agent_name_override,
+            if is_p2p:
+                # _fetch_worker_metadata() prefetched and generation-validated
+                # this manifest before _load_as_target() prepared target tensors.
+                tensor_protos = worker_tensor_descriptors(source_worker)
+                source_tensors = [
+                    TensorDescriptor(
+                        name=t.name, addr=t.addr, size=t.size,
+                        device_id=t.device_id, dtype=t.dtype,
+                    )
+                    for t in tensor_protos
+                ]
+                nixl_fetch_start = time.perf_counter()
+                ep = source_worker.metadata_endpoint
+                host, port_str = ep.rsplit(":", 1)
+                # Claimed before the dial so a fetch that fails part-way, leaving
+                # metadata that lands later, is still released.
+                remote_agent_name = source_worker.agent_name
+                ctx.nixl_manager.fetch_remote_and_wait(
+                    remote_agent_name=source_worker.agent_name,
+                    ip=host,
+                    port=int(port_str),
+                )
+                nixl_fetch_time = time.perf_counter() - nixl_fetch_start
+                logger.info(
+                    f"[Worker {ctx.global_rank}] [TIMING] P2P NIXL metadata fetch: "
+                    f"{nixl_fetch_time:.3f}s"
+                )
+            else:
+                source_tensors = [
+                    TensorDescriptor(
+                        name=t.name, addr=t.addr, size=t.size,
+                        device_id=t.device_id, dtype=t.dtype,
+                    )
+                    for t in worker_tensor_descriptors(source_worker)
+                ]
+                # Loaded here rather than inside receive_from_source so this method
+                # holds the name it is responsible for releasing.
+                add_start = time.perf_counter()
+                remote_agent_name = ctx.nixl_manager.add_remote_agent(
+                    source_worker.nixl_metadata
+                )
+                logger.info(
+                    f"[Worker {ctx.global_rank}] [TIMING] add_remote_agent: "
+                    f"{time.perf_counter() - add_start:.3f}s (agent={remote_agent_name})"
+                )
+
+            logger.info(
+                f"[Worker {ctx.global_rank}] Receiving {len(source_tensors)} tensors from source"
+                f"{' (P2P)' if is_p2p else ''}"
             )
-        except Exception as e:
-            raise SourceTransferError(f"RDMA receive failed: {e}") from e
-        transfer_time = time.perf_counter() - transfer_start
 
-        bandwidth_gbps = (bytes_transferred * 8) / (transfer_time * 1e9) if transfer_time > 0 else 0
-        logger.info(
-            f"[Worker {ctx.global_rank}] [TIMING] RDMA transfer complete: "
-            f"{tensor_count} tensors, {bytes_transferred / 1e9:.2f} GB, "
-            f"{transfer_time:.3f}s, {bandwidth_gbps:.1f} Gbps"
-        )
+            transfer_start = time.perf_counter()
+            try:
+                bytes_transferred, tensor_count, _ = ctx.nixl_manager.receive_from_source(
+                    source_metadata=source_worker.nixl_metadata,
+                    source_tensors=source_tensors,
+                    timeout_seconds=_transfer_timeout_seconds(),
+                    remote_agent_name=remote_agent_name,
+                )
+            except Exception as e:
+                raise SourceTransferError(f"RDMA receive failed: {e}") from e
+            transfer_time = time.perf_counter() - transfer_start
 
-        ctx.accelerator_backend.synchronize()
+            bandwidth_gbps = (
+                (bytes_transferred * 8) / (transfer_time * 1e9) if transfer_time > 0 else 0
+            )
+            logger.info(
+                f"[Worker {ctx.global_rank}] [TIMING] RDMA transfer complete: "
+                f"{tensor_count} tensors, {bytes_transferred / 1e9:.2f} GB, "
+                f"{transfer_time:.3f}s, {bandwidth_gbps:.1f} Gbps"
+            )
+
+            ctx.accelerator_backend.synchronize()
+        finally:
+            # A weight load is one-shot, so release the source here instead of at
+            # process exit: the engine process is torn down without running atexit
+            # hooks, and in P2P only the reader holds a record of the peer to
+            # invalidate. None means acquisition failed with nothing to release.
+            if remote_agent_name is not None:
+                ctx.nixl_manager.remove_remote_agent(remote_agent_name)
 
         total_time = time.perf_counter() - receive_start
         logger.info(f"[Worker {ctx.global_rank}] [TIMING] Total receive time: {total_time:.2f}s")

--- a/modelexpress_client/python/tests/test_rdma_peer_release.py
+++ b/modelexpress_client/python/tests/test_rdma_peer_release.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A reader must release the source as part of the load, not at process exit.
+
+Regression cover for nvbug 6519532, which reproduced on 0.5.0-rc.3 *after* the
+peer-disconnect machinery had shipped: it was reachable only from an ``atexit``
+hook, and the NIXL agent lives in a process that dies without running one. The
+disconnect existed and never ran, leaving the source with a half-open QP that
+stalled every later reader.
+
+These drive ``_receive_from_peer`` rather than calling teardown directly, so
+that reachability is asserted rather than assumed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modelexpress.load_strategy.base import SourceTransferError
+from modelexpress.load_strategy.rdma_strategy import RdmaStrategy
+
+P2P_AGENT = "mx-auto-worker0-0d6a01a9"
+BLOB_AGENT = "agent-from-blob"
+
+
+def _descriptor(name="w0"):
+    return SimpleNamespace(name=name, addr=4096, size=128, device_id=0, dtype="torch.bfloat16")
+
+
+def _manager():
+    mgr = MagicMock()
+    mgr.receive_from_source.return_value = (128, 1, 0.01)
+    mgr.add_remote_agent.return_value = BLOB_AGENT
+    mgr.remove_remote_agent.return_value = True
+    return mgr
+
+
+def _ctx(manager):
+    return SimpleNamespace(
+        global_rank=0,
+        worker_rank=0,
+        worker_id="target-0",
+        nixl_manager=manager,
+        accelerator_backend=SimpleNamespace(name="cuda", synchronize=MagicMock()),
+        adapter=MagicMock(),
+        identity=SimpleNamespace(model_name="m"),
+    )
+
+
+def _source_worker(p2p: bool):
+    """A source the strategy will read from, in P2P or centralized mode."""
+    return SimpleNamespace(
+        agent_name=P2P_AGENT,
+        # Presence of this endpoint is what selects the P2P branch.
+        worker_grpc_endpoint="10.0.18.37:5556" if p2p else "",
+        metadata_endpoint="10.0.18.37:5555",
+        nixl_metadata=b"blob",
+        accelerator="cuda",
+    )
+
+
+def _receive(manager, p2p=True, ctx=None):
+    strategy = RdmaStrategy()
+    with (
+        patch("modelexpress.load_strategy.rdma_strategy.register_tensors"),
+        patch(
+            "modelexpress.load_strategy.rdma_strategy.worker_tensor_descriptors",
+            return_value=[_descriptor()],
+        ),
+    ):
+        strategy._receive_from_peer(
+            MagicMock(), ctx or _ctx(manager), _source_worker(p2p), "src-1"
+        )
+
+
+class TestReleaseOnTheLoadPath:
+    def test_p2p_source_is_released_after_a_successful_load(self):
+        """The case rc.3 disproved: cleanup must not wait for interpreter exit."""
+        mgr = _manager()
+        _receive(mgr, p2p=True)
+        mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
+
+    def test_the_released_peer_is_the_one_that_was_fetched(self):
+        """Releasing a different name would leave the real QP half-open."""
+        mgr = _manager()
+        _receive(mgr, p2p=True)
+        fetched = mgr.fetch_remote_and_wait.call_args.kwargs["remote_agent_name"]
+        assert mgr.remove_remote_agent.call_args.args[0] == fetched
+
+    def test_the_peer_outlives_the_transfer_and_the_device_sync(self):
+        """Release has to be last. Disconnecting before the READ completes would
+        tear down the QP under it, and doing so before the device sync would rely
+        on receive_from_source's internal sync staying where it is - a silent
+        corruption if that ever moves, rather than a loud failure."""
+        mgr = _manager()
+        order = []
+        mgr.receive_from_source.side_effect = lambda **_: (
+            order.append("transfer") or (128, 1, 0.01)
+        )
+        mgr.remove_remote_agent.side_effect = lambda *_: order.append("release") or True
+        ctx = _ctx(mgr)
+        ctx.accelerator_backend.synchronize.side_effect = lambda: order.append("sync")
+
+        _receive(mgr, p2p=True, ctx=ctx)
+
+        assert order == ["transfer", "sync", "release"]
+
+
+class TestReleaseOnFailure:
+    def test_a_failed_transfer_still_releases_the_source(self):
+        """The wedged-source case. A reader that times out and moves to the next
+        candidate must not leave connection state behind on the way out."""
+        mgr = _manager()
+        mgr.receive_from_source.side_effect = TimeoutError("Transfer timed out")
+
+        with pytest.raises(SourceTransferError):
+            _receive(mgr, p2p=True)
+
+        mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
+
+    def test_the_transfer_error_reaches_the_caller(self):
+        """Retry and fallback both depend on the original failure propagating.
+
+        The release cannot get in the way: remove_remote_agent logs and swallows
+        its own failures by contract, so it has nothing to mask this with.
+        """
+        mgr = _manager()
+        mgr.receive_from_source.side_effect = TimeoutError("Transfer timed out")
+
+        with pytest.raises(SourceTransferError) as raised:
+            _receive(mgr, p2p=True)
+
+        assert isinstance(raised.value.__cause__, TimeoutError)
+
+    def test_a_half_finished_p2p_fetch_is_released(self):
+        """fetch_remote_and_wait dials the source and only then waits, so a
+        timeout can leave metadata that arrives afterwards. Claiming the name
+        before the dial is what gives that late arrival something to release it."""
+        mgr = _manager()
+        mgr.fetch_remote_and_wait.side_effect = TimeoutError(
+            "Timed out waiting for remote metadata"
+        )
+
+        with pytest.raises(TimeoutError):
+            _receive(mgr, p2p=True)
+
+        mgr.remove_remote_agent.assert_called_once_with(P2P_AGENT)
+
+    def test_a_failed_blob_load_releases_nothing(self):
+        """The centralized name only exists once add_remote_agent returns, so
+        there is no peer to release if it raises. Releasing a name we never got
+        would mean calling the manager with None."""
+        mgr = _manager()
+        mgr.add_remote_agent.side_effect = RuntimeError("bad metadata blob")
+
+        with pytest.raises(RuntimeError, match="bad metadata blob"):
+            _receive(mgr, p2p=False)
+
+        mgr.remove_remote_agent.assert_not_called()
+
+
+class TestCentralizedMode:
+    def test_centralized_load_releases_the_peer_it_loaded(self):
+        """Centralized readers load the source from a blob, so they own the same
+        teardown duty - the asymmetry that wedges the source is identical."""
+        mgr = _manager()
+        _receive(mgr, p2p=False)
+        mgr.add_remote_agent.assert_called_once_with(b"blob")
+        mgr.remove_remote_agent.assert_called_once_with(BLOB_AGENT)
+
+    def test_centralized_load_does_not_double_load_the_peer(self):
+        """The strategy loads the peer so it holds the name; passing it through
+        keeps receive_from_source from loading a second, untracked copy."""
+        mgr = _manager()
+        _receive(mgr, p2p=False)
+        assert mgr.receive_from_source.call_args.kwargs["remote_agent_name"] == BLOB_AGENT


### PR DESCRIPTION
Cherry-pick of #577 (`de5a4df`) onto `release/0.5.0`, which is the branch the bug was retested against — nvbug 6519532 reproduced 4/4 on `0.5.0-rc.3`.

#555 is already here via #575, but its disconnect runs only from `atexit`, which the vLLM EngineCore process does not reach when the pod is torn down, so it never fires. This releases the peer on the load path instead: a weight load is one-shot, so the reader can return the source's QP while the process is still healthy rather than at interpreter exit. That makes cleanup independent of how the process dies, including `SIGKILL` and OOM.

## Not a clean pick

This branch predates the repo-wide reformat and the per-adapter exact-catalog flag, both from #565, so the conflicting hunk in `_receive_from_peer` was resolved by hand:

* Dropped `require_exact_match` and the cross-family accelerator comparison that feeds it. `receive_from_source` does not accept that parameter on this branch, and `ctx.adapter.requires_exact_tensor_catalog()` does not exist here.
* Kept this branch's formatting instead of importing #565's, so the backport diff is the behaviour change and nothing else.

Everything else is identical to #577: the `try` opens at acquisition and the release sits in a `finally` after the device sync, the P2P agent name is claimed before the dial so a part-way fetch is still released, and the centralized branch loads the peer itself so the strategy holds the name it releases.

## One test omitted rather than adapted

`test_a_failure_before_the_transfer_still_releases_the_peer` injected its failure through `ctx.accelerator_backend.name`, which `_receive_from_peer` does not read on this branch — that read arrived with `require_exact_match`. Here the window between acquisition and transfer is a single log statement, so the test has nothing meaningful to target; forcing an injection point would have tested the mock rather than the code. The acquisition-failure case it partly covered is still covered by `test_a_half_finished_p2p_fetch_is_released`.

## Test

`tests/test_rdma_peer_release.py`, 9 tests. 8 of the 9 fail against this branch without the change; the 9th guards that cleanup does not swallow the transfer error retry and disk fallback depend on, so it holds either way.

Related suites: 167 passed (`test_rdma_peer_release`, `test_source_selection`, `test_nixl_peer_lifecycle`, `test_publisher_peer_teardown`, `test_rdma_transfer_timeout`, `test_publisher`, `test_nixl_backend`, `test_k8s_service_client`, `test_pool_registration`). Pre-commit clean.

## Hardware verification still needed

As on #577, the unit tests cover the client contract — that the reader releases its source — not the UCX behaviour that contract exists to avoid. The decisive check is QA's rc.3 procedure: after target A is scaled to zero, target D should load over RDMA instead of timing out, with no `mlx5dv_devx_obj_modify(opcode=0x503)` on the source. Worth the same 4 iterations, since this defect has passed intermittently before.