### PR TITLE
fix: honor ignore_weights when streaming model files from the server

### DIFF
--- a/modelexpress_client/go/gen/modelexpress/model/model.pb.go
+++ b/modelexpress_client/go/gen/modelexpress/model/model.pb.go
@@ -371,7 +371,10 @@ type ModelFilesRequest struct {
 	// Chunk size in bytes for streaming (0 = use server default)
 	ChunkSize uint32 `protobuf:"varint,3,opt,name=chunk_size,json=chunkSize,proto3" json:"chunk_size,omitempty"`
 	// Optional file selector. If unset, all files are streamed.
-	FileSelector  *ModelFileSelector `protobuf:"bytes,4,opt,name=file_selector,json=fileSelector,proto3" json:"file_selector,omitempty"`
+	FileSelector *ModelFileSelector `protobuf:"bytes,4,opt,name=file_selector,json=fileSelector,proto3" json:"file_selector,omitempty"`
+	// When true, weight files are skipped and only non-weight files
+	// (config, tokenizer, etc.) are streamed. Mirrors ModelDownloadRequest.
+	IgnoreWeights bool `protobuf:"varint,5,opt,name=ignore_weights,json=ignoreWeights,proto3" json:"ignore_weights,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -432,6 +435,13 @@ func (x *ModelFilesRequest) GetFileSelector() *ModelFileSelector {
 		return x.FileSelector
 	}
 	return nil
+}
+
+func (x *ModelFilesRequest) GetIgnoreWeights() bool {
+	if x != nil {
+		return x.IgnoreWeights
+	}
+	return false
 }
 
 // Selects files within a model directory
@@ -725,14 +735,15 @@ const file_model_proto_rawDesc = "" +
 	"\amessage\x18\x03 \x01(\tH\x00R\amessage\x88\x01\x01\x12>\n" +
 	"\bprovider\x18\x04 \x01(\x0e2\".model_express.model.ModelProviderR\bproviderB\n" +
 	"\n" +
-	"\b_message\"\xde\x01\n" +
+	"\b_message\"\x85\x02\n" +
 	"\x11ModelFilesRequest\x12\x1d\n" +
 	"\n" +
 	"model_name\x18\x01 \x01(\tR\tmodelName\x12>\n" +
 	"\bprovider\x18\x02 \x01(\x0e2\".model_express.model.ModelProviderR\bprovider\x12\x1d\n" +
 	"\n" +
 	"chunk_size\x18\x03 \x01(\rR\tchunkSize\x12K\n" +
-	"\rfile_selector\x18\x04 \x01(\v2&.model_express.model.ModelFileSelectorR\ffileSelector\")\n" +
+	"\rfile_selector\x18\x04 \x01(\v2&.model_express.model.ModelFileSelectorR\ffileSelector\x12%\n" +
+	"\x0eignore_weights\x18\x05 \x01(\bR\rignoreWeights\")\n" +
 	"\x11ModelFileSelector\x12\x14\n" +
 	"\x05paths\x18\x01 \x03(\tR\x05paths\"\xf7\x01\n" +
 	"\tFileChunk\x12#\n" +

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -367,6 +367,7 @@ impl Client {
         &mut self,
         model_name: &str,
         provider: ModelProvider,
+        ignore_weights: bool,
     ) -> CommonResult<()> {
         let cache_config = self.cache_config.as_ref().ok_or_else(|| {
             modelexpress_common::Error::Server(
@@ -393,6 +394,7 @@ impl Client {
             provider: modelexpress_common::grpc::model::ModelProvider::from(provider) as i32,
             chunk_size,
             file_selector: None,
+            ignore_weights,
         });
 
         let mut stream = self
@@ -728,7 +730,7 @@ impl Client {
                 "Shared storage disabled, streaming files from server for model {}",
                 model_name
             );
-            self.stream_model_files_from_server(&model_name, provider)
+            self.stream_model_files_from_server(&model_name, provider, ignore_weights)
                 .await?;
         }
 
@@ -1345,7 +1347,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
             .await;
 
         server_handle.abort();
@@ -1382,7 +1384,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
             .await;
 
         server_handle.abort();
@@ -1429,7 +1431,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
             .await;
 
         server_handle.abort();
@@ -1476,7 +1478,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
             .await;
 
         server_handle.abort();

--- a/modelexpress_common/proto/model.proto
+++ b/modelexpress_common/proto/model.proto
@@ -72,6 +72,9 @@ message ModelFilesRequest {
   uint32 chunk_size = 3;
   // Optional file selector. If unset, all files are streamed.
   ModelFileSelector file_selector = 4;
+  // When true, weight files are skipped and only non-weight files
+  // (config, tokenizer, etc.) are streamed. Mirrors ModelDownloadRequest.
+  bool ignore_weights = 5;
 }
 
 // Selects files within a model directory

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -73,14 +73,22 @@ pub trait ModelProviderTrait: Send + Sync {
     where
         Self: Sized,
     {
-        filename.ends_with(".bin")
-            || filename.ends_with(".safetensors")
-            || filename.ends_with(".h5")
-            || filename.ends_with(".msgpack")
-            || filename.ends_with(".ckpt.index")
-            || filename.ends_with(".iop")
-            || filename.ends_with(".gas")
+        is_weight_file(filename)
     }
+}
+
+/// Provider-agnostic check for whether a file is a model weight file.
+///
+/// Shared by the provider trait's `is_weight_file` default and by the server's
+/// file-streaming path so both use the same definition of "weight file".
+pub fn is_weight_file(filename: &str) -> bool {
+    filename.ends_with(".bin")
+        || filename.ends_with(".safetensors")
+        || filename.ends_with(".h5")
+        || filename.ends_with(".msgpack")
+        || filename.ends_with(".ckpt.index")
+        || filename.ends_with(".iop")
+        || filename.ends_with(".gas")
 }
 
 pub mod gcs;

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -17,6 +17,7 @@ use modelexpress_common::{
         },
     },
     models::{ModelProvider, ModelStatus},
+    providers::is_weight_file,
 };
 use std::{
     collections::HashMap,
@@ -141,6 +142,7 @@ fn collect_model_files(
     base_path: &Path,
     current_path: &Path,
     file_selector: Option<&ModelFileSelector>,
+    ignore_weights: bool,
 ) -> Vec<(PathBuf, u64)> {
     let mut files = Vec::new();
 
@@ -171,6 +173,10 @@ fn collect_model_files(
                                 path,
                                 relative
                             );
+                        } else if ignore_weights
+                            && is_weight_file(relative.to_string_lossy().as_ref())
+                        {
+                            // Weight file skipped because ignore_weights is set.
                         } else if file_selector.is_none_or(|selector| {
                             selector
                                 .paths
@@ -182,7 +188,12 @@ fn collect_model_files(
                     }
                 }
             } else if path.is_dir() {
-                files.extend(collect_model_files(base_path, &path, file_selector));
+                files.extend(collect_model_files(
+                    base_path,
+                    &path,
+                    file_selector,
+                    ignore_weights,
+                ));
             }
         }
     }
@@ -346,6 +357,7 @@ impl ModelService for ModelServiceImpl {
             &model_path,
             &model_path,
             files_request.file_selector.as_ref(),
+            files_request.ignore_weights,
         );
         ensure_selected_files_exist(&files, files_request.file_selector.as_ref())
             .map_err(Status::not_found)?;
@@ -494,6 +506,7 @@ impl ModelService for ModelServiceImpl {
             &model_path,
             &model_path,
             files_request.file_selector.as_ref(),
+            files_request.ignore_weights,
         );
         ensure_selected_files_exist(&files, files_request.file_selector.as_ref())
             .map_err(Status::not_found)?;
@@ -1237,7 +1250,7 @@ mod tests {
     #[test]
     fn test_collect_model_files_empty_dir() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let files = collect_model_files(temp_dir.path(), temp_dir.path(), None);
+        let files = collect_model_files(temp_dir.path(), temp_dir.path(), None, false);
         assert!(files.is_empty());
     }
 
@@ -1252,7 +1265,7 @@ mod tests {
         let file2_path = temp_dir.path().join("model.bin");
         std::fs::write(&file2_path, vec![0u8; 100]).expect("Failed to write file2");
 
-        let files = collect_model_files(temp_dir.path(), temp_dir.path(), None);
+        let files = collect_model_files(temp_dir.path(), temp_dir.path(), None, false);
 
         assert_eq!(files.len(), 2);
 
@@ -1270,6 +1283,51 @@ mod tests {
     }
 
     #[test]
+    fn test_collect_model_files_ignore_weights() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+        // Mix of non-weight and weight files, including a nested weight shard.
+        std::fs::write(temp_dir.path().join("config.json"), "{}").expect("write config");
+        std::fs::write(temp_dir.path().join("tokenizer.json"), "{}").expect("write tokenizer");
+        std::fs::write(temp_dir.path().join("model.safetensors"), vec![0u8; 10])
+            .expect("write safetensors");
+        std::fs::write(temp_dir.path().join("pytorch_model.bin"), vec![0u8; 10])
+            .expect("write bin");
+        let subdir = temp_dir.path().join("subdir");
+        std::fs::create_dir(&subdir).expect("create subdir");
+        std::fs::write(
+            subdir.join("model-00001-of-00002.safetensors"),
+            vec![0u8; 10],
+        )
+        .expect("write nested shard");
+
+        // ignore_weights = false streams everything.
+        let all = collect_model_files(temp_dir.path(), temp_dir.path(), None, false);
+        assert_eq!(all.len(), 5);
+
+        // ignore_weights = true keeps only the non-weight files (config + tokenizer),
+        // dropping weight shards at any depth.
+        let no_weights = collect_model_files(temp_dir.path(), temp_dir.path(), None, true);
+        let names: Vec<String> = no_weights
+            .iter()
+            .map(|(p, _)| p.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(
+            no_weights.len(),
+            2,
+            "expected only non-weight files: {names:?}"
+        );
+        assert!(names.contains(&"config.json".to_string()));
+        assert!(names.contains(&"tokenizer.json".to_string()));
+        assert!(
+            names
+                .iter()
+                .all(|n| !n.ends_with(".safetensors") && !n.ends_with(".bin")),
+            "weight files must be excluded: {names:?}"
+        );
+    }
+
+    #[test]
     fn test_collect_model_files_nested() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
@@ -1283,7 +1341,7 @@ mod tests {
         let file2_path = subdir.join("nested_file.txt");
         std::fs::write(&file2_path, "nested content").expect("Failed to write file2");
 
-        let files = collect_model_files(temp_dir.path(), temp_dir.path(), None);
+        let files = collect_model_files(temp_dir.path(), temp_dir.path(), None, false);
 
         assert_eq!(files.len(), 2);
 
@@ -1310,7 +1368,7 @@ mod tests {
         let selector = ModelFileSelector {
             paths: vec!["config.json".to_string(), "subdir/nested.txt".to_string()],
         };
-        let files = collect_model_files(temp_dir.path(), temp_dir.path(), Some(&selector));
+        let files = collect_model_files(temp_dir.path(), temp_dir.path(), Some(&selector), false);
 
         let mut paths: Vec<_> = files
             .iter()
@@ -1330,7 +1388,13 @@ mod tests {
 
         let empty_selector = ModelFileSelector { paths: vec![] };
         assert!(
-            collect_model_files(temp_dir.path(), temp_dir.path(), Some(&empty_selector)).is_empty()
+            collect_model_files(
+                temp_dir.path(),
+                temp_dir.path(),
+                Some(&empty_selector),
+                false
+            )
+            .is_empty()
         );
 
         let nonmatching_selector = ModelFileSelector {
@@ -1340,7 +1404,8 @@ mod tests {
             collect_model_files(
                 temp_dir.path(),
                 temp_dir.path(),
-                Some(&nonmatching_selector)
+                Some(&nonmatching_selector),
+                false
             )
             .is_empty()
         );
@@ -1374,6 +1439,7 @@ mod tests {
             file_selector: Some(ModelFileSelector {
                 paths: vec!["config.json".to_string(), "subdir/nested.txt".to_string()],
             }),
+            ignore_weights: false,
         });
 
         let response = service
@@ -1458,6 +1524,7 @@ mod tests {
             file_selector: Some(ModelFileSelector {
                 paths: vec!["config.json".to_string()],
             }),
+            ignore_weights: false,
         });
 
         let response = service
@@ -1501,6 +1568,7 @@ mod tests {
             file_selector: Some(ModelFileSelector {
                 paths: vec!["config.json".to_string(), "missing.json".to_string()],
             }),
+            ignore_weights: false,
         });
 
         let result = service.stream_model_files(request).await;
@@ -1521,6 +1589,7 @@ mod tests {
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
             chunk_size: 0,
             file_selector: None,
+            ignore_weights: false,
         });
 
         let result = service.list_model_files(request).await;
@@ -1538,6 +1607,7 @@ mod tests {
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
             chunk_size: 1024,
             file_selector: None,
+            ignore_weights: false,
         });
 
         let result = service.stream_model_files(request).await;
@@ -1572,6 +1642,7 @@ mod tests {
             provider: 99,
             chunk_size: 0,
             file_selector: None,
+            ignore_weights: false,
         });
 
         let result = service.list_model_files(request).await;
@@ -1590,6 +1661,7 @@ mod tests {
             provider: 99,
             chunk_size: 1024,
             file_selector: None,
+            ignore_weights: false,
         });
 
         let result = service.stream_model_files(request).await;
@@ -1622,6 +1694,7 @@ mod tests {
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
             chunk_size: 1024,
             file_selector: None,
+            ignore_weights: false,
         });
 
         let response = service
@@ -1663,6 +1736,7 @@ mod tests {
             provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
             chunk_size: 1024,
             file_selector: None,
+            ignore_weights: false,
         });
 
         let response = service


### PR DESCRIPTION
## What

`Client::request_model` takes an `ignore_weights` flag but never forwarded it to `stream_model_files_from_server`, which hard-coded `file_selector: None` and streamed **every** file including weight shards. So a config-only request still re-streamed the full weight set from the server whenever shared storage was disabled (`MODEL_EXPRESS_NO_SHARED_STORAGE=1`).

This PR:
- adds an `ignore_weights` field to `ModelFilesRequest` (mirrors `ModelDownloadRequest.ignore_weights`),
- threads the flag from `request_model` → `stream_model_files_from_server` → the gRPC request,
- has the server's `collect_model_files` skip weight files when set (applies to both `StreamModelFiles` and `ListModelFiles`),
- extracts the weight-file check into a shared `providers::is_weight_file` free function so the streaming path and the provider download path share one definition.

`StreamModelFiles`/`ListModelFiles` already supported selective streaming via `file_selector`; this makes weightless streaming a first-class option.

## Why

Defense-in-depth for the redundant-weight-stream class of bug (context: investigation of ai-dynamo/dynamo#12097). When a caller only needs config/tokenizer (e.g. building a model card) but runs with shared storage disabled, it should not re-pull the full weight set from the server. Today the miss is masked because callers that pass `ignore_weights=true` also cause the server to hold no weight files — but if the server already has the full model cached, the stream would pull the weights anyway. This makes the client request match its intent.

## Testing

- New unit test `test_collect_model_files_ignore_weights` (weight shards excluded at any depth; config/tokenizer kept).
- `cargo build --workspace`, `cargo clippy --workspace --all-targets` (no warnings), `cargo test -p modelexpress-server --lib` (230 passed), client stream tests, and `modelexpress-common` provider tests all green.

No Python change: the Python client is metadata-only and does not consume `ModelService`. The weight-file extension list is already documented in `docs/GCS_PROVIDER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model file downloads, listings, and streaming can now exclude weight files when requested.
  - Weight files are detected consistently, including nested weight shards.
  - Existing file selection and missing-file validation continue to work when weights are excluded.

- **Bug Fixes**
  - Improved consistency between model downloads and streamed file transfers when filtering out weight files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->