### PR TITLE
fix(trtllm): republish RDMA targets after post-load

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/trtllm/loader.py
+++ b/modelexpress_client/python/modelexpress/engines/trtllm/loader.py
@@ -97,11 +97,17 @@ class MxModelLoader:
         return {} if self.p2p_succeeded else value
 
     def publish_model(self, model: torch.nn.Module) -> None:
-        """Publish a native-loaded model after TRT post-load processing."""
+        """Publish the final TRT model after post-load processing."""
         try:
             result = LoadResult(value=model, model=model)
             self.adapter.current_model = model
             self._ctx.accelerator_backend.synchronize()
+            if self.p2p_succeeded and self._ctx.nixl_manager is not None:
+                # The receive-time registration may describe tensors before TRT
+                # finalizes aliases and storage. Rebuild it from the final model.
+                self._ctx.nixl_manager.shutdown()
+                self._ctx.nixl_manager = None
+                self._ctx.tensors = {}
             register_tensors(result, self._ctx)
             publish_metadata(self._ctx)
         except Exception as exc:  # noqa: BLE001 - publish is best effort

--- a/modelexpress_client/python/tests/test_trtllm_loader.py
+++ b/modelexpress_client/python/tests/test_trtllm_loader.py
@@ -147,7 +147,9 @@ def test_loader_preserves_native_engine_value(monkeypatch):
 def test_native_publish_uses_existing_context(monkeypatch):
     context = Mock()
     context.adapter.native_loaded = True
+    context.adapter.rdma_loaded = False
     context.adapter.current_model = None
+    manager = context.nixl_manager
     model = Mock()
 
     monkeypatch.setattr(
@@ -163,6 +165,35 @@ def test_native_publish_uses_existing_context(monkeypatch):
     loader.publish_model(model)
 
     context.accelerator_backend.synchronize.assert_called_once()
+    manager.shutdown.assert_not_called()
+    register.assert_called_once()
+    publish.assert_called_once_with(context)
+
+
+def test_rdma_target_rebuilds_registration_before_publish(monkeypatch):
+    context = Mock()
+    context.adapter.rdma_loaded = True
+    context.adapter.current_model = None
+    receive_manager = context.nixl_manager
+    context.tensors = {"receive.weight": Mock()}
+    model = Mock()
+
+    monkeypatch.setattr(
+        "modelexpress.engines.trtllm.loader.build_trtllm_load_context",
+        lambda **kwargs: context,
+    )
+    register = Mock()
+    publish = Mock()
+    monkeypatch.setattr("modelexpress.engines.trtllm.loader.register_tensors", register)
+    monkeypatch.setattr("modelexpress.engines.trtllm.loader.publish_metadata", publish)
+
+    loader = MxModelLoader(**_loader_kwargs())
+    loader.publish_model(model)
+
+    receive_manager.shutdown.assert_called_once_with()
+    assert context.nixl_manager is None
+    assert context.tensors == {}
+    context.accelerator_backend.synchronize.assert_called_once_with()
     register.assert_called_once()
     publish.assert_called_once_with(context)
 


### PR DESCRIPTION
## Overview

TRT-LLM must suppress the shared strategy chain publication point because its final post-load lifecycle has not completed yet. Once TensorRT-LLM invokes the late publish hook, an RDMA-loaded target should become a source so fan-out and rolling replacement do not depend on the original donor.

This change makes late TRT publication safe for both native and RDMA load paths:

- native-loaded sources keep the existing late registration and publication path;
- RDMA targets synchronize final CUDA writes, shut down the receive-time NIXL registration, rediscover the final TRT tensor catalog, create a fresh registration, and publish READY metadata;
- the early strategy-chain publication remains disabled by the TRT adapter.

The registration rebuild is intentional: the receive-time NIXL descriptors may describe the pre-finalized catalog, and the shared registration helper does not replace an existing manager.

Depends on the TensorRT-LLM lifecycle change in NVIDIA/TensorRT-LLM#17029.

## Validation

- `18 passed` for `test_trtllm_loader.py` and `test_trtllm_adapter.py`
- `git diff --check`
- Python syntax compilation for the changed implementation and test

A real donor -> receiver -> second-hop receiver GPU test remains required before marking this PR ready.