### PR TITLE
helm: support gRPC probes and label the service port as gRPC

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -128,12 +128,12 @@ The following table lists the configurable parameters of the ModelExpress chart 
 | `persistence.size`                           | Storage size                                   | `10Gi`   |
 | `persistence.mountPath`                      | Mount path                                     | `/root`  |
 | `env.MODEL_EXPRESS_SERVER_PORT`              | Server port                                    | `8001`   |
-| `env.MODEL_EXPRESS_LOGGING_LEVEL`            | Logging level                                  | `info`   |
+| `env.MODEL_EXPRESS_LOG_LEVEL`                | Logging level                                  | `info`   |
 | `env.MODEL_EXPRESS_CACHE_DIRECTORY`          | Cache directory                                | `/app/cache` |
 | `env.MX_METADATA_BACKEND`                    | Distributed backend (`redis` or `kubernetes`). Server fails to start without this. | `<required>` |
 | `env.REDIS_URL`                              | Redis connection URL; required when backend is `redis`. Chart does not bundle Redis. | `<required when backend=redis>` |
-| `livenessProbe.enabled`                      | Enable liveness probe                          | `true`   |
-| `readinessProbe.enabled`                     | Enable readiness probe                         | `true`   |
+| `livenessProbe.enabled`                      | Enable liveness probe (remaining keys render verbatim; default handler is `grpc`) | `true`   |
+| `readinessProbe.enabled`                     | Enable readiness probe (remaining keys render verbatim; default handler is `grpc`) | `true`   |
 | `nodeSelector`                               | Node selector                                  | `{}`     |
 | `tolerations`                                | Tolerations                                    | `[]`     |
 | `affinity`                                   | Affinity rules                                 | `{}`     |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           {{- end }}
           ports:
-            - name: http
+            - name: grpc
               containerPort: {{ .Values.service.port | default 8001 }}
               protocol: TCP
           env:
@@ -96,26 +96,23 @@ spec:
             {{- toYaml .Values.args | nindent 12 }}
           {{- end }}
           {{- if and .Values.livenessProbe .Values.livenessProbe.enabled }}
+          {{- $liveness := omit .Values.livenessProbe "enabled" }}
+          {{- /* A probe allows exactly one handler. Helm deep-merges values,
+               so an override with tcpSocket/httpGet/exec would otherwise
+               combine with the default grpc handler; drop grpc in that case. */}}
+          {{- if or $liveness.tcpSocket $liveness.httpGet $liveness.exec }}
+          {{- $liveness = omit $liveness "grpc" }}
+          {{- end }}
           livenessProbe:
-            {{- if .Values.livenessProbe.tcpSocket }}
-            tcpSocket:
-              {{- toYaml .Values.livenessProbe.tcpSocket | nindent 14 }}
-            {{- end }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 5 }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 10 }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 5 }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 3 }}
+            {{- toYaml $liveness | nindent 12 }}
           {{- end }}
           {{- if and .Values.readinessProbe .Values.readinessProbe.enabled }}
+          {{- $readiness := omit .Values.readinessProbe "enabled" }}
+          {{- if or $readiness.tcpSocket $readiness.httpGet $readiness.exec }}
+          {{- $readiness = omit $readiness "grpc" }}
+          {{- end }}
           readinessProbe:
-            {{- if .Values.readinessProbe.tcpSocket }}
-            tcpSocket:
-              {{- toYaml .Values.readinessProbe.tcpSocket | nindent 14 }}
-            {{- end }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 10 }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 5 }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 3 }}
+            {{- toYaml $readiness | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -12,8 +12,9 @@ spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
   ports:
     - port: {{ .Values.service.port | default 8001 }}
-      targetPort: http
+      targetPort: grpc
       protocol: TCP
-      name: http
+      name: grpc
+      appProtocol: grpc
   selector:
     {{- include "modelexpress.selectorLabels" . | nindent 4 }}

--- a/helm/test-values.yaml
+++ b/helm/test-values.yaml
@@ -41,14 +41,14 @@ persistence:
 
 env:
   MODEL_EXPRESS_SERVER_PORT: "8001"
-  MODEL_EXPRESS_LOGGING_LEVEL: "debug"
+  MODEL_EXPRESS_LOG_LEVEL: "debug"
   MODEL_EXPRESS_CACHE_DIRECTORY: "/root"
   MX_METADATA_BACKEND: "redis"
   REDIS_URL: "redis://redis:6379"
 
 livenessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 10
@@ -57,7 +57,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 10

--- a/helm/values-development.yaml
+++ b/helm/values-development.yaml
@@ -42,7 +42,7 @@ persistence:
 
 env:
   MODEL_EXPRESS_SERVER_PORT: "8001"
-  MODEL_EXPRESS_LOGGING_LEVEL: "debug"
+  MODEL_EXPRESS_LOG_LEVEL: "debug"
   MODEL_EXPRESS_CACHE_DIRECTORY: "/root"
   # Distributed backend selection. Required — the server fails to start without it.
   # This values file opinionates on Redis for dev convenience; override to
@@ -55,7 +55,7 @@ env:
 
 livenessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 30
@@ -64,7 +64,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 10

--- a/helm/values-local-storage.yaml
+++ b/helm/values-local-storage.yaml
@@ -65,7 +65,7 @@ extraVolumeMounts:
 
 env:
   MODEL_EXPRESS_SERVER_PORT: "8001"
-  MODEL_EXPRESS_LOGGING_LEVEL: "debug"
+  MODEL_EXPRESS_LOG_LEVEL: "debug"
   MODEL_EXPRESS_CACHE_DIRECTORY: "/root"
   # Note: HOME is set to /root so HuggingFace cache uses /root/.cache/huggingface
   HOME: "/root"
@@ -96,7 +96,7 @@ extraEnv:
 
 livenessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 10
   periodSeconds: 10
@@ -105,7 +105,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 5
   periodSeconds: 5

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -58,14 +58,14 @@ persistence:
 
 env:
   MODEL_EXPRESS_SERVER_PORT: "8001"
-  MODEL_EXPRESS_LOGGING_LEVEL: "info"
+  MODEL_EXPRESS_LOG_LEVEL: "info"
   MODEL_EXPRESS_CACHE_DIRECTORY: "/root"
   MX_METADATA_BACKEND: "redis"
   REDIS_URL: "redis://redis:6379"
 
 livenessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 10
@@ -74,7 +74,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 5

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -93,7 +93,7 @@ persistence:
 
 env:
   MODEL_EXPRESS_SERVER_PORT: "8001"
-  MODEL_EXPRESS_LOGGING_LEVEL: "info"
+  MODEL_EXPRESS_LOG_LEVEL: "info"
   MODEL_EXPRESS_CACHE_DIRECTORY: "/root"
   # Distributed backend selection. Required — the server fails to start without it.
   # Set MX_METADATA_BACKEND to "redis" or "kubernetes"; it drives both the P2P metadata
@@ -109,7 +109,7 @@ env:
 
 livenessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 10
@@ -118,7 +118,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  tcpSocket:
+  grpc:
     port: 8001
   initialDelaySeconds: 15
   periodSeconds: 10


### PR DESCRIPTION
The chart hardcoded tcpSocket probe handlers and named the service/container port `http`. Under an Istio sidecar a tcpSocket probe handshakes with the sidecar and reports Ready even when the server is down, and the `http` port name makes Istio protocol detection treat the broker's gRPC as HTTP/1.1, breaking it in-mesh.

Changes:
- Probe values now render verbatim (minus `enabled`), so `grpc`, `httpGet`, `exec`, and `tcpSocket` handlers all work. Defaults switch to the Kubernetes `grpc` probe against the server's gRPC health service, keeping the existing timing values.
- Service and container port renamed to `grpc`, with `appProtocol: grpc` on the Service.
- `MODEL_EXPRESS_LOGGING_LEVEL` renamed to `MODEL_EXPRESS_LOG_LEVEL`, the variable the server actually reads (`modelexpress_common/src/envs.rs`).

Backward compatible: existing values files with `tcpSocket` probes still render. Because Helm deep-merges overrides with the new grpc defaults, the template drops the default `grpc` handler when an override supplies its own handler, so old-style files do not produce a two-handler probe.

Validated with `helm lint helm/` and `helm template` against defaults, `test-values.yaml`, `values-development.yaml`, `values-production.yaml`, `values-local-storage.yaml`, plus an old-style tcpSocket override.