### PR TITLE
fix(sglang): adopt container-held derived tensors into the RDMA manifest

### DIFF
--- a/examples/p2p_transfer_k8s/client/sglang/Dockerfile.k3
+++ b/examples/p2p_transfer_k8s/client/sglang/Dockerfile.k3
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# SGLang Kimi-K3 support lives on the sgl-project/sglang `kimi-k3` branch and
+# is not in any published tag. Build it over a released image so the CUDA /
+# torch / flashinfer stack comes from the base and only the Python package is
+# replaced.
+#
+# Build:
+#   docker build -f examples/p2p_transfer_k8s/client/sglang/Dockerfile.k3 \
+#     --build-arg MX_REF=pull/589/head \
+#     -t <registry>/sglang-k3-mx:pr589 .
+#
+# MX_REF selects what ModelExpress client to install:
+#   pull/589/head  -> adopt container-held derived tensors into the manifest
+#   pull/585/head  -> re-derive after the transfer instead
+#   main           -> baseline for A/B runs
+
+ARG SGLANG_IMAGE=lmsysorg/sglang:v0.5.16
+FROM ${SGLANG_IMAGE}
+
+# Pinned tip of the kimi-k3 branch. Repin deliberately: the branch moves and
+# `_attn_res_cw_cache` / `get_cw` are private symbols the MX fix keys off.
+ARG SGLANG_K3_COMMIT=1f9d689b2918b17c2f3876997464ac686978d971
+RUN git clone --filter=blob:none https://github.com/sgl-project/sglang /opt/sglang-k3 && \
+    cd /opt/sglang-k3 && \
+    git checkout ${SGLANG_K3_COMMIT} && \
+    python3 -m pip install --no-cache-dir --no-deps -e python/
+
+RUN python3 -c "from sglang.srt.layers.attn_residual import get_cw; \
+    import inspect; assert '_attn_res_cw_cache' in inspect.getsource(get_cw)"
+
+ARG INSTALL_MOONCAKE=true
+RUN if [ "${INSTALL_MOONCAKE}" = "true" ]; then \
+        python3 -m pip install --no-cache-dir mooncake-transfer-engine-cuda13; \
+    fi
+
+ARG MX_REF=pull/589/head
+RUN python3 -m pip uninstall -y modelexpress 2>/dev/null || true && \
+    rm -rf "$(python3 -c 'import site; print(site.getsitepackages()[0])')"/modelexpress* && \
+    git clone --filter=blob:none https://github.com/ai-dynamo/modelexpress /opt/mx && \
+    cd /opt/mx && \
+    git fetch origin ${MX_REF}:mx-under-test && \
+    git checkout mx-under-test && \
+    python3 -m pip install --no-cache-dir --no-deps ./modelexpress_client/python
+
+# Receive-path diagnostics, auto-imported when /opt/probe is on PYTHONPATH.
+COPY examples/p2p_transfer_k8s/client/sglang/mx_receive_probe.py /opt/probe/sitecustomize.py
+
+WORKDIR /sgl-workspace

--- a/examples/p2p_transfer_k8s/client/sglang/Dockerfile.k3
+++ b/examples/p2p_transfer_k8s/client/sglang/Dockerfile.k3
@@ -1,40 +1,37 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# SGLang Kimi-K3 support lives on the sgl-project/sglang `kimi-k3` branch and
-# is not in any published tag. Build it over a released image so the CUDA /
-# torch / flashinfer stack comes from the base and only the Python package is
-# replaced.
+# ModelExpress over SGLang's Kimi-K3 release image.
 #
 # Build:
 #   docker build -f examples/p2p_transfer_k8s/client/sglang/Dockerfile.k3 \
 #     --build-arg MX_REF=pull/589/head \
 #     -t <registry>/sglang-k3-mx:pr589 .
 #
-# MX_REF selects what ModelExpress client to install:
+# MX_REF selects which ModelExpress client to install:
 #   pull/589/head  -> adopt container-held derived tensors into the manifest
 #   pull/585/head  -> re-derive after the transfer instead
 #   main           -> baseline for A/B runs
 
-ARG SGLANG_IMAGE=lmsysorg/sglang:v0.5.16
+ARG SGLANG_IMAGE=lmsysorg/sglang:kimi-k3
 FROM ${SGLANG_IMAGE}
 
-# Pinned tip of the kimi-k3 branch. Repin deliberately: the branch moves and
-# `_attn_res_cw_cache` / `get_cw` are private symbols the MX fix keys off.
-ARG SGLANG_K3_COMMIT=1f9d689b2918b17c2f3876997464ac686978d971
-RUN git clone --filter=blob:none https://github.com/sgl-project/sglang /opt/sglang-k3 && \
-    cd /opt/sglang-k3 && \
-    git checkout ${SGLANG_K3_COMMIT} && \
-    python3 -m pip install --no-cache-dir --no-deps -e python/
-
-RUN python3 -c "from sglang.srt.layers.attn_residual import get_cw; \
-    import inspect; assert '_attn_res_cw_cache' in inspect.getsource(get_cw)"
+# The derived state this image is used to verify lives on private symbols, so
+# fail the build rather than a six-hour cluster run if the base image moves.
+RUN python3 -c "\
+import inspect; \
+from sglang.srt.layers.attn_residual import get_cw; \
+from sglang.srt.models import kimi_k3; \
+assert '_attn_res_cw_cache' in inspect.getsource(get_cw), 'cw cache symbol missing'; \
+assert '_k3_fused_decode_args' in inspect.getsource(kimi_k3), 'fused-decode stash missing'"
 
 ARG INSTALL_MOONCAKE=true
 RUN if [ "${INSTALL_MOONCAKE}" = "true" ]; then \
         python3 -m pip install --no-cache-dir mooncake-transfer-engine-cuda13; \
     fi
 
+# The base image owns the CUDA / torch / sglang stack. Install only the
+# ModelExpress package so dependency resolution cannot downgrade it.
 ARG MX_REF=pull/589/head
 RUN python3 -m pip uninstall -y modelexpress 2>/dev/null || true && \
     rm -rf "$(python3 -c 'import site; print(site.getsitepackages()[0])')"/modelexpress* && \

--- a/examples/p2p_transfer_k8s/client/sglang/k3-full-verify.yaml
+++ b/examples/p2p_transfer_k8s/client/sglang/k3-full-verify.yaml
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Full Kimi-K3 verification for MX PR #589 (adopt container-held derived
+# tensors into the RDMA manifest).
+#
+# The decisive check is not inference quality -- a poisoned value cache still
+# produces fluent text for a while. Both roles dump a sha256 digest of every
+# tensor the manifest historically could not carry, and the two dumps are
+# diffed directly:
+#
+#   kubectl cp mx-k3-seed-0:/tmp/mx_state_dump.json   seed.json
+#   kubectl cp mx-k3-target-0:/tmp/mx_state_dump.json target.json
+#   ./mx_compare_state.py seed.json target.json
+#
+# Expected with the fix: the `cw` and `fused_decode` groups are byte-identical
+# alongside the `control` group. Without it, `cw` differs while `control`
+# still matches -- that pairing is the fingerprint of missed derived state
+# rather than a broken transfer.
+#
+# Sizing: TP16 across 2 nodes per replica on B200 (192GB). The checkpoint is
+# ~1.4T on disk, so ~90-120GB/rank leaves room for KV cache. TP32 (4 nodes,
+# the configuration PR #585 reported) halves per-rank residency if nodes are
+# available; raise NODES to 4 and TP to 32 in both roles.
+#
+# Deploy:
+#   kubectl apply -f k3-full-verify.yaml          # seed only
+#   # wait for mx-k3-seed-0 to serve, then:
+#   kubectl scale --replicas=1 lws/mx-k3-target   # (or apply with replicas: 1)
+#
+# Flush Redis between runs; stale source metadata makes a target pick a peer
+# that no longer exists.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: modelexpress
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mx-k3-launch
+data:
+  launch.sh: |
+    #!/bin/bash
+    # Both roles launch identically. MxModelLoader resolves the role at run
+    # time: the first instance finds no RDMA source, loads from disk and
+    # publishes itself; the second finds it and receives. Only MX_DUMP_ROLE
+    # differs, and only to label the dump.
+    set -x
+    exec python3 -m sglang.launch_server \
+      --model-path "$MODEL_NAME" \
+      --tp "$TP_SIZE" \
+      --nnodes "$NNODES" \
+      --node-rank "${LWS_WORKER_INDEX:-0}" \
+      --dist-init-addr "${LWS_LEADER_ADDRESS:-$POD_IP}:20000" \
+      --port 30000 \
+      --host 0.0.0.0 \
+      --trust-remote-code \
+      --skip-server-warmup \
+      --disable-cuda-graph \
+      --mem-fraction-static 0.85 \
+      --load-format remote_instance \
+      --remote-instance-weight-loader-backend modelexpress \
+      --modelexpress-config '{"url":"mx-k3-server:8001","source":true}'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mx-k3-server
+  labels: {app: mx-k3-server}
+spec:
+  type: ClusterIP
+  ports:
+    - {port: 8001, targetPort: 8001, name: grpc}
+  selector: {app: mx-k3-server}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mx-k3-server
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: mx-k3-server}}
+  template:
+    metadata:
+      labels: {app: mx-k3-server}
+    spec:
+      imagePullSecrets: [{name: nvcr-imagepullsecret}]
+      initContainers:
+        - name: redis
+          image: redis:7-alpine
+          restartPolicy: Always
+          ports: [{containerPort: 6379}]
+          resources:
+            requests: {cpu: 500m, memory: 2Gi}
+            limits: {cpu: "1", memory: 8Gi}
+          startupProbe:
+            tcpSocket: {port: 6379}
+            periodSeconds: 1
+            failureThreshold: 30
+      containers:
+        - name: modelexpress-server
+          image: nvcr.io/nvidian/dynamo-dev/modelexpress-server:latest
+          imagePullPolicy: Always
+          ports: [{containerPort: 8001}]
+          env:
+            - {name: MX_METADATA_BACKEND, value: "redis"}
+            - {name: REDIS_URL, value: "redis://localhost:6379"}
+          resources:
+            requests: {cpu: "4", memory: 8Gi}
+            limits: {cpu: "8", memory: 16Gi}
+          readinessProbe:
+            tcpSocket: {port: 8001}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+---
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: mx-k3-seed
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 2
+    restartPolicy: RecreateGroupOnPodRestart
+    leaderTemplate:
+      metadata:
+        labels: {app: mx-k3-seed, role: leader}
+      spec:
+        serviceAccountName: modelexpress
+        imagePullSecrets: [{name: nvcr-imagepullsecret}]
+        tolerations:
+          - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+        containers:
+          - name: sglang
+            image: nvcr.io/nvidian/dynamo-dev/sglang-k3-mx:pr589
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              capabilities: {add: [IPC_LOCK]}
+            command: ["/bin/bash", "-c"]
+            args: ["set -x; ulimit -l unlimited; exec /opt/launch.sh"]
+            env:
+              - {name: MX_DUMP_ROLE, value: "seed"}
+              - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
+              - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
+              - {name: PYTHONPATH, value: "/opt/probe"}
+              - {name: MODEL_EXPRESS_URL, value: "mx-k3-server:8001"}
+              - {name: MODEL_NAME, value: "moonshotai/Kimi-K3"}
+              - {name: HF_HUB_CACHE, value: "/models/hub"}
+              - {name: TP_SIZE, value: "16"}
+              - {name: NNODES, value: "2"}
+              - {name: MOONCAKE_DEVICE, value: "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_10,mlx5_11"}
+              - name: HF_TOKEN
+                valueFrom: {secretKeyRef: {name: hf-token-secret, key: HF_TOKEN}}
+              - name: POD_IP
+                valueFrom: {fieldRef: {fieldPath: status.podIP}}
+              - name: NODE_NAME
+                valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+              - name: POD_NAMESPACE
+                valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+            ports: [{containerPort: 30000}]
+            resources:
+              limits: {nvidia.com/gpu: "8", rdma/ib: "8"}
+              requests: {nvidia.com/gpu: "8", rdma/ib: "8", memory: "800Gi", cpu: "64"}
+            volumeMounts:
+              - {name: shm, mountPath: /dev/shm}
+              - {name: model-cache, mountPath: /models}
+              - {name: launch, mountPath: /opt/launch.sh, subPath: launch.sh}
+        volumes:
+          - name: shm
+            emptyDir: {medium: Memory, sizeLimit: 256Gi}
+          - name: model-cache
+            persistentVolumeClaim: {claimName: shared-model-cache}
+          - name: launch
+            configMap: {name: mx-k3-launch, defaultMode: 0755}
+    workerTemplate:
+      metadata:
+        labels: {app: mx-k3-seed, role: worker}
+      spec:
+        serviceAccountName: modelexpress
+        imagePullSecrets: [{name: nvcr-imagepullsecret}]
+        tolerations:
+          - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+        containers:
+          - name: sglang
+            image: nvcr.io/nvidian/dynamo-dev/sglang-k3-mx:pr589
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              capabilities: {add: [IPC_LOCK]}
+            command: ["/bin/bash", "-c"]
+            args: ["set -x; ulimit -l unlimited; exec /opt/launch.sh"]
+            env:
+              - {name: MX_DUMP_ROLE, value: "seed"}
+              - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
+              - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
+              - {name: PYTHONPATH, value: "/opt/probe"}
+              - {name: MODEL_EXPRESS_URL, value: "mx-k3-server:8001"}
+              - {name: MODEL_NAME, value: "moonshotai/Kimi-K3"}
+              - {name: HF_HUB_CACHE, value: "/models/hub"}
+              - {name: TP_SIZE, value: "16"}
+              - {name: NNODES, value: "2"}
+              - {name: MOONCAKE_DEVICE, value: "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_10,mlx5_11"}
+              - name: HF_TOKEN
+                valueFrom: {secretKeyRef: {name: hf-token-secret, key: HF_TOKEN}}
+              - name: POD_IP
+                valueFrom: {fieldRef: {fieldPath: status.podIP}}
+              - name: NODE_NAME
+                valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+              - name: POD_NAMESPACE
+                valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+            ports: [{containerPort: 30000}]
+            resources:
+              limits: {nvidia.com/gpu: "8", rdma/ib: "8"}
+              requests: {nvidia.com/gpu: "8", rdma/ib: "8", memory: "800Gi", cpu: "64"}
+            volumeMounts:
+              - {name: shm, mountPath: /dev/shm}
+              - {name: model-cache, mountPath: /models}
+              - {name: launch, mountPath: /opt/launch.sh, subPath: launch.sh}
+        volumes:
+          - name: shm
+            emptyDir: {medium: Memory, sizeLimit: 256Gi}
+          - name: model-cache
+            persistentVolumeClaim: {claimName: shared-model-cache}
+          - name: launch
+            configMap: {name: mx-k3-launch, defaultMode: 0755}
+---
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: mx-k3-target
+spec:
+  replicas: 0
+  leaderWorkerTemplate:
+    size: 2
+    restartPolicy: RecreateGroupOnPodRestart
+    leaderTemplate:
+      metadata:
+        labels: {app: mx-k3-target, role: leader}
+      spec:
+        serviceAccountName: modelexpress
+        imagePullSecrets: [{name: nvcr-imagepullsecret}]
+        tolerations:
+          - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+        containers:
+          - name: sglang
+            image: nvcr.io/nvidian/dynamo-dev/sglang-k3-mx:pr589
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              capabilities: {add: [IPC_LOCK]}
+            command: ["/bin/bash", "-c"]
+            args: ["set -x; ulimit -l unlimited; exec /opt/launch.sh"]
+            env:
+              - {name: MX_DUMP_ROLE, value: "target"}
+              - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
+              - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
+              - {name: PYTHONPATH, value: "/opt/probe"}
+              - {name: MODEL_EXPRESS_URL, value: "mx-k3-server:8001"}
+              - {name: MODEL_NAME, value: "moonshotai/Kimi-K3"}
+              - {name: HF_HUB_CACHE, value: "/models/hub"}
+              - {name: TP_SIZE, value: "16"}
+              - {name: NNODES, value: "2"}
+              - {name: MOONCAKE_DEVICE, value: "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_10,mlx5_11"}
+              - name: HF_TOKEN
+                valueFrom: {secretKeyRef: {name: hf-token-secret, key: HF_TOKEN}}
+              - name: POD_IP
+                valueFrom: {fieldRef: {fieldPath: status.podIP}}
+              - name: NODE_NAME
+                valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+              - name: POD_NAMESPACE
+                valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+            ports: [{containerPort: 30000}]
+            resources:
+              limits: {nvidia.com/gpu: "8", rdma/ib: "8"}
+              requests: {nvidia.com/gpu: "8", rdma/ib: "8", memory: "800Gi", cpu: "64"}
+            volumeMounts:
+              - {name: shm, mountPath: /dev/shm}
+              - {name: model-cache, mountPath: /models}
+              - {name: launch, mountPath: /opt/launch.sh, subPath: launch.sh}
+        volumes:
+          - name: shm
+            emptyDir: {medium: Memory, sizeLimit: 256Gi}
+          - name: model-cache
+            persistentVolumeClaim: {claimName: shared-model-cache}
+          - name: launch
+            configMap: {name: mx-k3-launch, defaultMode: 0755}
+    workerTemplate:
+      metadata:
+        labels: {app: mx-k3-target, role: worker}
+      spec:
+        serviceAccountName: modelexpress
+        imagePullSecrets: [{name: nvcr-imagepullsecret}]
+        tolerations:
+          - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+        containers:
+          - name: sglang
+            image: nvcr.io/nvidian/dynamo-dev/sglang-k3-mx:pr589
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              capabilities: {add: [IPC_LOCK]}
+            command: ["/bin/bash", "-c"]
+            args: ["set -x; ulimit -l unlimited; exec /opt/launch.sh"]
+            env:
+              - {name: MX_DUMP_ROLE, value: "target"}
+              - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
+              - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
+              - {name: PYTHONPATH, value: "/opt/probe"}
+              - {name: MODEL_EXPRESS_URL, value: "mx-k3-server:8001"}
+              - {name: MODEL_NAME, value: "moonshotai/Kimi-K3"}
+              - {name: HF_HUB_CACHE, value: "/models/hub"}
+              - {name: TP_SIZE, value: "16"}
+              - {name: NNODES, value: "2"}
+              - {name: MOONCAKE_DEVICE, value: "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_10,mlx5_11"}
+              - name: HF_TOKEN
+                valueFrom: {secretKeyRef: {name: hf-token-secret, key: HF_TOKEN}}
+              - name: POD_IP
+                valueFrom: {fieldRef: {fieldPath: status.podIP}}
+              - name: NODE_NAME
+                valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+              - name: POD_NAMESPACE
+                valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+            ports: [{containerPort: 30000}]
+            resources:
+              limits: {nvidia.com/gpu: "8", rdma/ib: "8"}
+              requests: {nvidia.com/gpu: "8", rdma/ib: "8", memory: "800Gi", cpu: "64"}
+            volumeMounts:
+              - {name: shm, mountPath: /dev/shm}
+              - {name: model-cache, mountPath: /models}
+              - {name: launch, mountPath: /opt/launch.sh, subPath: launch.sh}
+        volumes:
+          - name: shm
+            emptyDir: {medium: Memory, sizeLimit: 256Gi}
+          - name: model-cache
+            persistentVolumeClaim: {claimName: shared-model-cache}
+          - name: launch
+            configMap: {name: mx-k3-launch, defaultMode: 0755}

--- a/examples/p2p_transfer_k8s/client/sglang/mx-adopt-smoke.yaml
+++ b/examples/p2p_transfer_k8s/client/sglang/mx-adopt-smoke.yaml
@@ -114,8 +114,6 @@ spec:
           env:
             - {name: PYTHONPATH, value: "/opt/probe"}
             - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
-            - {name: MX_DUMP_ROLE, value: "target"}
-            - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
             - {name: MX_DUMP_ROLE, value: "seed"}
             - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
             - {name: MODEL_EXPRESS_URL, value: "mx-smoke-server:8001"}
@@ -189,6 +187,8 @@ spec:
           env:
             - {name: PYTHONPATH, value: "/opt/probe"}
             - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
+            - {name: MX_DUMP_ROLE, value: "target"}
+            - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
             - {name: MODEL_EXPRESS_URL, value: "mx-smoke-server:8001"}
             - {name: MODEL_NAME, value: "deepseek-ai/DeepSeek-V2-Lite"}
             - {name: HF_HUB_CACHE, value: "/models/hf"}

--- a/examples/p2p_transfer_k8s/client/sglang/mx-adopt-smoke.yaml
+++ b/examples/p2p_transfer_k8s/client/sglang/mx-adopt-smoke.yaml
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoke test for adopt_hidden_tensors on the SGLang path (MX PR #589).
+#
+# DeepSeek-V2-Lite is the model the disabled-by-default note called out: its
+# derived w_kc/w_vc are bare Tensor attributes that capture_tensor_attrs
+# already promotes, so adopting hidden tensors must not change its manifest.
+# A clean seed -> target transfer here is the regression signal before the
+# Kimi-K3 run, where the newly adopted dict/tuple entries actually matter.
+#
+# What to read afterwards:
+#   "Adopted N hidden accelerator tensors as module buffers in Xs"  (tensor_utils)
+#   "[Worker 0] [TIMING] ..." transfer telemetry                    (rdma_strategy)
+#   [mx-receive-probe] {...}                                        (sitecustomize)
+#
+# Deploy:
+#   kubectl apply -f mx-adopt-smoke.yaml
+#   kubectl scale deploy/mx-smoke-target --replicas=1   # after seed is Ready
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: modelexpress
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mx-smoke-server
+  labels: {app: mx-smoke-server}
+spec:
+  type: ClusterIP
+  ports:
+    - {port: 8001, targetPort: 8001, name: grpc}
+  selector: {app: mx-smoke-server}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mx-smoke-server
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: mx-smoke-server}}
+  template:
+    metadata:
+      labels: {app: mx-smoke-server}
+    spec:
+      imagePullSecrets: [{name: nvcr-imagepullsecret}]
+      initContainers:
+        - name: redis
+          image: redis:7-alpine
+          restartPolicy: Always
+          ports: [{containerPort: 6379}]
+          resources:
+            requests: {cpu: 500m, memory: 2Gi}
+            limits: {cpu: "1", memory: 4Gi}
+          startupProbe:
+            tcpSocket: {port: 6379}
+            periodSeconds: 1
+            failureThreshold: 30
+      containers:
+        - name: modelexpress-server
+          image: nvcr.io/nvidian/dynamo-dev/modelexpress-server:latest
+          imagePullPolicy: Always
+          ports: [{containerPort: 8001}]
+          env:
+            - {name: MX_METADATA_BACKEND, value: "redis"}
+            - {name: REDIS_URL, value: "redis://localhost:6379"}
+          resources:
+            requests: {cpu: "2", memory: 4Gi}
+            limits: {cpu: "4", memory: 8Gi}
+          readinessProbe:
+            tcpSocket: {port: 8001}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mx-smoke-seed
+  labels: {app: mx-smoke-seed}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: mx-smoke-seed}}
+  template:
+    metadata:
+      labels: {app: mx-smoke-seed}
+    spec:
+      serviceAccountName: modelexpress
+      imagePullSecrets: [{name: nvcr-imagepullsecret}]
+      tolerations:
+        - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+      containers:
+        - name: sglang
+          image: nvcr.io/nvidian/dynamo-dev/sglang-k3-mx:pr589
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities: {add: [IPC_LOCK]}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -x
+              ulimit -l unlimited
+              exec python3 -m sglang.launch_server \
+                --model-path "$MODEL_NAME" \
+                --tp 1 \
+                --port 30000 \
+                --host 0.0.0.0 \
+                --trust-remote-code \
+                --skip-server-warmup \
+                --disable-cuda-graph \
+                --mem-fraction-static 0.7 \
+                $LOAD_ARGS
+          env:
+            - {name: PYTHONPATH, value: "/opt/probe"}
+            - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
+            - {name: MX_DUMP_ROLE, value: "target"}
+            - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
+            - {name: MX_DUMP_ROLE, value: "seed"}
+            - {name: MX_DUMP_OUT, value: "/tmp/mx_state_dump.json"}
+            - {name: MODEL_EXPRESS_URL, value: "mx-smoke-server:8001"}
+            - {name: MODEL_NAME, value: "deepseek-ai/DeepSeek-V2-Lite"}
+            - {name: HF_HUB_CACHE, value: "/models/hf"}
+            - {name: SGL_ENABLE_JIT_DEEPGEMM, value: "0"}
+            - {name: MOONCAKE_DEVICE, value: "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_10,mlx5_11"}
+            - name: LOAD_ARGS
+              value: >-
+                --load-format remote_instance
+                --remote-instance-weight-loader-backend modelexpress
+                --modelexpress-config {"url":"mx-smoke-server:8001","source":true}
+            - name: HF_TOKEN
+              valueFrom: {secretKeyRef: {name: hf-token-secret, key: HF_TOKEN}}
+            - name: POD_IP
+              valueFrom: {fieldRef: {fieldPath: status.podIP}}
+            - name: NODE_NAME
+              valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+            - name: POD_NAMESPACE
+              valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+          ports: [{containerPort: 30000}]
+          resources:
+            limits: {nvidia.com/gpu: "1", rdma/ib: "1"}
+            requests: {nvidia.com/gpu: "1", rdma/ib: "1", memory: "100Gi", cpu: "8"}
+          volumeMounts:
+            - {name: shm, mountPath: /dev/shm}
+            - {name: model-cache, mountPath: /models}
+      volumes:
+        - name: shm
+          emptyDir: {medium: Memory, sizeLimit: 32Gi}
+        - name: model-cache
+          persistentVolumeClaim: {claimName: model-cache-block}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mx-smoke-target
+  labels: {app: mx-smoke-target}
+spec:
+  replicas: 0
+  selector: {matchLabels: {app: mx-smoke-target}}
+  template:
+    metadata:
+      labels: {app: mx-smoke-target}
+    spec:
+      serviceAccountName: modelexpress
+      imagePullSecrets: [{name: nvcr-imagepullsecret}]
+      tolerations:
+        - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+      containers:
+        - name: sglang
+          image: nvcr.io/nvidian/dynamo-dev/sglang-k3-mx:pr589
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities: {add: [IPC_LOCK]}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -x
+              ulimit -l unlimited
+              exec python3 -m sglang.launch_server \
+                --model-path "$MODEL_NAME" \
+                --tp 1 \
+                --port 30000 \
+                --host 0.0.0.0 \
+                --trust-remote-code \
+                --skip-server-warmup \
+                --disable-cuda-graph \
+                --mem-fraction-static 0.7 \
+                $LOAD_ARGS
+          env:
+            - {name: PYTHONPATH, value: "/opt/probe"}
+            - {name: MX_PROBE_OUT, value: "/tmp/mx_receive_probe.jsonl"}
+            - {name: MODEL_EXPRESS_URL, value: "mx-smoke-server:8001"}
+            - {name: MODEL_NAME, value: "deepseek-ai/DeepSeek-V2-Lite"}
+            - {name: HF_HUB_CACHE, value: "/models/hf"}
+            - {name: SGL_ENABLE_JIT_DEEPGEMM, value: "0"}
+            - {name: MOONCAKE_DEVICE, value: "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_10,mlx5_11"}
+            - name: LOAD_ARGS
+              value: >-
+                --load-format remote_instance
+                --remote-instance-weight-loader-backend modelexpress
+                --modelexpress-config {"url":"mx-smoke-server:8001","source":true}
+            - name: HF_TOKEN
+              valueFrom: {secretKeyRef: {name: hf-token-secret, key: HF_TOKEN}}
+            - name: POD_IP
+              valueFrom: {fieldRef: {fieldPath: status.podIP}}
+            - name: NODE_NAME
+              valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+            - name: POD_NAMESPACE
+              valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+          ports: [{containerPort: 30000}]
+          resources:
+            limits: {nvidia.com/gpu: "1", rdma/ib: "1"}
+            requests: {nvidia.com/gpu: "1", rdma/ib: "1", memory: "100Gi", cpu: "8"}
+          volumeMounts:
+            - {name: shm, mountPath: /dev/shm}
+            - {name: model-cache, mountPath: /models}
+      volumes:
+        - name: shm
+          emptyDir: {medium: Memory, sizeLimit: 32Gi}
+        - name: model-cache
+          persistentVolumeClaim: {claimName: model-cache-block}

--- a/examples/p2p_transfer_k8s/client/sglang/mx_compare_state.py
+++ b/examples/p2p_transfer_k8s/client/sglang/mx_compare_state.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Diff two mx_receive_probe state dumps: source (disk load) vs target (RDMA).
+
+    mx_compare_state.py source.json target.json
+
+The source loaded from disk, so its derived state is correct by
+construction. Every entry the target holds must be byte-identical. A
+mismatch names the exact tensor rather than showing up as degraded output
+several thousand tokens later.
+
+Entries are grouped so the verdict is readable on a 92-layer model:
+
+  cw             `_attn_res_cw_cache` -- the state PR #585 re-derives and
+                 PR #589 transfers; a poisoned target differs here
+  fused_decode   `_k3_fused_decode_args` -- the second container-held case,
+                 which has no torch reference implementation to fall back on
+  quant_method   tensors on non-Module objects
+  control        ordinary parameters; these ride the manifest either way, so
+                 a mismatch means the transfer itself is broken
+
+Exit status is 1 on any mismatch or missing entry.
+"""
+
+import json
+import sys
+
+
+def _group(name):
+    if name.startswith("[control]"):
+        return "control"
+    if "_attn_res_cw_cache" in name:
+        return "cw"
+    if "_k3_fused_decode_args" in name:
+        return "fused_decode"
+    if ".quant_method." in name:
+        return "quant_method"
+    return "other"
+
+
+def main(src_path, tgt_path):
+    src = json.load(open(src_path))
+    tgt = json.load(open(tgt_path))
+    se, te = src["entries"], tgt["entries"]
+    print(f"source role={src.get('role')} entries={len(se)}")
+    print(f"target role={tgt.get('role')} entries={len(te)}")
+
+    groups = {}
+    for name in sorted(set(se) | set(te)):
+        g = groups.setdefault(
+            _group(name), {"match": 0, "differ": [], "src_only": [], "tgt_only": []}
+        )
+        if name not in te:
+            g["src_only"].append(name)
+        elif name not in se:
+            g["tgt_only"].append(name)
+        elif se[name] == te[name]:
+            g["match"] += 1
+        else:
+            g["differ"].append(name)
+
+    print()
+    print(f"{'group':<14}{'match':>7}{'DIFFER':>8}{'src-only':>10}{'tgt-only':>10}")
+    print("-" * 49)
+    bad = 0
+    for name in ("cw", "fused_decode", "quant_method", "other", "control"):
+        g = groups.get(name)
+        if not g:
+            continue
+        bad += len(g["differ"]) + len(g["src_only"]) + len(g["tgt_only"])
+        print(
+            f"{name:<14}{g['match']:>7}{len(g['differ']):>8}"
+            f"{len(g['src_only']):>10}{len(g['tgt_only']):>10}"
+        )
+
+    for name, g in groups.items():
+        for entry in g["differ"][:10]:
+            print(f"\nDIFFER {entry}")
+            print(f"  source {se[entry]}")
+            print(f"  target {te[entry]}")
+        if len(g["differ"]) > 10:
+            print(f"  ... and {len(g['differ']) - 10} more in {name}")
+        for entry in (g["src_only"] + g["tgt_only"])[:10]:
+            side = "source" if entry in se else "target"
+            print(f"MISSING on the other side ({side} only): {entry}")
+
+    print()
+    if bad:
+        print(f"VERDICT: FAIL -- {bad} entries differ or are missing")
+    elif not any(groups.get(k, {}).get("match") for k in ("cw", "fused_decode")):
+        print(
+            "VERDICT: INCONCLUSIVE -- no cw or fused_decode entries were "
+            "dumped; this model has no container-held derived state"
+        )
+    else:
+        print("VERDICT: PASS -- every derived-state entry is byte-identical")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/examples/p2p_transfer_k8s/client/sglang/mx_receive_probe.py
+++ b/examples/p2p_transfer_k8s/client/sglang/mx_receive_probe.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dump weight-derived engine state so a source and a target can be diffed.
+
+Inference output is a weak oracle for this bug class: a poisoned value cache
+still produces fluent text for a while. The decisive check is byte equality
+of the derived state itself between a source that loaded from disk and a
+target that received over RDMA.
+
+Install by putting this file on PYTHONPATH as ``sitecustomize.py``. It hooks
+``MxModelLoader.load_model`` and, once the model is fully loaded, writes a
+digest of every tensor the manifest historically could not carry:
+
+  ``_attn_res_cw_cache[<dtype>]``   dict-held, read by SGLang's ``get_cw``
+  ``_k3_fused_decode_args[<i>]``    tuple-held, fused KDA decode kernel inputs
+  quant-method tensors              held on non-Module objects
+  control parameters                a fixed sample, to prove the method itself
+
+Both roles dump at the same logical point, so the files are directly
+comparable with ``mx_compare_state.py``. A target whose entries match the
+source is correct by construction; a mismatch localises to a named tensor
+instead of a vague quality regression.
+
+Env:
+  MX_DUMP_ROLE   label written into the dump (e.g. "source", "target")
+  MX_DUMP_OUT    output path, default /tmp/mx_state_dump.json
+  MX_PROBE_OUT   after_rdma_receive telemetry, default /tmp/mx_receive_probe.jsonl
+  MX_DUMP_CONTROLS  how many control parameters to digest, default 8
+"""
+
+import hashlib
+import importlib.abc
+import importlib.util
+import json
+import os
+import sys
+
+_ADAPTER = "modelexpress.engines.sglang.adapter"
+_LOADER = "modelexpress.engines.sglang.loader"
+_PROBE_OUT = os.environ.get("MX_PROBE_OUT", "/tmp/mx_receive_probe.jsonl")
+_DUMP_OUT = os.environ.get("MX_DUMP_OUT", "/tmp/mx_state_dump.json")
+_ROLE = os.environ.get("MX_DUMP_ROLE", "unset")
+_N_CONTROLS = int(os.environ.get("MX_DUMP_CONTROLS", "8"))
+
+
+def _log(msg):
+    print(f"[mx-state-dump] {msg}", file=sys.stderr, flush=True)
+
+
+def _digest(tensor):
+    """sha256 over the tensor's exact bytes, plus shape and dtype."""
+    import torch
+
+    t = tensor.detach().cpu().contiguous()
+    if t.dtype != torch.uint8:
+        try:
+            t = t.view(torch.uint8)
+        except RuntimeError:
+            t = t.to(torch.float32).view(torch.uint8)
+    return {
+        "shape": list(tensor.shape),
+        "dtype": str(tensor.dtype),
+        "sha256": hashlib.sha256(t.numpy().tobytes()).hexdigest(),
+    }
+
+
+def _collect(model):
+    """Digest the derived state the manifest historically missed."""
+    import torch
+
+    entries = {}
+    for name, module in model.named_modules():
+        cache = getattr(module, "_attn_res_cw_cache", None)
+        if isinstance(cache, dict):
+            for dtype, tensor in cache.items():
+                if isinstance(tensor, torch.Tensor):
+                    entries[f"{name}._attn_res_cw_cache[{dtype}]"] = _digest(tensor)
+
+        args = getattr(module, "_k3_fused_decode_args", None)
+        if isinstance(args, (tuple, list)):
+            for i, item in enumerate(args):
+                if isinstance(item, torch.Tensor):
+                    entries[f"{name}._k3_fused_decode_args[{i}]"] = _digest(item)
+
+        qm = getattr(module, "quant_method", None)
+        if qm is not None and not isinstance(qm, torch.nn.Module):
+            for attr, val in list(vars(qm).items()):
+                if isinstance(val, torch.Tensor) and val.numel():
+                    entries[f"{name}.quant_method.{attr}"] = _digest(val)
+
+    # Controls: a deterministic slice of ordinary parameters. These ride the
+    # manifest either way, so a mismatch here means the transfer itself is
+    # broken rather than the derived-state coverage.
+    for name, param in sorted(model.named_parameters())[:_N_CONTROLS]:
+        entries[f"[control] {name}"] = _digest(param.data)
+    return entries
+
+
+def _dump(model):
+    entries = _collect(model)
+    payload = {"role": _ROLE, "entries": entries}
+    with open(_DUMP_OUT, "w") as handle:
+        json.dump(payload, handle, indent=1, sort_keys=True)
+    kinds = {
+        "cw": sum(1 for k in entries if "_attn_res_cw_cache" in k),
+        "fused_decode": sum(1 for k in entries if "_k3_fused_decode_args" in k),
+        "quant_method": sum(1 for k in entries if ".quant_method." in k),
+        "control": sum(1 for k in entries if k.startswith("[control]")),
+    }
+    _log(f"role={_ROLE} wrote {len(entries)} entries to {_DUMP_OUT} {kinds}")
+
+
+def _install_loader(module):
+    original = module.MxModelLoader.load_model
+
+    def load_model(self, *args, **kwargs):
+        out = original(self, *args, **kwargs)
+        try:
+            model = out if hasattr(out, "named_modules") else getattr(out, "model", None)
+            if model is None:
+                _log("loader returned no module tree; nothing dumped")
+            else:
+                _dump(model)
+        except Exception as exc:
+            _log(f"dump failed: {exc!r}")
+        return out
+
+    module.MxModelLoader.load_model = load_model
+    _log("loader hook installed")
+
+
+def _install_adapter(module):
+    """Record what after_rdma_receive does, if anything overrides it."""
+    original = module.SglangAdapter.after_rdma_receive
+
+    def probed(self, result):
+        before = {}
+        try:
+            before = {
+                n: (t.data_ptr(), t.numel() * t.element_size())
+                for n, t in self.discover_tensors(result).items()
+            }
+        except Exception:
+            pass
+        out = original(self, result)
+        record = {"registered": len(before)}
+        try:
+            after = {n: t.data_ptr() for n, t in self.discover_tensors(out).items()}
+            moved = [n for n, (a, _) in before.items() if n in after and after[n] != a]
+            record["moved"] = len(moved)
+            record["moved_names"] = sorted(moved)[:20]
+            record["orphan_bytes"] = sum(before[n][1] for n in moved)
+        except Exception as exc:
+            record["error"] = repr(exc)
+        line = json.dumps(record, sort_keys=True)
+        print(f"[mx-receive-probe] {line}", file=sys.stderr, flush=True)
+        try:
+            with open(_PROBE_OUT, "a") as handle:
+                handle.write(line + "\n")
+        except OSError:
+            pass
+        return out
+
+    module.SglangAdapter.after_rdma_receive = probed
+
+
+class _Hook(importlib.abc.MetaPathFinder):
+    """Patch each target module once, immediately after its body executes."""
+
+    def __init__(self):
+        self.pending = {_ADAPTER: _install_adapter, _LOADER: _install_loader}
+
+    def find_spec(self, fullname, path=None, target=None):
+        install = self.pending.get(fullname)
+        if install is None:
+            return None
+        del self.pending[fullname]
+        if not self.pending and self in sys.meta_path:
+            sys.meta_path.remove(self)
+        was_present = self in sys.meta_path
+        if was_present:
+            sys.meta_path.remove(self)
+        spec = importlib.util.find_spec(fullname)
+        if was_present:
+            sys.meta_path.insert(0, self)
+        if spec is None or spec.loader is None:
+            return None
+        original_exec = spec.loader.exec_module
+
+        def exec_module(module):
+            original_exec(module)
+            try:
+                install(module)
+            except Exception as exc:
+                _log(f"install failed for {fullname}: {exc!r}")
+
+        spec.loader.exec_module = exec_module
+        return spec
+
+
+if os.environ.get("MX_PROBE", "1") != "0":
+    sys.meta_path.insert(0, _Hook())

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -20,6 +20,7 @@ from ...accelerators import accelerator_backend_for
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 from ...tensor_utils import (
+    adopt_hidden_tensors,
     capture_tensor_attrs,
     collect_module_tensors,
 )
@@ -79,17 +80,17 @@ class SglangAdapter(EngineAdapter):
     def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
         if result.model is None:
             raise RuntimeError("SGLang tensor discovery requires result.model")
-        # adopt_hidden_tensors() would also register accelerator tensors stashed
-        # on non-Module objects (e.g. SGLang's MXFP4 FusedMoE quant_method, which
-        # holds swizzled weights after deleting the original params). It is left
-        # commented out for now: it is a no-op for DeepSeek-V2-Lite (whose derived
-        # w_kc/w_vc are direct Tensor attributes, already promoted by
-        # capture_tensor_attrs), and enabling it adds new _mx_* manifest names,
-        # i.e. a transfer-ABI change that needs a version bump to avoid mixed
-        # old/new source/target manifests plus MXFP4 + CUTLASS FP8/W4A8 smoke
-        # tests. Enable it (with those guards) when SGLang nested-object coverage
-        # is in scope.
-        # adopt_hidden_tensors(result.model, self.accelerator_backend)
+        # Matches the vLLM adapter. capture_tensor_attrs only promotes bare
+        # Tensor attributes, so weight-derived tensors held inside containers or
+        # on non-Module objects stay out of the manifest: SGLang's MXFP4 FusedMoE
+        # quant_method holds swizzled weights after deleting the original params,
+        # and Kimi-K3 keeps `_attn_res_cw_cache` in a dict and
+        # `_k3_fused_decode_args` in a tuple. Those arrive at dummy values on an
+        # RDMA target, which passes every manifest check and then produces
+        # degraded output. adopt_hidden_tensors registers them (the same objects,
+        # so the container entries alias the transferred memory) and the receive
+        # path stays "transfer the final state, derive nothing afterwards".
+        adopt_hidden_tensors(result.model, self.accelerator_backend)
         return collect_module_tensors(result.model, self.accelerator_backend)
 
     def before_rdma_receive(self, result: LoadResult) -> LoadResult:

--- a/modelexpress_client/python/tests/test_sglang_hidden_tensors.py
+++ b/modelexpress_client/python/tests/test_sglang_hidden_tensors.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang manifest coverage for weight-derived tensors held in containers.
+
+``capture_tensor_attrs`` only promotes bare Tensor attributes assigned on an
+``nn.Module``. Weight-derived tensors that live inside a dict/tuple, or on a
+non-Module object such as a quant method, stay invisible to
+``named_parameters()``/``named_buffers()`` and so never reach the RDMA
+manifest. On a target they keep whatever was derived from random-init
+weights, which passes every manifest check and then degrades inference.
+
+Kimi-K3 has two of these: ``_attn_res_cw_cache`` (dict, read by ``get_cw``)
+and ``_k3_fused_decode_args`` (tuple, consumed by the fused KDA decode
+kernel). ``discover_tensors`` calls ``adopt_hidden_tensors`` so both are
+registered and transferred, which keeps the receive path on its original
+contract: transfer the final state, derive nothing afterwards.
+"""
+
+import contextlib
+import sys
+import types
+
+import torch
+from torch import nn
+
+_loader = types.ModuleType("sglang.srt.model_loader.loader")
+_loader.device_loading_context = contextlib.contextmanager(
+    lambda module, device: iter([None])
+)
+for _name, _mod in (
+    ("sglang", types.ModuleType("sglang")),
+    ("sglang.srt", types.ModuleType("sglang.srt")),
+    ("sglang.srt.model_loader", types.ModuleType("sglang.srt.model_loader")),
+    ("sglang.srt.model_loader.loader", _loader),
+):
+    sys.modules.setdefault(_name, _mod)
+
+from modelexpress.engines.sglang.adapter import SglangAdapter  # noqa: E402
+from modelexpress.load_strategy.context import LoadResult  # noqa: E402
+
+
+class _CpuAsAccel:
+    """Backend interface with CPU tensors treated as accelerator memory."""
+
+    torch_device_type = "cpu"
+
+    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
+        return tensor.device.type == "cpu"
+
+    def supports_rdma_p2p(self) -> bool:
+        return True
+
+    def supports_pool_reg(self) -> bool:
+        return True
+
+
+class _QuantMethod:
+    """Non-Module object holding a derived tensor, as SGLang quant methods do."""
+
+    def __init__(self, swizzled: torch.Tensor):
+        self.swizzled_weight = swizzled
+
+
+class _Layer(nn.Module):
+    def __init__(self, h=8):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(h, h))
+        # dict-held, keyed by dtype (cf. SGLang get_cw / _attn_res_cw_cache)
+        self._attn_res_cw_cache = {
+            torch.float32: torch.randn(h),
+            torch.bfloat16: torch.randn(h).to(torch.bfloat16),
+        }
+        # tuple-held, mixed tensors and a scalar (cf. _k3_fused_decode_args)
+        self._k3_fused_decode_args = (torch.randn(4, h), torch.randn(h), 1e-5)
+        self.quant_method = _QuantMethod(torch.randn(h, h))
+
+
+def _adapter() -> SglangAdapter:
+    adapter = SglangAdapter(
+        load_config=types.SimpleNamespace(),
+        model_config=types.SimpleNamespace(),
+        device_config=types.SimpleNamespace(device="cuda"),
+    )
+    adapter.accelerator_backend = _CpuAsAccel()
+    adapter.target_device = torch.device("cpu")
+    return adapter
+
+
+def _discover(model):
+    return _adapter().discover_tensors(LoadResult(value=model, model=model))
+
+
+def test_container_held_tensors_reach_the_manifest():
+    model = _Layer()
+    tensors = _discover(model)
+
+    # collect_module_tensors yields tensor.data, a fresh object over the same
+    # storage, so identity is by address rather than by id().
+    hidden = {
+        model._attn_res_cw_cache[torch.float32].data_ptr(),
+        model._attn_res_cw_cache[torch.bfloat16].data_ptr(),
+        model._k3_fused_decode_args[0].data_ptr(),
+        model._k3_fused_decode_args[1].data_ptr(),
+        model.quant_method.swizzled_weight.data_ptr(),
+    }
+    covered = {t.data_ptr() for t in tensors.values()}
+    assert hidden <= covered, (
+        f"{len(hidden - covered)} weight-derived tensors missing from the "
+        f"manifest: {sorted(tensors)}"
+    )
+
+
+def test_manifest_entry_aliases_the_container_entry():
+    """An RDMA write into the manifest entry must be visible via the container.
+
+    adopt_hidden_tensors registers the same tensor object rather than a copy,
+    so the dict entry and the buffer share storage. Without that, a transfer
+    would land in memory the engine never reads.
+    """
+    model = _Layer()
+    tensors = _discover(model)
+
+    cached = model._attn_res_cw_cache[torch.float32]
+    entry = next(t for t in tensors.values() if t.data_ptr() == cached.data_ptr())
+
+    with torch.no_grad():  # stand in for the RDMA write
+        entry.copy_(torch.full_like(entry, 4.25))
+
+    assert torch.equal(
+        model._attn_res_cw_cache[torch.float32],
+        torch.full_like(cached, 4.25),
+    ), "manifest entry does not alias the cached tensor"
+
+
+def test_non_tensor_container_members_are_ignored():
+    model = _Layer()
+    tensors = _discover(model)
+    assert all(isinstance(t, torch.Tensor) for t in tensors.values())
+
+
+def test_parameters_are_not_duplicated():
+    """Aliases of already-registered tensors are skipped by data_ptr dedup."""
+    model = _Layer()
+    model._alias_of_weight = (model.weight.data,)
+    tensors = _discover(model)
+
+    ptr = model.weight.data_ptr()
+    assert sum(1 for t in tensors.values() if t.data_ptr() == ptr) == 1

--- a/modelexpress_client/python/tests/test_sglang_hidden_tensors.py
+++ b/modelexpress_client/python/tests/test_sglang_hidden_tensors.py
@@ -134,9 +134,25 @@ def test_manifest_entry_aliases_the_container_entry():
 
 
 def test_non_tensor_container_members_are_ignored():
+    """The scalar in _k3_fused_decode_args must not become a manifest entry.
+
+    Counting the adopted entries rather than type-checking them: the
+    collector returns tensors by construction, so an isinstance check would
+    pass whether or not the scalar was adopted.
+    """
     model = _Layer()
     tensors = _discover(model)
-    assert all(isinstance(t, torch.Tensor) for t in tensors.values())
+
+    adopted = [n for n in tensors if "_k3_fused_decode_args" in n]
+    tensor_members = sum(
+        1 for m in model._k3_fused_decode_args if isinstance(m, torch.Tensor)
+    )
+    assert len(model._k3_fused_decode_args) > tensor_members, (
+        "fixture must hold a non-tensor member for this test to mean anything"
+    )
+    assert len(adopted) == tensor_members, (
+        f"expected {tensor_members} adopted entries, got {len(adopted)}: {adopted}"
+    )
 
 
 def test_parameters_are_not_duplicated():

--- a/modelexpress_client/python/tests/test_sglang_rdma_receive_invariants.py
+++ b/modelexpress_client/python/tests/test_sglang_rdma_receive_invariants.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Invariants for the SGLang RDMA receive path.
+
+A receiving worker runs
+
+    before_rdma_receive -> discover_tensors -> register -> [RDMA lands]
+      -> after_rdma_receive -> publish weight_info
+
+and then serves as a source for the next worker. ``weight_info`` snapshots
+``tensor.data_ptr()`` at registration time (engines/sglang/loader.py), and
+nixl_transfer.py documents the matching requirement: the registered tensors
+must remain the same objects the model computes with.
+
+Anything ``after_rdma_receive`` runs that reallocates a manifest tensor
+breaks that pairing. These tests pin both halves: the value-derived state
+must be rebuilt from the received weights, and rebuilding it must not move
+any tensor that was already registered.
+
+The model mirrors the structure of SGLang's Kimi-K3 ``post_load_weights``
+(kimi-k3 branch): MLA absorption into w_kc/w_vc, the horizontally-fused
+front merge, and the ``_attn_res_cw_cache`` value cache that ``get_cw``
+short-circuits on. Only the accelerator-device predicate is stubbed; the
+adapter code under test is the real one.
+"""
+
+import contextlib
+import sys
+import types
+
+import pytest
+import torch
+from torch import nn
+
+_loader = types.ModuleType("sglang.srt.model_loader.loader")
+_loader.device_loading_context = contextlib.contextmanager(
+    lambda module, device: iter([None])
+)
+for _name, _mod in (
+    ("sglang", types.ModuleType("sglang")),
+    ("sglang.srt", types.ModuleType("sglang.srt")),
+    ("sglang.srt.model_loader", types.ModuleType("sglang.srt.model_loader")),
+    ("sglang.srt.model_loader.loader", _loader),
+):
+    sys.modules.setdefault(_name, _mod)
+
+from modelexpress.engines.sglang.adapter import SglangAdapter  # noqa: E402
+from modelexpress.load_strategy.context import LoadResult  # noqa: E402
+from modelexpress.tensor_utils import capture_tensor_attrs  # noqa: E402
+
+
+class _CpuAsAccel:
+    """Backend interface with CPU tensors treated as accelerator memory."""
+
+    torch_device_type = "cpu"
+
+    def is_accel_tensor(self, tensor: torch.Tensor) -> bool:
+        return tensor.device.type == "cpu"
+
+    def supports_rdma_p2p(self) -> bool:
+        return True
+
+    def supports_pool_reg(self) -> bool:
+        return True
+
+
+def _merge_weights_as_views(mods):
+    """Transcribed from kimi_k3.py _merge_weights_as_views."""
+    ws = [m.weight.data for m in mods]
+    sizes = [w.shape[0] for w in ws]
+    merged = torch.cat(ws, dim=0).contiguous()
+    off = 0
+    for m, n in zip(mods, sizes):
+        m.weight.data = merged[off : off + n]
+        off += n
+    return merged
+
+
+def _get_cw(proj, norm, dtype=torch.float32):
+    """Transcribed from sglang attn_residual.get_cw."""
+    cache = getattr(proj, "_attn_res_cw_cache", None)
+    if cache is None:
+        cache = {}
+        proj._attn_res_cw_cache = cache
+    cw = cache.get(dtype)
+    if cw is None:
+        cw = (norm.weight.float() * proj.weight.squeeze().float()).contiguous()
+        cw = cache[dtype] = cw.to(dtype)
+    return cw
+
+
+class _MLAAttention(nn.Module):
+    def __init__(self, heads=2, qk_nope=4, v_head=4, kv_lora=8):
+        super().__init__()
+        self.qk_nope_head_dim = qk_nope
+        self.v_head_dim = v_head
+        self.kv_b_proj = nn.Linear(kv_lora, heads * (qk_nope + v_head), bias=False)
+
+    def absorb(self):
+        w_kc, w_vc = self.kv_b_proj.weight.unflatten(
+            0, (-1, self.qk_nope_head_dim + self.v_head_dim)
+        ).split([self.qk_nope_head_dim, self.v_head_dim], dim=1)
+        self.w_kc = w_kc.transpose(1, 2).contiguous().transpose(1, 2)
+        self.w_vc = w_vc.contiguous().transpose(1, 2)
+
+
+class _MoE(nn.Module):
+    def __init__(self, h=8):
+        super().__init__()
+        self.gate = nn.Linear(h, 4, bias=False)
+        self.routed_expert_down_proj = nn.Linear(h, 6, bias=False)
+        self._front_w = None
+
+    def merge_front(self):
+        self._front_w = _merge_weights_as_views(
+            [self.gate, self.routed_expert_down_proj]
+        )
+
+
+class _Layer(nn.Module):
+    def __init__(self, h=8):
+        super().__init__()
+        self.self_attn = _MLAAttention(kv_lora=h)
+        self.mlp = _MoE(h)
+        self.res_proj = nn.Linear(h, 1, bias=False)
+        self.res_norm = nn.LayerNorm(h)
+
+
+class _K3Like(nn.Module):
+    def __init__(self, h=8, layers=2):
+        super().__init__()
+        self.layers = nn.ModuleList([_Layer(h) for _ in range(layers)])
+
+    def post_load_weights(self):
+        for layer in self.layers:
+            layer.self_attn.absorb()
+            _get_cw(layer.res_proj, layer.res_norm, dtype=torch.bfloat16)
+            _get_cw(layer.res_proj, layer.res_norm)
+            layer.mlp.merge_front()
+
+
+def _adapter():
+    adapter = SglangAdapter(
+        load_config=types.SimpleNamespace(),
+        model_config=types.SimpleNamespace(),
+        device_config=types.SimpleNamespace(device="cuda"),
+    )
+    adapter.accelerator_backend = _CpuAsAccel()
+    adapter.target_device = torch.device("cpu")
+    return adapter
+
+
+@pytest.fixture
+def received():
+    """Drive a receive to just past after_rdma_receive.
+
+    Returns (adapter, result, registered, published) where ``registered``
+    holds the tensor objects handed to register_memory and ``published``
+    holds the (addr, numel, element_size) triples snapshotted alongside
+    them, exactly as loader.py builds weight_info.
+    """
+    torch.manual_seed(0)
+    adapter = _adapter()
+    model = _K3Like()
+    result = LoadResult(value=model, model=model)
+
+    result = adapter.before_rdma_receive(result)
+    registered = adapter.discover_tensors(result)
+    published = {
+        name: (t.data_ptr(), t.numel(), t.element_size())
+        for name, t in registered.items()
+    }
+
+    # The bytes that land come from a source that ran the same derivation on
+    # real weights, so derived tensors are self-consistent with their inputs.
+    torch.manual_seed(1234)
+    source = _K3Like()
+    with capture_tensor_attrs(adapter.accelerator_backend):
+        source.post_load_weights()
+    src = adapter.discover_tensors(LoadResult(value=source, model=source))
+    assert set(src) == set(registered), "source/target manifest asymmetry"
+    with torch.no_grad():
+        for name, tensor in registered.items():
+            tensor.copy_(src[name])
+
+    result = adapter.after_rdma_receive(result)
+    return adapter, result, registered, published
+
+
+def test_value_derived_cache_matches_the_received_weights(received):
+    """cw must equal a fresh derivation from the weights that landed.
+
+    Satisfied by manifest coverage: discover_tensors adopts the dict-held
+    entries, so the transfer writes the source's cw straight into them. No
+    post-receive derivation runs, so nothing can double-transform a weight
+    or move a registered tensor.
+    """
+    _, result, _, _ = received
+    for layer in result.model.layers:
+        cache = getattr(layer.res_proj, "_attn_res_cw_cache", None)
+        assert cache, "value-derived cache missing after receive"
+        expected = (
+            layer.res_norm.weight.float() * layer.res_proj.weight.squeeze().float()
+        ).contiguous()
+        for dtype, cached in cache.items():
+            assert torch.equal(cached, expected.to(dtype)), (
+                f"cw for {dtype} was not rebuilt from the received weights"
+            )
+
+
+def test_registered_tensors_keep_their_addresses(received):
+    """No manifest tensor may move after it has been registered.
+
+    weight_info is snapshotted at registration and published unchanged on
+    the success path (engines/sglang/loader.py) -- the loader never
+    re-discovers. A tensor that moves leaves the published entry pointing
+    at an orphaned copy that the model no longer computes with.
+    """
+    adapter, result, _, published = received
+    live = adapter.discover_tensors(result)
+    moved = {
+        name: (addr, live[name].data_ptr())
+        for name, (addr, _, _) in published.items()
+        if name in live and live[name].data_ptr() != addr
+    }
+    assert not moved, (
+        f"{len(moved)} of {len(published)} registered tensors moved after "
+        f"after_rdma_receive: {sorted(moved)}"
+    )
+
+
+def test_registered_tensors_are_the_tensors_the_model_uses(received):
+    """The registered objects must still be reachable from the module tree.
+
+    nixl_transfer.register_tensors documents this pairing: the registered
+    dict must hold the same objects as the live parameters/buffers, or a
+    later RDMA read serves memory the model has stopped updating.
+    """
+    adapter, result, registered, _ = received
+    live = adapter.discover_tensors(result)
+    detached = [
+        name
+        for name, tensor in registered.items()
+        if name in live and live[name].data_ptr() != tensor.data_ptr()
+    ]
+    assert not detached, (
+        f"registered tensors no longer paired with live model tensors: "
+        f"{sorted(detached)}"
+    )

--- a/modelexpress_client/python/tests/test_sglang_rdma_receive_invariants.py
+++ b/modelexpress_client/python/tests/test_sglang_rdma_receive_invariants.py
@@ -71,7 +71,7 @@ def _merge_weights_as_views(mods):
     sizes = [w.shape[0] for w in ws]
     merged = torch.cat(ws, dim=0).contiguous()
     off = 0
-    for m, n in zip(mods, sizes):
+    for m, n in zip(mods, sizes, strict=True):
         m.weight.data = merged[off : off + n]
         off += n
     return merged


### PR DESCRIPTION
## Problem

`capture_tensor_attrs` promotes bare `Tensor` attributes assigned on an `nn.Module`, which is how derived state like MLA's `w_kc`/`w_vc` reaches the manifest. It does not reach tensors held **inside a container**, or on a **non-Module object**:

- `module._attn_res_cw_cache = {}` assigns a `dict`, which fails the `isinstance(value, torch.Tensor)` check
- `cache[dtype] = cw` goes through `dict.__setitem__`, which never touches `nn.Module.__setattr__` at all

Such tensors are invisible to `named_parameters()`/`named_buffers()`, so they are absent from the RDMA manifest. On a target they keep whatever `before_rdma_receive` derived from **random-init** weights. The transfer then overwrites only manifest tensors, so the engine runs with part of its state computed from noise — while every manifest check (name, shape, dtype) passes and the transfer reports success.

Concretely on Kimi-K3:

| state | storage | reaches manifest today |
|---|---|---|
| `_attn_res_cw_cache` | `dict` keyed by dtype, short-circuited by `get_cw` | no |
| `_k3_fused_decode_args` | `tuple` consumed by the fused KDA decode kernel | no |

`cw = norm.weight * proj.weight.squeeze()` is the `[hidden_size]` scoring vector that weights the attention-residual mixture at every aggregation point, so a stale one silently distorts every layer's residual stream. SGLang's MXFP4 FusedMoE `quant_method` is a third case — it holds swizzled weights after deleting the original params.

## Fix

`discover_tensors` calls `adopt_hidden_tensors`, matching `engines/vllm/adapter.py:184`. The two adapters' `discover_tensors` were structurally identical apart from this line, which was commented out with a note to enable it "when SGLang nested-object coverage is in scope". Kimi-K3 is that case.

`adopt_hidden_tensors` registers the **same tensor objects** as non-persistent buffers, so the container entries alias the transferred memory — an RDMA write into the manifest entry is visible through the dict or tuple, with no engine-side change.

This keeps the receive path on its existing contract: **transfer the final state, derive nothing afterwards.** That contract is what keeps engine post-load hooks off the receive path, where re-running them would double-transform already-processed weights (e.g. `DeepseekV4ForCausalLM.post_load_weights` calls `_setup_fp8_wo_a_scales`, which re-lays-out `weight_scale_inv` with no already-transformed guard, under a default-on env flag) and would move tensors that are already registered and published.

## Tests

`tests/test_sglang_hidden_tensors.py` — dict-held, tuple-held and quant-method-held tensors reach the manifest; the manifest entry **aliases** the container entry so an RDMA write propagates; non-tensor tuple members are ignored; the non-tensor tuple member is not adopted (asserted by count, since the collector returns tensors by construction); aliases of existing parameters are not duplicated.

`tests/test_sglang_rdma_receive_invariants.py` — drives the real adapter through `before_rdma_receive -> discover -> register -> transfer` against a model transcribed from SGLang's `kimi_k3.py` / `attn_residual.py`, and pins two invariants: the value-derived cache matches a fresh derivation from the received weights, and no registered tensor moves or detaches from the model.

Python suite: 1083 passed, 1 skipped (excluding `tests/gpu`, which needs `transformers` and a GPU).

## Open question for maintainers: transfer-ABI version

This adds `_mx_*` manifest names. Same-family transfers tolerate subset manifests (`require_exact_match` defaults `False`), so **a target on this build paired with a source without it silently leaves the adopted entries at dummy values** -- the same failure mode this PR fixes.

`SourceIdentity` derives `mx_version` from the `modelexpress` package version and has no free-form capability field, so there is no surgical way to separate old and new workers short of a workspace version bump. Per `CLAUDE.md` that is a release action touching ~10 files plus regenerated source-id hashes, so I have not done it here.

**Please decide whether this should land together with a version bump, or wait for the next one.** Flagging rather than deciding, since it affects the release train.

## Hardware validation status

Mechanism and coverage are confirmed offline. A full Kimi-K3 run is staged but has not completed: the image now builds on `lmsysorg/sglang:kimi-k3` (thanks @zhengluo-nv -- the source checkout it replaced was unnecessary) with a build-time assertion on the two private symbols this depends on, and the 1.5T checkpoint is staged on a cluster PVC. Seed rank 0 came up and initialised correctly; rank 1 never scheduled -- nodes reporting `Ready`, uncordoned and fully unallocated were still rejected with `Insufficient nvidia.com/gpu`. Raised with the cluster maintainers.

Still unmeasured, and not claimed here:

- source/target `_mx_*` name symmetry on a real K3 (the collision suffix in `adopt_hidden_tensors` is order-dependent)
- what each quantization path newly adopts — MXFP4, CUTLASS FP8/W4A8 — and that none of it is device-local scratch such as the pointer arrays in `fp8.py`'s CUTLASS buffers, which are lazily created at first forward and therefore absent at discover time today, but only by timing
- `adopt_hidden_tensors` walk cost on a 92-layer model
- transfer size delta

A dry-run mode that reports what *would* be adopted, per quantization path, would de-risk the last three before enabling by default.

Related: #585 addresses the same Kimi-K3 symptom by re-running `post_load_weights` after the transfer; #471 (source-identity coverage for derived state).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to stream, list, or download model files without weight files.
  * Weight-file detection now works consistently across supported file formats and nested paths.
  * SGLang model discovery now includes hidden tensors in nested containers and cache state.

* **Bug Fixes**
  * Preserved tensor aliases and live tensor registrations during SGLang loading and RDMA transfers.

* **Tests**
  * Added coverage for hidden tensor discovery, weight exclusion, alias handling, and RDMA receive invariants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
