### PR TITLE
fix(nixl): record data-plane failures on the batched READ wait

### DIFF
--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -505,16 +505,27 @@ class NixlTransferManager:
 
         Sleeps only when a full sweep completed nothing, so the polling slop is
         paid once for the whole set rather than once per handle.
+
+        Records data-plane failures exactly as :meth:`_wait_for_xfer` does, for the
+        same reason: a wedged QP yields neither a completion nor an ERR status, so
+        the timeout is the only evidence anything went wrong, and recording it is
+        what lets ``is_healthy()`` stop advertising this agent.
         """
         if self._agent is None:
             raise RuntimeError("NIXL agent not initialized")
         pending = list(handles)
+        waited_on_something = bool(pending)
         wait_start = time.perf_counter()
         while pending:
             if (
                 timeout_seconds is not None
                 and time.perf_counter() - wait_start >= timeout_seconds
             ):
+                self._data_plane_error = (
+                    f"{label} timed out after {timeout_seconds:.1f}s with "
+                    f"{len(pending)} transfer(s) outstanding and no error status "
+                    f"from NIXL"
+                )
                 raise TimeoutError(
                     f"{label} timed out with {len(pending)} transfer(s) outstanding"
                 )
@@ -524,11 +535,19 @@ class NixlTransferManager:
                 if status in ("DONE", "SUCCESS"):
                     continue
                 if status in ("ERR", "ERROR", "FAIL"):
+                    self._data_plane_error = f"{label} failed with status {status}"
                     raise RuntimeError(f"{label} failed with status {status}")
                 still_pending.append(handle)
             if len(still_pending) == len(pending):
                 time.sleep(0.001)
             pending = still_pending
+        # Only once the whole set has completed, and only if there was a set. Nothing
+        # is proven by waiting on no handles, and clearing per handle would let a
+        # batch that failed on its last one report healthy. Health must not latch
+        # either: a completed batch is proof the data plane works, so a worker
+        # demoted for one transient timeout can return to READY.
+        if waited_on_something:
+            self._data_plane_error = None
 
     def _wait_for_xfer(
         self,

--- a/modelexpress_client/python/tests/test_nixl_peer_lifecycle.py
+++ b/modelexpress_client/python/tests/test_nixl_peer_lifecycle.py
@@ -18,6 +18,8 @@ without disconnecting leaves it holding a QP nothing can clean up.
 Run: pytest tests/test_nixl_peer_lifecycle.py
 """
 
+import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -277,3 +279,122 @@ class TestHealthReflectsDataPlane:
         source = _manager()
         assert source.data_plane_error is None
         assert source.is_healthy() is True
+
+
+class TestHealthReflectsTheBatchDataPlane:
+    """The same contract on the batched wait.
+
+    ``_wait_for_xfer`` records data-plane failures; ``_wait_for_xfers`` did not, and
+    it is the only wait a reshard refit performs. So the health signal that demotes a
+    worker existed on the classic load path and was absent on the refit path, which
+    is the path that pulls whole checkpoints across the fabric.
+    """
+
+    def test_a_batch_timeout_makes_the_agent_unhealthy(self):
+        class Stuck:
+            def check_xfer_state(self, handle):
+                return "PROC"
+
+        mgr = _manager(agent=Stuck())
+        with pytest.raises(TimeoutError):
+            mgr._wait_for_xfers([object(), object()], 0.02, "READ batch")
+
+        assert mgr.is_healthy() is False
+        assert "timed out" in (mgr.data_plane_error or "")
+
+    def test_a_batch_error_status_makes_the_agent_unhealthy(self):
+        class Failing:
+            def check_xfer_state(self, handle):
+                return "ERR"
+
+        mgr = _manager(agent=Failing())
+        with pytest.raises(RuntimeError):
+            mgr._wait_for_xfers([object()], 5.0, "READ batch")
+
+        assert mgr.is_healthy() is False
+        assert "ERR" in (mgr.data_plane_error or "")
+
+    def test_a_completed_batch_leaves_health_untouched(self):
+        class Done:
+            def check_xfer_state(self, handle):
+                return "DONE"
+
+        mgr = _manager(agent=Done())
+        mgr._wait_for_xfers([object(), object()], 5.0, "READ batch")
+
+        assert mgr.is_healthy() is True
+        assert mgr.data_plane_error is None
+
+    def test_a_later_successful_batch_clears_an_earlier_failure(self):
+        """Health must not latch on the batch path either."""
+
+        class Flaky:
+            def __init__(self):
+                self.state = "PROC"
+
+            def check_xfer_state(self, handle):
+                return self.state
+
+        agent = Flaky()
+        mgr = _manager(agent=agent)
+        with pytest.raises(TimeoutError):
+            mgr._wait_for_xfers([object()], 0.02, "READ batch")
+        assert mgr.is_healthy() is False
+
+        agent.state = "DONE"
+        mgr._wait_for_xfers([object()], 5.0, "READ batch")
+
+        assert mgr.is_healthy() is True
+        assert mgr.data_plane_error is None
+
+    def test_one_failed_handle_in_a_batch_is_not_cleared_by_its_siblings(self):
+        """The reason health is cleared once for the set rather than per completed
+        handle. A batch where most handles succeed and one fails is a failed batch."""
+
+        class OneBad:
+            def __init__(self):
+                self.seen = 0
+
+            def check_xfer_state(self, handle):
+                self.seen += 1
+                return "ERR" if self.seen == 3 else "DONE"
+
+        mgr = _manager(agent=OneBad())
+        with pytest.raises(RuntimeError):
+            mgr._wait_for_xfers([object(), object(), object()], 5.0, "READ batch")
+
+        assert mgr.is_healthy() is False
+
+    def test_waiting_on_nothing_does_not_clear_an_earlier_failure(self):
+        """An empty set proves nothing about the fabric, so it must not restore
+        health. ``await_read_batches`` returns early today, so this pins the helper
+        rather than that caller."""
+        mgr = _manager()
+        mgr._data_plane_error = "an earlier timeout"
+
+        mgr._wait_for_xfers([], 5.0, "READ batch")
+
+        assert mgr.is_healthy() is False
+        assert mgr.data_plane_error == "an earlier timeout"
+
+    def test_the_refit_wait_records_a_failure_through_the_public_entry_point(self):
+        """The gap reached health through `await_read_batches`, so cover it there and
+        not only on the private helper."""
+
+        class Stuck:
+            def check_xfer_state(self, handle):
+                return "PROC"
+
+            def release_xfer_handle(self, handle):
+                pass
+
+        mgr = _manager(agent=Stuck())
+        posted = SimpleNamespace(
+            handle=object(), total_bytes=1, num_ranges=1, posted_at=time.perf_counter()
+        )
+
+        with pytest.raises(TimeoutError):
+            mgr.await_read_batches([posted], timeout_seconds=0.02)
+
+        assert mgr.is_healthy() is False
+        assert "timed out" in (mgr.data_plane_error or "")


### PR DESCRIPTION
## Why this is needed

ModelExpress uses a health flag to stop advertising a transfer agent after the data plane fails. The single-transfer wait updates that flag, but the batched READ wait did not.

This matters because batched READs are now the normal path for reshard refits, and PR #588 also uses them for the `weight_transfer` path. Before this fix, a batch could time out or return a terminal NIXL error while `is_healthy()` continued to report the agent as healthy. Other workers could keep selecting a source whose network path was already known to be broken.

The failure is not theoretical. A wedged UCX/InfiniBand queue pair can remain pending until the application timeout without returning an error status. In that case, the timeout is the only signal that the data plane failed.

## What changes

`NixlTransferManager._wait_for_xfers` now follows the same health rules as the existing single-transfer wait:

- A timeout records `_data_plane_error` before raising `TimeoutError`.
- A terminal NIXL status records `_data_plane_error` before raising `RuntimeError`.
- The error is cleared only after every handle in a non-empty batch completes successfully.
- An empty batch does not clear an earlier failure because waiting on nothing does not prove the network recovered.

A later successful batch is allowed to clear an earlier failure. This lets a worker recover after a transient fault instead of remaining unhealthy for the life of the process.

## Where it sits

```mermaid
flowchart TB
    A["<b>1. Post a batch of NIXL READs</b>"] --> B["<b>2. Wait for all handles</b>"]
    B --> C{"<b>3. Batch result</b>"}
    C -->|Timeout| D["<b>4. Record data-plane error</b>"]
    C -->|NIXL error| D
    D --> E["<b>5. is_healthy returns false</b>"]
    C -->|All complete| F["<b>4. Clear earlier error</b>"]
    F --> G["<b>5. is_healthy returns true</b>"]
    C -->|No handles| H["<b>4. Leave health unchanged</b>"]

    classDef mx fill:#E8F5E9,stroke:#2E7D32,stroke-width:2px,color:#1B5E20,font-size:16px;
    classDef receiver fill:#EDE7F6,stroke:#5E35B1,stroke-width:2px,color:#311B92,font-size:16px;
    class A,B mx;
    class C,D,E,F,G,H receiver;
```

## Scope

Included:

- health-state updates for the existing batched wait;
- recovery semantics after a successful batch;
- unit coverage through both the private helper and public `await_read_batches` entry point.

Not included:

- changes to NIXL transfer posting;
- retry policy;
- source eviction or publisher teardown policy;
- changes specific to PR #588.

The bug predates PR #588 and affects every caller of `await_read_batches`, so the fix stays in the shared transfer manager.

## How to review

This PR has two files. Review them in this order:

1. **`modelexpress/nixl_transfer.py` — required review.** The source change is small. Confirm that failure is recorded before either exception, and that success clears the flag only after the full non-empty batch completes.
2. **`tests/test_nixl_peer_lifecycle.py` — required review.** Focus on `TestHealthReflectsTheBatchDataPlane`. It mirrors the existing single-transfer tests and covers timeout, terminal error, mixed handle outcomes, recovery, empty batches, and the public batch-wait method.

Questions for reviewers:

- Should one completed batch be sufficient evidence to restore health after a transient failure?
- Is whole-batch success the correct clearing boundary? Clearing per handle would allow a completed sibling to hide another handle's failure.
- Should an empty batch leave a previous failure latched? This PR says yes because no data-plane work was observed.

## Validation

- Python tests, lint, formatting, and DCO pass in CI.
- `tests/test_nixl_peer_lifecycle.py`: 27 passed.
- The broader reshard, refit, NIXL, publisher, and many-to-many transfer selection passed: 202 tests.
- Five new tests fail against the old helper, covering timeout, terminal error, recovery, one failed handle among siblings, and the public entry point.

No real Remote Direct Memory Access (RDMA) hardware is used in these unit tests; the NIXL agent is stubbed, consistent with the existing lifecycle suite.