### PR TITLE
feat(reshard-refit): publish a per-shard digest for later verification

### DIFF
--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -162,6 +162,7 @@ register_modelexpress_loaders()
 | `MX_RESHARD_HANDSHAKE_BACKOFF_S` | `2` | Pause after a full pass over the pending peers makes no progress, so a transient stall is waited out rather than hammered |
 | `MX_REFIT_STAGE_RECORD` | `1` | Emit one `refit-stage-v2` JSON record per refit, giving a benchmark harness the per-stage timings without parsing logs. Set to `0` to silence it |
 | `MX_RESHARD_MAX_GBPS` | `0` | Per-rank fabric ceiling in Gbps. A measured wire rate above it means the timing is wrong rather than the transfer being fast, so the refit is rejected. `0` disables the check, since only the operator knows the real per-rank limit |
+| `MX_RESHARD_PUBLISH_DIGEST` | `0` | Have each trainer publish a position-sensitive digest of every shard it advertises, so a receiver can later confirm it installed the bytes the publisher held. Off by default: the reduction costs a pass over every published tensor, which is large next to a ~1.5 s wire, so turn it on when qualifying a build rather than when measuring throughput |
 
 ### UCX/NIXL Tuning
 

--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     MX_RESHARD_HANDSHAKE_BACKOFF_S: float
     MX_REFIT_STAGE_RECORD: bool
     MX_RESHARD_MAX_GBPS: float
+    MX_RESHARD_PUBLISH_DIGEST: bool
     # Kubernetes service backend
     MX_K8S_SERVICE_PATTERN: str
     MX_K8S_SOURCE_RETRIES: str
@@ -268,6 +269,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # disables the check, and is the default because only the operator knows the
     # real per-rank limit for their fabric.
     "MX_RESHARD_MAX_GBPS": lambda: _env_float("MX_RESHARD_MAX_GBPS", 0.0),
+    # Have publishers digest each shard they advertise, so a receiver-side check has
+    # something to compare against. Off by default: it costs a reduction over every
+    # published tensor, which is a large relative cost against a ~1.5 s wire, so it
+    # belongs in a qualification run rather than a throughput measurement. See
+    # modelexpress.refit.reshard.verify.
+    "MX_RESHARD_PUBLISH_DIGEST": lambda: _env_bool("MX_RESHARD_PUBLISH_DIGEST", False),
     # ── Kubernetes service backend ─────────────────────────────────────────
     "MX_K8S_SERVICE_PATTERN": lambda: os.environ.get("MX_K8S_SERVICE_PATTERN", "mx-sources"),
     "MX_K8S_SOURCE_RETRIES": lambda: os.environ.get("MX_K8S_SOURCE_RETRIES", ""),

--- a/modelexpress_client/python/modelexpress/refit/README.md
+++ b/modelexpress_client/python/modelexpress/refit/README.md
@@ -180,7 +180,7 @@ A trainer restart, reshard, scale event, or buffer replacement requires rediscov
 | Topology-change handling | The cached plan is not invalidated after trainer restart, reshard, scaling, or address change. |
 | Partial/subset wire filtering | MDL accepts subset batches, but the reshard receiver currently executes its full cached plan on each update. |
 | Expert-aware wire filtering | Expert destination mapping exists in MDL; the reshard planner has no receiver-owned expert selector. |
-| Parameter digest verification | The package has reference equality tests but no distributed source-to-destination digest gate in the live receiver. |
+| Parameter digest verification | Publishers can stamp each shard with a position-sensitive digest (`MX_RESHARD_PUBLISH_DIGEST`, see `refit/reshard/verify.py`), and it is carried through discovery into the planning inputs, but the live receiver does not yet recompute and compare. The comparison needs a fresh-discovery refresh of the expectation, or ordinary training updates between prepare and a later step read as corruption. |
 | Inference-to-inference fan-out | Rollout workers do not republish installed refit buffers through this package. |
 | General engine support | The shared core is engine-neutral, but only a vLLM receiver adapter is present. |
 | General trainer support | Framework-specific FSDP, DTensor, and Megatron publisher adapters are not present here. |

--- a/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
@@ -70,6 +70,7 @@ from modelexpress.refit.reshard.rendezvous import (
     gather_sources,
     wrap_rendezvous_blob,
 )
+from modelexpress.refit.reshard.verify import shard_region, tensor_digest
 
 __all__ = [
     "InMemoryReferenceTransport",
@@ -109,5 +110,7 @@ __all__ = [
     "plan_transfer",
     "publish_megatron_reshard_view",
     "publish_registered_shard_table",
+    "shard_region",
+    "tensor_digest",
     "wrap_rendezvous_blob",
 ]

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_aliases.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from modelexpress.refit.reshard.rendezvous import PublishedShard, PublishedTensor
+from modelexpress.refit.reshard.verify import published_digest
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,7 @@ def _one_shard(
                 addr=int(tensor.data_ptr()),
                 shard_offset=tuple(offset),
                 shape=local_shape,
+                digest=published_digest(tensor),
             )
         ],
     )
@@ -171,6 +173,9 @@ def _build_qkv_aliases(
                     addr=int(tensor.data_ptr()),
                     shard_offset=(start, 0),
                     shape=tuple(int(dim) for dim in tensor.shape),
+                    # The narrow, not the fused parent: this is the box a receiver
+                    # reads from ``addr``, so it is the box whose bytes must match.
+                    digest=published_digest(tensor),
                 )
             )
     return [

--- a/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/megatron_publisher.py
@@ -13,6 +13,7 @@ from modelexpress.refit.reshard.rendezvous import (
     PublishedTensor,
     wrap_rendezvous_blob,
 )
+from modelexpress.refit.reshard.verify import published_digest
 
 
 @dataclass(frozen=True)
@@ -112,6 +113,7 @@ def publish_megatron_reshard_view(
                         addr=int(tensor.data_ptr()),
                         shard_offset=tuple(offset),
                         shape=local_shape,
+                        digest=published_digest(tensor),
                     )
                 ],
             )

--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -68,13 +68,20 @@ def _mx_version() -> str:
 @dataclass
 class PublishedShard:
     """One published shard of a source tensor: the sub-box it covers and where
-    to READ it from (owning agent / device / base address)."""
+    to READ it from (owning agent / device / base address).
+
+    ``digest`` is a position-sensitive digest over the shard's bytes, from
+    :func:`modelexpress.refit.reshard.verify.tensor_digest`. ``None`` means the
+    publisher did not compute one, which a checker must read as *unchecked* rather
+    than as agreement.
+    """
 
     agent_name: str
     device_id: int
     addr: int
     shard_offset: tuple
     shape: tuple
+    digest: str | None = None
 
 
 @dataclass
@@ -89,6 +96,25 @@ class PublishedTensor:
     shards: list  # list[PublishedShard]
 
 
+def _encode_shard(shard) -> dict:
+    """One shard as JSON.
+
+    ``digest`` is omitted rather than written as null when the publisher has none, so
+    a blob from a publisher that does not digest stays byte-identical to what a client
+    without this field would have produced.
+    """
+    encoded = {
+        "agent_name": shard.agent_name,
+        "device_id": shard.device_id,
+        "addr": shard.addr,
+        "shard_offset": list(shard.shard_offset),
+        "shape": list(shard.shape),
+    }
+    if shard.digest is not None:
+        encoded["digest"] = shard.digest
+    return encoded
+
+
 def encode_shard_table(tensors: list) -> bytes:
     """Serialize published tensors + shards to a JSON blob."""
     payload = {
@@ -99,16 +125,7 @@ def encode_shard_table(tensors: list) -> bytes:
                 "dtype": t.dtype,
                 "elsize": t.elsize,
                 "full_shape": list(t.full_shape),
-                "shards": [
-                    {
-                        "agent_name": s.agent_name,
-                        "device_id": s.device_id,
-                        "addr": s.addr,
-                        "shard_offset": list(s.shard_offset),
-                        "shape": list(s.shape),
-                    }
-                    for s in t.shards
-                ],
+                "shards": [_encode_shard(s) for s in t.shards],
             }
             for t in tensors
         ],
@@ -131,6 +148,7 @@ def decode_shard_table(blob: bytes) -> list:
                 addr=int(s["addr"]),
                 shard_offset=tuple(s["shard_offset"]),
                 shape=tuple(s["shape"]),
+                digest=s.get("digest"),
             )
             for s in t["shards"]
         ]
@@ -174,6 +192,7 @@ def build_sources(tensors: list) -> tuple:
                     session=session,
                     addr=s.addr,
                     elsize=t.elsize,
+                    digest=s.digest,
                 )
             )
             session_to_agent[session] = s.agent_name

--- a/modelexpress_client/python/modelexpress/refit/reshard/slice_plan.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/slice_plan.py
@@ -64,6 +64,10 @@ class Shard:
     session: str  # transfer-engine session id
     addr: int  # shard base address (element 0)
     elsize: int  # bytes per element
+    # Position-sensitive digest of the publisher's bytes, or None when it published
+    # none. Carried through planning so a receiver-side check has an expectation to
+    # compare against; nothing in the planner reads it.
+    digest: str | None = None
 
 
 @dataclass

--- a/modelexpress_client/python/modelexpress/refit/reshard/verify.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/verify.py
@@ -69,14 +69,28 @@ def tensor_digest(tensor) -> str:
     while the reduction itself stays one cheap kernel over the full tensor.
 
     The tensor is made contiguous first, since a strided view has no meaningful byte
-    order to digest. Returns a hex string so it can ride in JSON alongside the shard
-    table.
+    order to digest, and is rebased to a word-aligned start. Returns a hex string so it
+    can ride in JSON alongside the shard table.
     """
     import torch
 
     flat = tensor.detach().reshape(-1)
     if not flat.is_contiguous():
         flat = flat.contiguous()
+    elif (flat.storage_offset() * flat.element_size()) % 4:
+        # What a publisher actually passes. ``narrow`` returns a view that is
+        # contiguous *and* offset, so the branch above never fires, and
+        # ``.contiguous()`` would return self anyway - only a copy rebases the start.
+        # Without this the int32 view below raises on any shard whose byte offset is
+        # not a multiple of 4, which is every odd bf16 split: the gate/up narrow at an
+        # odd half, the QKV narrow at an odd row.
+        #
+        # Rebasing rather than skipping the leading bytes to reach an aligned
+        # boundary, which would be cheaper and wrong: the digest has to be a function
+        # of the shard's contents alone. A publisher digesting at offset 2818 and a
+        # receiver digesting the same bytes at offset 0 must agree, and they only do
+        # if neither one's result depends on where the bytes happen to sit.
+        flat = flat.clone()
     raw = flat.view(torch.uint8)
     n = int(raw.numel())
 

--- a/modelexpress_client/python/modelexpress/refit/reshard/verify.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/verify.py
@@ -134,9 +134,19 @@ def shard_region(full_tensor, global_shape, shard_offset, shape):
     Here rather than with the comparison gate because it is the inverse of what a
     publisher digests: the publisher hashes its own contiguous shard, and this is how
     a receiver recovers the same box out of the buffer it assembled.
+
+    The three ranks must agree. A short ``shard_offset`` would otherwise stop the
+    narrow loop early and return a larger region than the publisher digested, which
+    surfaces as a mismatch on a shard that transferred correctly - the most expensive
+    kind of wrong answer for a gate whose whole job is to be trusted.
     """
+    if not len(global_shape) == len(shard_offset) == len(shape):
+        raise ValueError(
+            f"rank mismatch: global_shape {tuple(global_shape)}, shard_offset "
+            f"{tuple(shard_offset)} and shape {tuple(shape)} must have equal rank"
+        )
     view = full_tensor.reshape(tuple(global_shape))
-    for axis, (start, extent) in enumerate(zip(shard_offset, shape)):
+    for axis, (start, extent) in enumerate(zip(shard_offset, shape, strict=True)):
         view = view.narrow(axis, int(start), int(extent))
     return view.contiguous()
 

--- a/modelexpress_client/python/modelexpress/refit/reshard/verify.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/verify.py
@@ -24,18 +24,21 @@ costs a pass over every published tensor.
 
 Scope, because it is narrower than "the refit is verified" and the difference matters
 when planning the consumer. A publisher digest covers a whole shard, so a receiver can
-only check it where it holds that whole shard - the full-pull path, which stages the
-entire logical source tensor contiguously and can recover any publisher's box with
-:func:`shard_region`. On the exact-segment path the receiver reads a sub-range straight
-into the live parameter and never materialises the shard, so there is nothing to
-recompute the digest over. That is not a corner case: where trainer and inference
-parallelism differ, most sources take the exact path. For strict qualification, the
-receiver must full-pull and verify the publisher's whole shard, derive the expected
-destination slice from that verified staging buffer, and compare it with the destination
-produced by the ordinary exact-segment read. Both reads must target the same immutable,
-step-stamped source version. A fingerprint over the contributing publishers is useful
-freshness evidence, but it is not a byte-for-byte expectation for a partial read and must
-not be presented as one.
+compare it directly only when the ordinary plan gives that receiver every byte of the
+shard. That includes a coarser inference topology which assembles whole trainer shards
+into known destination sub-boxes. A finer inference topology instead reads only part of
+each trainer shard, so its partial destination has no value comparable to the published
+whole-shard digest.
+
+For strict qualification of that partial-read case, the receiver must full-pull and
+verify the publisher's whole shard, derive the expected destination slice from the
+verified staging buffer, and compare it with the destination produced by the ordinary
+exact-segment read. Both reads must target the same immutable, step-stamped source
+version. :func:`shard_region` serves the full-pull reference path; the direct case needs
+the transfer plan's source-to-destination provenance to locate each complete publisher
+shard in the assembled destination. A fingerprint over the contributing publishers is
+useful freshness evidence, but it is not a byte-for-byte expectation for a partial read
+and must not be presented as one.
 """
 
 from __future__ import annotations

--- a/modelexpress_client/python/modelexpress/refit/reshard/verify.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/verify.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Shard digests for the reshard refit path.
+
+A refit that reports plausible timings can still install the wrong bytes: the wire
+can deliver correctly while the *plan* points a copy at the wrong sub-box, and
+generation-level metrics such as KL against a reference are too coarse to localise
+that. This module supplies the cheap half of the answer - a digest a publisher can
+compute over the shard it owns, and which a receiver can recompute over the bytes it
+actually received - so a mismatch names the offending tensor instead of showing up
+as a slightly worse loss curve three steps later.
+
+Why not a byte hash: hashing 30 GB per rank per refit on the GPU means either a
+device-side hash kernel we do not have, or a copy to host we cannot afford. The
+digest below is a *position-sensitive* reduction instead - see :func:`tensor_digest`
+for why plain sums are not enough.
+
+This module is the digest and the wire format for it. The receiver-side gate that
+recomputes and compares is deliberately not here; it needs the fresh-discovery
+refresh to avoid reporting ordinary training updates as corruption, which is its own
+change. Publishing is opt-in via ``MX_RESHARD_PUBLISH_DIGEST`` because the reduction
+costs a pass over every published tensor.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Words per digest row. Row sums are position-sensitive *between* rows, since the row
+# vector is hashed in order, so this is the granularity at which a permutation is
+# detected: reordering whole 4 KiB rows is caught, reordering words inside one row is
+# not. 1024 int32 words keeps the hashed vector ~4 KiB per MiB of tensor, small enough
+# to move to host, while staying coarse enough that the reduction is a single fast
+# kernel.
+_ROW_WORDS = 1024
+
+_U64 = (1 << 64) - 1
+
+# Position weights are the same vector for every shard of a given row count, and a
+# refit digests thousands of shards, so they are built once per (length, device)
+# rather than per call.
+_WEIGHT_CACHE: dict = {}
+
+
+def _row_weights(length: int, device):
+    """Cached ``[1..length]`` on ``device``, for the position-weighted reduction."""
+    import torch
+
+    key = (length, str(device))
+    weights = _WEIGHT_CACHE.get(key)
+    if weights is None:
+        weights = torch.arange(1, length + 1, device=device, dtype=torch.int64)
+        _WEIGHT_CACHE[key] = weights
+    return weights
+
+
+def tensor_digest(tensor) -> str:
+    """A position-sensitive digest of ``tensor``'s bytes, computed on-device.
+
+    Plain reductions (sum, sum-of-squares) are unusable here because the failure
+    mode we most need to catch is a *permutation*: a plan that copies the right
+    bytes to the wrong offsets preserves every order-independent statistic. So the
+    bytes are viewed as int32 words, reshaped into rows, reduced per row, and the
+    resulting row vector is hashed **in order** - reordering rows changes the hash,
+    while the reduction itself stays one cheap kernel over the full tensor.
+
+    The tensor is made contiguous first, since a strided view has no meaningful byte
+    order to digest. Returns a hex string so it can ride in JSON alongside the shard
+    table.
+    """
+    import torch
+
+    flat = tensor.detach().reshape(-1)
+    if not flat.is_contiguous():
+        flat = flat.contiguous()
+    raw = flat.view(torch.uint8)
+    n = int(raw.numel())
+
+    # int32 view needs a 4-byte-aligned length; digest the aligned body as words and
+    # fold the remainder in separately rather than silently dropping it.
+    body = n - (n % 4)
+    words = raw[:body].view(torch.int32)
+    rows = int(words.numel()) // _ROW_WORDS
+
+    # Reduce all the way to scalars on-device. Moving the row vector to the host
+    # instead would mean a per-element Python conversion for every one of the
+    # thousands of shards in a refit, which is slower than the transfer being
+    # verified. Position sensitivity survives the second reduction because the row
+    # sums are weighted by their index before being summed; int64 overflow simply
+    # makes it arithmetic mod 2**64, which is still order-dependent.
+    scalars = [n]
+    if rows:
+        # dtype=int64 accumulates without materialising an int64 copy of the input.
+        row_sums = (
+            words[: rows * _ROW_WORDS]
+            .view(rows, _ROW_WORDS)
+            .sum(dim=1, dtype=torch.int64)
+        )
+        weights = _row_weights(rows, row_sums.device)
+        scalars.append(int(row_sums.sum().item()))
+        scalars.append(int((row_sums * weights).sum().item()))
+    tail = words[rows * _ROW_WORDS :]
+    if tail.numel():
+        tail64 = tail.to(torch.int64)
+        scalars.append(int(tail64.sum().item()))
+        scalars.append(
+            int((tail64 * _row_weights(tail64.numel(), tail64.device)).sum().item())
+        )
+    if n % 4:
+        # The ragged bytes past the last whole int32 word. Folded in explicitly
+        # because dropping them would make two tensors differing only in their final
+        # bytes digest identically.
+        scalars.append(int(raw[body:].to(torch.int64).sum().item()))
+        scalars.append(n % 4)
+
+    h = hashlib.blake2b(digest_size=16)
+    for value in scalars:
+        h.update((value & _U64).to_bytes(8, "little"))
+    return h.hexdigest()
+
+
+def shard_region(full_tensor, global_shape, shard_offset, shape):
+    """The sub-box of an assembled full-pull staging buffer that one publisher owns.
+
+    ``full_tensor`` is the flat staging buffer holding the whole logical source
+    tensor; a publisher's shard occupies the box at ``shard_offset`` with ``shape``.
+    Returned as a contiguous copy because :func:`tensor_digest` digests byte order
+    and the box is generally strided inside the full tensor.
+
+    Here rather than with the comparison gate because it is the inverse of what a
+    publisher digests: the publisher hashes its own contiguous shard, and this is how
+    a receiver recovers the same box out of the buffer it assembled.
+    """
+    view = full_tensor.reshape(tuple(global_shape))
+    for axis, (start, extent) in enumerate(zip(shard_offset, shape)):
+        view = view.narrow(axis, int(start), int(extent))
+    return view.contiguous()
+
+
+def published_digest(tensor) -> str | None:
+    """``tensor_digest`` when digest publication is on, otherwise ``None``.
+
+    Read live rather than captured at import so a publisher can be switched without
+    reimporting, and so the tests do not have to reload this module.
+    """
+    from modelexpress import envs
+
+    if not envs.MX_RESHARD_PUBLISH_DIGEST:
+        return None
+    return tensor_digest(tensor)

--- a/modelexpress_client/python/modelexpress/refit/reshard/verify.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/verify.py
@@ -29,10 +29,13 @@ entire logical source tensor contiguously and can recover any publisher's box wi
 :func:`shard_region`. On the exact-segment path the receiver reads a sub-range straight
 into the live parameter and never materialises the shard, so there is nothing to
 recompute the digest over. That is not a corner case: where trainer and inference
-parallelism differ, most sources take the exact path. Covering it needs a gate at
-destination rather than shard granularity, which is a separate mechanism and not this
-one. This digest still contributes there, as a fingerprint over the contributing
-publishers that separates a trainer-side weight change from a transport fault.
+parallelism differ, most sources take the exact path. For strict qualification, the
+receiver must full-pull and verify the publisher's whole shard, derive the expected
+destination slice from that verified staging buffer, and compare it with the destination
+produced by the ordinary exact-segment read. Both reads must target the same immutable,
+step-stamped source version. A fingerprint over the contributing publishers is useful
+freshness evidence, but it is not a byte-for-byte expectation for a partial read and must
+not be presented as one.
 """
 
 from __future__ import annotations

--- a/modelexpress_client/python/modelexpress/refit/reshard/verify.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/verify.py
@@ -21,6 +21,18 @@ recomputes and compares is deliberately not here; it needs the fresh-discovery
 refresh to avoid reporting ordinary training updates as corruption, which is its own
 change. Publishing is opt-in via ``MX_RESHARD_PUBLISH_DIGEST`` because the reduction
 costs a pass over every published tensor.
+
+Scope, because it is narrower than "the refit is verified" and the difference matters
+when planning the consumer. A publisher digest covers a whole shard, so a receiver can
+only check it where it holds that whole shard - the full-pull path, which stages the
+entire logical source tensor contiguously and can recover any publisher's box with
+:func:`shard_region`. On the exact-segment path the receiver reads a sub-range straight
+into the live parameter and never materialises the shard, so there is nothing to
+recompute the digest over. That is not a corner case: where trainer and inference
+parallelism differ, most sources take the exact path. Covering it needs a gate at
+destination rather than shard granularity, which is a separate mechanism and not this
+one. This digest still contributes there, as a fingerprint over the contributing
+publishers that separates a trainer-side weight change from a transport fault.
 """
 
 from __future__ import annotations

--- a/modelexpress_client/python/tests/test_reshard_refit_verify.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_verify.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for the shard digest and its wire format.
+
+The digest exists to catch a refit that installs the wrong bytes while reporting
+healthy timings, so the tests that matter are the ones proving it *changes* when it
+should: a corrupted byte, and - the case plain checksums miss - a pure permutation of
+correct bytes.
+
+The rest cover the wire format, where the property worth pinning is that the field is
+optional in both directions. A fleet is upgraded one image at a time, so a publisher
+that does not digest must produce the blob an older client would have, and a reader
+must not invent agreement from a missing digest.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from modelexpress import envs  # noqa: E402
+from modelexpress.refit.reshard.rendezvous import (  # noqa: E402
+    PublishedShard,
+    PublishedTensor,
+    build_sources,
+    decode_shard_table,
+    encode_shard_table,
+    unwrap_rendezvous_blob,
+    wrap_rendezvous_blob,
+)
+from modelexpress.refit.reshard.verify import (  # noqa: E402
+    published_digest,
+    shard_region,
+    tensor_digest,
+)
+
+
+# ------------------------------------------------------------------- the digest
+def test_digest_is_stable_for_identical_bytes():
+    a = torch.arange(4096, dtype=torch.int32)
+    assert tensor_digest(a) == tensor_digest(a.clone())
+
+
+def test_digest_changes_when_a_single_value_changes():
+    a = torch.arange(4096, dtype=torch.int32)
+    b = a.clone()
+    b[1234] += 1
+    assert tensor_digest(a) != tensor_digest(b)
+
+
+def test_digest_detects_a_permutation():
+    """The reason this is not a plain sum.
+
+    A plan that copies the right bytes to the wrong offsets preserves every
+    order-independent statistic, so a sum-based digest would call it equal.
+    """
+    a = torch.arange(8192, dtype=torch.int32)
+    b = a.clone()
+    # swap two whole digest rows, so the multiset of values is untouched
+    row = 1024
+    b[0:row], b[row : 2 * row] = a[row : 2 * row].clone(), a[0:row].clone()
+    assert a.sum() == b.sum(), "precondition: sums must agree, else the test is trivial"
+    assert tensor_digest(a) != tensor_digest(b)
+
+
+def test_digest_covers_a_non_word_multiple_tail():
+    """Sizes that are not a multiple of the row or word width must still be digested.
+
+    An implementation that silently drops the ragged tail would report equal for
+    tensors differing only in their last bytes.
+    """
+    a = torch.arange(1024 + 7, dtype=torch.int16)
+    b = a.clone()
+    b[-1] += 1
+    assert tensor_digest(a) != tensor_digest(b)
+
+
+def test_digest_handles_a_strided_input():
+    dense = torch.arange(64, dtype=torch.int32).reshape(8, 8)
+    strided = dense[:, ::2]
+    assert tensor_digest(strided) == tensor_digest(strided.contiguous())
+
+
+# -------------------------------------------------------------------- the region
+def test_shard_region_extracts_the_publishers_box():
+    full = torch.arange(24, dtype=torch.int32).reshape(4, 6)
+    region = shard_region(full.reshape(-1), (4, 6), (1, 2), (2, 3))
+    assert torch.equal(region, full[1:3, 2:5])
+
+
+def test_a_region_digests_the_same_as_the_shard_its_publisher_held():
+    """The two halves of the eventual comparison have to agree on what they hash.
+
+    A publisher digests its own contiguous shard; a receiver recovers the box out of
+    a staging buffer it assembled. If those disagreed the gate would report every
+    shard as corrupt.
+    """
+    full = torch.arange(24, dtype=torch.int32).reshape(4, 6)
+    publisher_shard = full[1:3, 2:5].contiguous()
+
+    region = shard_region(full.reshape(-1), (4, 6), (1, 2), (2, 3))
+
+    assert tensor_digest(region) == tensor_digest(publisher_shard)
+
+
+# --------------------------------------------------------------- publication gate
+def test_publication_is_off_by_default(monkeypatch):
+    monkeypatch.delenv("MX_RESHARD_PUBLISH_DIGEST", raising=False)
+    assert published_digest(torch.arange(64, dtype=torch.int32)) is None
+
+
+def test_publication_is_read_live_not_frozen_at_import(monkeypatch):
+    """So a publisher can be switched without reimporting, and so these tests do not
+    have to reload the module the way a captured module constant would force."""
+    tensor = torch.arange(64, dtype=torch.int32)
+    monkeypatch.setenv("MX_RESHARD_PUBLISH_DIGEST", "1")
+    assert published_digest(tensor) == tensor_digest(tensor)
+
+    monkeypatch.setenv("MX_RESHARD_PUBLISH_DIGEST", "0")
+    assert published_digest(tensor) is None
+
+
+def test_the_flag_comes_from_the_env_registry(monkeypatch):
+    monkeypatch.setenv("MX_RESHARD_PUBLISH_DIGEST", "1")
+
+    assert envs.MX_RESHARD_PUBLISH_DIGEST is True
+
+
+# ------------------------------------------------------------------ the wire format
+def _table(digest=None):
+    return [
+        PublishedTensor(
+            name="layers.0.weight",
+            dtype="torch.bfloat16",
+            elsize=2,
+            full_shape=(8, 4),
+            shards=[
+                PublishedShard(
+                    agent_name="trainer-r0",
+                    device_id=0,
+                    addr=4096,
+                    shard_offset=(0, 0),
+                    shape=(4, 4),
+                    digest=digest,
+                )
+            ],
+        )
+    ]
+
+
+def _encoded_shard(table) -> dict:
+    """The one shard's JSON, out of the encoded table."""
+    payload = json.loads(encode_shard_table(table).decode("utf-8"))
+    return payload["tensors"][0]["shards"][0]
+
+
+def test_the_digest_round_trips():
+    (decoded,) = decode_shard_table(encode_shard_table(_table(digest="abc123")))
+    assert decoded.shards[0].digest == "abc123"
+
+
+def test_a_publisher_without_a_digest_decodes_as_none_not_as_agreement():
+    (decoded,) = decode_shard_table(encode_shard_table(_table()))
+    assert decoded.shards[0].digest is None
+
+
+def test_the_key_is_omitted_rather_than_nulled_when_absent():
+    """So an undigested publisher emits the blob an older client would have."""
+    assert "digest" not in _encoded_shard(_table())
+
+
+def test_the_digest_is_the_only_added_key():
+    """A wire-format change should be auditable by diffing the key sets."""
+    without = set(_encoded_shard(_table()))
+    with_digest = set(_encoded_shard(_table(digest="d")))
+
+    assert with_digest - without == {"digest"}
+
+
+def test_an_older_publishers_blob_is_still_readable():
+    """Forward compatibility: a blob written before this field existed."""
+    payload = json.loads(encode_shard_table(_table(digest="d")).decode("utf-8"))
+    del payload["tensors"][0]["shards"][0]["digest"]
+
+    (decoded,) = decode_shard_table(json.dumps(payload).encode("utf-8"))
+
+    assert decoded.shards[0].digest is None
+
+
+# --------------------------------------------------------------------- the read path
+def test_the_digest_survives_into_the_planning_inputs():
+    """The planner ignores it, but it has to arrive. ``build_sources`` is where a
+    published table becomes planning input, and a digest dropped here would leave a
+    future check with no expectation to compare against - the hole this field exists
+    to close."""
+    sources, _agents, _devices = build_sources(_table(digest="abc123"))
+
+    assert sources["layers.0.weight"].shards[0].digest == "abc123"
+
+
+def test_an_undigested_table_yields_no_expectation():
+    sources, _agents, _devices = build_sources(_table())
+
+    assert sources["layers.0.weight"].shards[0].digest is None
+
+
+def test_a_full_publish_to_discover_round_trip_keeps_the_digest():
+    """End to end across the two hops it has to survive: the shard-table encoding
+    inside the rendezvous blob, and the conversion into planning input."""
+    blob = wrap_rendezvous_blob(b"meta", "trainer-r0", "h:1", _table(digest="abc123"))
+
+    payload = unwrap_rendezvous_blob(blob)
+    sources, _agents, _devices = build_sources(payload.tensors)
+
+    assert sources["layers.0.weight"].shards[0].digest == "abc123"

--- a/modelexpress_client/python/tests/test_reshard_refit_verify.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_verify.py
@@ -85,6 +85,52 @@ def test_digest_handles_a_strided_input():
     assert tensor_digest(strided) == tensor_digest(strided.contiguous())
 
 
+@pytest.mark.parametrize(
+    "half",
+    [
+        pytest.param(1409, id="odd_bf16_split"),
+        pytest.param(17, id="odd_small_split"),
+    ],
+)
+def test_digest_handles_a_contiguous_view_at_an_unaligned_offset(half):
+    """What a publisher actually passes, and what the strided test above does not cover.
+
+    ``narrow`` returns a view that is contiguous *and* offset, so the non-contiguous
+    branch never fires and ``.contiguous()`` would be a no-op. Every odd bf16 split
+    lands here: the gate/up narrow at an odd half, the QKV narrow at an odd row.
+    """
+    fused = torch.arange(2 * half, dtype=torch.bfloat16)
+    view = fused.narrow(0, half, half)
+
+    assert view.is_contiguous(), "precondition: the non-contiguous branch must not fire"
+    assert (view.storage_offset() * view.element_size()) % 4, "precondition: unaligned"
+
+    assert tensor_digest(view) == tensor_digest(view.clone())
+
+
+def test_a_digest_does_not_depend_on_where_the_bytes_sit():
+    """The property the rebase exists to preserve, and the reason it is a copy rather
+    than a skip to the next aligned boundary.
+
+    A publisher digests its shard at whatever offset the fused parent gives it; a
+    receiver digests the same bytes at offset 0 in its own buffer. Those two must
+    agree, which they only do if neither result depends on the offset. Skipping
+    leading bytes to reach alignment would be cheaper and would break exactly this.
+    """
+    payload = torch.arange(1409, dtype=torch.bfloat16)
+
+    at_zero = payload.clone()
+    parent = torch.zeros(3 * 1409, dtype=torch.bfloat16)
+    parent.narrow(0, 1409, 1409).copy_(payload)
+    offset_odd = parent.narrow(0, 1409, 1409)
+    parent_even = torch.zeros(3 * 1409, dtype=torch.bfloat16)
+    parent_even.narrow(0, 1408, 1409).copy_(payload)
+    offset_even = parent_even.narrow(0, 1408, 1409)
+
+    assert tensor_digest(offset_odd) == tensor_digest(at_zero)
+    assert tensor_digest(offset_even) == tensor_digest(at_zero)
+
+
 # -------------------------------------------------------------------- the region
 def test_shard_region_extracts_the_publishers_box():
     full = torch.arange(24, dtype=torch.int32).reshape(4, 6)

--- a/modelexpress_client/python/tests/test_reshard_refit_verify.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_verify.py
@@ -92,6 +92,24 @@ def test_shard_region_extracts_the_publishers_box():
     assert torch.equal(region, full[1:3, 2:5])
 
 
+@pytest.mark.parametrize(
+    ("global_shape", "offset", "shape"),
+    [
+        ((4, 6), (1,), (2, 3)),  # short offset
+        ((4, 6), (1, 2), (2,)),  # short shape
+        ((4, 6, 2), (1, 2), (2, 3)),  # short against the global rank
+    ],
+)
+def test_a_rank_mismatch_is_rejected_rather_than_truncated(global_shape, offset, shape):
+    """A short coordinate would stop the narrow loop early and return a larger region
+    than the publisher digested, reporting a mismatch on a shard that transferred
+    correctly."""
+    full = torch.arange(48, dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="rank mismatch"):
+        shard_region(full, global_shape, offset, shape)
+
+
 def test_a_region_digests_the_same_as_the_shard_its_publisher_held():
     """The two halves of the eventual comparison have to agree on what they hash.
 


### PR DESCRIPTION
## Why this is needed

A refit can move the expected number of bytes and still install the wrong values. The transfer may succeed while the plan points a copy at the wrong region of a tensor. End-to-end loss or generation checks can reveal that the model changed, but they do not identify which published shard was wrong.

A receiver-side check needs an expected value for each shard: “these are the bytes the publisher held when it advertised this region.” This PR adds that expected value to the publish and discovery path. It is the producer half of verification; it does not yet reject a refit.

## What changes

- Publishers can compute a digest for each advertised shard when `MX_RESHARD_PUBLISH_DIGEST=1`.
- The optional digest is carried in the shard-table JSON, decoded during discovery, and preserved in the planner's `Shard` input.
- Megatron publishers compute the digest over the exact region they advertise. For Query-Key-Value (QKV) aliases, that means the narrow shard rather than the fused parent tensor.
- `shard_region` extracts the matching publisher-owned box from a full-pull staging buffer for the later receiver-side comparison.
- With the flag off, no digest is computed and the wire payload keeps its previous shape.

The feature is off by default because digesting every published tensor adds a full read pass over model weights. It is intended for correctness qualification, not throughput measurements.

## Where it sits

```mermaid
flowchart TB
    A["<b>1. Publisher owns a tensor shard</b>"] --> B{"<b>2. Digest publication enabled?</b>"}
    B -->|No| C["<b>3. Publish the existing shard entry</b>"]
    B -->|Yes| D["<b>3. Compute shard digest on GPU</b>"]
    D --> E["<b>4. Add digest to shard table</b>"]
    C --> F["<b>5. Catalog discovery</b>"]
    E --> F
    F --> G["<b>6. Planner carries expected digest</b>"]
    G -. Future PR .-> H["<b>7. Receiver recomputes and compares</b>"]

    classDef trainer fill:#E3F2FD,stroke:#1565C0,stroke-width:2px,color:#0D47A1,font-size:16px;
    classDef mx fill:#E8F5E9,stroke:#2E7D32,stroke-width:2px,color:#1B5E20,font-size:16px;
    classDef receiver fill:#EDE7F6,stroke:#5E35B1,stroke-width:2px,color:#311B92,font-size:16px;
    class A,B,D,E trainer;
    class C,F,G mx;
    class H receiver;
```

The dashed step is not part of this PR.

## Digest design and limits

This is a position-sensitive reduction, not a cryptographic byte hash.

The implementation views bytes as 32-bit words, reduces them in 4 KiB rows on the GPU, and folds the row results in index-weighted order before producing a compact host-side value. Index weighting matters because a copy plan can place correct data at the wrong offsets; a plain sum or sum-of-squares would not detect that permutation.

The current granularity catches whole-row reordering and value changes. It does not guarantee detection of every possible word permutation within one 4 KiB row. That tradeoff avoids copying full tensors to the CPU or adding a custom GPU hash kernel. Reviewers should treat the result as a qualification signal tailored to the known planning failure mode, not as a general integrity or security hash.

Ragged bytes after the last complete 32-bit word are included. The helper also rejects mismatched tensor ranks instead of allowing `zip` to silently truncate the requested shard coordinates.

## Compatibility contract

- A publisher without a digest omits the JSON key.
- A missing digest decodes to `None` and means “not checked,” not “matched.”
- Existing `Shard` construction remains valid because the field is optional with a default.
- With publication disabled, the normal path does not make a digest pass over model tensors.

## Scope

Included:

- digest generation;
- optional wire-format field;
- propagation through discovery and planner inputs;
- Megatron publication sites;
- shard-region extraction for a later comparison;
- environment-variable and compatibility documentation.

Not included:

- receiver-side recomputation and comparison;
- metadata freshness checks;
- retry or failure policy after a mismatch;
- performance claims for digest-enabled runs.

The receiver comparison must refresh discovery first. Comparing current weights against metadata retained from an earlier step would report normal training updates as corruption. PR #579 adds the training-step stamp needed to make that freshness decision explicit.

## How to review

Review the ten files in this order:

1. **`refit/reshard/verify.py` — required algorithm review.** Check position sensitivity, integer-overflow assumptions, ragged-byte handling, row granularity, device/host synchronization cost, and rank validation in `shard_region`.
2. **`tests/test_reshard_refit_verify.py` — required contract review.** Confirm the tests distinguish a position-sensitive digest from a plain checksum and cover the optional wire field in both directions.
3. **`refit/reshard/rendezvous.py` — required wire-format review.** Check that an absent digest remains absent on encode and becomes `None` on decode, then verify that `build_sources` carries it into the planner.
4. **`refit/reshard/megatron_aliases.py` and `megatron_publisher.py` — publication review.** Confirm each digest covers the same address range and shape that the publisher advertises.
5. **`refit/reshard/slice_plan.py`, `envs.py`, and `__init__.py` — mechanical review.** Optional field, flag registration, and exports.
6. **`README.md` and `refit/README.md` — documentation review.** Confirm that they describe producer support without claiming the receiver gate already exists.

Questions for reviewers:

- Does the reduction detect the planning mistakes that matter without making qualification runs impractical?
- Is 4 KiB the right detection granularity, or should a later implementation use a stronger GPU-side hash?
- Do all publication sites digest exactly the memory region represented by their shard metadata?
- Is keeping digest publication opt-in the right default until its cost is measured on the target model?

## Validation

- Python tests, lint, formatting, and DCO pass in CI.
- The focused verification suite covers stable bytes, value changes, row permutations, ragged tails, shard-region extraction, rank mismatch, optional publication, and wire round trips.
- Existing reshard tests that construct `Shard` without a digest continue to pass.

## Follow-up and merge relationship

PR #579 should land before the receiver-side comparison. It provides the publisher training-step stamp needed to distinguish stale expectations from incorrect bytes. If this PR lands after #553, the `envs.py` and README environment-variable blocks will need a small mechanical conflict resolution; the implementations do not otherwise depend on one another.