### PR TITLE
refactor(client): remove unused TransferFingerprint

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,7 +171,7 @@ ModelExpress/
 │       │       ├── adapter.py          # SglangAdapter and context builder
 │       │       └── loader.py           # MxModelLoader for remote_instance backend
 │       ├── tensor_utils.py             # Tensor collection, checksums, storage views
-│       ├── transfer_safety.py          # MLA feature gate, TransferFingerprint
+│       ├── transfer_safety.py          # Model feature detection for the P2P gate
 │       ├── rank_utils.py               # Rank detection utilities
 │       ├── vllm_worker.py              # Compatibility worker for older manual registration
 │       ├── types.py                    # TensorDescriptor, WorkerMetadata dataclasses

--- a/modelexpress_client/python/modelexpress/transfer_safety.py
+++ b/modelexpress_client/python/modelexpress/transfer_safety.py
@@ -4,33 +4,16 @@
 """
 Transfer safety checks for ModelExpress GPU-to-GPU weight transfer.
 
-Two independent safety mechanisms:
-
-1. Feature detection: surfaces model features (attention, quantization, MoE)
-   in the loader log so unexpected combinations are visible during QA.
-   Currently no feature combination blocks P2P transfer.
-
-2. Transfer fingerprint: captures the runtime environment and tensor
-   manifest structure. Source publishes its fingerprint; target computes
-   its own and rejects the transfer if they don't match.
+Feature detection surfaces model features (attention, quantization, MoE)
+in the loader log so unexpected combinations are visible during QA.
+Currently no feature combination blocks P2P transfer.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
-from dataclasses import dataclass, field
-
-import torch
-
-from . import envs
 
 logger = logging.getLogger("modelexpress.transfer_safety")
-
-# ---------------------------------------------------------------------------
-# Feature detection
-# ---------------------------------------------------------------------------
 
 
 def detect_model_features(model_config) -> dict[str, str]:
@@ -83,132 +66,3 @@ def check_transfer_allowed(model_config) -> tuple[bool, str]:
     features = detect_model_features(model_config)
     logger.info(f"[Transfer Safety] P2P transfer allowed. Features: {features}")
     return True, "allowed"
-
-
-# ---------------------------------------------------------------------------
-# Transfer fingerprint
-# ---------------------------------------------------------------------------
-
-def get_vllm_version() -> str:
-    try:
-        import vllm
-        return getattr(vllm, "__version__", "unknown")
-    except ImportError:
-        return "unknown"
-
-
-def get_torch_version() -> str:
-    return torch.__version__
-
-
-def get_cuda_version() -> str:
-    return getattr(torch.version, "cuda", "unknown") or "unknown"
-
-
-def _get_attention_backend() -> str:
-    """Get the selected attention backend name."""
-    try:
-        from vllm.config import get_current_vllm_config
-        config = get_current_vllm_config()
-        if hasattr(config, "model_config") and config.model_config is not None:
-            cache_config = getattr(config, "cache_config", None)
-            if cache_config is not None:
-                return getattr(cache_config, "attention_backend", "unknown") or "unknown"
-    except Exception:
-        pass
-    return envs.VLLM_ATTENTION_BACKEND
-
-
-def get_deep_gemm_version() -> str:
-    try:
-        from importlib.metadata import version
-        return version("deep-gemm")
-    except Exception:
-        return "unknown"
-
-
-def get_gpu_capability() -> str:
-    """Get the GPU compute capability as 'major.minor' (e.g. '9.0', '10.0').
-
-    Different GPU architectures can trigger different post-processing paths
-    (e.g. DeepGemm TMA scale packing differs between SM90 and SM100).
-    Including this in SourceIdentity ensures heterogeneous clusters don't
-    attempt cross-architecture transfers.
-
-    Returns 'unknown' if CUDA is not available.
-    """
-    try:
-        if torch.cuda.is_available():
-            props = torch.cuda.get_device_properties(0)
-            return f"{props.major}.{props.minor}"
-    except Exception:
-        pass
-    return "unknown"
-
-
-@dataclass
-class TransferFingerprint:
-    """Captures runtime environment and tensor manifest structure.
-
-    Published by the source alongside tensor metadata. The target computes
-    its own fingerprint and compares. Mismatches cause transfer rejection.
-    """
-    vllm_version: str = ""
-    torch_version: str = ""
-    cuda_version: str = ""
-    deep_gemm_version: str = ""
-    gpu_capability: str = ""
-    attention_backend: str = ""
-    manifest_hash: str = ""
-    tensor_count: int = 0
-
-    @classmethod
-    def from_environment(cls, tensors: dict[str, torch.Tensor] | None = None) -> TransferFingerprint:
-        """Build a fingerprint from the current runtime environment."""
-        fp = cls(
-            vllm_version=get_vllm_version(),
-            torch_version=get_torch_version(),
-            cuda_version=get_cuda_version(),
-            deep_gemm_version=get_deep_gemm_version(),
-            gpu_capability=get_gpu_capability(),
-            attention_backend=_get_attention_backend(),
-        )
-        if tensors is not None:
-            fp.manifest_hash = _compute_manifest_hash(tensors)
-            fp.tensor_count = len(tensors)
-        return fp
-
-    def to_json(self) -> str:
-        """Serialize to JSON string for inclusion in proto metadata."""
-        return json.dumps({
-            "vllm_version": self.vllm_version,
-            "torch_version": self.torch_version,
-            "cuda_version": self.cuda_version,
-            "deep_gemm_version": self.deep_gemm_version,
-            "gpu_capability": self.gpu_capability,
-            "attention_backend": self.attention_backend,
-            "manifest_hash": self.manifest_hash,
-            "tensor_count": self.tensor_count,
-        }, sort_keys=True)
-
-    @classmethod
-    def from_json(cls, s: str) -> TransferFingerprint:
-        """Deserialize from JSON string."""
-        d = json.loads(s)
-        return cls(**d)
-
-
-
-def _compute_manifest_hash(tensors: dict[str, torch.Tensor]) -> str:
-    """Compute a SHA256 hash of the tensor manifest structure.
-
-    Hashes tensor names, sizes, and dtypes (NOT addresses, which are
-    machine-specific). Two identical models with identical post-processing
-    should produce the same hash regardless of GPU memory layout.
-    """
-    entries = []
-    for name in sorted(tensors.keys()):
-        t = tensors[name]
-        entries.append(f"{name}:{list(t.shape)}:{t.dtype}:{t.numel() * t.element_size()}")
-    manifest_str = "\n".join(entries)
-    return hashlib.sha256(manifest_str.encode()).hexdigest()

--- a/modelexpress_client/python/tests/test_transfer_safety.py
+++ b/modelexpress_client/python/tests/test_transfer_safety.py
@@ -3,14 +3,9 @@
 
 """Tests for transfer safety checks."""
 
-import json
-
-import pytest
 import torch
 
 from modelexpress.transfer_safety import (
-    TransferFingerprint,
-    _compute_manifest_hash,
     check_transfer_allowed,
     detect_model_features,
 )
@@ -161,52 +156,3 @@ class TestCheckTransferAllowed:
         )
         allowed, _ = check_transfer_allowed(config)
         assert allowed
-
-
-# ---------------------------------------------------------------------------
-# Transfer fingerprint
-# ---------------------------------------------------------------------------
-
-class TestTransferFingerprint:
-    def test_round_trip_json(self):
-        fp = TransferFingerprint(
-            vllm_version="0.17.1",
-            torch_version="2.10.0",
-            cuda_version="12.9",
-            deep_gemm_version="2.3.0",
-            attention_backend="FLASHINFER_MLA",
-            manifest_hash="abc123",
-            tensor_count=729,
-        )
-        json_str = fp.to_json()
-        fp2 = TransferFingerprint.from_json(json_str)
-        assert fp2.vllm_version == "0.17.1"
-        assert fp2.tensor_count == 729
-        assert fp2.manifest_hash == "abc123"
-
-
-# ---------------------------------------------------------------------------
-# Manifest hash
-# ---------------------------------------------------------------------------
-
-class TestManifestHash:
-    def test_same_tensors_same_hash(self):
-        t1 = {"a": torch.zeros(10, dtype=torch.float32), "b": torch.zeros(20, dtype=torch.bfloat16)}
-        t2 = {"a": torch.ones(10, dtype=torch.float32), "b": torch.ones(20, dtype=torch.bfloat16)}
-        # Same shapes and dtypes, different values -> same hash
-        assert _compute_manifest_hash(t1) == _compute_manifest_hash(t2)
-
-    def test_different_shapes_different_hash(self):
-        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
-        t2 = {"a": torch.zeros(20, dtype=torch.float32)}
-        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)
-
-    def test_different_names_different_hash(self):
-        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
-        t2 = {"b": torch.zeros(10, dtype=torch.float32)}
-        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)
-
-    def test_different_dtypes_different_hash(self):
-        t1 = {"a": torch.zeros(10, dtype=torch.float32)}
-        t2 = {"a": torch.zeros(10, dtype=torch.float16)}
-        assert _compute_manifest_hash(t1) != _compute_manifest_hash(t2)


### PR DESCRIPTION
## Summary

`TransferFingerprint` in `transfer_safety.py` is dead code. It was added in #225 with the documented intent that the source publish it alongside tensor metadata and the target compute its own and reject the transfer on mismatch. That wiring was never built.

Verified before removing:
- Nothing outside the class and its own unit tests references it — no importer in `publish`, `rdma_strategy`, or anywhere in the client.
- No proto field carries it, and the Rust side has no counterpart.
- It is not re-exported from `modelexpress/__init__.py`, so it is not public API.

Removed: the `TransferFingerprint` dataclass, its environment getters (`get_vllm_version`, `get_torch_version`, `get_cuda_version`, `get_deep_gemm_version`, `get_gpu_capability`, `_get_attention_backend`), and `_compute_manifest_hash`, plus the now-unused `hashlib` / `json` / `dataclasses` / `torch` / `envs` imports and the tests covering only those.

## Deliberately kept

`check_transfer_allowed()` and `detect_model_features()` stay. `RdmaStrategy.is_available()` calls `check_transfer_allowed()` before attempting P2P transfer (`load_strategy/rdma_strategy.py:135`). It does always return `True`, but the feature log it emits is its documented purpose (`docs/ARCHITECTURE.md`), and it is the intended single place for future safety gates. Removing it would delete a live call site and the QA feature log, which is a behavior change rather than a dead-code cleanup.

Note that transfer-time validation is not lost by this change: `ManifestMismatchError` already covers source/target tensor name and size mismatch on the receive path.

## Test plan

Full Python suite run on this branch and on pristine `main`, failure sets diffed:

- baseline (`main`): 60 failed, 1017 passed, 7 skipped, 17 errors
- this branch: 60 failed, 1012 passed, 7 skipped, 17 errors

Identical failure and error sets — zero regressions. The pre-existing failures are the CUDA/GPU-dependent tests, unrelated to this change. The 5-test drop in passes is exactly the deleted fingerprint round-trip and manifest-hash tests. `tests/test_transfer_safety.py` passes 12/12.

`pre-commit run` passes on the staged files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Simplified transfer safety checks to focus on supported model features.
  - Removed environment and transfer-fingerprint comparisons from transfer validation.
  - Transfers are no longer blocked based solely on combinations of detected runtime features.

- **Documentation**
  - Updated architecture documentation to reflect the current transfer-safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->