### PR TITLE
feat: add RL experience transfer library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,135 @@ jobs:
       run: |
         .venv/bin/python -m pytest tests/ -v
 
+  rl-experience-python-test:
+    name: RL Experience Python (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      run: pip install uv==0.8.14
+
+    - name: Install dependencies
+      working-directory: rl_experience_transfer
+      run: uv sync --locked --dev
+
+    - name: Run tests
+      working-directory: rl_experience_transfer
+      run: uv run --locked pytest -m "not nixl and not requires_gpu and not requires_xpu" -v
+
+    - name: Lint
+      working-directory: rl_experience_transfer
+      run: |
+        uv run --locked ruff check src tests examples
+        uv run --locked ruff format --check src tests examples
+
+    - name: Type check
+      working-directory: rl_experience_transfer
+      run: uv run --locked mypy
+
+    - name: Build and smoke-test wheel
+      working-directory: rl_experience_transfer
+      run: |
+        uv build --out-dir "$RUNNER_TEMP/rlxfer-dist"
+        uv venv "$RUNNER_TEMP/rlxfer-wheel-env" --python "${{ matrix.python-version }}"
+        uv pip install --python "$RUNNER_TEMP/rlxfer-wheel-env/bin/python" "$RUNNER_TEMP"/rlxfer-dist/*.whl
+        "$RUNNER_TEMP/rlxfer-wheel-env/bin/python" -I -c "import rlxfer; assert rlxfer.__version__ == '0.1.0'"
+
+  rl-experience-framework-integration:
+    name: RL Experience Native + Pipeline Matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout ModelExpress
+      uses: actions/checkout@v4
+
+    - name: Checkout NeMo RL contract
+      uses: actions/checkout@v4
+      with:
+        repository: NVIDIA-NeMo/RL
+        ref: daf46ff37a64832d8c5637bdfbb0bc3252b47052
+        path: upstream/nemo-rl
+        persist-credentials: false
+
+    - name: Checkout PRIME-RL contract
+      uses: actions/checkout@v4
+      with:
+        repository: PrimeIntellect-ai/prime-rl
+        ref: 2873bf2b9109cb30ccfe950b52ac46bc2d8c142b
+        path: upstream/prime-rl
+        persist-credentials: false
+
+    - name: Checkout slime contract
+      uses: actions/checkout@v4
+      with:
+        repository: THUDM/slime
+        ref: a6272da0d4f3d0a08520c99a2f3b4f6c887960dc
+        path: upstream/slime
+        persist-credentials: false
+
+    - name: Checkout MILES contract
+      uses: actions/checkout@v4
+      with:
+        repository: radixark/miles
+        ref: 319716c0271259dc3afd15e032c81760535b23b3
+        path: upstream/miles
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install lightweight dependencies
+      working-directory: rl_experience_transfer
+      run: |
+        pip install uv==0.8.14
+        uv venv .framework-venv --python 3.12
+        uv pip install --python .framework-venv/bin/python --editable . pytest==9.0.2
+        uv pip install --python .framework-venv/bin/python \
+          beartype==0.22.9 datasets==4.8.5 httpx==0.28.1 hydra-core==1.3.5 jaxtyping==0.3.11 \
+          loguru==0.7.3 msgspec==0.19.0 pillow==11.3.0 \
+          prime-pydantic-config==0.4.2 pydantic==2.13.4 ray==2.55.1 \
+          renderers==0.1.10.dev1 tomli==2.4.1 tomli-w==1.2.0 \
+          transformers==5.6.0 wandb==0.21.4
+        uv pip install --python .framework-venv/bin/python \
+          torch==2.9.0 --index-url https://download.pytorch.org/whl/cpu
+
+    - name: Install lightweight framework package metadata
+      working-directory: rl_experience_transfer
+      run: |
+        uv pip install --python .framework-venv/bin/python --no-deps \
+          --editable ../upstream/prime-rl \
+          --editable ../upstream/slime \
+          --editable ../upstream/miles
+
+    - name: Run native framework matrix and pipeline components
+      working-directory: rl_experience_transfer
+      env:
+        PYTHONPATH: ${{ github.workspace }}/upstream/nemo-rl:${{ github.workspace }}/upstream/prime-rl/src:${{ github.workspace }}/upstream/prime-rl/packages/prime-rl-configs/src:${{ github.workspace }}/upstream/slime:${{ github.workspace }}/upstream/miles
+        RLXFER_RUN_FRAMEWORK_INTEGRATION: "1"
+        RLXFER_NEMO_RL_SOURCE: ${{ github.workspace }}/upstream/nemo-rl
+        RLXFER_PRIME_RL_SOURCE: ${{ github.workspace }}/upstream/prime-rl/src
+        RLXFER_SLIME_SOURCE: ${{ github.workspace }}/upstream/slime
+        RLXFER_MILES_SOURCE: ${{ github.workspace }}/upstream/miles
+      run: |
+        .framework-venv/bin/python -m pytest tests/test_framework_integration.py -v
+        .framework-venv/bin/python examples/framework_pipeline.py all --format markdown >> "$GITHUB_STEP_SUMMARY"
+
   go-test:
     name: Go Bindings
     runs-on: ubuntu-latest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,8 +55,298 @@ graph TD
 | Server | Rust | `modelexpress_server/` | gRPC server: model downloads, cache eviction, P2P coordination |
 | Rust Client | Rust | `modelexpress_client/src/` | Client library and CLI tool |
 | Python Client | Python | `modelexpress_client/python/` | Inference engine loaders, NIXL transfer manager, gRPC client |
+| RL Experience Transfer | Python | `rl_experience_transfer/` | Versioned RL experience schema, delivery APIs, framework adapters, and pluggable transports |
 | Common | Rust | `modelexpress_common/` | Protobuf definitions, shared types, provider trait, config |
 | Workspace Tests | Rust | `workspace-tests/` | Integration tests and Criterion benchmarks |
+
+## RL Experience Transfer Incubator
+
+`rl_experience_transfer/` is an isolated Python package for moving reinforcement-learning
+experience from rollout workers to training workers. It transfers prompts, tokens, trajectories,
+rewards, log probabilities, advantages, and related metadata. It does **not** transfer model
+weights and does not depend on the ModelExpress weight-transfer server.
+
+```mermaid
+graph TD
+    A[NeMo RL / PRIME-RL / slime / MILES adapter] --> B[Canonical ExperienceBatch]
+    B --> C[Consumer contract + schema migration]
+    C --> D[Safe JSON metadata + tensor catalog]
+    D --> E[Producer / Consumer delivery API]
+    E --> J[Durable deduplication + dead letters]
+    E --> K[Conservative transport fallback]
+    E --> L[Transport protocol]
+    L --> F[In-memory]
+    L --> G[Filesystem]
+    L --> H[NIXL data plane]
+    H --> I[Filesystem control plane]
+```
+
+The package is intentionally small and separately installable. The dependency direction is from
+framework adapters to the canonical model to transport protocols; adapters never import NIXL, and
+transport implementations never import an RL framework.
+
+### Package layout
+
+| Location | Responsibility |
+|----------|----------------|
+| `src/rlxfer/model.py` | Schema v1.0 dataclasses and contextual validation |
+| `src/rlxfer/serialization.py` | Allowlisted JSON metadata, raw tensor buffers, checksums |
+| `src/rlxfer/contracts.py` | Consumer preflight contracts and explicit schema migrations |
+| `src/rlxfer/api.py` | Producer, consumer, delivery settlement, duplicate suppression |
+| `src/rlxfer/state.py` | Bounded in-memory and durable SQLite consumer state |
+| `src/rlxfer/tracing.py` | Validated W3C trace-context propagation |
+| `src/rlxfer/transport.py` | Capabilities, transfer plans, protocol, instance-scoped registry |
+| `src/rlxfer/transports/` | Memory, filesystem, optional NIXL, and fallback routing |
+| `src/rlxfer/adapters/` | Guarded NeMo RL, PRIME-RL, slime, and MILES conversions |
+| `tests/` | Unit, integration, multiprocess, failure, and real-NIXL tests |
+| `examples/` | Basic, reliable delivery, filesystem, NIXL, and native adapter matrix runs |
+
+### Public API
+
+Application code selects a transport through dependency injection; no NIXL type escapes the
+transport package.
+
+```python
+from rlxfer import ExperienceConsumer, ExperienceProducer, TransportConfig, create_transport
+from rlxfer.adapters import create_adapter
+
+producer = ExperienceProducer(
+    create_transport(TransportConfig("memory")),
+    create_adapter("nemo_rl"),
+)
+receipt = producer.publish(framework_rollout)
+
+consumer = ExperienceConsumer(producer.transport, create_adapter("nemo_rl"))
+delivery = consumer.receive(timeout=1.0)
+training_batch = delivery.to_framework()
+delivery.ack()
+assert receipt.wait(1.0).state.value == "acked"
+```
+
+`publish_trajectory`, `publish_batch`, bounded timeouts, cancellation, negative acknowledgement
+with retry, permanent rejection, synchronous and async wrappers, health checks, idempotency keys,
+and `TransferPlan` capability checks use the same interface for every transport. See
+`examples/basic.py`, `examples/filesystem_process.py`, and
+`examples/reliable_transfer.py` for runnable examples from minimal to production-oriented.
+
+An optional `ConsumerContract` rejects incompatible schema versions, missing dotted field paths,
+semantic mismatches, and unacceptable policy lag before publication. Older batches are converted
+only through migrations explicitly registered in an instance-scoped `SchemaMigrationRegistry`;
+migrations must produce the declared version and preserve the experience ID. Numeric policy lag is
+bounded with `max_policy_lag` and is accepted only when policy and model identities match. The same
+contract can be applied again at the consumer as defense in depth.
+
+### Canonical schema and compatibility
+
+Schema version `1.0` includes `Transition`, `Trajectory`, `Episode`, `ExperienceBatch`,
+`TensorPayload`, `ExperienceMetadata`, `PolicyVersion`, `SampleIdentity`, and
+`TransferDescriptor`. Tensor metadata retains kind, dtype, shape, stride, layout, original device,
+wire device, and byte count. Variable-length trajectories remain separate rather than being
+silently padded. Nested mappings and sequences may contain NumPy arrays or guarded PyTorch
+tensors.
+
+Lossless framework state is retained in namespaced extensions such as
+`extensions["nemo_rl"]`; it is not forced into a lowest-common-denominator record. Compatibility
+reports compare algorithm, tokenizer, model, policy version, reward definition, sequence format,
+padding, chat template, truncation, and reference-policy requirements before a consumer uses the
+batch. Schema errors include the field, expected and actual values, producer and consumer versions,
+and experience ID. `examples/cross_framework.py` demonstrates an actionable early rejection.
+
+`with_trace_context` carries a validated W3C `traceparent` and optional `tracestate` in the
+`w3c.trace_context` extension without changing schema 1.0. Adapters and transports preserve this
+extension through canonical serialization; applications can recover it with `trace_context_from`.
+
+Metadata uses deterministic UTF-8 JSON with an allowlist of schema dataclasses. Pickle and other
+executable deserializers are not used. Tensor bytes are transferred separately; the catalog and
+optional SHA-256 checks validate names, sizes, shapes, dtypes, and values before reconstruction.
+Small tensors can be inlined, while external buffers can remain on CPU, pinned memory, or a
+supported accelerator. Configurable limits bound metadata, nesting, object counts, tensor counts,
+individual buffers, and aggregate bytes before staging or allocation. Wire tensors are contiguous;
+stride values are normalized to element units for both NumPy and PyTorch.
+
+`AuthenticatedExperienceSerializer` is an opt-in HMAC-SHA256 wrapper that authenticates the
+canonical metadata and every tensor buffer before reconstruction. Key IDs support rotation, keys
+must be supplied out of band, and a plain serializer rejects an authenticated envelope instead of
+silently ignoring its signature. Authentication necessarily reads every buffer and may therefore
+trade away a direct-buffer fast path.
+
+### Transport behavior
+
+| Transport | Data movement | Delivery guarantee | Persistence | Tested locally |
+|-----------|---------------|--------------------|-------------|----------------|
+| Memory | copied process-local buffers | At least once until process exit | No | Retry, duplicate, cancellation, timeout, backpressure |
+| Filesystem | private, fsynced atomic directories and raw buffers | At least once with idempotent consumption | Yes | Spawned multiprocess, lease/index recovery, concurrent bounds, byte exact |
+| NIXL UCX | registered CPU/CUDA scatter-gather pull | At least once while producer remains alive | Control only | Real multiprocess CPU, CUDA, multi-GPU, duplicate publish, failure cleanup |
+| Fallback | ordered composition of other transports | At least once | Intersection of children | Routed receipts/tokens, safe-error fallback, health aggregation |
+
+Capability negotiation exposes zero-copy, CPU and accelerator buffers, remote operation,
+scatter/gather, async operation, acknowledgement, persistence, maximum size, and registration
+requirements. A `TransferPlan` fails before publishing if its required capabilities are absent.
+The filesystem control plane and tensor data plane are distinct in the NIXL backend.
+The NIXL capability deliberately reports public `zero_copy=False`: NIXL writes directly into
+registered destination buffers, but canonical reconstruction currently makes an owning tensor
+copy before delivery.
+
+`FallbackTransport` advertises the conservative intersection of its children's capabilities and
+routes receipts and settlement tokens back to the backend that accepted them. By default it falls
+back only for failures known to occur before acceptance: backpressure, capability mismatch, or a
+closed backend. Applications may opt into broader exception classes, but retrying an ambiguous
+post-acceptance error can duplicate a delivery across backends.
+
+Consumers use bounded in-memory duplicate state by default. `SqliteDeliveryState` persists
+consumed idempotency keys across process restarts and records content-free dead letters containing
+only IDs, attempts, timestamps, and rejection reasons. A key is durably marked after application
+processing and before transport acknowledgement, so a failed acknowledgement can be safely
+retried. This closes a common restart gap but does not claim globally exactly-once processing.
+
+NIXL lifecycle:
+
+1. The producer stages only unsupported devices, synchronizes accelerator work, registers source
+   buffers, and publishes safe JSON descriptors plus opaque endpoint metadata.
+2. The consumer validates the serializer and NIXL catalogs before allocation, registers owned
+   destinations, adds the remote endpoint, and issues a NIXL `READ` scatter/gather transfer.
+3. Completion means the requested bytes arrived; it is not delivery acknowledgement. The consumer
+   synchronizes the destination device, deregisters it, then exposes storage through the delivery.
+4. `ack`, terminal `nack`, `reject`, or cancellation lets the producer deregister and reuse source
+   buffers. Producer buffers must remain alive and immutable until terminal settlement.
+5. Timeout or failure releases transfer handles, removes remote metadata, deregisters destinations,
+   and either retries through the control plane or records a terminal receipt. Graceful close
+   cancels pending work and does not release registrations still owned by an inflight transfer.
+
+NIXL supplies byte movement and completion. The library supplies catalog validation,
+acknowledgement, retries, duplicate handling, and cleanup. Exactly-once delivery is not claimed.
+
+### Extending the package
+
+A transport plugin implements `ExperienceTransport`, exposes a factory accepting an options
+mapping, and can register without changing core code:
+
+```python
+from rlxfer import TransportRegistry
+
+registry = TransportRegistry()
+registry.register("custom", CustomTransport.from_options)
+transport = registry.create(TransportConfig("custom", {"endpoint": "local"}))
+```
+
+Optional packages can publish the same factory through the `rlxfer.transports` Python entry-point
+group and call `registry.discover()`. A framework integration independently implements
+`from_framework`, `to_framework`, and `validate_compatible`, then registers its constructor with
+`AdapterRegistry`. Version-specific native imports stay inside that adapter, and all optional
+imports must fail with an installation hint.
+
+Metrics use a vendor-neutral hook. The built-in counters and observations include produced and
+consumed batches and trajectories, metadata and tensor bytes, serialization, registration,
+staging, transfer and acknowledgement latency, retries, duplicates, schema rejections, failures,
+and cleanup failures. Structured logs redact prompt, response, content, and text fields.
+
+### Installation and validation
+
+The core supports Python 3.10 and 3.12 without an RL framework:
+
+```bash
+cd rl_experience_transfer
+uv sync --locked --dev
+uv run --locked pytest -m "not nixl and not requires_gpu and not requires_xpu"
+uv run --locked ruff check src tests examples
+uv run --locked mypy
+```
+
+`.[nixl]` and `.[all]` install the tested optional data plane: NIXL 0.7.1,
+`nixl-cu12` 1.0.1, and PyTorch 2.9.x on Linux. Framework-named extras are
+declared as stable placeholders, but intentionally do not resolve framework dependencies: none of
+the four audited framework source revisions has one portable dependency solution. NeMo RL needs its
+own CUDA/PyTorch index, PRIME-RL has revision-specific submodules, and slime/MILES use source and
+container stacks that are substantially larger than the adapter. Install the actual distributions
+(`nemo-rl`, `prime-rl`, `slime`, or `miles`) in project-supported isolated environments, then
+install this package editable. Do not install a framework stack into the global environment.
+
+Real NIXL commands on the audited machine (the lockfile supplies the exact environment):
+
+```bash
+uv run --locked --extra nixl pytest tests/test_nixl.py -m nixl -q
+uv run --locked --extra nixl python examples/benchmark_nixl.py --device cpu
+uv run --locked --extra nixl python examples/benchmark_nixl.py --device cuda:0
+```
+
+Framework adapter integration is available through
+`python examples/framework_roundtrip.py {nemo_rl,prime_rl,slime,miles}`. This command reconstructs
+a real native record when the framework imports, transfers it through the filesystem backend, and
+executes a small real PyTorch optimizer update. It is explicitly an adapter integration test, not a
+substitute for a complete framework rollout/trainer run.
+
+`python examples/framework_matrix.py` exercises the declared 4-by-4 producer/consumer contract.
+The four self-roundtrips and the two explicitly contracted slime/MILES cross-conversions must
+reconstruct native training inputs; the other ten pairings must fail closed with actionable adapter
+errors and terminal rejected receipts. CI runs the same matrix as pytest integration cases against
+the four pinned source revisions.
+
+`python examples/framework_pipeline.py all --format markdown` adds runtime wiring at the
+framework-owned rollout and training boundaries. The wiring publishes native output through
+`ExperienceProducer`, reconstructs it through `ExperienceConsumer`, invokes the pinned upstream
+loss code, performs a finite CPU optimizer update, and acknowledges only after that update:
+
+| Framework | Rollout-side source component | Training-side source component | CPU-only substitute |
+|-----------|-------------------------------|--------------------------------|---------------------|
+| NeMo RL | `RolloutManager.generate_and_push` | `ClippedPGLossFn` | Deterministic generation and environment |
+| PRIME-RL | `TrainingBatchSender.send` | `compute_loss` | Synthetic native `TrainingBatch` |
+| slime | `call_rollout_fn` | `compute_policy_loss` | Test-time rollout plugin |
+| MILES | `call_rollout_fn` | `compute_policy_loss` | Test-time rollout plugin |
+
+Each claimed component is inspected at runtime and must resolve inside its pinned upstream checkout.
+Narrow import shims bypass eager GPU launcher and optional telemetry imports, but do not replace the
+listed orchestration, plugin dispatch, native records, or loss functions. The deterministic fixtures
+stand in for external model servers, environments, and distributed accelerator engines, so this is
+source-owned component integration rather than a complete distributed framework run.
+
+### Audited compatibility
+
+| Framework | Verified source | Python / PyTorch | Hardware | Transport | Coverage | Result | Artifact / limitation |
+|-----------|-----------------|------------------|----------|-----------|----------|--------|-----------------------|
+| NeMo RL | 0.5.0rc0, `6c708930` | 3.12.6 / 2.9.0+cu129 | RTX 6000 Ada | Filesystem | Real Qwen2.5-0.5B GRPO, two rollouts and updates | PASSED | `artifacts/nemo_rl/result.json`; latest main has newer external requirements |
+| PRIME-RL | 0.5.0, `2873bf2` | 3.12.6 / 2.11.0+cu128 | RTX 6000 Ada | NIXL UCX | Real GPT-2 rollout, PRIME loss/backward/update, subsequent rollout | PASSED | `artifacts/prime_real_nixl_e2e_result.json` |
+| slime | 0.3.1, `a6272da` | 3.12.3 / 2.11.0+cu129 | RTX 6000 Ada | Filesystem | Real Qwen2.5-0.5B SGLang/Megatron GRPO, two updates | PASSED | `artifacts/slime/full_e2e_result.json` |
+| MILES | 0.2.1, `319716c` | 3.12.3 / 2.11.0+cu129 | RTX 6000 Ada | Filesystem | Real Qwen2.5-0.5B SGLang/Megatron GRPO, two updates | PASSED | `artifacts/miles/full_e2e_result.json`; unfused attention used for local driver compatibility |
+
+Every passing framework row used actual framework code, a real generated rollout, canonical
+serialization, a real transport, a finite backward pass, an optimizer step with a verified
+parameter change, a subsequent batch, acknowledgement, and clean shutdown. No mocked framework or
+NIXL result is reported as a real run. Exact isolated-environment setup and commands are recorded
+beside each artifact; generated checkpoints, environments, caches, and logs remain ignored.
+
+| NIXL benchmark | Tensor / total bytes | Registration | NIXL transfer | End to end | Result |
+|----------------|----------------------|--------------|---------------|------------|--------|
+| UCX CPU | 49,152 / 51,324 | 1.871 ms | 0.127 ms | 69.902 ms | PASSED, byte exact, acked |
+| UCX CUDA | 49,152 / 51,342 | 0.395 ms | 6.201 ms | 86.931 ms | PASSED, byte exact, acked |
+
+These are single local measurements, not generalized throughput claims. The JSON records are
+`artifacts/nixl_cpu.json` and `artifacts/nixl_cuda.json`.
+
+The machine audit found two RTX 6000 Ada GPUs, driver 535.309.01, and no Intel XPU. Real NIXL
+0.7.1 with the `nixl-cu12` 1.0.1 wheel used UCX for CPU and CUDA transfers. Loopback/shared-memory
+and PCIe were available; InfiniBand was not. CPU, same-device CUDA, and cross-GPU paths passed.
+Measured JSON results are stored under
+`rl_experience_transfer/artifacts/` and remain uncommitted.
+
+Repository CI runs the dependency-light core on Python 3.10 and 3.12 with locked dependencies,
+including a 12-case public-API lifecycle matrix across memory/filesystem transports,
+JSON/authenticated serialization, and ack/retry/reject outcomes. It also runs every lightweight
+example, Ruff lint and formatting, strict mypy, wheel construction, and an isolated installed-wheel
+smoke test. A separate CPU job checks out the pinned NeMo RL, PRIME-RL, slime, and MILES sources and
+exercises all 16 producer/consumer pairings through actual native record types, filesystem transfer,
+native reconstruction or expected safe rejection, finite optimizer updates on the six supported
+paths, and terminal receipts. Dependency-light import shims bypass unrelated framework launch
+stacks. Four additional pipeline cases execute the source-owned boundaries listed above, verify
+their source provenance, perform framework loss backward/updates, and render a result table in the
+GitHub Actions job summary. Full model-server, distributed-trainer, and NIXL GPU runs remain
+reproducible local gates because standard runners do not provide their pinned CUDA/container stacks.
+
+Troubleshooting starts with `transport.health()` and capability output. For NIXL, verify the Python
+binding, backend plugin, memory type, driver, and device before enabling direct buffers; use CPU
+staging when the backend does not advertise that accelerator. A stale filesystem inflight directory
+is recovered after its lease. A schema rejection should be fixed at the named producer field rather
+than bypassed. Framework import failures belong in isolated framework environments so they cannot
+replace the core package's NumPy or PyTorch versions.
 
 ## Repository Structure
 

--- a/rl_experience_transfer/.gitignore
+++ b/rl_experience_transfer/.gitignore
@@ -1,0 +1,9 @@
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.venv/
+*.egg-info/
+__pycache__/
+artifacts/
+build/
+dist/

--- a/rl_experience_transfer/MANIFEST.in
+++ b/rl_experience_transfer/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include examples *.py

--- a/rl_experience_transfer/README.rst
+++ b/rl_experience_transfer/README.rst
@@ -1,0 +1,430 @@
+RL Experience Transfer
+======================
+
+Move reinforcement-learning experience from rollout workers to training workers without coupling
+either side to one transport or framework.
+
+``rl-experience-transfer`` provides a versioned canonical schema, safe serialization, explicit
+acknowledgement and retry semantics, durable duplicate suppression, consumer compatibility
+contracts, and adapters for NeMo RL, PRIME-RL, slime, and MILES. The Python import name is
+``rlxfer``.
+
+The library transfers experience data--tokens, rewards, log probabilities, advantages,
+trajectories, and metadata. It does not transfer model weights or implement a rollout scheduler,
+replay buffer, or trainer.
+
+Why use it?
+-----------
+
+* Keep rollout and training code independent of the data plane.
+* Preserve framework-native fields without using pickle or executable deserialization.
+* Reject incompatible algorithms, tokenizers, models, policy versions, or schemas before training.
+* Use the same producer/consumer API with memory, filesystem, or NIXL transports.
+* Make delivery outcomes explicit with ack, retrying nack, terminal rejection, and receipts.
+* Persist consumed idempotency keys and content-free dead letters across consumer restarts.
+* Add HMAC authentication and W3C trace context without changing the canonical schema.
+
+Quick start
+-----------
+
+Install from a source checkout:
+
+.. code-block:: console
+
+   python -m pip install .
+
+For development, ``uv`` creates the locked environment used by CI:
+
+.. code-block:: console
+
+   uv sync --locked --dev
+
+This complete in-process example publishes, receives, validates, and acknowledges one batch:
+
+.. code-block:: python
+
+   import numpy as np
+
+   from rlxfer import (
+       ExperienceBatch,
+       ExperienceConsumer,
+       ExperienceMetadata,
+       ExperienceProducer,
+       ReceiptState,
+       TensorPayload,
+       Trajectory,
+   )
+   from rlxfer.transports import InMemoryTransport
+
+   transport = InMemoryTransport()
+   producer = ExperienceProducer(transport)
+   consumer = ExperienceConsumer(transport)
+
+   batch = ExperienceBatch(
+       metadata=ExperienceMetadata(
+           producer_id="rollout-0",
+           producer_framework="custom",
+           producer_framework_version="1.0",
+       ),
+       trajectories=(
+           Trajectory(
+               tokens=TensorPayload(np.asarray([101, 102, 103], dtype=np.int64)),
+               rewards={"task": 1.0},
+           ),
+       ),
+   )
+
+   receipt = producer.publish(batch, idempotency_key="rollout-0:sample-42")
+   delivery = consumer.receive(timeout=1.0)
+   if delivery is None:
+       raise TimeoutError("experience was not delivered")
+
+   # Run the training step before acknowledging durable success.
+   assert delivery.batch.trajectories[0].rewards["task"] == 1.0
+   delivery.ack()
+   assert receipt.wait(timeout=1.0).state is ReceiptState.ACKED
+   transport.close()
+
+For separate processes on one host, construct ``FileSystemTransport`` instances with the same
+queue directory. See ``examples/filesystem_process.py`` for a runnable spawned-process example.
+
+Framework-native data
+---------------------
+
+Adapters convert native rollout records into ``ExperienceBatch`` and reconstruct native training
+inputs at the consumer. Framework imports are optional and happen only during native conversion.
+
+.. code-block:: python
+
+   from rlxfer import ExperienceConsumer, ExperienceProducer
+   from rlxfer.adapters import create_adapter
+   from rlxfer.transports import FileSystemTransport
+
+   queue = FileSystemTransport("/var/lib/rlxfer/queue")
+   adapter = create_adapter("slime")
+   producer = ExperienceProducer(queue, adapter=adapter)
+   consumer = ExperienceConsumer(queue, adapter=adapter)
+
+   receipt = producer.publish(native_rollout_output)
+   delivery = consumer.receive(timeout=10.0)
+   if delivery is None:
+       raise TimeoutError("experience was not delivered")
+   native_training_input = delivery.to_framework()
+   # trainer.step(native_training_input)
+   delivery.ack()
+
+Install the framework itself in its project-supported environment, then install this package into
+that environment. Framework-named extras are intentionally dependency-free placeholders because
+the audited frameworks do not share one portable PyTorch/CUDA dependency solution.
+
+The adapters fail closed outside their audited native API ranges:
+
+.. list-table:: Audited adapter compatibility
+   :header-rows: 1
+
+   * - Framework
+     - Native versions
+     - Verified revision
+   * - NeMo RL
+     - 0.5.x through 0.7.x
+     - ``daf46ff`` / ``81aa43d``
+   * - PRIME-RL
+     - 0.5.x
+     - ``2873bf2``
+   * - slime
+     - 0.3.x
+     - ``a6272da``
+   * - MILES
+     - 0.2.x
+     - ``319716c``
+
+Native conversion matrix
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Self-roundtrips are supported for all four adapters. slime and MILES can also exchange native
+records when the consumer supplies explicit, matching semantic requirements. Other cross-framework
+pairings are rejected because their preserved native fields do not provide a lossless target
+representation.
+
+.. list-table:: Producer to consumer conversion
+   :header-rows: 1
+
+   * - Producer
+     - NeMo RL
+     - PRIME-RL
+     - slime
+     - MILES
+   * - NeMo RL
+     - Supported
+     - Rejected
+     - Rejected
+     - Rejected
+   * - PRIME-RL
+     - Rejected
+     - Supported
+     - Rejected
+     - Rejected
+   * - slime
+     - Rejected
+     - Rejected
+     - Supported
+     - Supported with contract
+   * - MILES
+     - Rejected
+     - Rejected
+     - Supported with contract
+     - Supported
+
+Run one real native integration or the complete 4-by-4 contract matrix after installing the pinned
+framework sources:
+
+.. code-block:: console
+
+   python examples/framework_roundtrip.py slime
+   python examples/framework_roundtrip.py slime --consumer-framework miles
+   python examples/framework_matrix.py
+
+These commands use real native record classes, filesystem serialization, native reconstruction, a
+finite PyTorch backward pass, a verified optimizer update, and terminal settlement. They are adapter
+integration tests, not full framework trainer runs.
+
+Pinned framework pipeline components can also be wired at test time without patching the upstream
+repositories:
+
+.. code-block:: console
+
+   python examples/framework_pipeline.py all --format markdown
+
+This CPU-safe harness verifies the source path of every claimed upstream component, publishes with
+``ExperienceProducer``, consumes with ``ExperienceConsumer``, runs the framework-owned loss, updates
+a tiny policy, and acknowledges only after the update:
+
+.. list-table:: Framework-owned CI component paths
+   :header-rows: 1
+
+   * - Framework
+     - Rollout-side boundary
+     - Training-side boundary
+     - CPU stand-in
+   * - NeMo RL
+     - ``RolloutManager.generate_and_push``
+     - ``ClippedPGLossFn``
+     - Deterministic generation and environment
+   * - PRIME-RL
+     - ``TrainingBatchSender.send``
+     - ``compute_loss``
+     - Synthetic native batch
+   * - slime
+     - ``call_rollout_fn``
+     - ``compute_policy_loss``
+     - Test-time rollout plugin
+   * - MILES
+     - ``call_rollout_fn``
+     - ``compute_policy_loss``
+     - Test-time rollout plugin
+
+The stand-ins replace external model servers, environments, or GPU-distributed engines; the listed
+orchestration, plugin, native-type, and loss code is imported from the pinned upstream checkout.
+This is real component integration, but it is not presented as a complete distributed trainer run.
+
+Choose a transport
+------------------
+
+.. list-table:: Built-in transports
+   :header-rows: 1
+
+   * - Transport
+     - Use it for
+     - Persistence
+     - Notes
+   * - ``InMemoryTransport``
+     - Tests and threads in one process
+     - No
+     - Bounded queue, failure injection, at-least-once until process exit
+   * - ``FileSystemTransport``
+     - Processes on one host
+     - Yes
+     - Atomic private files, fsync, leases, stale-inflight recovery
+   * - ``NixlTransport``
+     - Registered CPU/CUDA buffers
+     - Control plane only
+     - Optional Linux dependency; UCX data plane with explicit buffer lifetime
+   * - ``FallbackTransport``
+     - Ordered transport failover
+     - Child-dependent
+     - Advertises the conservative intersection of child capabilities
+
+Transport capabilities are checked before publication with ``TransferPlan``. Fallback retries only
+errors known to occur before acceptance by default; broadening its exception list can duplicate a
+delivery if an error was raised after acceptance.
+
+For the optional NIXL data plane:
+
+.. code-block:: console
+
+   python -m pip install ".[nixl]"
+   python examples/benchmark_nixl.py --device cpu
+
+Reliable delivery
+-----------------
+
+Delivery is at least once. Exactly-once processing is not claimed. Use a stable idempotency key for
+the logical training item and acknowledge only after the training-side effect is durable.
+
+.. code-block:: python
+
+   delivery = consumer.receive(timeout=10.0)
+   if delivery is not None:
+       try:
+           train_durably(delivery.batch)
+       except TemporaryTrainerError as error:
+           delivery.nack(str(error), retry=True)
+       except IncompatibleBatchError as error:
+           delivery.reject(str(error))
+       else:
+           delivery.ack()
+
+``SqliteDeliveryState`` persists consumed keys and dead letters across restarts:
+
+.. code-block:: python
+
+   from rlxfer import ExperienceConsumer, SqliteDeliveryState
+
+   consumer = ExperienceConsumer(
+       transport,
+       state_store=SqliteDeliveryState("/var/lib/rlxfer/delivery.sqlite"),
+   )
+
+Dead-letter records contain IDs, attempt counts, timestamps, and reasons--never prompts, responses,
+or tensor payloads. ``examples/reliable_transfer.py`` composes durable state, retry, authentication,
+consumer contracts, policy staleness, tracing, and filesystem delivery in one runnable example.
+
+Consumer contracts
+------------------
+
+Use the same contract at publication and consumption for preflight validation and defense in depth:
+
+.. code-block:: python
+
+   from rlxfer import CompatibilityRequirements, ConsumerContract, PolicyVersion
+
+   contract = ConsumerContract(
+       CompatibilityRequirements(
+           consumer_framework="trainer",
+           consumer_framework_version="1.0",
+           algorithm="grpo",
+           tokenizer_id="tokenizer-revision",
+           model_id="model-revision",
+           policy_version=PolicyVersion(120, policy_id="actor", model_id="model-revision"),
+           max_policy_lag=2,
+       ),
+       required_fields=frozenset({"trajectories.tokens"}),
+   )
+
+Contracts can require algorithm, tokenizer, model, reward definition, sequence format, padding,
+chat template, truncation, policy identity/staleness, reference log probabilities, and dotted field
+paths. Schema changes are applied only through explicit functions registered in an instance-scoped
+``SchemaMigrationRegistry``.
+
+Authentication and tracing
+--------------------------
+
+``AuthenticatedExperienceSerializer`` signs the canonical metadata and every external tensor
+buffer with HMAC-SHA256. Key IDs allow rotation; key material is supplied out of band.
+
+.. code-block:: python
+
+   import os
+
+   from rlxfer import AuthenticatedExperienceSerializer
+
+   key = bytes.fromhex(os.environ["RLXFER_HMAC_KEY_HEX"])
+   serializer = AuthenticatedExperienceSerializer(
+       {"2026-08": key},
+       signing_key_id="2026-08",
+   )
+   producer = ExperienceProducer(transport, serializer=serializer)
+   consumer = ExperienceConsumer(transport, serializer=serializer)
+
+Authentication detects tampering and the wrong key; it does not encrypt payloads. Protect queue
+storage and network links separately when experience contains sensitive data. Authentication reads
+every buffer and can trade away a direct-buffer fast path.
+
+Use ``with_trace_context`` and ``trace_context_from`` to propagate validated W3C ``traceparent`` and
+``tracestate`` values through adapters and transports.
+
+Production checklist
+--------------------
+
+* Assign a stable idempotency key to every logical training item.
+* Use ``SqliteDeliveryState`` or an application implementation of ``DeliveryStateStore``.
+* Declare a ``ConsumerContract`` instead of accepting unspecified training semantics.
+* Set bounded publish/receive/receipt timeouts and a finite retry budget.
+* Treat permanent incompatibility as ``reject``; reserve ``nack(retry=True)`` for transient errors.
+* Authenticate transfers that cross a trust boundary and encrypt sensitive storage and links.
+* Monitor health, receipt states, retries, dead letters, queue depth, and end-to-end latency.
+* Test the exact framework revision and accelerator stack used in production.
+* Keep producer buffers alive and immutable until terminal settlement when using NIXL.
+* Plan for duplicate delivery; acknowledgement alone is not distributed exactly-once execution.
+
+Examples
+--------
+
+.. list-table:: Runnable examples
+   :header-rows: 1
+
+   * - Command
+     - Demonstrates
+   * - ``python examples/basic.py``
+     - Minimal canonical publish, receive, and acknowledgement
+   * - ``python examples/filesystem_process.py``
+     - Persistent transfer between spawned processes
+   * - ``python examples/reliable_transfer.py``
+     - Authentication, trace context, retry, contract, and durable state
+   * - ``python examples/cross_framework.py``
+     - Actionable semantic incompatibility reporting
+   * - ``python examples/framework_roundtrip.py slime``
+     - One real framework-native adapter roundtrip and optimizer update
+   * - ``python examples/framework_matrix.py``
+     - All 16 declared framework pairings, including expected safe rejections
+   * - ``python examples/framework_pipeline.py all --format markdown``
+     - Pinned framework rollout boundaries, transfer lifecycle, losses, and optimizer updates
+   * - ``python examples/benchmark_nixl.py --device cpu``
+     - Byte-exact NIXL transfer with machine-readable timings
+
+Develop and test
+----------------
+
+The dependency-light suite supports Python 3.10 and 3.12:
+
+.. code-block:: console
+
+   uv sync --locked --dev
+   uv run --locked pytest -m "not nixl and not requires_gpu and not requires_xpu"
+   uv run --locked ruff check src tests examples
+   uv run --locked ruff format --check src tests examples
+   uv run --locked mypy
+   uv build
+
+Tests are marked ``unit``, ``integration``, ``e2e``, ``multi_process``, ``nixl``, ``requires_gpu``,
+``requires_xpu``, and by framework. CI runs the core suite on Python 3.10 and 3.12, builds and installs
+the wheel in an isolated environment, and runs the full native 4-by-4 adapter contract matrix
+against pinned framework source revisions on CPU. The same job runs four framework-owned component
+pipelines and publishes their exact rollout boundary, loss boundary, CPU stand-in, and result to the
+GitHub Actions summary. Full model servers, distributed trainers, and accelerator tests remain
+explicit environment-specific gates.
+
+Security and compatibility guarantees
+-------------------------------------
+
+* Metadata is deterministic allowlisted JSON; pickle is never accepted.
+* Tensor catalogs validate dtype, shape, size, layout, checksum, and buffer agreement before use.
+* Configurable limits bound metadata, nesting, item count, tensor count, and aggregate allocation.
+* Unknown schema types and unauthenticated payloads in authenticated mode fail closed.
+* Framework-specific state stays in namespaced extensions instead of being silently discarded.
+* Python API version ``0.x`` may evolve; the wire schema is independently versioned and validated.
+
+License
+-------
+
+Apache License 2.0. See the repository license file for the full terms.

--- a/rl_experience_transfer/examples/__init__.py
+++ b/rl_experience_transfer/examples/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Runnable RL experience transfer examples."""

--- a/rl_experience_transfer/examples/basic.py
+++ b/rl_experience_transfer/examples/basic.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal transport-independent producer and consumer."""
+
+import numpy as np
+
+from rlxfer import (
+    ExperienceBatch,
+    ExperienceConsumer,
+    ExperienceMetadata,
+    ExperienceProducer,
+    TensorPayload,
+)
+from rlxfer.transports import InMemoryTransport
+
+transport = InMemoryTransport()
+producer = ExperienceProducer(transport)
+consumer = ExperienceConsumer(transport)
+batch = ExperienceBatch(
+    metadata=ExperienceMetadata("rollout-0", "canonical", "1"),
+    tensors={"tokens": TensorPayload(np.asarray([[1, 2, 3]], dtype=np.int64))},
+)
+receipt = producer.publish(batch)
+delivery = consumer.receive(timeout=1.0)
+assert delivery is not None
+np.testing.assert_array_equal(delivery.batch.tensors["tokens"].data, [[1, 2, 3]])
+delivery.ack()
+assert receipt.wait(1.0).state.value == "acked"
+consumer.close()

--- a/rl_experience_transfer/examples/benchmark_nixl.py
+++ b/rl_experience_transfer/examples/benchmark_nixl.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run one byte-exact NIXL transfer and emit machine-readable measurements."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import tempfile
+import time
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from rlxfer.model import SCHEMA_VERSION, ExperienceBatch, ExperienceMetadata, TensorPayload
+from rlxfer.observability import InMemoryMetrics
+from rlxfer.serialization import JsonExperienceSerializer
+from rlxfer.transports.nixl import NixlTransport
+
+
+def _version(distribution: str) -> str:
+    try:
+        return metadata.version(distribution)
+    except metadata.PackageNotFoundError:
+        return "unavailable"
+
+
+def run(device: str) -> dict[str, Any]:
+    """Run the measured transfer on ``device`` and return its result."""
+
+    import torch
+
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is unavailable")
+    tokens = torch.arange(4096, dtype=torch.int64, device=device).reshape(16, 256)
+    rewards = torch.linspace(-1, 1, 4096, dtype=torch.float32, device=device).reshape(16, 256)
+    batch = ExperienceBatch(
+        metadata=ExperienceMetadata("benchmark", "native-torch", torch.__version__),
+        tensors={
+            "tokens": TensorPayload(tokens),
+            "per_token_rewards": TensorPayload(rewards),
+        },
+    )
+    serializer = JsonExperienceSerializer(
+        cpu_staging=False,
+        preserve_device=device != "cpu",
+    )
+    producer_metrics = InMemoryMetrics()
+    consumer_metrics = InMemoryMetrics()
+    with tempfile.TemporaryDirectory(prefix="rlxfer-nixl-") as control_path:
+        producer = NixlTransport(
+            control_path,
+            agent_name=f"benchmark-producer-{device.replace(':', '-')}",
+            metrics=producer_metrics,
+        )
+        consumer = NixlTransport(
+            control_path,
+            agent_name=f"benchmark-consumer-{device.replace(':', '-')}",
+            target_device=device,
+            metrics=consumer_metrics,
+        )
+        end_to_end_started = time.perf_counter()
+        serialize_started = time.perf_counter()
+        payload = serializer.serialize(batch)
+        serialization_seconds = time.perf_counter() - serialize_started
+        publish_started = time.perf_counter()
+        receipt = producer.publish(
+            payload,
+            experience_id=batch.experience_id,
+            idempotency_key=f"benchmark-{device}",
+        )
+        publish_seconds = time.perf_counter() - publish_started
+        receive_started = time.perf_counter()
+        delivery = consumer.receive(10.0)
+        receive_seconds = time.perf_counter() - receive_started
+        if delivery is None:
+            raise RuntimeError("NIXL benchmark receive timed out")
+        deserialize_started = time.perf_counter()
+        restored = serializer.deserialize(delivery.payload)
+        deserialization_seconds = time.perf_counter() - deserialize_started
+        if not torch.equal(restored.tensors["tokens"].data, tokens):
+            raise RuntimeError("token tensor failed byte-exact validation")
+        if not torch.equal(restored.tensors["per_token_rewards"].data, rewards):
+            raise RuntimeError("reward tensor failed byte-exact validation")
+        ack_started = time.perf_counter()
+        consumer.ack(delivery.token)
+        receipt_result = receipt.wait(2.0)
+        acknowledgement_seconds = time.perf_counter() - ack_started
+        end_to_end_seconds = time.perf_counter() - end_to_end_started
+        producer.close()
+        consumer.close()
+    producer_counters, producer_observations = producer_metrics.snapshot()
+    consumer_counters, consumer_observations = consumer_metrics.snapshot()
+    return {
+        "result": "PASSED",
+        "python": platform.python_version(),
+        "torch": torch.__version__,
+        "nixl": _version("nixl"),
+        "nixl_backend_wheel": _version("nixl-cu12"),
+        "transport": "nixl:ucx",
+        "device": device,
+        "schema_version": SCHEMA_VERSION,
+        "experience_id": batch.experience_id,
+        "trajectory_count": 0,
+        "tensor_count": len(payload.buffers),
+        "tensor_catalog": [
+            {"name": segment.name, "shape": segment.shape, "dtype": segment.dtype}
+            for segment in payload.buffers
+        ],
+        "metadata_bytes": len(payload.metadata),
+        "tensor_bytes": sum(segment.nbytes for segment in payload.buffers),
+        "total_bytes": payload.nbytes,
+        "serialization_seconds": serialization_seconds,
+        "registration_and_publish_seconds": publish_seconds,
+        "receive_and_transfer_seconds": receive_seconds,
+        "deserialization_seconds": deserialization_seconds,
+        "acknowledgement_seconds": acknowledgement_seconds,
+        "end_to_end_seconds": end_to_end_seconds,
+        "acknowledgement": receipt_result.state.value,
+        "byte_exact": True,
+        "producer_metrics": producer_counters | producer_observations,
+        "consumer_metrics": consumer_counters | consumer_observations,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args()
+    result = run(arguments.device)
+    encoded = json.dumps(result, indent=2, sort_keys=True)
+    if arguments.output is not None:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+
+
+if __name__ == "__main__":
+    main()

--- a/rl_experience_transfer/examples/cross_framework.py
+++ b/rl_experience_transfer/examples/cross_framework.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Show actionable rejection of unsafe cross-framework experience."""
+
+from rlxfer.compatibility import CompatibilityRequirements, check_compatibility
+from rlxfer.model import ExperienceBatch, ExperienceMetadata
+
+batch = ExperienceBatch(
+    metadata=ExperienceMetadata(
+        "slime-rollout",
+        "slime",
+        "0.3.1",
+        algorithm="grpo",
+        tokenizer_id="tokenizer-a",
+        model_id="model-a",
+    ),
+    payload={"reward": 1.0},
+)
+report = check_compatibility(
+    batch,
+    CompatibilityRequirements(
+        consumer_framework="prime_rl",
+        consumer_framework_version="0.5.0",
+        algorithm="ppo",
+        tokenizer_id="tokenizer-b",
+        model_id="model-a",
+    ),
+)
+assert not report.compatible
+for issue in report.issues:
+    print(issue)

--- a/rl_experience_transfer/examples/filesystem_process.py
+++ b/rl_experience_transfer/examples/filesystem_process.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal persistent multiprocess filesystem transfer."""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from rlxfer import (
+    ExperienceBatch,
+    ExperienceConsumer,
+    ExperienceMetadata,
+    ExperienceProducer,
+    TensorPayload,
+)
+from rlxfer.transports import FileSystemTransport
+
+
+def consume(path: str) -> None:
+    transport = FileSystemTransport(path)
+    delivery = ExperienceConsumer(transport).receive(timeout=5.0)
+    if delivery is None:
+        raise RuntimeError("receive timed out")
+    np.testing.assert_array_equal(delivery.batch.tensors["rewards"].data, [1.0, -1.0])
+    delivery.ack()
+    transport.close()
+
+
+def run(path: Path) -> None:
+    transport = FileSystemTransport(path)
+    producer = ExperienceProducer(transport)
+    batch = ExperienceBatch(
+        metadata=ExperienceMetadata("rollout-0", "canonical", "1"),
+        tensors={"rewards": TensorPayload(np.asarray([1.0, -1.0], dtype=np.float32))},
+    )
+    receipt = producer.publish(batch)
+    process = multiprocessing.get_context("spawn").Process(target=consume, args=(str(path),))
+    process.start()
+    process.join(10.0)
+    if process.exitcode != 0 or receipt.wait(1.0).state.value != "acked":
+        raise RuntimeError("multiprocess transfer failed")
+    transport.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", type=Path)
+    arguments = parser.parse_args()
+    if arguments.path is not None:
+        run(arguments.path)
+        return
+    with tempfile.TemporaryDirectory(prefix="rlxfer-filesystem-") as temporary:
+        run(Path(temporary))
+
+
+if __name__ == "__main__":
+    main()

--- a/rl_experience_transfer/examples/framework_matrix.py
+++ b/rl_experience_transfer/examples/framework_matrix.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run every declared producer-to-consumer native adapter pairing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from itertools import product
+from pathlib import Path
+
+if __package__:
+    from .framework_roundtrip import FRAMEWORKS, run_framework_case
+else:
+    from framework_roundtrip import FRAMEWORKS, run_framework_case
+
+
+def run_matrix(queue_root: Path) -> dict[str, object]:
+    """Run the 4x4 conversion matrix and return a machine-readable summary."""
+
+    cases = [
+        run_framework_case(producer, consumer, queue_root / f"{producer}-to-{consumer}")
+        for producer, consumer in product(FRAMEWORKS, repeat=2)
+    ]
+    return {
+        "cases": cases,
+        "converted": sum(case["expected_outcome"] == "converted" for case in cases),
+        "expected_rejections": sum(
+            case["expected_outcome"] == "rejected_as_unsafe" for case in cases
+        ),
+        "frameworks": list(FRAMEWORKS),
+        "result": "PASSED" if all(case["result"] == "PASSED" for case in cases) else "FAILED",
+        "total": len(cases),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--queue-root", type=Path)
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args()
+    try:
+        if arguments.queue_root is None:
+            with tempfile.TemporaryDirectory(prefix="rlxfer-framework-matrix-") as temporary:
+                result = run_matrix(Path(temporary))
+        else:
+            result = run_matrix(arguments.queue_root)
+    except Exception as error:
+        result = {"error": f"{type(error).__name__}: {error}", "result": "FAILED"}
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    print(rendered)
+    if arguments.output is not None:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if result["result"] == "PASSED" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rl_experience_transfer/examples/framework_pipeline.py
+++ b/rl_experience_transfer/examples/framework_pipeline.py
@@ -1,0 +1,560 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU framework-pipeline checks using pinned upstream code and test-time wiring."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import inspect
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+from rlxfer.adapters import MilesAdapter, NemoRLAdapter, PrimeRLAdapter, SlimeAdapter
+from rlxfer.api import ExperienceConsumer, ExperienceProducer
+from rlxfer.transport import ReceiptState
+from rlxfer.transports.filesystem import FileSystemTransport
+
+FRAMEWORKS = ("nemo_rl", "prime_rl", "slime", "miles")
+
+
+def _source_roots() -> dict[str, Path]:
+    roots = {
+        framework: Path(os.environ[f"RLXFER_{framework.upper()}_SOURCE"]).resolve()
+        for framework in FRAMEWORKS
+    }
+    missing = [str(root) for root in roots.values() if not root.is_dir()]
+    if missing:
+        raise FileNotFoundError(f"framework source directories do not exist: {missing}")
+    return roots
+
+
+def _source_package(name: str, path: Path) -> ModuleType:
+    package = ModuleType(name)
+    package.__path__ = [str(path)]
+    sys.modules[name] = package
+    return package
+
+
+def install_framework_source_shims() -> None:
+    """Bypass eager GPU launch imports while retaining pinned source modules."""
+
+    roots = _source_roots()
+
+    _source_package("prime_rl.transport", roots["prime_rl"] / "prime_rl" / "transport")
+
+    miles_data_source = ModuleType("miles.rollout.data_source")
+    miles_data_source.DataSource = object  # type: ignore[attr-defined]
+    sys.modules[miles_data_source.__name__] = miles_data_source
+
+    nemo_root = roots["nemo_rl"] / "nemo_rl"
+    nemo_logger = ModuleType("nemo_rl.utils.logger")
+    nemo_logger.Logger = object  # type: ignore[attr-defined]
+    sys.modules[nemo_logger.__name__] = nemo_logger
+
+    nemo_policy = _source_package("nemo_rl.models.policy", nemo_root / "models" / "policy")
+    nemo_policy.TokenizerConfig = dict  # type: ignore[attr-defined]
+    _source_package("nemo_rl.models.generation", nemo_root / "models" / "generation")
+    _source_package(
+        "nemo_rl.algorithms.async_utils",
+        nemo_root / "algorithms" / "async_utils",
+    )
+    nemo_replay = ModuleType("nemo_rl.algorithms.async_utils.replay_buffer")
+    nemo_replay.TQReplayBuffer = object  # type: ignore[attr-defined]
+    sys.modules[nemo_replay.__name__] = nemo_replay
+    _source_package("nemo_rl.algorithms.loss", nemo_root / "algorithms" / "loss")
+
+
+class _TransferBridge:
+    def __init__(self, queue: Path, adapter: Any) -> None:
+        self._producer = ExperienceProducer(FileSystemTransport(queue), adapter=adapter)
+        self._consumer = ExperienceConsumer(FileSystemTransport(queue), adapter=adapter)
+        self._receipt: Any = None
+        self._delivery: Any = None
+
+    def __enter__(self) -> _TransferBridge:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        del exc_type, exc, traceback
+        if self._delivery is not None and not self._delivery.settled:
+            self._delivery.reject("framework pipeline did not finish")
+        self._producer.close()
+        self._consumer.close()
+
+    def publish(self, native: object) -> None:
+        if self._receipt is not None:
+            raise RuntimeError("the pipeline bridge accepts one native batch")
+        self._receipt = self._producer.publish(native, timeout=5.0)
+
+    def receive(self) -> object:
+        self._delivery = self._consumer.receive(timeout=5.0)
+        if self._delivery is None:
+            raise TimeoutError("framework pipeline transfer timed out")
+        return self._delivery.to_framework()
+
+    def settle(self) -> dict[str, object]:
+        if self._delivery is None or self._receipt is None:
+            raise RuntimeError("cannot settle an incomplete framework transfer")
+        self._delivery.ack()
+        result = self._receipt.wait(timeout=5.0)
+        if result.state is not ReceiptState.ACKED:
+            raise RuntimeError(f"unexpected receipt state {result.state.value!r}")
+        return {
+            "acknowledged": True,
+            "canonical_schema": self._delivery.batch.metadata.schema_version,
+            "experience_id": self._delivery.experience_id,
+            "trajectories": len(self._delivery.batch.trajectories),
+        }
+
+
+def _source_file(framework: str, component: Any) -> str:
+    source = inspect.getsourcefile(inspect.unwrap(component))
+    if source is None:
+        raise RuntimeError(f"cannot locate source for {component!r}")
+    root = _source_roots()[framework]
+    path = Path(source).resolve()
+    try:
+        return str(path.relative_to(root))
+    except ValueError as error:
+        message = f"{component!r} loaded from {path}, outside pinned source {root}"
+        raise RuntimeError(message) from error
+
+
+def _optimizer_update(torch: Any, model: Any, loss: Any) -> dict[str, object]:
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+    before = [parameter.detach().clone() for parameter in model.parameters()]
+    optimizer.zero_grad(set_to_none=True)
+    loss.backward()
+    gradients = [
+        parameter.grad
+        for parameter in model.parameters()
+        if parameter.requires_grad and parameter.grad is not None
+    ]
+    gradient_finite = bool(gradients) and all(
+        bool(torch.isfinite(gradient).all()) for gradient in gradients
+    )
+    optimizer.step()
+    parameter_changed = any(
+        not torch.equal(previous, parameter.detach())
+        for previous, parameter in zip(before, model.parameters(), strict=True)
+    )
+    return {
+        "gradient_finite": gradient_finite,
+        "gradient_present": bool(gradients),
+        "loss": float(loss.detach()),
+        "parameter_changed": parameter_changed,
+    }
+
+
+def _prime_pipeline(queue: Path) -> dict[str, object]:
+    torch: Any = importlib.import_module("torch")
+
+    base: Any = importlib.import_module("prime_rl.transport.base")
+    types: Any = importlib.import_module("prime_rl.transport.types")
+    batch_module: Any = importlib.import_module("prime_rl.trainer.batch")
+    loss_module: Any = importlib.import_module("prime_rl.trainer.rl.loss")
+    configs: Any = importlib.import_module("prime_rl.configs.trainer")
+
+    with _TransferBridge(queue, PrimeRLAdapter()) as bridge:
+
+        class Sender(base.TrainingBatchSender):  # type: ignore[misc]
+            async def send(self, batch: object) -> None:
+                bridge.publish(batch)
+
+        class Receiver(base.TrainingBatchReceiver):  # type: ignore[misc]
+            def can_receive(self) -> bool:
+                return True
+
+            def receive(self) -> list[object]:
+                return [bridge.receive()]
+
+        native = types.TrainingBatch(
+            examples=[
+                types.TrainingSample(
+                    prompt_ids=[1, 2],
+                    prompt_mask=[False, False],
+                    completion_ids=[3, 4],
+                    completion_mask=[True, True],
+                    completion_logprobs=[-0.1, -0.2],
+                    completion_temperatures=[1.0, 1.0],
+                    env_name="rlxfer-ci",
+                    advantage=1.0,
+                    reward=1.0,
+                )
+            ],
+            step=3,
+            run_idx=0,
+        )
+        sender = Sender(queue)
+        receiver = Receiver()
+        asyncio.run(sender.send(native))
+        restored = receiver.receive()[0]
+        if not isinstance(restored, types.TrainingBatch):
+            raise TypeError(f"expected TrainingBatch, received {type(restored).__name__}")
+
+        micro = batch_module.prepare_sample(restored.examples[0], seq_len=8)
+        input_ids = torch.tensor([micro.input_ids], dtype=torch.long)
+        inference_logprobs = torch.tensor([micro.inference_logprobs], dtype=torch.float32)
+        advantages = torch.tensor([micro.advantages], dtype=torch.float32)
+        loss_mask = torch.tensor([micro.loss_mask], dtype=torch.bool)
+        temperatures = torch.tensor([micro.temperatures], dtype=torch.float32)
+        torch.manual_seed(11)
+        model = torch.nn.Sequential(torch.nn.Embedding(16, 8), torch.nn.Linear(8, 16))
+        logits = model(input_ids) / temperatures.unsqueeze(-1)
+        labels = loss_module.shift_tensor_left(input_ids)
+        trainer_logprobs = loss_module.selective_log_softmax(logits, labels)
+        trainer_logprobs = loss_module.shift_tensor_right(trainer_logprobs, pad_value=0.0)
+        loss, _ = loss_module.compute_loss(
+            trainer_logprobs=[trainer_logprobs[0]],
+            inference_logprobs=[inference_logprobs[0]],
+            teacher_logprobs=None,
+            advantages=[advantages[0]],
+            loss_mask=[loss_mask[0]],
+            loss_fns=loss_module.setup_loss_fns(configs.DefaultLossConfig()),
+            loss_scale=max(int(loss_mask.sum()), 1),
+            training_mode=restored.examples[0].training_mode,
+        )
+        update = _optimizer_update(torch, model, loss)
+        settlement = bridge.settle()
+
+    return {
+        "framework": "prime_rl",
+        "rollout_component": "prime_rl.transport.base.TrainingBatchSender.send",
+        "rollout_source": _source_file("prime_rl", base.TrainingBatchSender.send),
+        "trainer_component": "prime_rl.trainer.rl.loss.compute_loss",
+        "trainer_source": _source_file("prime_rl", loss_module.compute_loss),
+        "native_training_type": type(restored).__name__,
+        "external_fixtures": "synthetic TrainingBatch; CPU tiny policy",
+        "result": "PASSED",
+        **settlement,
+        **update,
+    }
+
+
+def _grouped_pipeline(framework: str, queue: Path) -> dict[str, object]:
+    torch: Any = importlib.import_module("torch")
+
+    outputs: Any = importlib.import_module(f"{framework}.rollout.base_types")
+    types: Any = importlib.import_module(f"{framework}.utils.types")
+    adapter: Any
+    if framework == "slime":
+        loss_module = importlib.import_module("slime.utils.ppo_utils")
+        adapter = SlimeAdapter()
+    else:
+        loss_module = importlib.import_module("miles.backends.training_utils.loss_hub.math_utils")
+        adapter = MilesAdapter()
+
+    class DataSource:
+        def get_samples(self, rollout_id: int) -> list[list[object]]:
+            sample = types.Sample(
+                index=rollout_id,
+                group_index=0,
+                rollout_id=rollout_id,
+                prompt="Count to two.",
+                tokens=[1, 2, 3, 4],
+                response="one two",
+                response_length=2,
+                reward=1.0,
+                loss_mask=[1, 1],
+                weight_versions=[str(rollout_id)],
+                rollout_log_probs=[-0.1, -0.2],
+                status=types.Sample.Status.COMPLETED,
+            )
+            return [[sample]]
+
+    def rollout_plugin(
+        args: object,
+        rollout_id: int,
+        data_source: DataSource,
+        evaluation: bool = False,
+    ) -> object:
+        del args
+        if evaluation:
+            raise ValueError("the training pipeline fixture does not run evaluation")
+        return outputs.RolloutFnTrainOutput(
+            samples=data_source.get_samples(rollout_id),
+            metrics={"fixture": "cpu"},
+        )
+
+    native = outputs.call_rollout_fn(
+        rollout_plugin,
+        None,
+        5,
+        DataSource(),
+        evaluation=False,
+    )
+    with _TransferBridge(queue, adapter) as bridge:
+        bridge.publish(native)
+        restored = bridge.receive()
+        if not isinstance(restored, outputs.RolloutFnTrainOutput):
+            raise TypeError(f"expected RolloutFnTrainOutput, received {type(restored).__name__}")
+        sample = restored.samples[0][0]
+        response_tokens = torch.tensor(sample.tokens[-sample.response_length :], dtype=torch.long)
+        old_logprobs = torch.tensor(sample.rollout_log_probs, dtype=torch.float32)
+        advantages = torch.full_like(old_logprobs, float(sample.reward))
+        torch.manual_seed(13)
+        model = torch.nn.Sequential(torch.nn.Embedding(16, 8), torch.nn.Linear(8, 16))
+        logits = model(response_tokens)
+        current_logprobs = (
+            logits.log_softmax(-1).gather(-1, response_tokens.unsqueeze(-1)).squeeze(-1)
+        )
+        losses, _ = loss_module.compute_policy_loss(
+            old_logprobs - current_logprobs,
+            advantages,
+            0.2,
+            0.2,
+        )
+        update = _optimizer_update(torch, model, losses.mean())
+        settlement = bridge.settle()
+
+    return {
+        "framework": framework,
+        "rollout_component": f"{framework}.rollout.base_types.call_rollout_fn",
+        "rollout_source": _source_file(framework, outputs.call_rollout_fn),
+        "trainer_component": f"{loss_module.__name__}.compute_policy_loss",
+        "trainer_source": _source_file(framework, loss_module.compute_policy_loss),
+        "native_training_type": type(restored).__name__,
+        "external_fixtures": "test-time rollout plugin; CPU tiny policy",
+        "result": "PASSED",
+        **settlement,
+        **update,
+    }
+
+
+def _nemo_pipeline(queue: Path) -> dict[str, object]:
+    torch: Any = importlib.import_module("torch")
+
+    manager_module: Any = importlib.import_module("nemo_rl.experience.rollout_manager")
+    interfaces: Any = importlib.import_module("nemo_rl.environments.interfaces")
+    batched: Any = importlib.import_module("nemo_rl.distributed.batched_data_dict")
+    loss_module: Any = importlib.import_module("nemo_rl.algorithms.loss.loss_functions")
+
+    class Tokenizer:
+        def decode(self, tokens: object, *, skip_special_tokens: bool) -> str:
+            del tokens, skip_special_tokens
+            return "one two"
+
+        def __call__(self, text: str, **kwargs: object) -> SimpleNamespace:
+            del text, kwargs
+            return SimpleNamespace(input_ids=torch.tensor([[5]], dtype=torch.long))
+
+    class Generation:
+        calls = 0
+
+        async def generate_async(self, data: Any) -> Any:
+            self.calls += 1
+            prompt_ids = data["input_ids"]
+            generated = torch.tensor([[3, 4]], dtype=torch.long)
+            output_ids = torch.cat([prompt_ids, generated], dim=1)
+            logprobs = torch.zeros_like(output_ids, dtype=torch.float32)
+            logprobs[:, -2:] = torch.tensor([[-0.1, -0.2]])
+            yield (
+                0,
+                batched.BatchedDataDict(
+                    {
+                        "output_ids": output_ids,
+                        "generation_lengths": torch.tensor([2]),
+                        "unpadded_sequence_lengths": torch.tensor([output_ids.shape[1]]),
+                        "logprobs": logprobs,
+                        "truncated": torch.tensor([False]),
+                    }
+                ),
+            )
+
+    def calculate_rewards(data: Any, task_to_env: object) -> object:
+        del task_to_env
+        return interfaces.EnvironmentReturn(
+            observations=[{"role": "user", "content": "done"}],
+            metadata=data["extra_env_info"],
+            next_stop_strings=[None],
+            rewards=torch.tensor([1.0]),
+            terminateds=torch.tensor([True]),
+            answers=[None],
+        )
+
+    with _TransferBridge(queue, NemoRLAdapter()) as bridge:
+
+        class TransferBuffer:
+            def __init__(self) -> None:
+                self.group_id: str | None = None
+
+            def reserve(self, *, weight_version: int, target_step: int | None) -> str:
+                self.group_id = f"nemo-{weight_version}-{target_step}"
+                return self.group_id
+
+            async def commit(
+                self,
+                group_id: str,
+                record: object,
+                start_weight_version: int,
+                end_weight_version: int,
+            ) -> None:
+                if group_id != self.group_id or start_weight_version != end_weight_version:
+                    raise RuntimeError("NeMo rollout version or reservation changed")
+                bridge.publish(record)
+
+            async def remove_group(self, group_id: str) -> int:
+                if group_id != self.group_id:
+                    raise ValueError(f"unknown group {group_id!r}")
+                self.group_id = None
+                return 1
+
+        generation = Generation()
+        manager = manager_module.RolloutManager(
+            tokenizer=Tokenizer(),
+            task_to_env={"cpu": object()},
+            num_generations_per_prompt=2,
+            max_seq_len=16,
+            max_rollout_turns=1,
+            policy_generation=generation,
+            tq_buffer=TransferBuffer(),
+        )
+        manager.set_weight_version(4)
+        original_rewards = manager_module.calculate_rewards
+        manager_module.calculate_rewards = calculate_rewards
+        try:
+            asyncio.run(
+                manager.generate_and_push(
+                    {
+                        "idx": 7,
+                        "message_log": [
+                            {
+                                "role": "user",
+                                "content": "Count to two.",
+                                "token_ids": torch.tensor([1, 2]),
+                            }
+                        ],
+                        "extra_env_info": {},
+                        "task_name": "cpu",
+                        "stop_strings": None,
+                    },
+                    target_step=5,
+                )
+            )
+        finally:
+            manager_module.calculate_rewards = original_rewards
+
+        restored = bridge.receive()
+        record_type = importlib.import_module("nemo_rl.experience.interfaces").PromptGroupRecord
+        if not isinstance(restored, record_type):
+            raise TypeError(f"expected PromptGroupRecord, received {type(restored).__name__}")
+
+        response_tokens: list[list[int]] = []
+        response_logprobs: list[list[float]] = []
+        for completion in restored.completions:
+            assistant = next(
+                message
+                for message in completion.message_log
+                if message.get("generation_logprobs") is not None
+            )
+            response_tokens.append(torch.as_tensor(assistant["token_ids"]).tolist())
+            response_logprobs.append(
+                torch.as_tensor(assistant["generation_logprobs"]).float().tolist()
+            )
+
+        tokens = torch.tensor([[0, *values] for values in response_tokens], dtype=torch.long)
+        old = torch.tensor([[0.0, *values] for values in response_logprobs])
+        mask = torch.tensor([[0.0, 1.0, 1.0]] * len(response_tokens))
+        advantages = torch.tensor([[0.0, sign, sign] for sign in (1.0, -1.0)], dtype=torch.float32)
+        training_data = batched.BatchedDataDict(
+            {
+                "input_ids": tokens,
+                "advantages": advantages,
+                "prev_logprobs": old,
+                "generation_logprobs": old,
+                "token_mask": mask,
+                "sample_mask": torch.ones(len(response_tokens)),
+            }
+        )
+        torch.manual_seed(17)
+        model = torch.nn.Sequential(torch.nn.Embedding(16, 8), torch.nn.Linear(8, 16))
+        logits = model(tokens[:, 1:])
+        current = logits.log_softmax(-1).gather(-1, tokens[:, 1:].unsqueeze(-1)).squeeze(-1)
+        loss_fn = loss_module.ClippedPGLossFn(
+            loss_module.ClippedPGLossConfig(reference_policy_kl_penalty=0.0)
+        )
+        loss, _ = loss_fn(
+            current,
+            training_data,
+            global_valid_seqs=torch.tensor(float(len(response_tokens))),
+            global_valid_toks=mask[:, 1:].sum(),
+        )
+        update = _optimizer_update(torch, model, loss)
+        settlement = bridge.settle()
+
+    return {
+        "framework": "nemo_rl",
+        "rollout_component": "nemo_rl.experience.rollout_manager.RolloutManager.generate_and_push",
+        "rollout_source": _source_file("nemo_rl", manager_module.RolloutManager.generate_and_push),
+        "trainer_component": "nemo_rl.algorithms.loss.loss_functions.ClippedPGLossFn",
+        "trainer_source": _source_file("nemo_rl", loss_module.ClippedPGLossFn.__call__),
+        "native_rollout_type": type(restored).__name__,
+        "native_training_type": type(training_data).__name__,
+        "external_fixtures": "deterministic generation/environment; CPU tiny policy",
+        "generation_calls": generation.calls,
+        "result": "PASSED",
+        **settlement,
+        **update,
+    }
+
+
+def run_framework_pipeline(framework: str, queue: Path) -> dict[str, object]:
+    """Run one pinned framework rollout-to-loss component pipeline."""
+
+    if framework not in FRAMEWORKS:
+        raise ValueError(f"unknown framework {framework!r}")
+    if framework == "nemo_rl":
+        return _nemo_pipeline(queue)
+    if framework == "prime_rl":
+        return _prime_pipeline(queue)
+    return _grouped_pipeline(framework, queue)
+
+
+def _markdown(results: list[dict[str, object]]) -> str:
+    lines = [
+        "## RL Experience framework pipeline components",
+        "",
+        "| Framework | Real rollout boundary | Real training component | "
+        "CPU-only stand-ins | Result |",
+        "|---|---|---|---|---|",
+    ]
+    for result in results:
+        lines.append(
+            "| {framework} | `{rollout_component}` | `{trainer_component}` | "
+            "{external_fixtures} | {result} |".format(**result)
+        )
+    lines.extend(
+        [
+            "",
+            "Each row imports the named boundary from the pinned upstream checkout, transfers "
+            "native experience through `ExperienceProducer` and `ExperienceConsumer`, runs a "
+            "finite backward/optimizer step, and acknowledges only after the update.",
+            "GPU model servers and distributed trainer engines remain separate accelerator gates.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("framework", choices=(*FRAMEWORKS, "all"))
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    args = parser.parse_args()
+    install_framework_source_shims()
+    selected = FRAMEWORKS if args.framework == "all" else (args.framework,)
+    with tempfile.TemporaryDirectory(prefix="rlxfer-framework-pipeline-") as temporary:
+        root = Path(temporary)
+        results = [run_framework_pipeline(name, root / name) for name in selected]
+    print(_markdown(results) if args.format == "markdown" else json.dumps(results, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rl_experience_transfer/examples/framework_roundtrip.py
+++ b/rl_experience_transfer/examples/framework_roundtrip.py
@@ -1,0 +1,358 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Real adapter/transport smoke test; this is not a full framework trainer run."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import platform
+import tempfile
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import replace
+from pathlib import Path
+from types import MappingProxyType
+
+import numpy as np
+
+from rlxfer.adapters import (
+    ExperienceAdapter,
+    IncompatibleExperienceError,
+    MilesAdapter,
+    SlimeAdapter,
+    create_adapter,
+)
+from rlxfer.api import ExperienceConsumer, ExperienceProducer
+from rlxfer.compatibility import CompatibilityRequirements
+from rlxfer.model import ExperienceBatch, TensorPayload
+from rlxfer.serialization import JsonExperienceSerializer
+from rlxfer.transport import ReceiptState
+from rlxfer.transports.filesystem import FileSystemTransport
+
+
+def _prime_native() -> object:
+    types = importlib.import_module("prime_rl.transport.types")
+    sample = types.TrainingSample(
+        prompt_ids=[1, 2],
+        prompt_mask=[False, False],
+        completion_ids=[3, 4],
+        completion_mask=[True, True],
+        completion_logprobs=[-0.1, -0.2],
+        completion_temperatures=[1.0, 1.0],
+        env_name="rlxfer-smoke",
+        advantage=1.0,
+        reward=1.0,
+    )
+    return types.TrainingBatch(examples=[sample], step=0, run_idx=0)
+
+
+def _grouped_native(framework: str) -> object:
+    types = importlib.import_module(f"{framework}.utils.types")
+    outputs = importlib.import_module(f"{framework}.rollout.base_types")
+    sample = types.Sample(
+        index=0,
+        group_index=0,
+        prompt="Count to two.",
+        tokens=[1, 2, 3, 4],
+        response="one two",
+        response_length=2,
+        reward=1.0,
+        loss_mask=[1, 1],
+        weight_versions=["0"],
+        rollout_log_probs=[-0.1, -0.2],
+        status=types.Sample.Status.COMPLETED,
+    )
+    return outputs.RolloutFnTrainOutput(samples=[[sample]], metrics={"smoke": 1})
+
+
+def _nemo_native() -> object:
+    interfaces = importlib.import_module("nemo_rl.experience.interfaces")
+    completion = interfaces.Completion(
+        message_log=[
+            {
+                "role": "assistant",
+                "content": "one two",
+                "token_ids": [3, 4],
+                "generation_logprobs": [-0.1, -0.2],
+            }
+        ],
+        env_extras=None,
+        truncated=False,
+        reward=1.0,
+    )
+    return interfaces.PromptGroupRecord(
+        prompt_idx=0,
+        prompt=[{"role": "user", "content": "Count to two."}],
+        extra_env_info=None,
+        metadata={"smoke": True},
+        completions=[completion],
+        rollout_metrics={"tokens": 2},
+    )
+
+
+_BUILDERS: Mapping[str, Callable[[], object]] = MappingProxyType(
+    {
+        "miles": lambda: _grouped_native("miles"),
+        "nemo_rl": _nemo_native,
+        "prime_rl": _prime_native,
+        "slime": lambda: _grouped_native("slime"),
+    }
+)
+FRAMEWORKS = tuple(sorted(_BUILDERS))
+SUPPORTED_CONVERSIONS = frozenset(
+    {(framework, framework) for framework in FRAMEWORKS} | {("miles", "slime"), ("slime", "miles")}
+)
+
+
+def supports_conversion(producer_framework: str, consumer_framework: str) -> bool:
+    """Return whether a lossless native conversion is part of the adapter contract."""
+
+    return (producer_framework, consumer_framework) in SUPPORTED_CONVERSIONS
+
+
+def _consumer_adapter(producer_framework: str, consumer_framework: str) -> ExperienceAdapter:
+    adapter = create_adapter(consumer_framework)
+    if producer_framework == consumer_framework:
+        return adapter
+    requirements = CompatibilityRequirements(
+        consumer_framework=consumer_framework,
+        consumer_framework_version=adapter.framework_version,
+        algorithm="grpo",
+        chat_template="rlxfer-test-template",
+        model_id="rlxfer-test-model",
+        padding="right",
+        reward_definition="rlxfer-test-reward",
+        sequence_format="prompt-response",
+        tokenizer_id="rlxfer-test-tokenizer",
+        truncation="right",
+    )
+    if consumer_framework == "miles":
+        return MilesAdapter(requirements)
+    if consumer_framework == "slime":
+        return SlimeAdapter(requirements)
+    return adapter
+
+
+def _with_declared_semantics(batch: ExperienceBatch) -> ExperienceBatch:
+    return replace(
+        batch,
+        metadata=replace(
+            batch.metadata,
+            algorithm="grpo",
+            chat_template="rlxfer-test-template",
+            model_id="rlxfer-test-model",
+            padding="right",
+            reward_definition="rlxfer-test-reward",
+            sequence_format="prompt-response",
+            tokenizer_id="rlxfer-test-tokenizer",
+            truncation="right",
+        ),
+    )
+
+
+def _training_signature(batch: ExperienceBatch) -> list[dict[str, object]]:
+    signature = []
+    for trajectory in batch.trajectories:
+        signature.append(
+            {
+                "log_probs": _payload_values(trajectory.log_probs),
+                "rewards": dict(trajectory.rewards),
+                "terminal": trajectory.terminal,
+                "tokens": _payload_values(trajectory.tokens),
+                "truncated": trajectory.truncated,
+            }
+        )
+    return signature
+
+
+def _payload_values(payload: TensorPayload | None) -> object:
+    return None if payload is None else np.asarray(payload.data).tolist()
+
+
+def _tiny_update(batch: ExperienceBatch) -> dict[str, object]:
+    torch = importlib.import_module("torch")
+    payload = next(
+        (
+            trajectory.tokens
+            for trajectory in batch.trajectories
+            if trajectory.tokens is not None and trajectory.tokens.shape[-1] > 0
+        ),
+        None,
+    )
+    if payload is None:
+        raise RuntimeError("the canonical batch has no tokens for the optimizer smoke step")
+    tokens = torch.as_tensor(payload.data, device="cpu").reshape(-1).long().remainder(128)
+    torch.manual_seed(0)
+    model = torch.nn.Sequential(torch.nn.Embedding(128, 8), torch.nn.Linear(8, 1))
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+    before = [parameter.detach().clone() for parameter in model.parameters()]
+    prediction = model(tokens).reshape(-1)
+    target = torch.ones_like(prediction)
+    loss = torch.nn.functional.mse_loss(prediction, target)
+    optimizer.zero_grad()
+    loss.backward()
+    gradients = [parameter.grad for parameter in model.parameters()]
+    gradients_present = all(gradient is not None for gradient in gradients)
+    gradients_finite = all(
+        bool(torch.isfinite(gradient).all()) for gradient in gradients if gradient is not None
+    )
+    optimizer.step()
+    parameter_changed = any(
+        not torch.equal(old, parameter.detach())
+        for old, parameter in zip(before, model.parameters(), strict=True)
+    )
+    return {
+        "gradient_finite": gradients_finite,
+        "gradient_present": gradients_present,
+        "loss": float(loss.detach()),
+        "model": "Embedding(128,8)+Linear(8,1)",
+        "parameter_changed": parameter_changed,
+        "torch_version": str(torch.__version__),
+    }
+
+
+def run_framework_case(
+    producer_framework: str,
+    consumer_framework: str,
+    queue_dir: Path,
+) -> dict[str, object]:
+    """Exercise one declared native conversion or its required safe rejection."""
+
+    started = time.perf_counter()
+    expected_conversion = supports_conversion(producer_framework, consumer_framework)
+    producer_adapter = create_adapter(producer_framework)
+    consumer_adapter = _consumer_adapter(producer_framework, consumer_framework)
+    native = _BUILDERS[producer_framework]()
+    batch = _with_declared_semantics(producer_adapter.from_framework(native))
+    serializer = JsonExperienceSerializer(checksum=True)
+    transport = FileSystemTransport(queue_dir)
+    try:
+        receipt = ExperienceProducer(transport, serializer=serializer).publish(
+            batch,
+            idempotency_key=(f"{producer_framework}:{consumer_framework}:{batch.experience_id}"),
+            timeout=5.0,
+        )
+        consumer = ExperienceConsumer(
+            transport,
+            adapter=consumer_adapter,
+            serializer=serializer,
+        )
+        try:
+            delivery = consumer.receive(timeout=5.0)
+        except IncompatibleExperienceError as error:
+            receipt_state = receipt.wait(timeout=5.0).state
+            if expected_conversion:
+                raise
+            if receipt_state is not ReceiptState.REJECTED:
+                raise RuntimeError(
+                    f"unexpected rejection receipt state: {receipt_state.value}"
+                ) from error
+            return {
+                "consumer_framework": consumer_framework,
+                "coverage": "native adapter contract and safe-rejection integration",
+                "elapsed_seconds": time.perf_counter() - started,
+                "expected_outcome": "rejected_as_unsafe",
+                "producer_framework": producer_framework,
+                "python_version": platform.python_version(),
+                "rejection": str(error),
+                "result": "PASSED",
+                "transport": "filesystem",
+            }
+        if delivery is None:
+            raise RuntimeError("filesystem transport timed out")
+        if not expected_conversion:
+            delivery.reject("an undeclared cross-framework conversion unexpectedly validated")
+            raise RuntimeError("unsafe cross-framework conversion unexpectedly succeeded")
+        native_training = delivery.to_framework()
+        training_batch = consumer_adapter.from_framework(native_training)
+        if _training_signature(training_batch) != _training_signature(batch):
+            delivery.reject("native reconstruction changed canonical training values")
+            raise RuntimeError("native reconstruction changed canonical training values")
+        update = _tiny_update(training_batch)
+        delivery.ack()
+        receipt_state = receipt.wait(timeout=5.0).state
+    finally:
+        transport.close()
+    if receipt_state is not ReceiptState.ACKED:
+        raise RuntimeError(f"unexpected delivery receipt state: {receipt_state.value}")
+    token_count = sum(
+        trajectory.tokens.shape[-1]
+        for trajectory in training_batch.trajectories
+        if isinstance(trajectory.tokens, TensorPayload)
+    )
+    return {
+        "acknowledged": True,
+        "canonical_schema": training_batch.metadata.schema_version,
+        "consumer_adapter_version": consumer_adapter.adapter_version,
+        "consumer_framework": consumer_framework,
+        "consumer_framework_version": consumer_adapter.framework_version,
+        "coverage": "native adapter integration; not a full framework trainer",
+        "elapsed_seconds": time.perf_counter() - started,
+        "expected_outcome": "converted",
+        "native_training_type": type(native_training).__name__,
+        "producer_adapter_version": producer_adapter.adapter_version,
+        "producer_framework": producer_framework,
+        "producer_framework_version": producer_adapter.framework_version,
+        "python_version": platform.python_version(),
+        "result": "PASSED",
+        "tokens": token_count,
+        "trajectories": len(training_batch.trajectories),
+        "transport": "filesystem",
+        **update,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("producer_framework", choices=FRAMEWORKS)
+    parser.add_argument("--consumer-framework", choices=FRAMEWORKS)
+    parser.add_argument("--queue-dir", type=Path)
+    parser.add_argument("--output", type=Path, help="optional JSON result path")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    consumer_framework = args.consumer_framework or args.producer_framework
+    try:
+        if args.queue_dir is None:
+            with tempfile.TemporaryDirectory(prefix="rlxfer-framework-") as temporary:
+                result = run_framework_case(
+                    args.producer_framework,
+                    consumer_framework,
+                    Path(temporary),
+                )
+        else:
+            result = run_framework_case(
+                args.producer_framework,
+                consumer_framework,
+                args.queue_dir,
+            )
+    except ImportError as error:
+        result = {
+            "consumer_framework": consumer_framework,
+            "coverage": "native adapter integration; not a full framework trainer",
+            "error": f"{type(error).__name__}: {error}",
+            "producer_framework": args.producer_framework,
+            "result": "BLOCKED",
+        }
+    except Exception as error:
+        result = {
+            "consumer_framework": consumer_framework,
+            "coverage": "native adapter integration; not a full framework trainer",
+            "error": f"{type(error).__name__}: {error}",
+            "producer_framework": args.producer_framework,
+            "result": "FAILED",
+        }
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if result["result"] == "PASSED" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rl_experience_transfer/examples/reliable_transfer.py
+++ b/rl_experience_transfer/examples/reliable_transfer.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run an authenticated, traced, retrying transfer with durable consumer state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from rlxfer import (
+    AuthenticatedExperienceSerializer,
+    CompatibilityRequirements,
+    ConsumerContract,
+    ExperienceBatch,
+    ExperienceConsumer,
+    ExperienceMetadata,
+    ExperienceProducer,
+    PolicyVersion,
+    ReceiptState,
+    SqliteDeliveryState,
+    TensorPayload,
+    TraceContext,
+    Trajectory,
+    trace_context_from,
+    with_trace_context,
+)
+from rlxfer.transports import FileSystemTransport
+
+_TRACE = TraceContext("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+
+
+def run(queue_path: Path, state_path: Path) -> dict[str, object]:
+    """Transfer one batch, retry once, acknowledge it, and verify durable state."""
+
+    policy = PolicyVersion(7, policy_id="actor", model_id="tiny-policy")
+    batch = with_trace_context(
+        ExperienceBatch(
+            metadata=ExperienceMetadata(
+                "rollout-worker",
+                "canonical",
+                "1.0",
+                idempotency_key="reliable-example",
+                policy_version=policy,
+            ),
+            trajectories=(
+                Trajectory(
+                    policy_version=policy,
+                    tokens=TensorPayload(np.asarray([3, 4], dtype=np.int64)),
+                    rewards={"task": 1.0},
+                ),
+            ),
+        ),
+        _TRACE,
+    )
+    contract = ConsumerContract(
+        CompatibilityRequirements(
+            "trainer",
+            "1.0",
+            policy_version=PolicyVersion(8, policy_id="actor", model_id="tiny-policy"),
+            max_policy_lag=1,
+        ),
+        required_fields=frozenset({"extensions.w3c.trace_context.traceparent"}),
+    )
+    serializer = AuthenticatedExperienceSerializer(
+        {"example-key": b"rlxfer-example-signing-key-32byt"},
+        signing_key_id="example-key",
+    )
+    state = SqliteDeliveryState(state_path)
+    transport = FileSystemTransport(queue_path)
+    producer = ExperienceProducer(
+        transport,
+        serializer=serializer,
+        consumer_contract=contract,
+    )
+    consumer = ExperienceConsumer(
+        transport,
+        serializer=serializer,
+        consumer_contract=contract,
+        state_store=state,
+    )
+    try:
+        receipt = producer.publish(batch, max_retries=1)
+        first = consumer.receive(1.0)
+        if first is None:
+            raise RuntimeError("first receive timed out")
+        first.nack("transient trainer backpressure")
+        retried = consumer.receive(1.0)
+        if retried is None:
+            raise RuntimeError("retry receive timed out")
+        if retried.attempt != 2 or trace_context_from(retried.batch) != _TRACE:
+            raise RuntimeError("retry or trace context was not preserved")
+        retried.ack()
+        result = receipt.wait(1.0)
+    finally:
+        transport.close()
+    if result.state is not ReceiptState.ACKED or not state.was_consumed("reliable-example"):
+        raise RuntimeError("terminal receipt or durable idempotency state is incorrect")
+    return {
+        "attempts": result.attempts,
+        "authenticated": True,
+        "durably_consumed": True,
+        "result": "PASSED",
+        "state": result.state.value,
+        "traceparent": _TRACE.traceparent,
+        "transport": "filesystem",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--queue-path", type=Path)
+    parser.add_argument("--state-path", type=Path)
+    arguments = parser.parse_args()
+    try:
+        if arguments.queue_path is None and arguments.state_path is None:
+            with tempfile.TemporaryDirectory(prefix="rlxfer-reliable-") as temporary:
+                root = Path(temporary)
+                result = run(root / "queue", root / "delivery.sqlite")
+        elif arguments.queue_path is not None and arguments.state_path is not None:
+            result = run(arguments.queue_path, arguments.state_path)
+        else:
+            raise ValueError("--queue-path and --state-path must be supplied together")
+    except Exception as error:
+        result = {"error": f"{type(error).__name__}: {error}", "result": "FAILED"}
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["result"] == "PASSED" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rl_experience_transfer/pyproject.toml
+++ b/rl_experience_transfer/pyproject.toml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools>=77.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rl-experience-transfer"
+version = "0.1.0"
+description = "Transport-independent reinforcement-learning experience transfer"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+dependencies = [
+    "numpy>=1.24,<2.3",
+]
+
+[project.optional-dependencies]
+nemo-rl = []
+prime-rl = []
+nixl = [
+    "nixl==0.7.1 ; sys_platform == 'linux'",
+    "nixl-cu12==1.0.1 ; sys_platform == 'linux'",
+    "torch>=2.9,<2.10",
+]
+slime = []
+miles = []
+all = [
+    "nixl==0.7.1 ; sys_platform == 'linux'",
+    "nixl-cu12==1.0.1 ; sys_platform == 'linux'",
+    "torch>=2.9,<2.10",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+testpaths = ["tests"]
+pythonpath = ["."]
+markers = [
+    "unit: deterministic isolated tests",
+    "integration: multi-component tests",
+    "e2e: end-to-end workflow tests",
+    "nixl: requires real NIXL bindings",
+    "nemo_rl: requires NeMo RL",
+    "prime_rl: requires PRIME-RL",
+    "slime: requires slime",
+    "miles: requires MILES",
+    "requires_gpu: requires a supported GPU",
+    "requires_xpu: requires an Intel XPU",
+    "multi_process: launches multiple processes",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+files = ["src", "tests"]
+
+[dependency-groups]
+dev = [
+    "mypy>=2.3.0",
+    "pytest>=8",
+    "pytest-asyncio>=1.4.0",
+    "ruff>=0.16.1",
+]

--- a/rl_experience_transfer/src/rlxfer/__init__.py
+++ b/rl_experience_transfer/src/rlxfer/__init__.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Transport-independent reinforcement-learning experience transfer."""
+
+from .adapters import AdapterRegistry, ExperienceAdapter, create_adapter
+from .api import Delivery, ExperienceConsumer, ExperienceProducer
+from .compatibility import CompatibilityReport, CompatibilityRequirements, check_compatibility
+from .contracts import ConsumerContract, SchemaMigration, SchemaMigrationRegistry
+from .errors import MigrationError
+from .model import (
+    SCHEMA_VERSION,
+    Episode,
+    ExperienceBatch,
+    ExperienceMetadata,
+    PolicyVersion,
+    SampleIdentity,
+    TensorPayload,
+    Trajectory,
+    TransferDescriptor,
+    Transition,
+)
+from .serialization import (
+    AuthenticatedExperienceSerializer,
+    BufferManager,
+    DefaultBufferManager,
+    ExperienceSerializer,
+    JsonExperienceSerializer,
+    SerializationLimits,
+    SerializedExperience,
+)
+from .state import (
+    DeadLetter,
+    DeliveryStateStore,
+    InMemoryDeliveryState,
+    SqliteDeliveryState,
+)
+from .tracing import TraceContext, trace_context_from, with_trace_context
+from .transport import (
+    DeliveryReceipt,
+    ExperienceTransport,
+    HealthStatus,
+    ReceiptResult,
+    ReceiptState,
+    TransferPlan,
+    TransportCapabilities,
+    TransportConfig,
+    TransportFactory,
+    TransportRegistry,
+    create_transport,
+)
+from .transports.fallback import FallbackTransport
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "AdapterRegistry",
+    "AuthenticatedExperienceSerializer",
+    "BufferManager",
+    "CompatibilityReport",
+    "CompatibilityRequirements",
+    "ConsumerContract",
+    "DeadLetter",
+    "DefaultBufferManager",
+    "Delivery",
+    "DeliveryReceipt",
+    "DeliveryStateStore",
+    "Episode",
+    "ExperienceAdapter",
+    "ExperienceBatch",
+    "ExperienceConsumer",
+    "ExperienceMetadata",
+    "ExperienceProducer",
+    "ExperienceSerializer",
+    "ExperienceTransport",
+    "FallbackTransport",
+    "HealthStatus",
+    "InMemoryDeliveryState",
+    "JsonExperienceSerializer",
+    "MigrationError",
+    "PolicyVersion",
+    "ReceiptResult",
+    "ReceiptState",
+    "SampleIdentity",
+    "SchemaMigration",
+    "SchemaMigrationRegistry",
+    "SerializationLimits",
+    "SerializedExperience",
+    "SqliteDeliveryState",
+    "TensorPayload",
+    "TraceContext",
+    "Trajectory",
+    "TransferDescriptor",
+    "TransferPlan",
+    "Transition",
+    "TransportCapabilities",
+    "TransportConfig",
+    "TransportFactory",
+    "TransportRegistry",
+    "check_compatibility",
+    "create_adapter",
+    "create_transport",
+    "trace_context_from",
+    "with_trace_context",
+]

--- a/rl_experience_transfer/src/rlxfer/adapters/__init__.py
+++ b/rl_experience_transfer/src/rlxfer/adapters/__init__.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Optional RL-framework adapters."""
+
+from collections.abc import Callable, Mapping
+from types import MappingProxyType
+
+from rlxfer.errors import MissingDependencyError
+
+from .base import ExperienceAdapter, IncompatibleExperienceError
+from .miles import MilesAdapter
+from .nemo_rl import NemoRLAdapter
+from .prime_rl import PrimeRLAdapter
+from .slime import SlimeAdapter
+
+AdapterFactory = Callable[[], ExperienceAdapter]
+
+
+class AdapterRegistry:
+    """Instance-scoped framework-adapter registry."""
+
+    def __init__(self, factories: Mapping[str, AdapterFactory] | None = None) -> None:
+        self._factories = dict(factories or {})
+
+    def register(self, name: str, factory: AdapterFactory) -> None:
+        """Register one factory without modifying framework or transport code."""
+        if not name or name in self._factories:
+            raise ValueError(f"adapter {name!r} is already registered or invalid")
+        self._factories[name] = factory
+
+    def create(self, name: str) -> ExperienceAdapter:
+        """Create an adapter by registered framework name."""
+        try:
+            factory = self._factories[name]
+        except KeyError as error:
+            available = ", ".join(sorted(self._factories)) or "none"
+            raise ValueError(
+                f"unknown adapter {name!r}; registered adapters: {available}"
+            ) from error
+        return factory()
+
+
+def default_adapter_registry() -> AdapterRegistry:
+    """Return a fresh registry containing the four built-in adapters."""
+    factories: Mapping[str, AdapterFactory] = MappingProxyType(
+        {
+            "miles": MilesAdapter,
+            "nemo_rl": NemoRLAdapter,
+            "prime_rl": PrimeRLAdapter,
+            "slime": SlimeAdapter,
+        }
+    )
+    return AdapterRegistry(factories)
+
+
+def create_adapter(name: str, registry: AdapterRegistry | None = None) -> ExperienceAdapter:
+    """Create a built-in or caller-registered framework adapter."""
+    return (registry or default_adapter_registry()).create(name)
+
+
+__all__ = [
+    "AdapterFactory",
+    "AdapterRegistry",
+    "ExperienceAdapter",
+    "IncompatibleExperienceError",
+    "MilesAdapter",
+    "MissingDependencyError",
+    "NemoRLAdapter",
+    "PrimeRLAdapter",
+    "SlimeAdapter",
+    "create_adapter",
+    "default_adapter_registry",
+]

--- a/rl_experience_transfer/src/rlxfer/adapters/base.py
+++ b/rl_experience_transfer/src/rlxfer/adapters/base.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Small framework-adapter contract and shared optional-import helpers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from base64 import b64decode, b64encode
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from importlib import import_module, metadata
+from typing import Any, ClassVar, Protocol, TypeGuard, cast, runtime_checkable
+
+import numpy as np
+
+from rlxfer.compatibility import CompatibilityRequirements, ensure_compatible
+from rlxfer.errors import CompatibilityError, MissingDependencyError
+from rlxfer.model import (
+    ExperienceBatch,
+    ExperienceMetadata,
+    PolicyVersion,
+    SampleIdentity,
+    TensorPayload,
+    Trajectory,
+)
+
+from .compat import SUPPORT, verify_framework_version
+
+
+class IncompatibleExperienceError(CompatibilityError):
+    """Raised when a batch cannot safely be consumed by an adapter."""
+
+
+@runtime_checkable
+class ExperienceAdapter(Protocol):
+    """Transport-independent conversion contract for one RL framework."""
+
+    framework_name: ClassVar[str]
+
+    @property
+    def framework_version(self) -> str:
+        """Return the detected framework version or ``"unavailable"``."""
+        ...
+
+    @property
+    def adapter_version(self) -> str:
+        """Return the rlxfer adapter implementation version."""
+        ...
+
+    def from_framework(self, native: Any) -> ExperienceBatch:
+        """Convert a native rollout batch to canonical experience."""
+        ...
+
+    def to_framework(self, batch: ExperienceBatch) -> Any:
+        """Reconstruct the native training input."""
+        ...
+
+    def validate_compatible(self, batch: ExperienceBatch) -> None:
+        """Reject experience that this adapter cannot consume safely."""
+        ...
+
+
+class BaseAdapter(ABC):
+    """Common version detection and dependency diagnostics."""
+
+    framework_name: ClassVar[str]
+    distribution_name: ClassVar[str]
+    import_name: ClassVar[str]
+    extra_name: ClassVar[str]
+
+    @property
+    def adapter_version(self) -> str:
+        """Return this package's adapter implementation version."""
+
+        return SUPPORT[self.framework_name].adapter_version
+
+    def _verify_framework_version(self) -> None:
+        verify_framework_version(self.framework_name, self.framework_version)
+
+    @property
+    def framework_version(self) -> str:
+        try:
+            return metadata.version(self.distribution_name)
+        except metadata.PackageNotFoundError:
+            try:
+                module = import_module(self.import_name)
+            except ModuleNotFoundError:
+                return "unavailable"
+            return str(getattr(module, "__version__", "unknown"))
+
+    def _require(self, module_name: str) -> Any:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError as error:
+            message = (
+                f"{self.framework_name} native conversion requires {self.distribution_name!r}; "
+                f"install rl-experience-transfer[{self.extra_name}] in an isolated environment"
+            )
+            raise MissingDependencyError(message) from error
+
+    def _batch(self, **values: Any) -> ExperienceBatch:
+        return ExperienceBatch(
+            metadata=ExperienceMetadata(
+                producer_id=f"{self.framework_name}-adapter",
+                producer_framework=self.framework_name,
+                producer_framework_version=self.framework_version,
+            ),
+            **values,
+        )
+
+    def _validate_batch(self, batch: ExperienceBatch) -> None:
+        self._verify_framework_version()
+        batch.validate(
+            consumer_framework=self.framework_name,
+            consumer_framework_version=self.framework_version,
+        )
+
+    @abstractmethod
+    def from_framework(self, native: Any) -> ExperienceBatch:
+        """Convert native rollout data to a canonical batch."""
+
+    @abstractmethod
+    def to_framework(self, batch: ExperienceBatch) -> Any:
+        """Reconstruct native training data."""
+
+    @abstractmethod
+    def validate_compatible(self, batch: ExperienceBatch) -> None:
+        """Validate framework-specific training requirements."""
+
+
+class GroupedSampleAdapter(BaseAdapter):
+    """Shared adapter for the intentionally compatible slime/MILES rollout shape."""
+
+    sample_module: ClassVar[str]
+    rollout_module: ClassVar[str]
+    compatible_namespaces: ClassVar[tuple[str, ...]] = ("slime", "miles")
+
+    def __init__(
+        self,
+        cross_framework_requirements: CompatibilityRequirements | None = None,
+    ) -> None:
+        self.cross_framework_requirements = cross_framework_requirements
+
+    def from_framework(self, native: Any) -> ExperienceBatch:
+        if is_sequence(native):
+            groups_value: Any = native
+            metrics: Any = None
+        else:
+            output = native_fields(native)
+            groups_value = output.get("samples")
+            metrics = output.get("metrics")
+        groups = _sample_groups(groups_value)
+
+        trajectories: list[Trajectory] = []
+        layout: list[list[int]] = []
+        for group in groups:
+            indexes: list[int] = []
+            for sample in group:
+                indexes.append(len(trajectories))
+                trajectories.append(self._sample_to_trajectory(sample))
+            layout.append(indexes)
+
+        batch = self._batch(
+            trajectories=tuple(trajectories),
+            extensions={
+                self.framework_name: {
+                    "groups": layout,
+                    "metrics": safe_native_value(metrics),
+                }
+            },
+        )
+        self.validate_compatible(batch)
+        return batch
+
+    def to_framework(self, batch: ExperienceBatch) -> Any:
+        self.validate_compatible(batch)
+        sample_type = self._require(self.sample_module).Sample
+        output_type = self._require(self.rollout_module).RolloutFnTrainOutput
+        samples = []
+        for trajectory in batch.trajectories:
+            extension = self._sample_extension(trajectory)
+            state = restore_native_value(extension)
+            if not isinstance(state, Mapping):
+                raise IncompatibleExperienceError("native sample extension must be a mapping")
+            samples.append(construct_record(sample_type, self._prepare_state(dict(state))))
+
+        extension = self._batch_extension(batch)
+        layout = extension.get("groups")
+        if not isinstance(layout, list):
+            raise IncompatibleExperienceError("grouped rollout extension lacks a groups list")
+        groups = [[samples[int(index)] for index in group] for group in layout]
+        metrics = restore_native_value(extension.get("metrics"))
+        return output_type(samples=groups, metrics=metrics)
+
+    def validate_compatible(self, batch: ExperienceBatch) -> None:
+        self._validate_batch(batch)
+        if batch.metadata.producer_framework != self.framework_name:
+            requirements = self.cross_framework_requirements
+            if requirements is None:
+                raise IncompatibleExperienceError(
+                    f"cross-framework {batch.metadata.producer_framework} -> "
+                    f"{self.framework_name} conversion is unsafe without explicit consumer "
+                    "requirements"
+                )
+            if requirements.consumer_framework != self.framework_name:
+                raise IncompatibleExperienceError(
+                    "cross-framework requirements target a different consumer framework"
+                )
+            ensure_compatible(batch, requirements)
+        for index, trajectory in enumerate(batch.trajectories):
+            state = restore_native_value(self._sample_extension(trajectory))
+            if not isinstance(state, Mapping):
+                raise IncompatibleExperienceError(f"trajectory {index} native state is malformed")
+            tokens = as_list(state.get("tokens"), field="tokens")
+            response_length = state.get("response_length", 0)
+            if not isinstance(response_length, int) or not 0 <= response_length <= len(tokens):
+                raise IncompatibleExperienceError(
+                    f"trajectory {index} response_length {response_length!r} is invalid for "
+                    f"{len(tokens)} tokens"
+                )
+            for field in ("loss_mask", "rollout_log_probs", "teacher_log_probs"):
+                value = state.get(field)
+                if value is not None and len(as_list(value, field=field)) != response_length:
+                    raise IncompatibleExperienceError(
+                        f"trajectory {index} {field} length must equal response_length"
+                    )
+
+        extension = self._batch_extension(batch)
+        layout = extension.get("groups")
+        if not isinstance(layout, list) or any(not isinstance(group, list) for group in layout):
+            raise IncompatibleExperienceError("grouped rollout extension lacks valid group nesting")
+        flattened = [int(index) for group in layout for index in group]
+        if sorted(flattened) != list(range(len(batch.trajectories))):
+            raise IncompatibleExperienceError(
+                "group nesting must reference every trajectory exactly once"
+            )
+
+    def _sample_to_trajectory(self, native: Any) -> Trajectory:
+        state = native_fields(native)
+        tokens = as_list(state.get("tokens"), field="tokens")
+        response_length = state.get("response_length", 0)
+        if not isinstance(response_length, int) or not 0 <= response_length <= len(tokens):
+            raise ValueError(
+                f"response_length {response_length!r} is invalid for {len(tokens)} tokens"
+            )
+        log_probs_value = state.get("rollout_log_probs")
+        log_probs = (
+            as_list(log_probs_value, field="rollout_log_probs")
+            if log_probs_value is not None
+            else None
+        )
+        status_value = getattr(state.get("status"), "value", state.get("status"))
+        rewards = canonical_rewards(state.get("reward"))
+        index_value = state.get("index")
+        rollout_id = state.get("rollout_id", index_value)
+        versions = state.get("weight_versions")
+        policy_version = None
+        if isinstance(versions, Sequence) and not isinstance(versions, (str, bytes)) and versions:
+            latest_version = versions[-1]
+            if isinstance(latest_version, (str, int)) and not isinstance(latest_version, bool):
+                policy_version = PolicyVersion(latest_version)
+        sequence_number = (
+            index_value
+            if isinstance(index_value, int)
+            and not isinstance(index_value, bool)
+            and index_value >= 0
+            else None
+        )
+        response_tokens = tokens[-response_length:] if response_length else []
+        return Trajectory(
+            identity=SampleIdentity(
+                request_id=str(rollout_id) if rollout_id is not None else None,
+                producer_id=f"{self.framework_name}-adapter",
+                sequence_number=sequence_number,
+            ),
+            policy_version=policy_version,
+            prompt=state.get("prompt") if isinstance(state.get("prompt"), str) else None,
+            response=state.get("response") if isinstance(state.get("response"), str) else None,
+            tokens=TensorPayload(np.asarray(response_tokens), name="tokens"),
+            rewards=rewards,
+            log_probs=TensorPayload(np.asarray(log_probs), name="log_probs")
+            if log_probs is not None
+            else None,
+            terminal=status_value == "completed",
+            truncated=status_value == "truncated",
+            extensions={self.framework_name: safe_native_value(state)},
+        )
+
+    def _sample_extension(self, trajectory: Trajectory) -> Any:
+        for namespace in (self.framework_name, *self.compatible_namespaces):
+            extension = trajectory.extensions.get(namespace)
+            if isinstance(extension, Mapping):
+                return extension
+        raise IncompatibleExperienceError(
+            f"{self.framework_name} needs a slime/MILES native sample extension"
+        )
+
+    def _batch_extension(self, batch: ExperienceBatch) -> Mapping[str, Any]:
+        for namespace in (self.framework_name, *self.compatible_namespaces):
+            extension = batch.extensions.get(namespace)
+            if isinstance(extension, Mapping):
+                return extension
+        raise IncompatibleExperienceError(
+            f"{self.framework_name} needs preserved slime/MILES group nesting"
+        )
+
+    def _prepare_state(self, state: dict[str, Any]) -> dict[str, Any]:
+        return state
+
+
+def native_fields(value: Any) -> dict[str, Any]:
+    """Return public constructor fields from a mapping, dataclass, or msgspec struct."""
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if is_dataclass(value) and not isinstance(value, type):
+        return {field.name: getattr(value, field.name) for field in fields(value)}
+    struct_fields = getattr(type(value), "__struct_fields__", ())
+    if struct_fields:
+        return {str(name): getattr(value, name) for name in struct_fields}
+    state = getattr(value, "__dict__", None)
+    if isinstance(state, Mapping):
+        return {str(key): item for key, item in state.items() if not str(key).startswith("_")}
+    raise TypeError(f"expected a mapping or native record, got {type(value).__name__}")
+
+
+def safe_native_value(value: Any) -> Any:
+    """Remove framework class instances while preserving supported tensor/array leaves."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, bytes):
+        return {"$rlxfer.bytes": b64encode(value).decode("ascii")}
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return TensorPayload(value)
+    module = type(value).__module__.split(".", 1)[0]
+    if module == "torch" and hasattr(value, "shape") and hasattr(value, "dtype"):
+        return TensorPayload(value)
+    if isinstance(value, Enum):
+        return safe_native_value(value.value)
+    if isinstance(value, Mapping):
+        return {str(key): safe_native_value(item) for key, item in value.items()}
+    if is_sequence(value):
+        return [safe_native_value(item) for item in value]
+    return {key: safe_native_value(item) for key, item in native_fields(value).items()}
+
+
+def restore_native_value(value: Any) -> Any:
+    """Restore tensor and byte leaves from a framework extension."""
+    if isinstance(value, TensorPayload):
+        return value.data
+    if isinstance(value, Mapping):
+        if set(value) == {"$rlxfer.bytes"}:
+            encoded = value["$rlxfer.bytes"]
+            if not isinstance(encoded, str):
+                raise TypeError("invalid encoded native byte payload")
+            return b64decode(encoded.encode("ascii"))
+        return {str(key): restore_native_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [restore_native_value(item) for item in value]
+    return value
+
+
+def as_list(value: Any, *, field: str) -> list[Any]:
+    """Normalize a one-dimensional tensor, array, or sequence without importing torch."""
+    if value is None:
+        return []
+    if isinstance(value, np.ndarray):
+        if value.ndim != 1:
+            raise TypeError(f"{field} must be one-dimensional, got shape {value.shape}")
+        return cast(list[Any], value.tolist())
+    if hasattr(value, "detach") and hasattr(value, "reshape"):
+        shape = getattr(value, "shape", ())
+        if len(shape) != 1:
+            raise TypeError(f"{field} must be one-dimensional, got shape {tuple(shape)}")
+        return list(value.detach().cpu().tolist())
+    if is_sequence(value):
+        result = list(value)
+        if any(is_sequence(item) for item in result):
+            raise TypeError(f"{field} must be one-dimensional")
+        return result
+    raise TypeError(f"{field} must be a one-dimensional tensor, array, or sequence")
+
+
+def construct_record(record_type: type[Any], state: Mapping[str, Any]) -> Any:
+    """Construct a native record, preferring its version-aware ``from_dict`` hook."""
+    from_dict = getattr(record_type, "from_dict", None)
+    if callable(from_dict):
+        return from_dict(dict(state))
+    return record_type(**dict(state))
+
+
+def is_sequence(value: Any) -> TypeGuard[Sequence[Any]]:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+
+
+def canonical_rewards(value: Any) -> dict[str, float | TensorPayload]:
+    if isinstance(value, (int, float)):
+        return {"reward": float(value)}
+    if isinstance(value, Mapping):
+        return {
+            str(key): float(item) for key, item in value.items() if isinstance(item, (int, float))
+        }
+    return {}
+
+
+def _sample_groups(value: Any) -> list[list[Any]]:
+    if not is_sequence(value):
+        raise TypeError("RolloutFnTrainOutput.samples must be a sequence of groups")
+    groups: list[list[Any]] = []
+    for group in value:
+        if not is_sequence(group):
+            raise TypeError("each rollout sample group must be a sequence")
+        groups.append(list(group))
+    return groups

--- a/rl_experience_transfer/src/rlxfer/adapters/compat.py
+++ b/rl_experience_transfer/src/rlxfer/adapters/compat.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Audited native-version boundaries for framework adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from rlxfer.errors import CompatibilityError
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterSupport:
+    """One adapter's version and verified native API range."""
+
+    adapter_version: str
+    native_prefixes: tuple[str, ...]
+    verified_revision: str
+
+
+SUPPORT: Mapping[str, AdapterSupport] = MappingProxyType(
+    {
+        "miles": AdapterSupport("0.1.0", ("0.2",), "319716c"),
+        "nemo_rl": AdapterSupport("0.1.0", ("0.5", "0.6", "0.7"), "daf46ff/81aa43d"),
+        "prime_rl": AdapterSupport("0.1.0", ("0.5",), "2873bf2"),
+        "slime": AdapterSupport("0.1.0", ("0.3",), "a6272da"),
+    }
+)
+
+
+def verify_framework_version(framework: str, detected: str) -> None:
+    """Reject a known version outside the audited native API range."""
+
+    if detected in {"unknown", "unavailable"}:
+        return
+    support = SUPPORT[framework]
+    revisions = tuple(support.verified_revision.split("/"))
+    if not detected.startswith((*support.native_prefixes, *revisions)):
+        expected = ", ".join(f"{prefix}.x" for prefix in support.native_prefixes)
+        raise CompatibilityError(
+            f"{framework} {detected} is outside adapter {support.adapter_version}'s "
+            f"audited versions ({expected}); install a verified framework revision or "
+            "add a version-specific compatibility implementation"
+        )

--- a/rl_experience_transfer/src/rlxfer/adapters/miles.py
+++ b/rl_experience_transfer/src/rlxfer/adapters/miles.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""MILES v0.2.1 rollout adapter."""
+
+from typing import Any, ClassVar
+
+from .base import GroupedSampleAdapter, construct_record
+
+
+class MilesAdapter(GroupedSampleAdapter):
+    """Convert MILES ``Sample`` groups and ``RolloutFnTrainOutput`` objects."""
+
+    framework_name: ClassVar[str] = "miles"
+    distribution_name: ClassVar[str] = "miles"
+    import_name: ClassVar[str] = "miles"
+    extra_name: ClassVar[str] = "miles"
+    sample_module: ClassVar[str] = "miles.utils.types"
+    rollout_module: ClassVar[str] = "miles.rollout.base_types"
+
+    def _prepare_state(self, state: dict[str, Any]) -> dict[str, Any]:
+        types = self._require(self.sample_module)
+        if isinstance(state.get("adapter"), dict):
+            state["adapter"] = construct_record(types.AdapterRef, state["adapter"])
+        if isinstance(state.get("reward_spec"), dict):
+            state["reward_spec"] = construct_record(types.RewardSpec, state["reward_spec"])
+        return state

--- a/rl_experience_transfer/src/rlxfer/adapters/nemo_rl.py
+++ b/rl_experience_transfer/src/rlxfer/adapters/nemo_rl.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""NeMo RL adapter for BatchedDataDict and v0.7 PromptGroupRecord rollouts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, ClassVar
+
+import numpy as np
+
+from rlxfer.errors import MissingDependencyError
+from rlxfer.model import ExperienceBatch, SampleIdentity, TensorPayload, Trajectory
+
+from .base import (
+    BaseAdapter,
+    IncompatibleExperienceError,
+    as_list,
+    construct_record,
+    is_sequence,
+    native_fields,
+    restore_native_value,
+    safe_native_value,
+)
+
+
+class NemoRLAdapter(BaseAdapter):
+    """Convert NeMo RL rollout containers without exposing NeMo transport internals."""
+
+    framework_name: ClassVar[str] = "nemo_rl"
+    distribution_name: ClassVar[str] = "nemo-rl"
+    import_name: ClassVar[str] = "nemo_rl"
+    extra_name: ClassVar[str] = "nemo-rl"
+
+    def from_framework(self, native: Any) -> ExperienceBatch:
+        if isinstance(native, tuple) and len(native) == 2 and isinstance(native[0], Mapping):
+            return self._from_batched(native[0], metrics=native[1])
+        if isinstance(native, Mapping):
+            return self._from_batched(native)
+        if _is_prompt_group(native):
+            return self._from_prompt_groups([native], single=True)
+        if is_sequence(native):
+            records = list(native)
+            if all(_is_prompt_group(record) for record in records):
+                return self._from_prompt_groups(records, single=False)
+        raise TypeError(
+            "NeMo RL adapter expects BatchedDataDict, (BatchedDataDict, metrics), "
+            "PromptGroupRecord, or a PromptGroupRecord sequence"
+        )
+
+    def to_framework(self, batch: ExperienceBatch) -> Any:
+        self.validate_compatible(batch)
+        extension = batch.extensions[self.framework_name]
+        if not isinstance(extension, Mapping):
+            raise IncompatibleExperienceError("extensions['nemo_rl'] must be a mapping")
+        kind = extension.get("kind")
+        if kind == "batched_data_dict":
+            module = self._require("nemo_rl.distributed.batched_data_dict")
+            fields = restore_native_value(extension.get("fields"))
+            if not isinstance(fields, Mapping):
+                raise IncompatibleExperienceError("NeMo BatchedDataDict fields are malformed")
+            return module.BatchedDataDict(dict(fields))
+        if kind == "prompt_group_records":
+            try:
+                interfaces = self._require("nemo_rl.experience.interfaces")
+            except MissingDependencyError as error:
+                raise IncompatibleExperienceError(
+                    "PromptGroupRecord reconstruction requires NeMo RL v0.7 or newer; "
+                    "v0.5 supports BatchedDataDict rollouts only"
+                ) from error
+            records_value = restore_native_value(extension.get("records"))
+            if not isinstance(records_value, list):
+                raise IncompatibleExperienceError("NeMo prompt-group records are malformed")
+            records = []
+            for record_value in records_value:
+                if not isinstance(record_value, Mapping):
+                    raise IncompatibleExperienceError("NeMo prompt-group record is malformed")
+                state = dict(record_value)
+                completions_value = state.get("completions")
+                if not isinstance(completions_value, list):
+                    raise IncompatibleExperienceError("NeMo completions must be a list")
+                state["completions"] = [
+                    construct_record(interfaces.Completion, completion)
+                    for completion in completions_value
+                    if isinstance(completion, Mapping)
+                ]
+                if len(state["completions"]) != len(completions_value):
+                    raise IncompatibleExperienceError("NeMo completion record is malformed")
+                records.append(construct_record(interfaces.PromptGroupRecord, state))
+            return records[0] if extension.get("single") else records
+        raise IncompatibleExperienceError(f"unsupported NeMo RL native kind {kind!r}")
+
+    def validate_compatible(self, batch: ExperienceBatch) -> None:
+        self._validate_batch(batch)
+        extension = batch.extensions.get(self.framework_name)
+        if not isinstance(extension, Mapping):
+            raise IncompatibleExperienceError(
+                "NeMo RL reconstruction requires extensions['nemo_rl']"
+            )
+        kind = extension.get("kind")
+        if kind == "batched_data_dict":
+            fields = restore_native_value(extension.get("fields"))
+            if not isinstance(fields, Mapping):
+                raise IncompatibleExperienceError("NeMo BatchedDataDict fields are malformed")
+            for ids_name, lengths_name in (
+                ("input_ids", "input_lengths"),
+                ("output_ids", "unpadded_sequence_lengths"),
+            ):
+                if ids_name in fields and lengths_name not in fields:
+                    raise IncompatibleExperienceError(
+                        f"NeMo field {ids_name!r} requires {lengths_name!r}"
+                    )
+            return
+        if kind == "prompt_group_records":
+            records = restore_native_value(extension.get("records"))
+            if not isinstance(records, list):
+                raise IncompatibleExperienceError("NeMo prompt-group records must be a list")
+            for record in records:
+                if not isinstance(record, Mapping) or not isinstance(
+                    record.get("completions"), list
+                ):
+                    raise IncompatibleExperienceError(
+                        "each NeMo prompt group must contain a completions list"
+                    )
+            return
+        raise IncompatibleExperienceError(f"unsupported NeMo RL native kind {kind!r}")
+
+    def _from_batched(self, native: Mapping[str, Any], metrics: Any = None) -> ExperienceBatch:
+        state = native_fields(native)
+        tensors = {
+            name: TensorPayload(value, name=name)
+            for name, value in state.items()
+            if _is_tensor(value)
+        }
+        batch = self._batch(
+            trajectories=tuple(_batched_trajectories(state)),
+            tensors=tensors,
+            payload={"native_kind": "batched_data_dict"},
+            extensions={
+                self.framework_name: {
+                    "kind": "batched_data_dict",
+                    "fields": safe_native_value(state),
+                    "metrics": safe_native_value(metrics),
+                }
+            },
+        )
+        self.validate_compatible(batch)
+        return batch
+
+    def _from_prompt_groups(self, records: list[Any], *, single: bool) -> ExperienceBatch:
+        trajectories: list[Trajectory] = []
+        layout: list[list[int]] = []
+        safe_records: list[Any] = []
+        for record in records:
+            state = native_fields(record)
+            completions = state.get("completions")
+            if not is_sequence(completions):
+                raise TypeError("PromptGroupRecord.completions must be a sequence")
+            indexes: list[int] = []
+            for completion_index, completion in enumerate(completions):
+                indexes.append(len(trajectories))
+                trajectories.append(
+                    _completion_trajectory(
+                        completion,
+                        prompt_index=state.get("prompt_idx"),
+                        completion_index=completion_index,
+                    )
+                )
+            layout.append(indexes)
+            safe_records.append(safe_native_value(state))
+
+        batch = self._batch(
+            trajectories=tuple(trajectories),
+            payload={"native_kind": "prompt_group_records"},
+            extensions={
+                self.framework_name: {
+                    "kind": "prompt_group_records",
+                    "single": single,
+                    "groups": layout,
+                    "records": safe_records,
+                }
+            },
+        )
+        self.validate_compatible(batch)
+        return batch
+
+
+def _is_prompt_group(value: Any) -> bool:
+    try:
+        return "completions" in native_fields(value) and "prompt_idx" in native_fields(value)
+    except TypeError:
+        return False
+
+
+def _is_tensor(value: Any) -> bool:
+    return isinstance(value, np.ndarray) or (
+        hasattr(value, "shape") and hasattr(value, "dtype") and hasattr(value, "stride")
+    )
+
+
+def _batched_trajectories(state: Mapping[str, Any]) -> list[Trajectory]:
+    ids_name, lengths_name = _batch_pair(state)
+    if ids_name is None or lengths_name is None:
+        return []
+    ids = state[ids_name]
+    lengths = as_list(state[lengths_name], field=lengths_name)
+    try:
+        row_count = len(ids)
+    except TypeError as error:
+        raise TypeError(f"{ids_name} must be a two-dimensional batch") from error
+    if len(lengths) != row_count:
+        raise ValueError(
+            f"{lengths_name} length {len(lengths)} must equal {ids_name} rows {row_count}"
+        )
+    trajectories = []
+    for index, length_value in enumerate(lengths):
+        if isinstance(length_value, (bool, float, complex)) or not hasattr(
+            length_value, "__index__"
+        ):
+            raise ValueError(f"{lengths_name}[{index}] must be an integer")
+        length = int(length_value)
+        if length < 0:
+            raise ValueError(f"{lengths_name}[{index}] must be non-negative")
+        token_row = _slice_row(ids, index, length)
+        kwargs: dict[str, Any] = {
+            "identity": SampleIdentity(producer_id="nemo_rl-adapter", sequence_number=index),
+            "tokens": TensorPayload(token_row, name="tokens"),
+            "extensions": {"nemo_rl": {"batch_index": index}},
+        }
+        for source, destination in (
+            ("token_mask", "attention_mask"),
+            ("generation_logprobs", "log_probs"),
+            ("prev_logprobs", "log_probs"),
+            ("reference_policy_logprobs", "reference_log_probs"),
+            ("values", "values"),
+            ("advantages", "advantages"),
+            ("returns", "returns"),
+        ):
+            if source in state and destination not in kwargs:
+                kwargs[destination] = TensorPayload(
+                    _slice_row(state[source], index, length), name=destination
+                )
+        trajectories.append(Trajectory(**kwargs))
+    return trajectories
+
+
+def _batch_pair(state: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    if "input_ids" in state and "input_lengths" in state:
+        return "input_ids", "input_lengths"
+    if "output_ids" in state and "unpadded_sequence_lengths" in state:
+        return "output_ids", "unpadded_sequence_lengths"
+    return None, None
+
+
+def _slice_row(value: Any, index: int, length: int) -> Any:
+    try:
+        row = value[index]
+        width = len(row)
+    except (IndexError, TypeError) as error:
+        raise ValueError("batched tensor must contain indexable one-dimensional rows") from error
+    if length > width:
+        raise ValueError(f"sequence length {length} exceeds padded row width {width}")
+    return row[:length]
+
+
+def _completion_trajectory(native: Any, *, prompt_index: Any, completion_index: int) -> Trajectory:
+    state = native_fields(native)
+    messages = state.get("message_log")
+    tokens: list[Any] = []
+    fallback_tokens: list[Any] = []
+    log_probs: list[Any] = []
+    response_parts: list[str] = []
+    if is_sequence(messages):
+        for message in messages:
+            if not isinstance(message, Mapping):
+                continue
+            token_ids = message.get("token_ids")
+            generation_logprobs = message.get("generation_logprobs")
+            if generation_logprobs is not None:
+                generated = as_list(generation_logprobs, field="generation_logprobs")
+                message_tokens = as_list(token_ids, field="token_ids")
+                if len(message_tokens) != len(generated):
+                    raise ValueError(
+                        "NeMo completion token_ids and generation_logprobs must have equal length"
+                    )
+                tokens.extend(message_tokens)
+                log_probs.extend(generated)
+            elif token_ids is not None and message.get("role") == "assistant":
+                fallback_tokens.extend(as_list(token_ids, field="token_ids"))
+            if message.get("role") == "assistant" and isinstance(message.get("content"), str):
+                response_parts.append(message["content"])
+    reward = state.get("reward")
+    if not log_probs:
+        tokens = fallback_tokens
+    return Trajectory(
+        identity=SampleIdentity(
+            request_id=str(prompt_index) if prompt_index is not None else None,
+            producer_id="nemo_rl-adapter",
+            sequence_number=completion_index,
+        ),
+        response="".join(response_parts) or None,
+        tokens=TensorPayload(np.asarray(tokens), name="tokens") if tokens else None,
+        rewards={"reward": float(reward)} if isinstance(reward, (int, float)) else {},
+        log_probs=TensorPayload(np.asarray(log_probs), name="log_probs") if log_probs else None,
+        terminal=not bool(state.get("truncated", False)),
+        truncated=bool(state.get("truncated", False)),
+        extensions={"nemo_rl": safe_native_value(state)},
+    )

--- a/rl_experience_transfer/src/rlxfer/adapters/prime_rl.py
+++ b/rl_experience_transfer/src/rlxfer/adapters/prime_rl.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""PRIME-RL adapter for TrainingBatch/TrainingSample at commit 2873bf2."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, ClassVar
+
+import numpy as np
+
+from rlxfer.model import ExperienceBatch, SampleIdentity, TensorPayload, Trajectory
+
+from .base import (
+    BaseAdapter,
+    IncompatibleExperienceError,
+    as_list,
+    canonical_rewards,
+    construct_record,
+    native_fields,
+    restore_native_value,
+    safe_native_value,
+)
+
+
+class PrimeRLAdapter(BaseAdapter):
+    """Convert PRIME-RL ``TrainingBatch`` objects without importing PRIME at startup."""
+
+    framework_name: ClassVar[str] = "prime_rl"
+    distribution_name: ClassVar[str] = "prime-rl"
+    import_name: ClassVar[str] = "prime_rl"
+    extra_name: ClassVar[str] = "prime-rl"
+
+    def from_framework(self, native: Any) -> ExperienceBatch:
+        batch_state = native_fields(native)
+        examples = batch_state.get("examples")
+        if not isinstance(examples, Sequence) or isinstance(examples, (str, bytes)):
+            raise TypeError("PRIME-RL TrainingBatch.examples must be a sequence")
+
+        trajectories = tuple(
+            self._to_trajectory(example, index=index) for index, example in enumerate(examples)
+        )
+        batch = self._batch(
+            trajectories=trajectories,
+            extensions={
+                self.framework_name: {
+                    "step": batch_state.get("step"),
+                    "run_idx": batch_state.get("run_idx"),
+                }
+            },
+        )
+        self.validate_compatible(batch)
+        return batch
+
+    def to_framework(self, batch: ExperienceBatch) -> Any:
+        self.validate_compatible(batch)
+        types = self._require("prime_rl.transport.types")
+        sample_type = types.TrainingSample
+        examples = []
+        for trajectory in batch.trajectories:
+            extension = trajectory.extensions.get(self.framework_name)
+            if not isinstance(extension, Mapping):
+                raise IncompatibleExperienceError(
+                    "PRIME-RL reconstruction needs extensions['prime_rl'] for each trajectory; "
+                    "prompt/completion boundaries are otherwise ambiguous"
+                )
+            state = restore_native_value(extension)
+            if not isinstance(state, Mapping):
+                raise IncompatibleExperienceError("invalid PRIME-RL native sample extension")
+            state = dict(state)
+            routed = state.get("routed_experts")
+            if isinstance(routed, Mapping):
+                state["routed_experts"] = construct_record(types.RoutedExperts, routed)
+            mm_kwargs = state.get("mm_kwargs")
+            if isinstance(mm_kwargs, Mapping):
+                state["mm_kwargs"] = {
+                    str(key): construct_record(types.EncodedTensor, value)
+                    if isinstance(value, Mapping)
+                    else value
+                    for key, value in mm_kwargs.items()
+                }
+            examples.append(construct_record(sample_type, state))
+
+        batch_extension = batch.extensions.get(self.framework_name, {})
+        if not isinstance(batch_extension, Mapping):
+            raise IncompatibleExperienceError("extensions['prime_rl'] must be a mapping")
+        return types.TrainingBatch(
+            examples=examples,
+            step=int(batch_extension.get("step", 0)),
+            run_idx=batch_extension.get("run_idx"),
+        )
+
+    def validate_compatible(self, batch: ExperienceBatch) -> None:
+        self._validate_batch(batch)
+        for index, trajectory in enumerate(batch.trajectories):
+            extension = trajectory.extensions.get(self.framework_name)
+            if not isinstance(extension, Mapping):
+                raise IncompatibleExperienceError(
+                    f"trajectory {index} lacks PRIME-RL prompt/completion metadata"
+                )
+            required = {
+                "prompt_ids",
+                "prompt_mask",
+                "completion_ids",
+                "completion_mask",
+                "completion_logprobs",
+                "completion_temperatures",
+                "env_name",
+            }
+            missing = sorted(required.difference(extension))
+            if missing:
+                raise IncompatibleExperienceError(
+                    f"trajectory {index} is missing PRIME-RL fields: {', '.join(missing)}"
+                )
+            prompt_ids = as_list(extension["prompt_ids"], field="prompt_ids")
+            prompt_mask = as_list(extension["prompt_mask"], field="prompt_mask")
+            if len(prompt_mask) != len(prompt_ids):
+                raise IncompatibleExperienceError(
+                    f"trajectory {index} prompt_mask length {len(prompt_mask)} does not match "
+                    f"prompt_ids length {len(prompt_ids)}"
+                )
+            completion_ids = as_list(extension["completion_ids"], field="completion_ids")
+            for field in ("completion_mask", "completion_logprobs", "completion_temperatures"):
+                values = as_list(extension[field], field=field)
+                if len(values) != len(completion_ids):
+                    raise IncompatibleExperienceError(
+                        f"trajectory {index} {field} length {len(values)} does not match "
+                        f"completion_ids length {len(completion_ids)}"
+                    )
+            teacher = extension.get("teacher_logprobs")
+            if teacher is not None:
+                teacher_length = len(as_list(teacher, field="teacher_logprobs"))
+                expected_lengths = (len(completion_ids), len(prompt_ids) + len(completion_ids))
+                if teacher_length not in expected_lengths:
+                    raise IncompatibleExperienceError(
+                        f"trajectory {index} teacher_logprobs must align with the completion "
+                        "or full sequence"
+                    )
+
+    def _to_trajectory(self, native: Any, *, index: int) -> Trajectory:
+        state = native_fields(native)
+        as_list(state.get("prompt_ids"), field="prompt_ids")
+        completion_ids = as_list(state.get("completion_ids"), field="completion_ids")
+        completion_logprobs = as_list(state.get("completion_logprobs"), field="completion_logprobs")
+        return Trajectory(
+            identity=SampleIdentity(producer_id="prime_rl-adapter", sequence_number=index),
+            tokens=TensorPayload(np.asarray(completion_ids), name="tokens"),
+            rewards=canonical_rewards(state.get("reward")),
+            log_probs=TensorPayload(np.asarray(completion_logprobs), name="log_probs")
+            if completion_logprobs
+            else None,
+            advantages=TensorPayload(
+                np.full(len(completion_ids), float(state["advantage"])), name="advantages"
+            )
+            if state.get("advantage") is not None
+            else None,
+            extensions={self.framework_name: safe_native_value(state)},
+        )

--- a/rl_experience_transfer/src/rlxfer/adapters/slime.py
+++ b/rl_experience_transfer/src/rlxfer/adapters/slime.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""slime v0.3.1 rollout adapter."""
+
+from typing import ClassVar
+
+from .base import GroupedSampleAdapter
+
+
+class SlimeAdapter(GroupedSampleAdapter):
+    """Convert slime ``Sample`` groups and ``RolloutFnTrainOutput`` objects."""
+
+    framework_name: ClassVar[str] = "slime"
+    distribution_name: ClassVar[str] = "slime"
+    import_name: ClassVar[str] = "slime"
+    extra_name: ClassVar[str] = "slime"
+    sample_module: ClassVar[str] = "slime.utils.types"
+    rollout_module: ClassVar[str] = "slime.rollout.base_types"

--- a/rl_experience_transfer/src/rlxfer/api.py
+++ b/rl_experience_transfer/src/rlxfer/api.py
@@ -1,0 +1,547 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Transport-independent producer, consumer, and delivery APIs."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field, replace
+from threading import Lock
+from typing import TypeVar
+from uuid import uuid4
+
+from .adapters.base import ExperienceAdapter
+from .contracts import ConsumerContract, SchemaMigrationRegistry
+from .errors import ClosedError, DeliveryError, IntegrityError
+from .model import SCHEMA_VERSION, ExperienceBatch, ExperienceMetadata, Trajectory
+from .observability import Metrics, NullMetrics, structured_log
+from .serialization import ExperienceSerializer, JsonExperienceSerializer
+from .state import DeadLetter, DeliveryStateStore, InMemoryDeliveryState
+from .transport import (
+    DeliveryReceipt,
+    ExperienceTransport,
+    HealthStatus,
+    TransferPlan,
+    TransportCapabilities,
+    TransportDelivery,
+)
+
+_EndpointT = TypeVar("_EndpointT", bound="_Endpoint")
+
+
+class _Endpoint:
+    """Shared transport lifecycle for producers and consumers."""
+
+    _role = "endpoint"
+
+    def __init__(
+        self,
+        transport: ExperienceTransport,
+        serializer: ExperienceSerializer | None,
+        metrics: Metrics | None,
+        logger: logging.Logger | None,
+    ) -> None:
+        self.transport = transport
+        self.serializer = serializer or JsonExperienceSerializer()
+        self.metrics = metrics or NullMetrics()
+        self.logger = logger
+        self._closed = False
+        self._close_lock = Lock()
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        """Return the selected transport's advertised capabilities."""
+
+        return self.transport.capabilities
+
+    def health(self) -> HealthStatus:
+        """Return transport health."""
+
+        return self.transport.health()
+
+    def close(self, timeout: float | None = None) -> None:
+        """Gracefully close the selected transport."""
+
+        with self._close_lock:
+            if self._closed:
+                return
+            self.transport.close(timeout)
+            self._closed = True
+
+    async def close_async(self, timeout: float | None = None) -> None:
+        """Asynchronously close using a worker thread."""
+
+        await asyncio.to_thread(self.close, timeout)
+
+    def __enter__(self: _EndpointT) -> _EndpointT:
+        self._ensure_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        del exc_type, exc_value, traceback
+        self.close()
+
+    async def __aenter__(self: _EndpointT) -> _EndpointT:
+        self._ensure_open()
+        return self
+
+    async def __aexit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        del exc_type, exc_value, traceback
+        await self.close_async()
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ClosedError(f"experience {self._role} is closed")
+
+    def _log(self, event: str, **fields: object) -> None:
+        if self.logger is not None:
+            structured_log(self.logger, event, **fields)
+
+
+@dataclass(slots=True)
+class Delivery:
+    """One received experience with explicit, single-use settlement methods."""
+
+    experience: ExperienceBatch
+    attempt: int
+    published_at: float
+    idempotency_key: str
+    _adapter: ExperienceAdapter | None = field(default=None, repr=False)
+    _ack_callback: Callable[[], None] = field(repr=False, default=lambda: None)
+    _nack_callback: Callable[[str, bool], None] = field(
+        repr=False, default=lambda _reason, _retry: None
+    )
+    _reject_callback: Callable[[str], None] = field(repr=False, default=lambda _reason: None)
+    _state: str | None = field(init=False, default=None, repr=False)
+    _lock: Lock = field(init=False, default_factory=Lock, repr=False)
+
+    @property
+    def batch(self) -> ExperienceBatch:
+        """Alias for :attr:`experience`."""
+
+        return self.experience
+
+    @property
+    def experience_id(self) -> str:
+        """Return the canonical experience identifier."""
+
+        return self.experience.experience_id
+
+    @property
+    def settled(self) -> bool:
+        """Whether this delivery was acknowledged, nacked, or rejected."""
+
+        return self._state is not None
+
+    @property
+    def state(self) -> str | None:
+        """Return ``acknowledged``, ``nacked``, ``rejected``, or ``None``."""
+
+        return self._state
+
+    def to_framework(self) -> object:
+        """Convert to native training input, or return the canonical batch unchanged."""
+
+        if self._adapter is None:
+            return self.experience
+        return self._adapter.to_framework(self.experience)
+
+    def ack(self) -> None:
+        """Acknowledge successful, idempotent consumption."""
+
+        self._settle("acknowledged", self._ack_callback)
+
+    def nack(self, reason: str, *, retry: bool = True) -> None:
+        """Negatively acknowledge, optionally requesting redelivery."""
+
+        if not reason:
+            raise ValueError("nack reason must be non-empty")
+        self._settle("nacked", lambda: self._nack_callback(reason, retry))
+
+    def reject(self, reason: str) -> None:
+        """Permanently reject an incompatible or malformed experience."""
+
+        if not reason:
+            raise ValueError("rejection reason must be non-empty")
+        self._settle("rejected", lambda: self._reject_callback(reason))
+
+    async def ack_async(self) -> None:
+        """Asynchronously acknowledge using a worker thread."""
+
+        await asyncio.to_thread(self.ack)
+
+    async def nack_async(self, reason: str, *, retry: bool = True) -> None:
+        """Asynchronously nack using a worker thread."""
+
+        await asyncio.to_thread(self.nack, reason, retry=retry)
+
+    async def reject_async(self, reason: str) -> None:
+        """Asynchronously reject using a worker thread."""
+
+        await asyncio.to_thread(self.reject, reason)
+
+    def _settle(self, state: str, callback: Callable[[], None]) -> None:
+        with self._lock:
+            if self._state is not None:
+                raise DeliveryError(f"delivery is already {self._state}")
+            callback()
+            self._state = state
+
+
+class ExperienceProducer(_Endpoint):
+    """Validate, serialize, and publish framework-native or canonical experience."""
+
+    _role = "producer"
+
+    def __init__(
+        self,
+        transport: ExperienceTransport,
+        adapter: ExperienceAdapter | None = None,
+        serializer: ExperienceSerializer | None = None,
+        metrics: Metrics | None = None,
+        logger: logging.Logger | None = None,
+        *,
+        producer_id: str | None = None,
+        producer_framework: str | None = None,
+        producer_framework_version: str | None = None,
+        transfer_plan: TransferPlan | None = None,
+        consumer_contract: ConsumerContract | None = None,
+        migration_registry: SchemaMigrationRegistry | None = None,
+    ) -> None:
+        super().__init__(transport, serializer, metrics, logger)
+        self.adapter = adapter
+        self.producer_id = producer_id or f"producer-{uuid4()}"
+        self.producer_framework = producer_framework or (
+            adapter.framework_name if adapter is not None else "canonical"
+        )
+        self.producer_framework_version = producer_framework_version or (
+            adapter.framework_version if adapter is not None else SCHEMA_VERSION
+        )
+        self.transfer_plan = transfer_plan
+        self.consumer_contract = consumer_contract
+        self.migration_registry = migration_registry
+
+    def publish(
+        self,
+        value: object,
+        *,
+        timeout: float | None = None,
+        max_retries: int = 3,
+        idempotency_key: str | None = None,
+    ) -> DeliveryReceipt:
+        """Publish a native rollout, canonical batch, or one trajectory."""
+
+        self._ensure_open()
+        batch = self._canonicalize(value)
+        key = idempotency_key or batch.metadata.idempotency_key or batch.experience_id
+        if not key:
+            raise ValueError("idempotency key must be non-empty")
+        if batch.metadata.idempotency_key != key:
+            batch = replace(batch, metadata=replace(batch.metadata, idempotency_key=key))
+        if self.consumer_contract is not None:
+            batch = self.consumer_contract.negotiate(batch, self.migration_registry)
+            if batch.metadata.idempotency_key != key:
+                batch = replace(batch, metadata=replace(batch.metadata, idempotency_key=key))
+        serialization_started = time.monotonic()
+        try:
+            serialized = self.serializer.serialize(batch)
+        except Exception:
+            self.metrics.increment("serialization_failures")
+            raise
+        self.metrics.observe(
+            "serialization_latency_seconds", time.monotonic() - serialization_started
+        )
+        self.metrics.observe("metadata_bytes", float(len(serialized.metadata)))
+        actual_devices = frozenset(
+            segment.wire_device.split(":", 1)[0] for segment in serialized.buffers
+        ) or frozenset({"cpu"})
+        requirements = self.transfer_plan or TransferPlan(device_types=frozenset())
+        replace(
+            requirements,
+            total_bytes=serialized.nbytes,
+            buffer_count=len(serialized.buffers),
+            device_types=requirements.device_types | actual_devices,
+        ).check(self.transport.capabilities)
+        transfer_started = time.monotonic()
+        try:
+            receipt = self.transport.publish(
+                serialized,
+                experience_id=batch.experience_id,
+                idempotency_key=key,
+                timeout=timeout,
+                max_retries=max_retries,
+            )
+        except Exception:
+            self.metrics.increment("transfer_failures")
+            raise
+        self.metrics.observe("transfer_latency_seconds", time.monotonic() - transfer_started)
+        self.metrics.increment("produced_batches")
+        self.metrics.increment("produced_trajectories", _trajectory_count(batch))
+        self.metrics.increment("bytes_transferred", serialized.nbytes)
+        self._log(
+            "experience_published",
+            experience_id=batch.experience_id,
+            producer_id=batch.metadata.producer_id,
+            producer_framework=batch.metadata.producer_framework,
+            transport=self.transport.capabilities.name,
+            trajectories=_trajectory_count(batch),
+            bytes=serialized.nbytes,
+        )
+        return receipt
+
+    def publish_batch(
+        self,
+        batch: ExperienceBatch,
+        *,
+        timeout: float | None = None,
+        max_retries: int = 3,
+        idempotency_key: str | None = None,
+    ) -> DeliveryReceipt:
+        """Typed convenience wrapper around :meth:`publish`."""
+
+        return self.publish(
+            batch,
+            timeout=timeout,
+            max_retries=max_retries,
+            idempotency_key=idempotency_key,
+        )
+
+    def publish_trajectory(
+        self,
+        trajectory: Trajectory,
+        *,
+        timeout: float | None = None,
+        max_retries: int = 3,
+        idempotency_key: str | None = None,
+    ) -> DeliveryReceipt:
+        """Wrap and publish one canonical trajectory."""
+
+        return self.publish(
+            trajectory,
+            timeout=timeout,
+            max_retries=max_retries,
+            idempotency_key=idempotency_key,
+        )
+
+    async def publish_async(
+        self,
+        value: object,
+        *,
+        timeout: float | None = None,
+        max_retries: int = 3,
+        idempotency_key: str | None = None,
+    ) -> DeliveryReceipt:
+        """Asynchronously publish using a worker thread."""
+
+        return await asyncio.to_thread(
+            self.publish,
+            value,
+            timeout=timeout,
+            max_retries=max_retries,
+            idempotency_key=idempotency_key,
+        )
+
+    def cancel(self, receipt: DeliveryReceipt, reason: str = "cancelled") -> None:
+        """Cancel a publish that has not become inflight."""
+
+        if not reason:
+            raise ValueError("cancellation reason must be non-empty")
+        self.transport.cancel(receipt.receipt_id, reason)
+
+    async def cancel_async(self, receipt: DeliveryReceipt, reason: str = "cancelled") -> None:
+        """Asynchronously cancel a pending publish."""
+
+        await asyncio.to_thread(self.cancel, receipt, reason)
+
+    def _canonicalize(self, value: object) -> ExperienceBatch:
+        if isinstance(value, ExperienceBatch):
+            return value
+        if isinstance(value, Trajectory):
+            metadata = ExperienceMetadata(
+                producer_id=self.producer_id,
+                producer_framework=self.producer_framework,
+                producer_framework_version=self.producer_framework_version,
+                policy_version=value.policy_version,
+            )
+            return ExperienceBatch(metadata=metadata, trajectories=(value,))
+        if self.adapter is None:
+            raise TypeError("publishing framework-native experience requires an ExperienceAdapter")
+        return self.adapter.from_framework(value)
+
+
+class ExperienceConsumer(_Endpoint):
+    """Receive canonical experience with explicit settlement and duplicate suppression."""
+
+    _role = "consumer"
+
+    def __init__(
+        self,
+        transport: ExperienceTransport,
+        adapter: ExperienceAdapter | None = None,
+        serializer: ExperienceSerializer | None = None,
+        metrics: Metrics | None = None,
+        logger: logging.Logger | None = None,
+        *,
+        duplicate_cache_size: int = 4096,
+        state_store: DeliveryStateStore | None = None,
+        consumer_contract: ConsumerContract | None = None,
+        migration_registry: SchemaMigrationRegistry | None = None,
+    ) -> None:
+        if isinstance(duplicate_cache_size, bool) or duplicate_cache_size < 1:
+            raise ValueError("duplicate_cache_size must be positive")
+        super().__init__(transport, serializer, metrics, logger)
+        self.adapter = adapter
+        self.consumer_contract = consumer_contract
+        self.migration_registry = migration_registry
+        self.state_store = state_store or InMemoryDeliveryState(duplicate_cache_size)
+
+    def receive(self, timeout: float | None = None) -> Delivery | None:
+        """Receive the next non-duplicate delivery, blocking up to ``timeout`` seconds."""
+
+        self._ensure_open()
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            raw = self.transport.receive(remaining)
+            if raw is None:
+                return None
+            if self._was_seen(raw.idempotency_key):
+                self.transport.ack(raw.token)
+                self.metrics.increment("duplicate_deliveries")
+                self._log(
+                    "duplicate_delivery_acknowledged",
+                    experience_id=raw.experience_id,
+                    transport=self.transport.capabilities.name,
+                )
+                continue
+            return self._prepare(raw)
+
+    async def receive_async(self, timeout: float | None = None) -> Delivery | None:
+        """Asynchronously receive using a worker thread."""
+
+        return await asyncio.to_thread(self.receive, timeout)
+
+    def _prepare(self, raw: TransportDelivery) -> Delivery:
+        started = time.monotonic()
+        try:
+            batch = self.serializer.deserialize(raw.payload)
+            if batch.experience_id != raw.experience_id:
+                raise IntegrityError("transport and payload experience IDs differ")
+            if (
+                batch.metadata.idempotency_key is not None
+                and batch.metadata.idempotency_key != raw.idempotency_key
+            ):
+                raise IntegrityError("transport and payload idempotency keys differ")
+            if self.consumer_contract is not None:
+                batch = self.consumer_contract.negotiate(batch, self.migration_registry)
+            if self.adapter is not None:
+                batch.validate(
+                    consumer_framework=self.adapter.framework_name,
+                    consumer_framework_version=self.adapter.framework_version,
+                )
+                self.adapter.validate_compatible(batch)
+        except Exception as error:
+            self.metrics.increment("rejected_deliveries")
+            reason = _safe_reason(error)
+            self._log(
+                "experience_rejected",
+                experience_id=raw.experience_id,
+                error_type=type(error).__name__,
+                transport=self.transport.capabilities.name,
+            )
+            self._record_dead_letter(raw, reason)
+            try:
+                self.transport.reject(raw.token, reason)
+            except Exception:
+                self.metrics.increment("cleanup_failures")
+            raise
+        self.metrics.observe("deserialization_latency_seconds", time.monotonic() - started)
+        self.metrics.increment("received_batches")
+        self._log(
+            "experience_received",
+            experience_id=batch.experience_id,
+            producer_framework=batch.metadata.producer_framework,
+            transport=self.transport.capabilities.name,
+            attempt=raw.attempt,
+        )
+
+        def ack() -> None:
+            ack_started = time.monotonic()
+            self._remember(raw.idempotency_key)
+            self.transport.ack(raw.token)
+            self.metrics.increment("consumed_batches")
+            self.metrics.increment("consumed_trajectories", _trajectory_count(batch))
+            self.metrics.observe("acknowledgement_latency_seconds", time.monotonic() - ack_started)
+            self.metrics.observe(
+                "end_to_end_latency_seconds", max(0.0, time.time() - raw.published_at)
+            )
+            self._log(
+                "experience_acknowledged",
+                experience_id=batch.experience_id,
+                transport=self.transport.capabilities.name,
+            )
+
+        def nack(reason: str, retry: bool) -> None:
+            if not retry or raw.attempt > raw.max_retries:
+                self._record_dead_letter(raw, reason)
+            self.transport.nack(raw.token, reason, retry=retry)
+            self.metrics.increment("nacks")
+            if retry:
+                self.metrics.increment("retries")
+            self._log(
+                "experience_nacked",
+                experience_id=batch.experience_id,
+                retry=retry,
+                transport=self.transport.capabilities.name,
+            )
+
+        def reject(reason: str) -> None:
+            self._record_dead_letter(raw, reason)
+            self.transport.reject(raw.token, reason)
+            self.metrics.increment("rejected_deliveries")
+            self._log(
+                "experience_rejected",
+                experience_id=batch.experience_id,
+                transport=self.transport.capabilities.name,
+            )
+
+        return Delivery(
+            experience=batch,
+            attempt=raw.attempt,
+            published_at=raw.published_at,
+            idempotency_key=raw.idempotency_key,
+            _adapter=self.adapter,
+            _ack_callback=ack,
+            _nack_callback=nack,
+            _reject_callback=reject,
+        )
+
+    def _was_seen(self, key: str) -> bool:
+        return self.state_store.was_consumed(key)
+
+    def _remember(self, key: str) -> None:
+        self.state_store.mark_consumed(key)
+
+    def _record_dead_letter(self, raw: TransportDelivery, reason: str) -> None:
+        try:
+            self.state_store.record_dead_letter(
+                DeadLetter(
+                    experience_id=raw.experience_id,
+                    idempotency_key=raw.idempotency_key,
+                    reason=reason[:2048],
+                    attempt=raw.attempt,
+                )
+            )
+        except Exception:
+            self.metrics.increment("state_store_failures")
+
+
+def _trajectory_count(batch: ExperienceBatch) -> int:
+    return len(batch.trajectories) + sum(len(episode.trajectories) for episode in batch.episodes)
+
+
+def _safe_reason(error: Exception) -> str:
+    return f"{type(error).__name__}: delivery validation failed"

--- a/rl_experience_transfer/src/rlxfer/compatibility.py
+++ b/rl_experience_transfer/src/rlxfer/compatibility.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Semantic compatibility checks between experience producers and consumers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .errors import CompatibilityError
+from .model import ExperienceBatch, PolicyVersion
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityRequirements:
+    """Consumer semantics that must match before a transfer begins."""
+
+    consumer_framework: str
+    consumer_framework_version: str
+    algorithm: str | None = None
+    tokenizer_id: str | None = None
+    model_id: str | None = None
+    policy_version: PolicyVersion | None = None
+    reward_definition: str | None = None
+    sequence_format: str | None = None
+    padding: str | None = None
+    chat_template: str | None = None
+    truncation: str | None = None
+    requires_reference_log_probs: bool = False
+    max_policy_lag: int | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("consumer_framework", "consumer_framework_version"):
+            if not isinstance(getattr(self, name), str) or not getattr(self, name):
+                raise ValueError(f"{name} must be non-empty")
+        if self.max_policy_lag is not None and (
+            isinstance(self.max_policy_lag, bool)
+            or not isinstance(self.max_policy_lag, int)
+            or self.max_policy_lag < 0
+        ):
+            raise ValueError("max_policy_lag must be a non-negative integer or None")
+        if self.policy_version is not None:
+            self.policy_version.validate()
+        if self.max_policy_lag is not None:
+            if self.policy_version is None:
+                raise ValueError("max_policy_lag requires policy_version")
+            if not isinstance(self.policy_version.version, int):
+                raise ValueError("max_policy_lag requires an integer policy version")
+        if not isinstance(self.requires_reference_log_probs, bool):
+            raise ValueError("requires_reference_log_probs must be a boolean")
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityIssue:
+    """One actionable incompatibility."""
+
+    field: str
+    producer_value: object
+    consumer_value: object
+    reason: str
+    action: str
+
+    def __str__(self) -> str:
+        return (
+            f"{self.field}: {self.reason} "
+            f"(producer={self.producer_value!r}, consumer={self.consumer_value!r}); "
+            f"action: {self.action}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityReport:
+    """Complete compatibility result; all detected problems are retained."""
+
+    experience_id: str
+    producer_framework: str
+    producer_framework_version: str
+    consumer_framework: str
+    consumer_framework_version: str
+    issues: tuple[CompatibilityIssue, ...] = ()
+
+    @property
+    def compatible(self) -> bool:
+        """Whether the experience is safe for this consumer."""
+
+        return not self.issues
+
+    def raise_if_incompatible(self) -> None:
+        """Raise an actionable error when any requirement is unmet."""
+
+        if self.compatible:
+            return
+        detail = "; ".join(str(issue) for issue in self.issues)
+        raise CompatibilityError(
+            f"experience {self.experience_id} from "
+            f"{self.producer_framework}@{self.producer_framework_version} is incompatible with "
+            f"{self.consumer_framework}@{self.consumer_framework_version}: {detail}"
+        )
+
+
+def check_compatibility(
+    batch: ExperienceBatch,
+    requirements: CompatibilityRequirements,
+) -> CompatibilityReport:
+    """Validate schema and compare every declared consumer semantic requirement."""
+
+    batch.validate(
+        consumer_framework=requirements.consumer_framework,
+        consumer_framework_version=requirements.consumer_framework_version,
+    )
+    metadata = batch.metadata
+    issues: list[CompatibilityIssue] = []
+    semantic_fields = (
+        "algorithm",
+        "tokenizer_id",
+        "model_id",
+        "reward_definition",
+        "sequence_format",
+        "padding",
+        "chat_template",
+        "truncation",
+    )
+    for field_name in semantic_fields:
+        producer_value = getattr(metadata, field_name)
+        consumer_value = getattr(requirements, field_name)
+        issue = _semantic_issue(field_name, producer_value, consumer_value)
+        if issue is not None:
+            issues.append(issue)
+    policy_issue = _policy_issue(metadata.policy_version, requirements)
+    if policy_issue is not None:
+        issues.append(policy_issue)
+    trajectories = batch.trajectories + tuple(
+        trajectory for episode in batch.episodes for trajectory in episode.trajectories
+    )
+    for index, trajectory in enumerate(trajectories):
+        if trajectory.policy_version in {None, metadata.policy_version}:
+            continue
+        issue = _policy_issue(
+            trajectory.policy_version,
+            requirements,
+            field=f"trajectories[{index}].policy_version",
+        )
+        if issue is not None:
+            issues.append(issue)
+    if requirements.requires_reference_log_probs and not _has_reference_log_probs(batch):
+        issues.append(
+            CompatibilityIssue(
+                "reference_log_probs",
+                "absent",
+                "required",
+                "the consumer algorithm requires reference-policy log probabilities",
+                "generate reference log probabilities during rollout before publishing",
+            )
+        )
+    return CompatibilityReport(
+        experience_id=metadata.experience_id,
+        producer_framework=metadata.producer_framework,
+        producer_framework_version=metadata.producer_framework_version,
+        consumer_framework=requirements.consumer_framework,
+        consumer_framework_version=requirements.consumer_framework_version,
+        issues=tuple(issues),
+    )
+
+
+def ensure_compatible(batch: ExperienceBatch, requirements: CompatibilityRequirements) -> None:
+    """Raise :class:`CompatibilityError` unless ``batch`` meets ``requirements``."""
+
+    check_compatibility(batch, requirements).raise_if_incompatible()
+
+
+def _semantic_issue(field: str, producer: object, consumer: object) -> CompatibilityIssue | None:
+    if consumer is None or producer == consumer:
+        return None
+    missing = producer is None
+    return CompatibilityIssue(
+        field,
+        producer,
+        consumer,
+        "producer did not declare a required semantic" if missing else "semantic values differ",
+        (
+            f"set producer metadata.{field} to the consumer-compatible value"
+            if missing
+            else "use matching rollout/training configuration or reject this experience"
+        ),
+    )
+
+
+def _policy_issue(
+    producer: PolicyVersion | None,
+    requirements: CompatibilityRequirements,
+    *,
+    field: str = "policy_version",
+) -> CompatibilityIssue | None:
+    consumer = requirements.policy_version
+    if consumer is None or producer == consumer:
+        return None
+    if producer is None:
+        return CompatibilityIssue(
+            field,
+            producer,
+            consumer,
+            "policy identity is missing or differs",
+            "use a matching policy or configure max_policy_lag for matching integer versions",
+        )
+    lag = requirements.max_policy_lag
+    matching_identity = (
+        producer.policy_id == consumer.policy_id and producer.model_id == consumer.model_id
+    )
+    if (
+        lag is not None
+        and matching_identity
+        and isinstance(producer.version, int)
+        and isinstance(consumer.version, int)
+        and 0 <= consumer.version - producer.version <= lag
+    ):
+        return None
+    if not matching_identity:
+        reason = "policy identity is missing or differs"
+    elif isinstance(producer.version, int) and isinstance(consumer.version, int):
+        delta = consumer.version - producer.version
+        reason = "producer policy is newer than the consumer" if delta < 0 else "policy is stale"
+    else:
+        reason = "non-numeric policy versions must match exactly"
+    return CompatibilityIssue(
+        field,
+        producer,
+        consumer,
+        reason,
+        "use a matching policy or configure max_policy_lag for matching integer versions",
+    )
+
+
+def _has_reference_log_probs(batch: ExperienceBatch) -> bool:
+    trajectories = batch.trajectories + tuple(
+        trajectory for episode in batch.episodes for trajectory in episode.trajectories
+    )
+    return (
+        bool(trajectories)
+        and all(trajectory.reference_log_probs is not None for trajectory in trajectories)
+    ) or any(name in batch.tensors for name in ("reference_log_probs", "ref_log_probs"))

--- a/rl_experience_transfer/src/rlxfer/contracts.py
+++ b/rl_experience_transfer/src/rlxfer/contracts.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Consumer preflight contracts and explicit schema migrations."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+from .compatibility import CompatibilityRequirements, ensure_compatible
+from .errors import CompatibilityError, MigrationError
+from .model import SCHEMA_VERSION, ExperienceBatch
+
+SchemaMigration = Callable[[ExperienceBatch], ExperienceBatch]
+
+
+class SchemaMigrationRegistry:
+    """Instance-scoped graph of explicit, deterministic schema migrations."""
+
+    def __init__(
+        self,
+        migrations: Mapping[tuple[str, str], SchemaMigration] | None = None,
+    ) -> None:
+        self._migrations: dict[tuple[str, str], SchemaMigration] = {}
+        for (source, target), migration in (migrations or {}).items():
+            self.register(source, target, migration)
+
+    def register(self, source: str, target: str, migration: SchemaMigration) -> None:
+        """Register one directed migration without replacing an existing edge."""
+
+        if (
+            not isinstance(source, str)
+            or not isinstance(target, str)
+            or not source
+            or not target
+            or source == target
+        ):
+            raise ValueError("migration versions must be distinct non-empty strings")
+        if not callable(migration):
+            raise TypeError("migration must be callable")
+        edge = (source, target)
+        if edge in self._migrations:
+            raise ValueError(f"migration {source!r} -> {target!r} is already registered")
+        self._migrations[edge] = migration
+
+    def migrate(
+        self,
+        batch: ExperienceBatch,
+        target: str = SCHEMA_VERSION,
+    ) -> ExperienceBatch:
+        """Apply the shortest registered migration path and validate the result."""
+
+        if not isinstance(batch, ExperienceBatch) or not isinstance(target, str) or not target:
+            raise TypeError("migrate requires an ExperienceBatch and non-empty target version")
+        source = batch.metadata.schema_version
+        result = batch
+        original_id = batch.experience_id
+        for expected_source, expected_target in self._path(source, target):
+            try:
+                migrated = self._migrations[(expected_source, expected_target)](result)
+            except Exception as error:
+                raise MigrationError(
+                    f"schema migration {expected_source!r} -> {expected_target!r} failed"
+                ) from error
+            if not isinstance(migrated, ExperienceBatch):
+                raise MigrationError("schema migration must return an ExperienceBatch")
+            if migrated.metadata.schema_version != expected_target:
+                raise MigrationError(
+                    f"schema migration {expected_source!r} -> {expected_target!r} returned "
+                    f"version {migrated.metadata.schema_version!r}"
+                )
+            if migrated.experience_id != original_id:
+                raise MigrationError("schema migration changed experience_id")
+            result = migrated
+        if target == SCHEMA_VERSION:
+            result.validate()
+        return result
+
+    def _path(self, source: str, target: str) -> tuple[tuple[str, str], ...]:
+        if source == target:
+            return ()
+        queue: deque[tuple[str, tuple[tuple[str, str], ...]]] = deque([(source, ())])
+        visited = {source}
+        while queue:
+            version, path = queue.popleft()
+            for edge in sorted(edge for edge in self._migrations if edge[0] == version):
+                next_version = edge[1]
+                next_path = (*path, edge)
+                if next_version == target:
+                    return next_path
+                if next_version not in visited:
+                    visited.add(next_version)
+                    queue.append((next_version, next_path))
+        raise MigrationError(f"no schema migration path from {source!r} to {target!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsumerContract:
+    """Schema, field, and semantic requirements checked before publication."""
+
+    requirements: CompatibilityRequirements
+    supported_schema_versions: frozenset[str] = frozenset({SCHEMA_VERSION})
+    required_fields: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.requirements, CompatibilityRequirements):
+            raise TypeError("requirements must be CompatibilityRequirements")
+        if not self.supported_schema_versions or any(
+            not isinstance(version, str) or not version
+            for version in self.supported_schema_versions
+        ):
+            raise ValueError("supported_schema_versions must contain non-empty versions")
+        if SCHEMA_VERSION not in self.supported_schema_versions:
+            raise ValueError(f"supported_schema_versions must include {SCHEMA_VERSION!r}")
+        if any(
+            not isinstance(path, str) or not path or ".." in path for path in self.required_fields
+        ):
+            raise ValueError("required_fields must contain valid dotted paths")
+
+    def negotiate(
+        self,
+        batch: ExperienceBatch,
+        migrations: SchemaMigrationRegistry | None = None,
+    ) -> ExperienceBatch:
+        """Migrate when configured, then reject unsupported or incomplete experience."""
+
+        result = batch
+        if result.metadata.schema_version != SCHEMA_VERSION:
+            if migrations is None:
+                raise CompatibilityError(
+                    f"consumer does not support schema {result.metadata.schema_version!r}; "
+                    f"supported versions: {sorted(self.supported_schema_versions)!r}"
+                )
+            result = migrations.migrate(result)
+        ensure_compatible(result, self.requirements)
+        missing = sorted(path for path in self.required_fields if not _field_present(result, path))
+        if missing:
+            raise CompatibilityError(f"consumer-required fields are missing: {missing!r}")
+        return result
+
+
+def _field_present(root: object, path: str) -> bool:
+    return _present(root, tuple(path.split(".")))
+
+
+def _present(value: object, parts: tuple[str, ...]) -> bool:
+    if not parts:
+        return value is not None
+    if isinstance(value, Mapping):
+        for width in range(len(parts), 0, -1):
+            key = ".".join(parts[:width])
+            if key in value:
+                return _present(value[key], parts[width:])
+        return False
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return bool(value) and all(_present(item, parts) for item in value)
+    return hasattr(value, parts[0]) and _present(getattr(value, parts[0]), parts[1:])

--- a/rl_experience_transfer/src/rlxfer/errors.py
+++ b/rl_experience_transfer/src/rlxfer/errors.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Exceptions raised by :mod:`rlxfer`."""
+
+from __future__ import annotations
+
+
+class RlxferError(Exception):
+    """Base class for all library errors."""
+
+
+class SchemaValidationError(RlxferError, ValueError):
+    """A schema error with producer, consumer, and experience context."""
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        field: str = "<unknown>",
+        expected: object = "valid value",
+        actual: object = None,
+        producer_framework: str | None = None,
+        producer_framework_version: str | None = None,
+        consumer_framework: str | None = None,
+        consumer_framework_version: str | None = None,
+        experience_id: str | None = None,
+    ) -> None:
+        self.field = field
+        self.expected = expected
+        self.actual = actual
+        self.producer_framework = producer_framework
+        self.producer_framework_version = producer_framework_version
+        self.consumer_framework = consumer_framework
+        self.consumer_framework_version = consumer_framework_version
+        self.experience_id = experience_id
+        detail = message or f"invalid {field}: expected {expected!r}, got {_short_repr(actual)}"
+        context = (
+            f"experience_id={experience_id or '<unknown>'}, "
+            f"producer={_framework(producer_framework, producer_framework_version)}, "
+            f"consumer={_framework(consumer_framework, consumer_framework_version)}"
+        )
+        super().__init__(f"{detail} ({context})")
+
+
+class CompatibilityError(RlxferError, ValueError):
+    """Experience cannot safely be consumed by the requested consumer."""
+
+
+class MigrationError(CompatibilityError):
+    """An experience cannot be migrated to the requested schema version."""
+
+
+class SerializationError(RlxferError, ValueError):
+    """Metadata or tensor serialization failed."""
+
+
+class IntegrityError(SerializationError):
+    """Transferred data failed an integrity check."""
+
+
+class TransportError(RlxferError):
+    """A transport operation failed."""
+
+
+class CapabilityError(TransportError):
+    """A transport does not provide a required capability."""
+
+
+class BackpressureError(TransportError):
+    """A bounded transport cannot currently accept more data."""
+
+
+class DeliveryError(TransportError):
+    """A delivery could not be completed or acknowledged."""
+
+
+class MissingDependencyError(RlxferError, ImportError):
+    """An optional integration dependency is unavailable."""
+
+
+class ClosedError(RlxferError):
+    """An operation was attempted on a closed component."""
+
+
+class TransferTimeoutError(TransportError, TimeoutError):
+    """A transfer operation exceeded its deadline."""
+
+
+def _framework(name: str | None, version: str | None) -> str:
+    if name is None:
+        return "<unknown>"
+    return f"{name}@{version or '<unknown>'}"
+
+
+def _short_repr(value: object, limit: int = 160) -> str:
+    text = repr(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3]}..."

--- a/rl_experience_transfer/src/rlxfer/model.py
+++ b/rl_experience_transfer/src/rlxfer/model.py
@@ -1,0 +1,732 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Transport- and framework-independent reinforcement-learning experience model."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from time import time
+from typing import Any, NoReturn, SupportsInt, TypeVar, cast
+from uuid import UUID, uuid4
+
+from .errors import SchemaValidationError
+
+SCHEMA_VERSION = "1.0"
+_NAMESPACE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*(?:\.[A-Za-z0-9_-]+)*$")
+_ValidatedT = TypeVar("_ValidatedT")
+_INTEGER_DTYPES = {"uint8", "int8", "int16", "int32", "int64", "long"}
+
+
+@dataclass(slots=True)
+class TensorPayload:
+    """A tensor/array plus the metadata needed to reconstruct it."""
+
+    data: object
+    name: str = ""
+    shape: tuple[int, ...] = ()
+    dtype: str = ""
+    device: str = ""
+    stride: tuple[int, ...] | None = None
+    layout: str = "strided"
+    nbytes: int | None = None
+
+    def __post_init__(self) -> None:
+        actual_shape = _shape_of(self.data)
+        if not self.shape and actual_shape is not None:
+            self.shape = actual_shape
+        if not self.dtype:
+            self.dtype = _dtype_of(self.data) or ""
+        if not self.device:
+            self.device = str(getattr(self.data, "device", "cpu"))
+        if self.stride is None:
+            self.stride = _stride_of(self.data)
+        if self.nbytes is None:
+            self.nbytes = _nbytes_of(self.data)
+
+    def validate(self, *, field_path: str = "tensor") -> None:
+        """Validate metadata against the attached tensor-like object."""
+
+        if not isinstance(self.dtype, str) or not self.dtype:
+            _invalid(field_path + ".dtype", "non-empty dtype", self.dtype)
+        if any(
+            not isinstance(size, int) or isinstance(size, bool) or size < 0 for size in self.shape
+        ):
+            _invalid(field_path + ".shape", "non-negative integer dimensions", self.shape)
+        actual_shape = _shape_of(self.data)
+        if actual_shape is None:
+            _invalid(field_path + ".data", "tensor or NumPy-compatible array", type(self.data))
+        if actual_shape != self.shape:
+            _invalid(field_path + ".shape", actual_shape, self.shape)
+        actual_dtype = _dtype_of(self.data)
+        if not isinstance(self.device, str) or not self.device:
+            _invalid(field_path + ".device", "non-empty device", self.device)
+        if not isinstance(self.layout, str) or not self.layout:
+            _invalid(field_path + ".layout", "non-empty layout", self.layout)
+        if self.stride is not None and (
+            len(self.stride) != len(self.shape)
+            or any(isinstance(size, bool) or not isinstance(size, int) for size in self.stride)
+        ):
+            _invalid(field_path + ".stride", f"{len(self.shape)} integer dimensions", self.stride)
+        if self.nbytes is not None and (
+            isinstance(self.nbytes, bool) or not isinstance(self.nbytes, int) or self.nbytes < 0
+        ):
+            _invalid(field_path + ".nbytes", "non-negative integer", self.nbytes)
+        comparisons = (
+            ("dtype", actual_dtype, _normalize_dtype(self.dtype), actual_dtype is not None),
+            ("device", _device_of(self.data), self.device, True),
+            ("layout", _layout_of(self.data), self.layout, True),
+            ("stride", _stride_of(self.data), self.stride, self.stride is not None),
+            ("nbytes", _nbytes_of(self.data), self.nbytes, self.nbytes is not None),
+        )
+        for name, actual, declared, required in comparisons:
+            if (
+                required
+                and declared != actual
+                and (actual is not None or name in {"stride", "nbytes"})
+            ):
+                _invalid(f"{field_path}.{name}", actual, getattr(self, name))
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyVersion:
+    """Identity of the policy that generated an experience."""
+
+    version: str | int
+    policy_id: str = "default"
+    model_id: str | None = None
+
+    def validate(self, *, field_path: str = "policy_version") -> None:
+        if not isinstance(self.policy_id, str) or not self.policy_id:
+            _invalid(field_path + ".policy_id", "non-empty string", self.policy_id)
+        if isinstance(self.version, bool) or not isinstance(self.version, (str, int)):
+            _invalid(field_path + ".version", "string or non-negative integer", self.version)
+        if isinstance(self.version, str) and not self.version:
+            _invalid(field_path + ".version", "non-empty string", self.version)
+        if isinstance(self.version, int) and self.version < 0:
+            _invalid(field_path + ".version", "non-negative integer", self.version)
+        if self.model_id is not None and (not isinstance(self.model_id, str) or not self.model_id):
+            _invalid(field_path + ".model_id", "non-empty string or null", self.model_id)
+
+
+@dataclass(frozen=True, slots=True)
+class SampleIdentity:
+    """Stable identifiers used for tracing and idempotent consumption."""
+
+    sample_id: str = field(default_factory=lambda: str(uuid4()))
+    request_id: str | None = None
+    producer_id: str | None = None
+    sequence_number: int | None = None
+    idempotency_key: str | None = None
+
+    def validate(self, *, field_path: str = "identity") -> None:
+        if not isinstance(self.sample_id, str) or not self.sample_id:
+            _invalid(field_path + ".sample_id", "non-empty string", self.sample_id)
+        _validate_optional_non_negative_int(self, "sequence_number", field_path)
+        _validate_optional_strings(
+            self, ("request_id", "producer_id", "idempotency_key"), field_path
+        )
+
+
+@dataclass(slots=True)
+class Transition:
+    """One environment transition; values may be JSON data or tensor payloads."""
+
+    observation: object | None = None
+    action: object | None = None
+    reward: float | None = None
+    next_observation: object | None = None
+    terminal: bool = False
+    truncated: bool = False
+    log_probability: float | None = None
+    reference_log_probability: float | None = None
+    value: float | None = None
+    advantage: float | None = None
+    return_value: float | None = None
+    extensions: dict[str, object] = field(default_factory=dict)
+
+    def validate(self, *, field_path: str = "transition") -> None:
+        _validate_completion_flags(self, field_path)
+        _validate_optional_finite_numbers(
+            self,
+            (
+                "reward",
+                "log_probability",
+                "reference_log_probability",
+                "value",
+                "advantage",
+                "return_value",
+            ),
+            field_path,
+        )
+        for name in ("observation", "action", "next_observation"):
+            _validate_nested(getattr(self, name), f"{field_path}.{name}")
+        _validate_extensions(self.extensions, field_path + ".extensions")
+
+
+@dataclass(slots=True)
+class Trajectory:
+    """A variable-length rollout trajectory with token-aligned tensor fields."""
+
+    identity: SampleIdentity | None = None
+    policy_version: PolicyVersion | None = None
+    transitions: tuple[Transition, ...] = ()
+    prompt: str | None = None
+    response: str | None = None
+    tokens: TensorPayload | None = None
+    attention_mask: TensorPayload | None = None
+    rewards: dict[str, float | TensorPayload] = field(default_factory=dict)
+    per_token_rewards: TensorPayload | None = None
+    log_probs: TensorPayload | None = None
+    reference_log_probs: TensorPayload | None = None
+    values: TensorPayload | None = None
+    advantages: TensorPayload | None = None
+    returns: TensorPayload | None = None
+    terminal: bool = False
+    truncated: bool = False
+    generation_metadata: dict[str, object] = field(default_factory=dict)
+    extensions: dict[str, object] = field(default_factory=dict)
+
+    def validate(self, *, field_path: str = "trajectory") -> None:
+        if self.identity is not None:
+            _validated(self.identity, SampleIdentity, field_path + ".identity", nullable=True)
+        if self.policy_version is not None:
+            _validated(
+                self.policy_version,
+                PolicyVersion,
+                field_path + ".policy_version",
+                nullable=True,
+            )
+        _validate_completion_flags(self, field_path)
+        _validate_optional_strings(self, ("prompt", "response"), field_path, non_empty=False)
+        for index, transition in enumerate(self.transitions):
+            path = f"{field_path}.transitions[{index}]"
+            _validated(transition, Transition, path)
+        if self.attention_mask is not None and self.tokens is None:
+            _invalid(field_path + ".attention_mask", "tokens to define alignment", "tokens missing")
+        token_shape: tuple[int, ...] | None = None
+        if self.tokens is not None:
+            _validated(self.tokens, TensorPayload, field_path + ".tokens", nullable=True)
+            token_shape = self.tokens.shape
+            if _normalize_dtype(self.tokens.dtype) not in _INTEGER_DTYPES:
+                _invalid(field_path + ".tokens.dtype", "integer token IDs", self.tokens.dtype)
+        aligned = {
+            "attention_mask": self.attention_mask,
+            "per_token_rewards": self.per_token_rewards,
+            "log_probs": self.log_probs,
+            "reference_log_probs": self.reference_log_probs,
+            "values": self.values,
+            "advantages": self.advantages,
+            "returns": self.returns,
+        }
+        for name, tensor in aligned.items():
+            if tensor is None:
+                continue
+            tensor = _validated(tensor, TensorPayload, f"{field_path}.{name}", nullable=True)
+            if token_shape is None:
+                _invalid(f"{field_path}.{name}", "tokens to define alignment", "tokens missing")
+            if tensor.shape != token_shape:
+                _invalid(f"{field_path}.{name}.shape", token_shape, tensor.shape)
+            if name == "attention_mask" and _normalize_dtype(tensor.dtype) not in (
+                _INTEGER_DTYPES | {"bool"}
+            ):
+                _invalid(
+                    field_path + ".attention_mask.dtype",
+                    "boolean or integer mask",
+                    tensor.dtype,
+                )
+        for name, reward in self.rewards.items():
+            if not isinstance(name, str) or not name:
+                _invalid(field_path + ".rewards", "non-empty reward names", name)
+            if isinstance(reward, TensorPayload):
+                reward.validate(field_path=f"{field_path}.rewards[{name!r}]")
+            elif not _is_finite_number(reward):
+                _invalid(
+                    f"{field_path}.rewards[{name!r}]", "finite number or TensorPayload", reward
+                )
+        _validate_nested(self.generation_metadata, field_path + ".generation_metadata")
+        _validate_extensions(self.extensions, field_path + ".extensions")
+
+
+@dataclass(slots=True)
+class Episode:
+    """One or more trajectories belonging to the same environment episode."""
+
+    trajectories: tuple[Trajectory, ...] = ()
+    episode_id: str = field(default_factory=lambda: str(uuid4()))
+    terminal: bool = False
+    truncated: bool = False
+    rewards: dict[str, float] = field(default_factory=dict)
+    extensions: dict[str, object] = field(default_factory=dict)
+
+    def validate(self, *, field_path: str = "episode") -> None:
+        if not isinstance(self.episode_id, str) or not self.episode_id:
+            _invalid(field_path + ".episode_id", "non-empty string", self.episode_id)
+        if not self.trajectories:
+            _invalid(field_path + ".trajectories", "at least one trajectory", self.trajectories)
+        _validate_completion_flags(self, field_path)
+        for index, trajectory in enumerate(self.trajectories):
+            path = f"{field_path}.trajectories[{index}]"
+            _validated(trajectory, Trajectory, path)
+        for name, reward in self.rewards.items():
+            if not isinstance(name, str) or not name or not _is_finite_number(reward):
+                _invalid(f"{field_path}.rewards[{name!r}]", "named finite reward", reward)
+        _validate_extensions(self.extensions, field_path + ".extensions")
+
+
+@dataclass(slots=True)
+class ExperienceMetadata:
+    """Routing, provenance, and semantic compatibility metadata for a batch."""
+
+    producer_id: str
+    producer_framework: str
+    producer_framework_version: str
+    experience_id: str = field(default_factory=lambda: str(uuid4()))
+    schema_version: str = SCHEMA_VERSION
+    created_at: float = field(default_factory=time)
+    sequence_number: int | None = None
+    idempotency_key: str | None = None
+    policy_version: PolicyVersion | None = None
+    algorithm: str | None = None
+    tokenizer_id: str | None = None
+    model_id: str | None = None
+    reward_definition: str | None = None
+    sequence_format: str | None = None
+    padding: str | None = None
+    chat_template: str | None = None
+    truncation: str | None = None
+    requires_reference_log_probs: bool = False
+    generation: dict[str, object] = field(default_factory=dict)
+
+    def validate(
+        self,
+        *,
+        consumer_framework: str | None = None,
+        consumer_framework_version: str | None = None,
+    ) -> None:
+        context = self.validation_context(consumer_framework, consumer_framework_version)
+        try:
+            UUID(self.experience_id)
+        except (ValueError, AttributeError, TypeError):
+            _invalid("metadata.experience_id", "UUID string", self.experience_id, **context)
+        if self.schema_version != SCHEMA_VERSION:
+            _invalid("metadata.schema_version", SCHEMA_VERSION, self.schema_version, **context)
+        for name in ("producer_id", "producer_framework", "producer_framework_version"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                _invalid(f"metadata.{name}", "non-empty string", value, **context)
+        if not _is_finite_number(self.created_at) or self.created_at < 0:
+            _invalid(
+                "metadata.created_at", "non-negative Unix timestamp", self.created_at, **context
+            )
+        _validate_optional_non_negative_int(self, "sequence_number", "metadata", context=context)
+        _validate_optional_strings(self, ("idempotency_key",), "metadata", context=context)
+        if self.policy_version is not None:
+            _validated(
+                self.policy_version,
+                PolicyVersion,
+                "metadata.policy_version",
+                nullable=True,
+                context=context,
+            )
+        _validate_optional_strings(
+            self,
+            (
+                "algorithm",
+                "tokenizer_id",
+                "model_id",
+                "reward_definition",
+                "sequence_format",
+                "padding",
+                "chat_template",
+                "truncation",
+            ),
+            "metadata",
+            context=context,
+        )
+        if not isinstance(self.requires_reference_log_probs, bool):
+            _invalid(
+                "metadata.requires_reference_log_probs",
+                "boolean",
+                self.requires_reference_log_probs,
+                **context,
+            )
+        _validate_nested(self.generation, "metadata.generation", **context)
+
+    def validation_context(
+        self,
+        consumer_framework: str | None = None,
+        consumer_framework_version: str | None = None,
+    ) -> dict[str, str | None]:
+        """Return error context suitable for :class:`SchemaValidationError`."""
+
+        return {
+            "producer_framework": self.producer_framework,
+            "producer_framework_version": self.producer_framework_version,
+            "consumer_framework": consumer_framework,
+            "consumer_framework_version": consumer_framework_version,
+            "experience_id": self.experience_id,
+        }
+
+
+@dataclass(slots=True)
+class ExperienceBatch:
+    """Canonical transfer unit shared by producers, consumers, and adapters."""
+
+    metadata: ExperienceMetadata
+    trajectories: tuple[Trajectory, ...] = ()
+    episodes: tuple[Episode, ...] = ()
+    tensors: dict[str, TensorPayload] = field(default_factory=dict)
+    payload: dict[str, object] = field(default_factory=dict)
+    extensions: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def experience_id(self) -> str:
+        """Return the globally unique ID carried by this batch."""
+
+        return self.metadata.experience_id
+
+    def validate(
+        self,
+        *,
+        consumer_framework: str | None = None,
+        consumer_framework_version: str | None = None,
+    ) -> None:
+        """Validate structure before serialization or expensive transfer work."""
+
+        if not isinstance(self.metadata, ExperienceMetadata):
+            _invalid("metadata", "ExperienceMetadata", type(self.metadata))
+        self.metadata.validate(
+            consumer_framework=consumer_framework,
+            consumer_framework_version=consumer_framework_version,
+        )
+        context = self.metadata.validation_context(consumer_framework, consumer_framework_version)
+        if not (self.trajectories or self.episodes or self.tensors or self.payload):
+            _invalid(
+                "batch",
+                "at least one trajectory, episode, tensor, or payload value",
+                "empty",
+                **context,
+            )
+        sample_ids: set[str] = set()
+        for index, trajectory in enumerate(self.trajectories):
+            _validated(trajectory, Trajectory, f"trajectories[{index}]", context=context)
+            _record_sample_id(trajectory, f"trajectories[{index}]", sample_ids, context)
+        for index, episode in enumerate(self.episodes):
+            _validated(episode, Episode, f"episodes[{index}]", context=context)
+            for trajectory in episode.trajectories:
+                _record_sample_id(
+                    trajectory, f"episodes[{index}].trajectories", sample_ids, context
+                )
+        for name, tensor in self.tensors.items():
+            if not isinstance(name, str) or not name:
+                _invalid("tensors", "non-empty tensor names", name, **context)
+            _validated(tensor, TensorPayload, f"tensors[{name!r}]", context=context)
+        _validate_nested(self.payload, "payload", **context)
+        _validate_extensions(self.extensions, "extensions", **context)
+
+
+@dataclass(slots=True)
+class TransferDescriptor:
+    """Transport-neutral catalog of externally transferred tensor buffers."""
+
+    experience_id: str
+    transfer_id: str = field(default_factory=lambda: str(uuid4()))
+    strategy: str = "external"
+    tensor_names: tuple[str, ...] = ()
+    byte_sizes: dict[str, int] = field(default_factory=dict)
+    checksums: dict[str, str] = field(default_factory=dict)
+    metadata_bytes: int = 0
+    extensions: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def total_bytes(self) -> int:
+        """Return metadata plus tensor bytes described by this transfer."""
+
+        return self.metadata_bytes + sum(self.byte_sizes.values())
+
+    def validate(self) -> None:
+        for name, value in (
+            ("experience_id", self.experience_id),
+            ("transfer_id", self.transfer_id),
+        ):
+            try:
+                UUID(value)
+            except (ValueError, AttributeError, TypeError):
+                _invalid(name, "UUID string", value, experience_id=self.experience_id)
+        if not self.strategy:
+            _invalid(
+                "strategy", "non-empty string", self.strategy, experience_id=self.experience_id
+            )
+        if (
+            isinstance(self.metadata_bytes, bool)
+            or not isinstance(self.metadata_bytes, int)
+            or self.metadata_bytes < 0
+        ):
+            _invalid(
+                "metadata_bytes",
+                "non-negative integer",
+                self.metadata_bytes,
+                experience_id=self.experience_id,
+            )
+        if len(set(self.tensor_names)) != len(self.tensor_names):
+            _invalid(
+                "tensor_names", "unique names", self.tensor_names, experience_id=self.experience_id
+            )
+        expected_names = set(self.tensor_names)
+        if set(self.byte_sizes) != expected_names:
+            _invalid(
+                "byte_sizes", expected_names, set(self.byte_sizes), experience_id=self.experience_id
+            )
+        for name, size in self.byte_sizes.items():
+            if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+                _invalid(
+                    f"byte_sizes[{name!r}]",
+                    "non-negative integer",
+                    size,
+                    experience_id=self.experience_id,
+                )
+        if not set(self.checksums).issubset(expected_names):
+            _invalid(
+                "checksums",
+                f"keys within {expected_names}",
+                set(self.checksums),
+                experience_id=self.experience_id,
+            )
+        _validate_extensions(self.extensions, "extensions", experience_id=self.experience_id)
+
+
+def _validated(
+    value: object,
+    expected_type: type[_ValidatedT],
+    field_path: str,
+    *,
+    nullable: bool = False,
+    context: Mapping[str, str | None] | None = None,
+) -> _ValidatedT:
+    expected = expected_type.__name__ + (" or null" if nullable else "")
+    if not isinstance(value, expected_type):
+        _invalid(field_path, expected, type(value), **(context or {}))
+    try:
+        cast(Any, value).validate(field_path=field_path)
+    except SchemaValidationError as error:
+        if context:
+            raise _with_context(error, context) from error
+        raise
+    return value
+
+
+def _record_sample_id(
+    trajectory: Trajectory,
+    field_path: str,
+    seen: set[str],
+    context: Mapping[str, str | None],
+) -> None:
+    if trajectory.identity is None:
+        return
+    sample_id = trajectory.identity.sample_id
+    if sample_id in seen:
+        _invalid(
+            field_path + ".identity.sample_id",
+            "unique sample ID within batch",
+            sample_id,
+            **context,
+        )
+    seen.add(sample_id)
+
+
+def _validate_extensions(
+    extensions: Mapping[str, object],
+    field_path: str,
+    **context: str | None,
+) -> None:
+    if not isinstance(extensions, Mapping):
+        _invalid(field_path, "mapping of extension namespaces", type(extensions), **context)
+    for namespace, value in extensions.items():
+        if not isinstance(namespace, str) or _NAMESPACE.fullmatch(namespace) is None:
+            _invalid(
+                f"{field_path}.<namespace>",
+                "namespace matching [A-Za-z][A-Za-z0-9_.-]*",
+                namespace,
+                **context,
+            )
+        _validate_nested(value, f"{field_path}.{namespace}", **context)
+
+
+def _validate_completion_flags(value: object, field_path: str) -> None:
+    flags = tuple(getattr(value, name) for name in ("terminal", "truncated"))
+    for name, flag in zip(("terminal", "truncated"), flags, strict=True):
+        if not isinstance(flag, bool):
+            _invalid(f"{field_path}.{name}", "boolean", flag)
+    if all(flags):
+        _invalid(field_path, "terminal and truncated not both true", flags)
+
+
+def _validate_optional_finite_numbers(
+    value: object,
+    names: Iterable[str],
+    field_path: str,
+) -> None:
+    for name in names:
+        item = getattr(value, name)
+        if item is not None and not _is_finite_number(item):
+            _invalid(f"{field_path}.{name}", "finite number or null", item)
+
+
+def _is_finite_number(value: object) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def _validate_optional_non_negative_int(
+    value: object,
+    name: str,
+    field_path: str,
+    *,
+    context: Mapping[str, str | None] | None = None,
+) -> None:
+    item = getattr(value, name)
+    if item is not None and (isinstance(item, bool) or not isinstance(item, int) or item < 0):
+        _invalid(f"{field_path}.{name}", "non-negative integer", item, **(context or {}))
+
+
+def _validate_optional_strings(
+    value: object,
+    names: Iterable[str],
+    field_path: str,
+    *,
+    non_empty: bool = True,
+    context: Mapping[str, str | None] | None = None,
+) -> None:
+    for name in names:
+        item = getattr(value, name)
+        if item is not None and (not isinstance(item, str) or (non_empty and not item)):
+            expected = "non-empty string or null" if non_empty else "string or null"
+            actual = item if non_empty else type(item).__name__
+            _invalid(f"{field_path}.{name}", expected, actual, **(context or {}))
+
+
+def _validate_nested(value: object, field_path: str, **context: str | None) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return
+        _invalid(field_path, "finite JSON number", value, **context)
+    if isinstance(value, TensorPayload):
+        try:
+            value.validate(field_path=field_path)
+        except SchemaValidationError as error:
+            raise _with_context(error, context) from error
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                _invalid(field_path, "mapping with string keys", key, **context)
+            _validate_nested(item, f"{field_path}.{key}", **context)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, item in enumerate(value):
+            _validate_nested(item, f"{field_path}[{index}]", **context)
+        return
+    _invalid(field_path, "JSON-safe value or TensorPayload", type(value).__name__, **context)
+
+
+def _shape_of(value: object) -> tuple[int, ...] | None:
+    shape = getattr(value, "shape", None)
+    if shape is None or isinstance(shape, (str, bytes)) or not isinstance(shape, Iterable):
+        return None
+    try:
+        return tuple(int(cast(SupportsInt, size)) for size in cast(Iterable[object], shape))
+    except (TypeError, ValueError):
+        return None
+
+
+def _dtype_of(value: object) -> str | None:
+    dtype = getattr(value, "dtype", None)
+    return None if dtype is None else _normalize_dtype(str(dtype))
+
+
+def _normalize_dtype(dtype: str) -> str:
+    return dtype.removeprefix("torch.").removeprefix("numpy.")
+
+
+def _device_of(value: object) -> str | None:
+    if _shape_of(value) is None:
+        return None
+    return str(getattr(value, "device", "cpu"))
+
+
+def _layout_of(value: object) -> str | None:
+    layout = getattr(value, "layout", None)
+    if layout is not None:
+        return str(layout).removeprefix("torch.")
+    if getattr(value, "strides", None) is not None:
+        return "strided"
+    return None
+
+
+def _stride_of(value: object) -> tuple[int, ...] | None:
+    stride: object = getattr(value, "stride", None)
+    if callable(stride):
+        stride = stride()
+        return _integer_stride(stride)
+    if stride is not None:
+        return _integer_stride(stride)
+    stride = getattr(value, "strides", None)
+    if stride is None or isinstance(stride, (str, bytes)) or not isinstance(stride, Iterable):
+        return None
+    try:
+        byte_stride = tuple(int(cast(SupportsInt, size)) for size in cast(Iterable[object], stride))
+        itemsize = int(cast(SupportsInt, cast(Any, value).itemsize))
+    except (TypeError, ValueError, AttributeError):
+        return None
+    if itemsize <= 0 or any(size % itemsize for size in byte_stride):
+        return None
+    return tuple(size // itemsize for size in byte_stride)
+
+
+def _integer_stride(value: object) -> tuple[int, ...] | None:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
+        return None
+    try:
+        return tuple(int(cast(SupportsInt, size)) for size in cast(Iterable[object], value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _nbytes_of(value: object) -> int | None:
+    nbytes = getattr(value, "nbytes", None)
+    if isinstance(nbytes, int):
+        return nbytes
+    element_size = getattr(value, "element_size", None)
+    numel = getattr(value, "numel", None)
+    if callable(element_size) and callable(numel):
+        return int(element_size()) * int(numel())
+    return None
+
+
+def _invalid(
+    field: str,
+    expected: object,
+    actual: object,
+    **context: str | None,
+) -> NoReturn:
+    raise SchemaValidationError(field=field, expected=expected, actual=actual, **context)
+
+
+def _with_context(
+    error: SchemaValidationError,
+    context: Mapping[str, str | None],
+) -> SchemaValidationError:
+    return SchemaValidationError(
+        field=error.field,
+        expected=error.expected,
+        actual=error.actual,
+        producer_framework=context.get("producer_framework"),
+        producer_framework_version=context.get("producer_framework_version"),
+        consumer_framework=context.get("consumer_framework"),
+        consumer_framework_version=context.get("consumer_framework_version"),
+        experience_id=context.get("experience_id"),
+    )

--- a/rl_experience_transfer/src/rlxfer/observability.py
+++ b/rl_experience_transfer/src/rlxfer/observability.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency-free metric hooks and content-safe structured logging."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Protocol
+
+MetricAttributes = Mapping[str, str | int | float | bool]
+_SENSITIVE_NAMES = (
+    "prompt",
+    "response",
+    "completion",
+    "content",
+    "message",
+    "text",
+    "token",
+    "input_ids",
+    "output_ids",
+)
+
+
+class Metrics(Protocol):
+    """Small vendor-neutral metrics interface used by the core library."""
+
+    def increment(
+        self,
+        name: str,
+        value: int = 1,
+        attributes: MetricAttributes | None = None,
+    ) -> None:
+        """Increase a counter."""
+
+    def observe(
+        self,
+        name: str,
+        value: float,
+        attributes: MetricAttributes | None = None,
+    ) -> None:
+        """Record a measurement."""
+
+
+@dataclass(slots=True)
+class NullMetrics:
+    """No-op default that avoids global state and optional dependencies."""
+
+    def increment(
+        self,
+        name: str,
+        value: int = 1,
+        attributes: MetricAttributes | None = None,
+    ) -> None:
+        del name, value, attributes
+
+    def observe(
+        self,
+        name: str,
+        value: float,
+        attributes: MetricAttributes | None = None,
+    ) -> None:
+        del name, value, attributes
+
+
+@dataclass(slots=True)
+class InMemoryMetrics:
+    """Thread-safe metric recorder for deterministic tests and examples."""
+
+    counters: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    observations: dict[str, list[float]] = field(default_factory=lambda: defaultdict(list))
+    _lock: Lock = field(default_factory=Lock, repr=False)
+
+    def increment(
+        self,
+        name: str,
+        value: int = 1,
+        attributes: MetricAttributes | None = None,
+    ) -> None:
+        key = _metric_key(name, attributes)
+        with self._lock:
+            self.counters[key] += value
+
+    def observe(
+        self,
+        name: str,
+        value: float,
+        attributes: MetricAttributes | None = None,
+    ) -> None:
+        key = _metric_key(name, attributes)
+        with self._lock:
+            self.observations[key].append(value)
+
+    def snapshot(self) -> tuple[dict[str, int], dict[str, tuple[float, ...]]]:
+        """Return an immutable-value copy of all recorded metrics."""
+
+        with self._lock:
+            return dict(self.counters), {
+                name: tuple(values) for name, values in self.observations.items()
+            }
+
+
+def structured_log(logger: logging.Logger, event: str, **fields: object) -> None:
+    """Log one event after recursively removing prompt/response-like content."""
+
+    logger.info(event, extra={"rlxfer": _redact(fields)})
+
+
+def _metric_key(name: str, attributes: MetricAttributes | None) -> str:
+    if not attributes:
+        return name
+    suffix = ",".join(f"{key}={attributes[key]}" for key in sorted(attributes))
+    return f"{name}{{{suffix}}}"
+
+
+def _redact(value: object) -> object:
+    if isinstance(value, Mapping):
+        result: dict[str, object] = {}
+        for key, item in value.items():
+            name = str(key)
+            lowered = name.lower()
+            if any(secret in lowered for secret in _SENSITIVE_NAMES):
+                result[name] = "<redacted>"
+            else:
+                result[name] = _redact(item)
+        return result
+    if isinstance(value, (list, tuple)):
+        return [_redact(item) for item in value]
+    return value

--- a/rl_experience_transfer/src/rlxfer/serialization.py
+++ b/rl_experience_transfer/src/rlxfer/serialization.py
@@ -1,0 +1,1226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Safe JSON metadata and separately transferable tensor buffers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import importlib
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, fields, is_dataclass, replace
+from datetime import datetime
+from enum import Enum
+from types import ModuleType
+from typing import Any, Protocol, cast
+from uuid import UUID
+
+import numpy as np
+
+from . import model
+from .errors import IntegrityError, SerializationError
+from .model import ExperienceBatch
+
+_FORMAT = "rlxfer-json"
+_SERIALIZER_VERSION = 1
+_PathPart = str | int
+_CATALOG_FIELDS = (
+    "name",
+    "path",
+    "kind",
+    "dtype",
+    "shape",
+    "stride",
+    "layout",
+    "original_device",
+    "wire_device",
+    "nbytes",
+    "sha256",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SerializationLimits:
+    """Resource limits applied to metadata and logical tensor payloads.
+
+    Limits are checked while serializing and before deserialization restores any
+    tensor buffer. ``max_depth`` and ``max_items`` apply to the encoded JSON tree.
+    Tensor byte limits count logical contiguous values, not backing-storage spans.
+    """
+
+    max_metadata_bytes: int = 16 * 1024 * 1024
+    max_depth: int = 64
+    max_items: int = 100_000
+    max_tensor_count: int = 4_096
+    max_tensor_bytes: int = 2 * 1024 * 1024 * 1024
+    max_total_tensor_bytes: int = 8 * 1024 * 1024 * 1024
+
+    def __post_init__(self) -> None:
+        for setting in fields(self):
+            value = getattr(self, setting.name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{setting.name} must be a positive integer")
+
+
+_DEFAULT_LIMITS = SerializationLimits()
+
+
+def _torch() -> ModuleType | None:
+    try:
+        return importlib.import_module("torch")
+    except ModuleNotFoundError:
+        return None
+
+
+def _is_torch_tensor(value: object) -> bool:
+    torch = _torch()
+    return torch is not None and isinstance(value, torch.Tensor)
+
+
+def _synchronize(torch: Any, tensor: Any) -> None:
+    backend = getattr(torch, tensor.device.type, None)
+    synchronize = getattr(backend, "synchronize", None)
+    if callable(synchronize):
+        synchronize(tensor.device)
+
+
+def _tensor_bytes(value: object) -> bytes:
+    """Return logical tensor values in contiguous row-major order."""
+
+    if isinstance(value, np.ndarray):
+        if value.dtype.hasobject:
+            raise SerializationError("NumPy object arrays are not safe to serialize")
+        return value.tobytes(order="C")
+    if _is_torch_tensor(value):
+        torch = cast(Any, _torch())
+        tensor = cast(Any, value).detach()
+        if tensor.layout != torch.strided:
+            raise SerializationError(f"unsupported PyTorch layout: {tensor.layout}")
+        if tensor.device.type != "cpu":
+            _synchronize(torch, tensor)
+            tensor = tensor.to("cpu")
+        tensor = tensor.contiguous()
+        return cast(bytes, tensor.view(torch.uint8).numpy().tobytes())
+    raise SerializationError(f"unsupported tensor value: {type(value).__name__}")
+
+
+@dataclass(frozen=True, slots=True)
+class BufferSegment:
+    """One tensor buffer plus the complete transport-neutral tensor catalog entry.
+
+    ``owner`` keeps a staged or direct tensor alive until transfer completion. A
+    transport that needs bytes (notably the filesystem transport) calls
+    :meth:`materialize`. ``stride`` is a normalized C-contiguous stride measured
+    in elements for both NumPy and PyTorch tensors.
+    """
+
+    name: str
+    path: tuple[_PathPart, ...]
+    kind: str
+    dtype: str
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    layout: str
+    original_device: str
+    wire_device: str
+    nbytes: int
+    sha256: str | None = None
+    data: bytes | memoryview | None = field(default=None, repr=False, compare=False)
+    owner: object | None = field(default=None, repr=False, compare=False)
+
+    def materialize(self) -> bytes:
+        """Return transfer bytes, staging a retained tensor owner when necessary."""
+
+        if self.data is not None:
+            return bytes(self.data)
+        if self.owner is not None:
+            return _tensor_bytes(self.owner)
+        raise IntegrityError(f"buffer {self.name!r} has neither data nor an owner")
+
+    def catalog_entry(self) -> dict[str, object]:
+        """Return the JSON-safe transport metadata for this buffer."""
+
+        result = {name: getattr(self, name) for name in _CATALOG_FIELDS}
+        result.update({name: list(getattr(self, name)) for name in ("path", "shape", "stride")})
+        return result
+
+    @classmethod
+    def from_catalog_entry(
+        cls,
+        value: Mapping[str, Any],
+        *,
+        data: bytes | memoryview | None = None,
+        owner: object | None = None,
+    ) -> BufferSegment:
+        """Rebuild a segment from validated JSON-safe transport metadata."""
+
+        return cls(
+            name=str(value["name"]),
+            path=tuple(
+                item
+                for item in value["path"]
+                if isinstance(item, (str, int)) and not isinstance(item, bool)
+            ),
+            kind=str(value["kind"]),
+            dtype=str(value["dtype"]),
+            shape=tuple(int(item) for item in value["shape"]),
+            stride=tuple(int(item) for item in value["stride"]),
+            layout=str(value["layout"]),
+            original_device=str(value["original_device"]),
+            wire_device=str(value["wire_device"]),
+            nbytes=int(value["nbytes"]),
+            sha256=str(value["sha256"]) if value["sha256"] is not None else None,
+            data=data,
+            owner=owner,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SerializedExperience:
+    """Deterministic UTF-8 JSON metadata and its external tensor buffers."""
+
+    metadata: bytes = field(repr=False)
+    buffers: tuple[BufferSegment, ...] = ()
+
+    @property
+    def nbytes(self) -> int:
+        """Return the total encoded size without materializing direct buffers."""
+
+        return len(self.metadata) + sum(buffer.nbytes for buffer in self.buffers)
+
+
+def validate_transfer_limits(
+    *,
+    metadata_bytes: int,
+    tensor_sizes: Iterable[int],
+    limits: SerializationLimits | None = None,
+) -> None:
+    """Reject a transfer catalog that could exceed configured resource bounds."""
+
+    active = limits or _DEFAULT_LIMITS
+    if (
+        isinstance(metadata_bytes, bool)
+        or not isinstance(metadata_bytes, int)
+        or metadata_bytes < 0
+    ):
+        raise SerializationError("metadata size must be a non-negative integer")
+    if metadata_bytes > active.max_metadata_bytes:
+        raise SerializationError(
+            f"metadata size {metadata_bytes} exceeds byte limit {active.max_metadata_bytes}"
+        )
+    total = 0
+    for count, size in enumerate(tensor_sizes, start=1):
+        if count > active.max_tensor_count:
+            raise SerializationError(f"tensor count exceeds limit {active.max_tensor_count}")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise SerializationError("tensor size must be a non-negative integer")
+        if size > active.max_tensor_bytes:
+            raise SerializationError(
+                f"tensor size {size} exceeds per-tensor byte limit {active.max_tensor_bytes}"
+            )
+        total += size
+        if total > active.max_total_tensor_bytes:
+            raise SerializationError(
+                f"total tensor size {total} exceeds byte limit {active.max_total_tensor_bytes}"
+            )
+
+
+class BufferManager(Protocol):
+    """Stages tensor-like values and reconstructs their logical values."""
+
+    def stage(
+        self,
+        value: object,
+        *,
+        name: str,
+        path: tuple[_PathPart, ...],
+        checksum: bool,
+    ) -> BufferSegment: ...
+
+    def restore(self, segment: BufferSegment, *, preserve_device: bool) -> object: ...
+
+
+class DefaultBufferManager:
+    """Default NumPy/PyTorch buffer manager with optional CPU or pinned staging."""
+
+    def __init__(self, *, cpu_staging: bool = True, pinned_memory: bool = False) -> None:
+        self.cpu_staging = cpu_staging
+        self.pinned_memory = pinned_memory
+
+    def stage(
+        self,
+        value: object,
+        *,
+        name: str,
+        path: tuple[_PathPart, ...],
+        checksum: bool,
+    ) -> BufferSegment:
+        if isinstance(value, np.ndarray):
+            return self._stage_numpy(value, name=name, path=path, checksum=checksum)
+        if _is_torch_tensor(value):
+            return self._stage_torch(value, name=name, path=path, checksum=checksum)
+        raise SerializationError(f"unsupported tensor value: {type(value).__name__}")
+
+    def restore(self, segment: BufferSegment, *, preserve_device: bool) -> object:
+        raw = segment.materialize()
+        if segment.kind == "numpy":
+            dtype = _numpy_dtype(segment.dtype)
+            return np.frombuffer(raw, dtype=dtype).copy().reshape(segment.shape)
+        if segment.kind == "torch":
+            torch = _torch()
+            if torch is None:
+                raise SerializationError("PyTorch is required to deserialize a PyTorch tensor")
+            dtype = _torch_dtype(torch, segment.dtype)
+            byte_tensor = torch.frombuffer(bytearray(raw), dtype=torch.uint8)
+            tensor = byte_tensor.view(dtype).reshape(segment.shape).clone()
+            if preserve_device and segment.original_device != "cpu":
+                try:
+                    tensor = tensor.to(segment.original_device)
+                except (RuntimeError, ValueError) as error:
+                    raise SerializationError(
+                        f"cannot restore tensor {segment.name!r} on {segment.original_device!r}"
+                    ) from error
+            return tensor
+        raise SerializationError(f"unsupported tensor kind: {segment.kind!r}")
+
+    def _stage_numpy(
+        self,
+        value: np.ndarray[Any, Any],
+        *,
+        name: str,
+        path: tuple[_PathPart, ...],
+        checksum: bool,
+    ) -> BufferSegment:
+        if value.dtype.hasobject:
+            raise SerializationError("NumPy object arrays are not safe to serialize")
+        owner = np.ascontiguousarray(value)
+        raw = memoryview(cast(Any, owner)).cast("B")
+        return BufferSegment(
+            name=name,
+            path=path,
+            kind="numpy",
+            dtype=value.dtype.str,
+            shape=tuple(value.shape),
+            stride=_contiguous_stride(tuple(value.shape)),
+            layout="strided",
+            original_device="cpu",
+            wire_device="cpu",
+            nbytes=len(raw),
+            sha256=_digest(raw) if checksum else None,
+            data=raw,
+            owner=owner,
+        )
+
+    def _stage_torch(
+        self,
+        value: object,
+        *,
+        name: str,
+        path: tuple[_PathPart, ...],
+        checksum: bool,
+    ) -> BufferSegment:
+        torch = cast(Any, _torch())
+        tensor = cast(Any, value).detach()
+        if tensor.layout != torch.strided:
+            raise SerializationError(f"unsupported PyTorch layout: {tensor.layout}")
+        original_device = str(tensor.device)
+        staged = tensor.contiguous().view(-1).view(tensor.shape)
+        should_stage = self.cpu_staging or tensor.device.type == "cpu"
+        if should_stage and tensor.device.type != "cpu":
+            _synchronize(torch, tensor)
+            staged = staged.to("cpu")
+        if should_stage and self.pinned_memory and not staged.is_pinned():
+            staged = staged.pin_memory()
+        data: bytes | memoryview | None = None
+        if should_stage:
+            data = memoryview(staged.view(torch.uint8).numpy()).cast("B")
+        raw = bytes(data) if data is not None else (_tensor_bytes(staged) if checksum else None)
+        return BufferSegment(
+            name=name,
+            path=path,
+            kind="torch",
+            dtype=str(tensor.dtype).removeprefix("torch."),
+            shape=tuple(tensor.shape),
+            stride=tuple(staged.stride()),
+            layout=str(tensor.layout).removeprefix("torch."),
+            original_device=original_device,
+            wire_device="cpu" if should_stage else original_device,
+            nbytes=tensor.numel() * tensor.element_size(),
+            sha256=_digest(raw) if raw is not None and checksum else None,
+            data=data,
+            owner=staged,
+        )
+
+
+class ExperienceSerializer(Protocol):
+    """Transport-independent experience serializer contract."""
+
+    def serialize(self, experience: ExperienceBatch) -> SerializedExperience: ...
+
+    def deserialize(self, serialized: SerializedExperience) -> ExperienceBatch: ...
+
+
+@dataclass(slots=True)
+class _EncodeState:
+    buffers: list[BufferSegment] = field(default_factory=list)
+    catalogs: list[dict[str, object]] = field(default_factory=list)
+    tensor_bytes: int = 0
+
+
+class JsonExperienceSerializer:
+    """Versioned safe serializer using JSON metadata and raw tensor buffers."""
+
+    def __init__(
+        self,
+        *,
+        inline_threshold: int = 0,
+        checksum: bool = True,
+        cpu_staging: bool = True,
+        pinned_memory: bool = False,
+        preserve_device: bool = False,
+        buffer_manager: BufferManager | None = None,
+        allowed_types: Iterable[type[object]] = (),
+        limits: SerializationLimits | None = None,
+    ) -> None:
+        if inline_threshold < 0:
+            raise ValueError("inline_threshold must be non-negative")
+        self.inline_threshold = inline_threshold
+        self.checksum = checksum
+        self.preserve_device = preserve_device
+        self.buffer_manager = buffer_manager or DefaultBufferManager(
+            cpu_staging=cpu_staging,
+            pinned_memory=pinned_memory,
+        )
+        self._types = _safe_types(allowed_types)
+        self.limits = limits or _DEFAULT_LIMITS
+
+    def serialize(self, experience: ExperienceBatch) -> SerializedExperience:
+        """Validate and encode an experience without pickle or executable metadata."""
+
+        if not isinstance(experience, ExperienceBatch):
+            raise SerializationError("serialize expects an ExperienceBatch")
+        _check_source_limits(experience, self.limits)
+        state = _EncodeState()
+        try:
+            experience.validate()
+            root = self._encode(experience, (), state)
+        except RecursionError as error:
+            raise SerializationError("metadata nesting exceeds Python recursion safety") from error
+        document = {
+            "format": _FORMAT,
+            "serializer_version": _SERIALIZER_VERSION,
+            "schema_version": experience.metadata.schema_version,
+            "root": root,
+            "tensors": state.catalogs,
+        }
+        _check_json_limits(document, self.limits)
+        metadata = _dump_document(document, self.limits)
+        return SerializedExperience(metadata=metadata, buffers=tuple(state.buffers))
+
+    def deserialize(self, serialized: SerializedExperience) -> ExperienceBatch:
+        """Validate the complete catalog and all buffers before object construction."""
+
+        document = _load_document(serialized.metadata, self.limits)
+        catalog = _validate_catalog(
+            document.get("tensors"),
+            serialized.buffers,
+            self.limits,
+        )
+        values: dict[str, object] = {}
+        for name, segment in catalog.items():
+            values[name] = self.buffer_manager.restore(
+                segment,
+                preserve_device=self.preserve_device,
+            )
+        result = self._decode(document["root"], values)
+        if not isinstance(result, ExperienceBatch):
+            raise SerializationError("metadata root is not an ExperienceBatch")
+        if result.metadata.schema_version != document["schema_version"]:
+            raise IntegrityError("root schema version disagrees with serializer envelope")
+        result.validate()
+        return result
+
+    def validate_metadata(self, metadata: bytes) -> tuple[BufferSegment, ...]:
+        """Validate an envelope and catalog before allocating external buffers."""
+
+        return validate_metadata(metadata, limits=self.limits)
+
+    def _encode(
+        self,
+        value: object,
+        path: tuple[_PathPart, ...],
+        state: _EncodeState,
+    ) -> object:
+        if isinstance(value, np.ndarray) or _is_torch_tensor(value):
+            name = f"tensor-{len(state.catalogs):06d}"
+            segment = self.buffer_manager.stage(
+                value,
+                name=name,
+                path=path,
+                checksum=self.checksum,
+            )
+            _check_encoded_segment(segment, state, self.limits)
+            entry = segment.catalog_entry()
+            if segment.nbytes <= self.inline_threshold:
+                if _base64_size(segment.nbytes) > self.limits.max_metadata_bytes:
+                    raise SerializationError(
+                        f"inline tensor {name!r} cannot fit within metadata byte limit "
+                        f"{self.limits.max_metadata_bytes}"
+                    )
+                entry["inline"] = base64.b64encode(segment.materialize()).decode("ascii")
+            else:
+                entry["external"] = True
+                state.buffers.append(segment)
+            state.catalogs.append(entry)
+            state.tensor_bytes += segment.nbytes
+            return {"$type": "tensor", "name": name}
+        if value is None or isinstance(value, (str, bool, int)):
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise SerializationError("non-finite floats are not valid metadata")
+            return value
+        if isinstance(value, bytes):
+            return {"$type": "bytes", "data": base64.b64encode(value).decode("ascii")}
+        if isinstance(value, UUID):
+            return {"$type": "uuid", "value": str(value)}
+        if isinstance(value, datetime):
+            return {"$type": "datetime", "value": value.isoformat()}
+        if isinstance(value, Enum):
+            key = _type_key(type(value))
+            if key not in self._types:
+                raise SerializationError(f"enum type is not allowed: {key}")
+            return {
+                "$type": "enum",
+                "class": key,
+                "value": self._encode(value.value, path, state),
+            }
+        if is_dataclass(value) and not isinstance(value, type):
+            key = _type_key(type(value))
+            if key not in self._types:
+                raise SerializationError(f"dataclass type is not allowed: {key}")
+            encoded_fields = {
+                field.name: self._encode(
+                    _normalized_field(value, field.name),
+                    (*path, field.name),
+                    state,
+                )
+                for field in fields(value)
+            }
+            return {
+                "$type": "dataclass",
+                "class": key,
+                "fields": encoded_fields,
+            }
+        if isinstance(value, Mapping):
+            encoded = [
+                [
+                    self._encode(key, (*path, "<key>"), state),
+                    self._encode(item, (*path, str(key)), state),
+                ]
+                for key, item in value.items()
+            ]
+            encoded.sort(key=lambda pair: _canonical(pair[0]))
+            return {"$type": "mapping", "items": encoded}
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            kind = "tuple" if isinstance(value, tuple) else "list"
+            return {
+                "$type": kind,
+                "items": [
+                    self._encode(item, (*path, index), state) for index, item in enumerate(value)
+                ],
+            }
+        raise SerializationError(f"unsupported metadata value at {path!r}: {type(value).__name__}")
+
+    def _decode(self, value: object, tensors: Mapping[str, object]) -> object:
+        if value is None or isinstance(value, (str, bool, int, float)):
+            return value
+        if not isinstance(value, dict) or not isinstance(value.get("$type"), str):
+            raise SerializationError("malformed tagged metadata value")
+        tag = value["$type"]
+        if tag == "tensor":
+            name = _required_str(value, "name")
+            try:
+                return tensors[name]
+            except KeyError as error:
+                raise IntegrityError(f"tensor {name!r} is absent from the catalog") from error
+        if tag == "bytes":
+            return _decode_base64(_required_str(value, "data"), "bytes metadata")
+        if tag == "uuid":
+            try:
+                return UUID(_required_str(value, "value"))
+            except ValueError as error:
+                raise SerializationError("invalid UUID metadata") from error
+        if tag == "datetime":
+            try:
+                return datetime.fromisoformat(_required_str(value, "value"))
+            except ValueError as error:
+                raise SerializationError("invalid datetime metadata") from error
+        if tag == "enum":
+            cls = self._allowed_class(value)
+            if not issubclass(cls, Enum):
+                raise SerializationError("encoded enum class is not an Enum")
+            return cls(self._decode(value.get("value"), tensors))
+        if tag == "dataclass":
+            cls = self._allowed_class(value)
+            encoded_fields = value.get("fields")
+            if not isinstance(encoded_fields, dict):
+                raise SerializationError("dataclass fields must be an object")
+            expected = {field.name for field in fields(cast(Any, cls))}
+            if set(encoded_fields) != expected:
+                raise SerializationError(
+                    f"fields for {_type_key(cls)} differ: expected {sorted(expected)!r}"
+                )
+            decoded_fields = {
+                name: self._decode(item, tensors) for name, item in encoded_fields.items()
+            }
+            instance = cls(**decoded_fields)
+            if isinstance(instance, model.TensorPayload):
+                instance.stride = _element_stride(instance.data)
+                instance.layout = _tensor_layout(instance.data)
+                instance.device = _tensor_device(instance.data)
+                instance.nbytes = _logical_tensor_nbytes(instance.data)
+            return instance
+        if tag in {"mapping", "list", "tuple"}:
+            items = value.get("items")
+            if not isinstance(items, list):
+                raise SerializationError(f"{tag} items must be a list")
+            if tag == "mapping":
+                result: dict[object, object] = {}
+                for pair in items:
+                    if not isinstance(pair, list) or len(pair) != 2:
+                        raise SerializationError("mapping entries must be key/value pairs")
+                    key = self._decode(pair[0], tensors)
+                    try:
+                        if key in result:
+                            raise SerializationError("decoded mapping keys must be unique")
+                        result[key] = self._decode(pair[1], tensors)
+                    except TypeError as error:
+                        raise SerializationError("decoded mapping key is unhashable") from error
+                return result
+            sequence = [self._decode(item, tensors) for item in items]
+            return tuple(sequence) if tag == "tuple" else sequence
+        raise SerializationError(f"unknown metadata tag: {tag!r}")
+
+    def _allowed_class(self, value: Mapping[str, object]) -> type[object]:
+        key = _required_str(value, "class")
+        try:
+            return self._types[key]
+        except KeyError as error:
+            raise SerializationError(f"metadata class is not allowed: {key}") from error
+
+
+class AuthenticatedExperienceSerializer:
+    """HMAC-SHA256 authentication wrapper for the safe JSON serializer."""
+
+    def __init__(
+        self,
+        keys: Mapping[str, bytes],
+        *,
+        signing_key_id: str,
+        serializer: JsonExperienceSerializer | None = None,
+    ) -> None:
+        self.serializer = serializer or JsonExperienceSerializer()
+        self.limits = self.serializer.limits
+        self._keys = dict(keys)
+        if signing_key_id not in self._keys:
+            raise ValueError("signing_key_id must identify a configured key")
+        for key_id, key in self._keys.items():
+            if not _valid_key_id(key_id):
+                raise ValueError(f"invalid authentication key ID: {key_id!r}")
+            if not isinstance(key, bytes) or len(key) < 32:
+                raise ValueError("authentication keys must contain at least 32 bytes")
+        self.signing_key_id = signing_key_id
+
+    def serialize(self, experience: ExperienceBatch) -> SerializedExperience:
+        """Serialize and authenticate the complete metadata and tensor payload."""
+
+        serialized = self.serializer.serialize(experience)
+        document = _load_document(serialized.metadata, self.limits)
+        document["authentication"] = {
+            "algorithm": "hmac-sha256",
+            "key_id": self.signing_key_id,
+            "signature": _signature(
+                self._keys[self.signing_key_id],
+                self.signing_key_id,
+                serialized.metadata,
+                serialized.buffers,
+            ),
+        }
+        return replace(serialized, metadata=_dump_document(document, self.limits))
+
+    def deserialize(self, serialized: SerializedExperience) -> ExperienceBatch:
+        """Authenticate all bytes before schema reconstruction."""
+
+        document = _load_document(
+            serialized.metadata,
+            self.limits,
+            allow_authentication=True,
+        )
+        authentication = cast(dict[str, object], document.pop("authentication", None))
+        if not authentication:
+            raise IntegrityError("authenticated serializer requires a signature")
+        key_id = cast(str, authentication["key_id"])
+        try:
+            key = self._keys[key_id]
+        except KeyError as error:
+            raise IntegrityError(f"unknown authentication key ID: {key_id!r}") from error
+        metadata = _dump_document(document, self.limits)
+        expected = _signature(key, key_id, metadata, serialized.buffers)
+        if not hmac.compare_digest(expected, cast(str, authentication["signature"])):
+            raise IntegrityError("experience authentication failed")
+        return self.serializer.deserialize(replace(serialized, metadata=metadata))
+
+    def validate_metadata(self, metadata: bytes) -> tuple[BufferSegment, ...]:
+        """Validate a signed envelope and its catalog before buffer allocation."""
+
+        return validate_metadata(metadata, limits=self.limits)
+
+
+def _check_source_limits(root: object, limits: SerializationLimits) -> None:
+    """Bound recursive input before schema validation or tensor staging."""
+
+    item_count = 0
+    tensor_count = 0
+    tensor_bytes = 0
+    active: set[int] = set()
+    stack: list[tuple[object, int, bool]] = [(root, 0, False)]
+    while stack:
+        value, depth, leaving = stack.pop()
+        identity = id(value)
+        if leaving:
+            active.remove(identity)
+            continue
+        if depth > limits.max_depth:
+            raise SerializationError(f"metadata nesting depth exceeds limit {limits.max_depth}")
+        item_count += 1
+        if item_count > limits.max_items:
+            raise SerializationError(f"metadata item count exceeds limit {limits.max_items}")
+        if isinstance(value, np.ndarray) or _is_torch_tensor(value):
+            nbytes = _logical_tensor_nbytes(value)
+            tensor_count += 1
+            tensor_bytes += nbytes
+            if tensor_count > limits.max_tensor_count:
+                raise SerializationError(f"tensor count exceeds limit {limits.max_tensor_count}")
+            if nbytes > limits.max_tensor_bytes:
+                raise SerializationError(
+                    f"tensor size {nbytes} exceeds per-tensor byte limit {limits.max_tensor_bytes}"
+                )
+            if tensor_bytes > limits.max_total_tensor_bytes:
+                raise SerializationError(
+                    f"total tensor size {tensor_bytes} exceeds byte limit "
+                    f"{limits.max_total_tensor_bytes}"
+                )
+            continue
+        if isinstance(value, bytes):
+            if _base64_size(len(value)) > limits.max_metadata_bytes:
+                raise SerializationError(
+                    f"encoded bytes metadata cannot fit within metadata byte limit "
+                    f"{limits.max_metadata_bytes}"
+                )
+            continue
+        if isinstance(value, str) and len(value) > limits.max_metadata_bytes:
+            raise SerializationError(
+                f"string metadata cannot fit within metadata byte limit {limits.max_metadata_bytes}"
+            )
+
+        children: list[object] | None = None
+        if isinstance(value, Enum):
+            children = [value.value]
+        elif is_dataclass(value) and not isinstance(value, type):
+            children = [getattr(value, item.name) for item in fields(value)]
+        elif isinstance(value, Mapping):
+            if len(value) > limits.max_items:
+                raise SerializationError(f"metadata item count exceeds limit {limits.max_items}")
+            children = []
+            for key, item in value.items():
+                children.extend((key, item))
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            if len(value) > limits.max_items:
+                raise SerializationError(f"metadata item count exceeds limit {limits.max_items}")
+            children = list(value)
+        if children is None:
+            continue
+        if identity in active:
+            raise SerializationError("cyclic metadata is not supported")
+        active.add(identity)
+        stack.append((value, depth, True))
+        stack.extend((child, depth + 1, False) for child in children)
+
+
+def _check_json_limits(root: object, limits: SerializationLimits) -> None:
+    item_count = 0
+    stack: list[tuple[object, int]] = [(root, 0)]
+    while stack:
+        value, depth = stack.pop()
+        if depth > limits.max_depth:
+            raise SerializationError(f"metadata nesting depth exceeds limit {limits.max_depth}")
+        item_count += 1
+        if isinstance(value, dict):
+            item_count += len(value)
+            stack.extend((item, depth + 1) for item in value.values())
+        elif isinstance(value, list):
+            stack.extend((item, depth + 1) for item in value)
+        if item_count > limits.max_items:
+            raise SerializationError(f"metadata item count exceeds limit {limits.max_items}")
+
+
+def _check_metadata_size(metadata: bytes, limits: SerializationLimits) -> None:
+    if len(metadata) > limits.max_metadata_bytes:
+        raise SerializationError(
+            f"metadata size {len(metadata)} exceeds byte limit {limits.max_metadata_bytes}"
+        )
+
+
+def _check_encoded_segment(
+    segment: BufferSegment,
+    state: _EncodeState,
+    limits: SerializationLimits,
+) -> None:
+    if (
+        isinstance(segment.nbytes, bool)
+        or not isinstance(segment.nbytes, int)
+        or segment.nbytes < 0
+    ):
+        raise SerializationError(f"tensor {segment.name!r} has invalid nbytes")
+    if len(state.catalogs) >= limits.max_tensor_count:
+        raise SerializationError(f"tensor count exceeds limit {limits.max_tensor_count}")
+    if segment.nbytes > limits.max_tensor_bytes:
+        raise SerializationError(
+            f"tensor {segment.name!r} size {segment.nbytes} exceeds per-tensor byte limit "
+            f"{limits.max_tensor_bytes}"
+        )
+    total = state.tensor_bytes + segment.nbytes
+    if total > limits.max_total_tensor_bytes:
+        raise SerializationError(
+            f"total tensor size {total} exceeds byte limit {limits.max_total_tensor_bytes}"
+        )
+
+
+def _logical_tensor_nbytes(value: object) -> int:
+    if isinstance(value, np.ndarray):
+        return int(value.size) * int(value.dtype.itemsize)
+    if _is_torch_tensor(value):
+        tensor = cast(Any, value)
+        return int(tensor.numel()) * int(tensor.element_size())
+    raise SerializationError(f"unsupported tensor value: {type(value).__name__}")
+
+
+def _normalized_field(value: object, name: str) -> object:
+    field_value = getattr(value, name)
+    if not isinstance(value, model.TensorPayload):
+        return field_value
+    if name == "stride":
+        return _contiguous_stride(value.shape)
+    if name == "layout":
+        return "strided"
+    return field_value
+
+
+def _contiguous_stride(shape: tuple[int, ...]) -> tuple[int, ...]:
+    stride = [0] * len(shape)
+    running = 1
+    for index in range(len(shape) - 1, -1, -1):
+        stride[index] = running
+        running *= max(shape[index], 1)
+    return tuple(stride)
+
+
+def _element_stride(value: object) -> tuple[int, ...] | None:
+    if isinstance(value, np.ndarray):
+        itemsize = value.dtype.itemsize
+        if itemsize <= 0 or any(size % itemsize for size in value.strides):
+            raise SerializationError("NumPy byte strides are not aligned to the element size")
+        return tuple(size // itemsize for size in value.strides)
+    if _is_torch_tensor(value):
+        return tuple(int(size) for size in cast(Any, value).stride())
+    return None
+
+
+def _tensor_layout(value: object) -> str:
+    if isinstance(value, np.ndarray):
+        return "strided"
+    if _is_torch_tensor(value):
+        return str(cast(Any, value).layout).removeprefix("torch.")
+    return "strided"
+
+
+def _tensor_device(value: object) -> str:
+    return str(getattr(value, "device", "cpu"))
+
+
+def _base64_size(nbytes: int) -> int:
+    return 4 * ((nbytes + 2) // 3)
+
+
+def _safe_types(extra: Iterable[type[object]]) -> dict[str, type[object]]:
+    classes: list[type[object]] = []
+    for value in vars(model).values():
+        if isinstance(value, type) and (is_dataclass(value) or issubclass(value, Enum)):
+            classes.append(value)
+    classes.extend(extra)
+    result: dict[str, type[object]] = {}
+    for cls in classes:
+        if not (is_dataclass(cls) or issubclass(cls, Enum)):
+            raise ValueError(f"allowed type must be a dataclass or Enum: {cls!r}")
+        key = _type_key(cls)
+        if key in result and result[key] is not cls:
+            raise ValueError(f"duplicate allowed type key: {key}")
+        result[key] = cls
+    return result
+
+
+def _load_document(
+    metadata: bytes,
+    limits: SerializationLimits = _DEFAULT_LIMITS,
+    *,
+    allow_authentication: bool = False,
+) -> dict[str, object]:
+    if not isinstance(metadata, bytes):
+        raise SerializationError("serializer metadata must be bytes")
+    _check_metadata_size(metadata, limits)
+    try:
+        value = json.loads(metadata.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+        raise SerializationError(f"invalid UTF-8 JSON metadata: {error}") from error
+    _check_json_limits(value, limits)
+    if not isinstance(value, dict):
+        raise SerializationError("serializer metadata must be a JSON object")
+    if value.get("format") != _FORMAT:
+        raise SerializationError(f"unsupported serializer format: {value.get('format')!r}")
+    if value.get("serializer_version") != _SERIALIZER_VERSION:
+        raise SerializationError(
+            f"unsupported serializer version: {value.get('serializer_version')!r}"
+        )
+    if value.get("schema_version") != model.SCHEMA_VERSION:
+        raise SerializationError(f"unsupported schema version: {value.get('schema_version')!r}")
+    expected = {"format", "serializer_version", "schema_version", "root", "tensors"}
+    authentication = value.get("authentication")
+    if allow_authentication and authentication is not None:
+        _validate_authentication(authentication)
+        expected.add("authentication")
+    if set(value) != expected:
+        raise SerializationError("serializer envelope has unknown or missing fields")
+    if "root" not in value:
+        raise SerializationError("serializer metadata is missing root")
+    return cast(dict[str, object], value)
+
+
+def validate_metadata(
+    metadata: bytes,
+    *,
+    limits: SerializationLimits | None = None,
+) -> tuple[BufferSegment, ...]:
+    """Validate metadata and return catalog-only descriptors for transfer planning."""
+
+    active_limits = limits or _DEFAULT_LIMITS
+    document = _load_document(metadata, active_limits, allow_authentication=True)
+    return tuple(
+        _validate_catalog(
+            document.get("tensors"), (), active_limits, require_buffers=False
+        ).values()
+    )
+
+
+def _check_catalog_limits(value: object, limits: SerializationLimits) -> None:
+    if not isinstance(value, list):
+        raise SerializationError("tensor catalog must be a list")
+    if len(value) > limits.max_tensor_count:
+        raise SerializationError(f"tensor count exceeds limit {limits.max_tensor_count}")
+    sizes: list[int] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise SerializationError("tensor catalog entries must be objects")
+        nbytes = item.get("nbytes")
+        if isinstance(nbytes, bool) or not isinstance(nbytes, int) or nbytes < 0:
+            raise SerializationError(f"tensor catalog entry {index} has invalid nbytes")
+        sizes.append(nbytes)
+    validate_transfer_limits(metadata_bytes=0, tensor_sizes=sizes, limits=limits)
+
+
+def _validate_catalog(
+    value: object,
+    buffers: tuple[BufferSegment, ...],
+    limits: SerializationLimits,
+    *,
+    require_buffers: bool = True,
+) -> dict[str, BufferSegment]:
+    _check_catalog_limits(value, limits)
+    items = cast(list[object], value)
+    supplied = {segment.name: segment for segment in buffers}
+    if len(supplied) != len(buffers):
+        raise IntegrityError("external buffer names must be unique")
+    result: dict[str, BufferSegment] = {}
+    external_names: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            raise SerializationError("tensor catalog entries must be objects")
+        segment = _segment_from_catalog(
+            cast(dict[str, object], item), supplied, require_buffer=require_buffers
+        )
+        if segment.name in result:
+            raise IntegrityError(f"duplicate tensor catalog name: {segment.name!r}")
+        if require_buffers or segment.data is not None:
+            raw = segment.materialize()
+            if len(raw) != segment.nbytes:
+                raise IntegrityError(
+                    f"buffer {segment.name!r} size mismatch: expected "
+                    f"{segment.nbytes}, got {len(raw)}"
+                )
+            if segment.sha256 is not None and _digest(raw) != segment.sha256:
+                raise IntegrityError(f"buffer {segment.name!r} checksum mismatch")
+            segment = replace(segment, data=raw, owner=None)
+        result[segment.name] = segment
+        if item.get("external") is True:
+            external_names.add(segment.name)
+    if require_buffers and external_names != set(supplied):
+        raise IntegrityError(
+            f"external buffer catalog mismatch: expected {sorted(external_names)!r}, "
+            f"got {sorted(supplied)!r}"
+        )
+    return result
+
+
+def _segment_from_catalog(
+    entry: dict[str, object],
+    supplied: Mapping[str, BufferSegment],
+    *,
+    require_buffer: bool = True,
+) -> BufferSegment:
+    name = _required_str(entry, "name")
+    kind = _required_str(entry, "kind")
+    dtype = _required_str(entry, "dtype")
+    shape = _integer_tuple(entry.get("shape"), "shape", non_negative=True)
+    stride = _integer_tuple(entry.get("stride"), "stride", non_negative=False)
+    if len(shape) != len(stride):
+        raise SerializationError(f"tensor {name!r} shape and stride rank differ")
+    expected_stride = _contiguous_stride(shape)
+    if stride != expected_stride:
+        raise IntegrityError(
+            f"tensor {name!r} catalog stride mismatch: expected normalized "
+            f"element stride {expected_stride}, got {stride}"
+        )
+    layout = _required_str(entry, "layout")
+    if layout != "strided":
+        raise SerializationError(f"tensor {name!r} has unsupported layout {layout!r}")
+    original_device = _required_str(entry, "original_device")
+    wire_device = _required_str(entry, "wire_device")
+    path = _path(entry.get("path"))
+    nbytes = entry.get("nbytes")
+    if isinstance(nbytes, bool) or not isinstance(nbytes, int) or nbytes < 0:
+        raise SerializationError(f"tensor {name!r} has invalid nbytes")
+    expected_size = _expected_nbytes(kind, dtype, shape)
+    if expected_size != nbytes:
+        raise IntegrityError(
+            f"tensor {name!r} catalog size mismatch: shape/dtype require "
+            f"{expected_size}, got {nbytes}"
+        )
+    checksum = entry.get("sha256")
+    if checksum is not None and (
+        not isinstance(checksum, str)
+        or len(checksum) != 64
+        or any(character not in "0123456789abcdef" for character in checksum)
+    ):
+        raise SerializationError(f"tensor {name!r} has invalid sha256")
+    external = entry.get("external") is True
+    inline = entry.get("inline")
+    if external == (inline is not None):
+        raise SerializationError(f"tensor {name!r} must be exactly one of inline or external")
+    if inline is not None:
+        if not isinstance(inline, str):
+            raise SerializationError(f"tensor {name!r} inline payload must be base64 text")
+        expected_inline_size = _base64_size(nbytes)
+        if len(inline) != expected_inline_size:
+            raise IntegrityError(
+                f"tensor {name!r} inline size mismatch: expected "
+                f"{expected_inline_size} base64 characters, got {len(inline)}"
+            )
+    expected_keys = {*_CATALOG_FIELDS, "external" if external else "inline"}
+    if set(entry) != expected_keys:
+        raise SerializationError(f"tensor {name!r} has unknown or missing catalog fields")
+    catalog = BufferSegment(
+        name=name,
+        path=path,
+        kind=kind,
+        dtype=dtype,
+        shape=shape,
+        stride=stride,
+        layout=layout,
+        original_device=original_device,
+        wire_device=wire_device,
+        nbytes=nbytes,
+        sha256=checksum,
+        data=_decode_base64(inline, f"tensor {name!r}") if inline is not None else None,
+    )
+    if not external:
+        return catalog
+    if not require_buffer:
+        return catalog
+    try:
+        provided = supplied[name]
+    except KeyError as error:
+        raise IntegrityError(f"external buffer {name!r} is missing") from error
+    if provided.catalog_entry() != catalog.catalog_entry():
+        raise IntegrityError(f"external buffer {name!r} metadata disagrees with catalog")
+    return provided
+
+
+def _expected_nbytes(kind: str, dtype: str, shape: tuple[int, ...]) -> int:
+    count = math.prod(shape)
+    if kind == "numpy":
+        itemsize = _numpy_dtype(dtype).itemsize
+    elif kind == "torch":
+        torch = _torch()
+        if torch is None:
+            raise SerializationError("PyTorch is required to validate a PyTorch tensor")
+        itemsize = torch.empty((), dtype=_torch_dtype(torch, dtype)).element_size()
+    else:
+        raise SerializationError(f"unsupported tensor kind: {kind!r}")
+    return count * itemsize
+
+
+def _numpy_dtype(value: str) -> np.dtype[Any]:
+    try:
+        dtype = np.dtype(value)
+    except TypeError as error:
+        raise SerializationError(f"invalid NumPy dtype: {value!r}") from error
+    if dtype.hasobject:
+        raise SerializationError("NumPy object dtypes are not safe to deserialize")
+    return dtype
+
+
+def _torch_dtype(torch: Any, value: str) -> Any:
+    allowed = {
+        name: getattr(torch, name)
+        for name in (
+            "bool",
+            "uint8",
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "float16",
+            "bfloat16",
+            "float32",
+            "float64",
+            "complex64",
+            "complex128",
+        )
+        if hasattr(torch, name)
+    }
+    try:
+        return allowed[value.removeprefix("torch.")]
+    except KeyError as error:
+        raise SerializationError(f"unsupported PyTorch dtype: {value!r}") from error
+
+
+def _integer_tuple(value: object, field: str, *, non_negative: bool) -> tuple[int, ...]:
+    if not isinstance(value, list) or any(
+        isinstance(item, bool) or not isinstance(item, int) or (non_negative and item < 0)
+        for item in value
+    ):
+        raise SerializationError(f"tensor catalog {field} must be a list of integers")
+    return tuple(value)
+
+
+def _path(value: object) -> tuple[_PathPart, ...]:
+    if not isinstance(value, list) or any(
+        isinstance(item, bool) or not isinstance(item, (str, int)) for item in value
+    ):
+        raise SerializationError("tensor catalog path must contain strings and integers")
+    return tuple(value)
+
+
+def _required_str(value: Mapping[str, object], key: str) -> str:
+    result = value.get(key)
+    if not isinstance(result, str) or not result:
+        raise SerializationError(f"metadata {key!r} must be a non-empty string")
+    return result
+
+
+def _decode_base64(value: str, context: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except (ValueError, TypeError) as error:
+        raise SerializationError(f"invalid base64 in {context}") from error
+
+
+def _digest(value: bytes | memoryview) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _signature(
+    key: bytes,
+    key_id: str,
+    metadata: bytes,
+    buffers: tuple[BufferSegment, ...],
+) -> str:
+    signature = hmac.new(key, digestmod=hashlib.sha256)
+    protected = _canonical({"algorithm": "hmac-sha256", "key_id": key_id}).encode()
+    for part in (protected, metadata):
+        signature.update(len(part).to_bytes(8, "big"))
+        signature.update(part)
+    for buffer in buffers:
+        part = buffer.materialize()
+        signature.update(len(part).to_bytes(8, "big"))
+        signature.update(part)
+    return signature.hexdigest()
+
+
+def _valid_key_id(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= 128
+        and value.isascii()
+        and all(character.isalnum() or character in "._-" for character in value)
+    )
+
+
+def _validate_authentication(value: object) -> None:
+    if not isinstance(value, dict) or set(value) != {"algorithm", "key_id", "signature"}:
+        raise SerializationError("authentication metadata is malformed")
+    if value.get("algorithm") != "hmac-sha256" or not _valid_key_id(value.get("key_id")):
+        raise SerializationError("authentication algorithm or key ID is invalid")
+    signature = value.get("signature")
+    if (
+        not isinstance(signature, str)
+        or len(signature) != 64
+        or any(character not in "0123456789abcdef" for character in signature)
+    ):
+        raise SerializationError("authentication signature is invalid")
+
+
+def _dump_document(value: object, limits: SerializationLimits) -> bytes:
+    _check_json_limits(value, limits)
+    try:
+        metadata = _canonical(value).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError) as error:
+        raise SerializationError(f"metadata encoding failed: {error}") from error
+    _check_metadata_size(metadata, limits)
+    return metadata
+
+
+def _type_key(value: type[object]) -> str:
+    return f"{value.__module__}:{value.__qualname__}"
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SerializationError(f"duplicate JSON object key: {key!r}")
+        result[key] = value
+    return result

--- a/rl_experience_transfer/src/rlxfer/state.py
+++ b/rl_experience_transfer/src/rlxfer/state.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Consumer delivery state with in-memory and durable SQLite implementations."""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+from time import time
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class DeadLetter:
+    """Content-free record of a permanently rejected delivery."""
+
+    experience_id: str
+    idempotency_key: str
+    reason: str
+    attempt: int
+    recorded_at: float = field(default_factory=time)
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not value
+            for value in (self.experience_id, self.idempotency_key, self.reason)
+        ):
+            raise ValueError("dead-letter identifiers and reason must be non-empty")
+        if len(self.reason) > 2048:
+            raise ValueError("dead-letter reason cannot exceed 2048 characters")
+        if isinstance(self.attempt, bool) or not isinstance(self.attempt, int) or self.attempt < 1:
+            raise ValueError("dead-letter attempt must be a positive integer")
+        if (
+            isinstance(self.recorded_at, bool)
+            or not isinstance(self.recorded_at, (int, float))
+            or not math.isfinite(self.recorded_at)
+            or self.recorded_at < 0
+        ):
+            raise ValueError("dead-letter timestamp must be a non-negative finite number")
+
+
+class DeliveryStateStore(Protocol):
+    """Consumer-owned idempotency and dead-letter persistence contract."""
+
+    def was_consumed(self, idempotency_key: str) -> bool: ...
+
+    def mark_consumed(self, idempotency_key: str) -> None: ...
+
+    def record_dead_letter(self, letter: DeadLetter) -> None: ...
+
+    def dead_letters(self, limit: int = 100) -> tuple[DeadLetter, ...]: ...
+
+
+class InMemoryDeliveryState:
+    """Bounded process-local delivery state used by default."""
+
+    def __init__(self, max_entries: int = 4096) -> None:
+        if isinstance(max_entries, bool) or not isinstance(max_entries, int) or max_entries < 1:
+            raise ValueError("max_entries must be positive")
+        self._max_entries = max_entries
+        self._consumed: set[str] = set()
+        self._order: deque[str] = deque()
+        self._dead_letters: deque[DeadLetter] = deque(maxlen=max_entries)
+        self._lock = Lock()
+
+    def was_consumed(self, idempotency_key: str) -> bool:
+        with self._lock:
+            return idempotency_key in self._consumed
+
+    def mark_consumed(self, idempotency_key: str) -> None:
+        if not idempotency_key:
+            raise ValueError("idempotency_key must be non-empty")
+        with self._lock:
+            if idempotency_key in self._consumed:
+                return
+            self._consumed.add(idempotency_key)
+            self._order.append(idempotency_key)
+            while len(self._order) > self._max_entries:
+                self._consumed.remove(self._order.popleft())
+
+    def record_dead_letter(self, letter: DeadLetter) -> None:
+        with self._lock:
+            self._dead_letters.append(letter)
+
+    def dead_letters(self, limit: int = 100) -> tuple[DeadLetter, ...]:
+        """Return up to ``limit`` newest retained dead letters, newest first."""
+
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
+            raise ValueError("limit must be positive")
+        with self._lock:
+            return tuple(reversed(self._dead_letters))[:limit]
+
+
+class SqliteDeliveryState:
+    """Multiprocess-safe durable idempotency and dead-letter state."""
+
+    def __init__(self, path: str | os.PathLike[str], *, timeout: float = 5.0) -> None:
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            raise ValueError("timeout must be positive")
+        self._path = Path(path).expanduser().resolve()
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._timeout = timeout
+        with self._connect() as connection:
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS consumed "
+                "(idempotency_key TEXT PRIMARY KEY, consumed_at REAL NOT NULL)"
+            )
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS dead_letters "
+                "(id INTEGER PRIMARY KEY, experience_id TEXT NOT NULL, "
+                "idempotency_key TEXT NOT NULL, reason TEXT NOT NULL, "
+                "attempt INTEGER NOT NULL, recorded_at REAL NOT NULL)"
+            )
+        os.chmod(self._path, 0o600)
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._path, timeout=self._timeout)
+        connection.execute(f"PRAGMA busy_timeout = {int(self._timeout * 1000)}")
+        return connection
+
+    def was_consumed(self, idempotency_key: str) -> bool:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT 1 FROM consumed WHERE idempotency_key = ?",
+                (idempotency_key,),
+            ).fetchone()
+        return row is not None
+
+    def mark_consumed(self, idempotency_key: str) -> None:
+        if not idempotency_key:
+            raise ValueError("idempotency_key must be non-empty")
+        with self._connect() as connection:
+            connection.execute(
+                "INSERT OR IGNORE INTO consumed VALUES (?, ?)",
+                (idempotency_key, time()),
+            )
+
+    def record_dead_letter(self, letter: DeadLetter) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "INSERT INTO dead_letters "
+                "(experience_id, idempotency_key, reason, attempt, recorded_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    letter.experience_id,
+                    letter.idempotency_key,
+                    letter.reason,
+                    letter.attempt,
+                    letter.recorded_at,
+                ),
+            )
+
+    def dead_letters(self, limit: int = 100) -> tuple[DeadLetter, ...]:
+        """Return up to ``limit`` newest dead letters, newest first."""
+
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
+            raise ValueError("limit must be positive")
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT experience_id, idempotency_key, reason, attempt, recorded_at "
+                "FROM dead_letters ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return tuple(DeadLetter(*row) for row in rows)

--- a/rl_experience_transfer/src/rlxfer/tracing.py
+++ b/rl_experience_transfer/src/rlxfer/tracing.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency-free W3C trace-context propagation helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+
+from .model import ExperienceBatch
+
+_TRACE_NAMESPACE = "w3c.trace_context"
+_TRACEPARENT = re.compile(
+    r"^(?P<version>[0-9a-f]{2})-(?P<trace_id>[0-9a-f]{32})-"
+    r"(?P<parent_id>[0-9a-f]{16})-(?P<flags>[0-9a-f]{2})$"
+)
+_TRACESTATE_KEY = re.compile(
+    r"^(?:[a-z][a-z0-9_*/-]{0,255}|[a-z0-9][a-z0-9_*/-]{0,240}"
+    r"@[a-z][a-z0-9_*/-]{0,13})$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TraceContext:
+    """Validated W3C traceparent and optional tracestate values."""
+
+    traceparent: str
+    tracestate: str | None = None
+
+    def __post_init__(self) -> None:
+        match = (
+            _TRACEPARENT.fullmatch(self.traceparent) if isinstance(self.traceparent, str) else None
+        )
+        if (
+            match is None
+            or match["version"] == "ff"
+            or int(match["trace_id"], 16) == 0
+            or int(match["parent_id"], 16) == 0
+        ):
+            raise ValueError("traceparent is not a valid W3C trace context")
+        if self.tracestate is not None and not _valid_tracestate(self.tracestate):
+            raise ValueError("tracestate is not a valid W3C trace state")
+
+
+def with_trace_context(batch: ExperienceBatch, context: TraceContext) -> ExperienceBatch:
+    """Return a shallow batch copy carrying trace context in a safe extension."""
+
+    extensions = dict(batch.extensions)
+    extensions[_TRACE_NAMESPACE] = {
+        key: value
+        for key, value in (
+            ("traceparent", context.traceparent),
+            ("tracestate", context.tracestate),
+        )
+        if value is not None
+    }
+    return replace(batch, extensions=extensions)
+
+
+def trace_context_from(batch: ExperienceBatch) -> TraceContext | None:
+    """Read and validate trace context from a canonical batch."""
+
+    value = batch.extensions.get(_TRACE_NAMESPACE)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping) or not set(value).issubset({"traceparent", "tracestate"}):
+        raise ValueError("trace-context extension is malformed")
+    traceparent = value.get("traceparent")
+    tracestate = value.get("tracestate")
+    if not isinstance(traceparent, str) or (
+        tracestate is not None and not isinstance(tracestate, str)
+    ):
+        raise ValueError("trace-context extension is malformed")
+    return TraceContext(traceparent, tracestate)
+
+
+def _valid_tracestate(value: object) -> bool:
+    if not isinstance(value, str) or not value or len(value) > 512 or not value.isascii():
+        return False
+    members = value.split(",")
+    if len(members) > 32:
+        return False
+    keys: set[str] = set()
+    for member in members:
+        key, separator, state = member.partition("=")
+        if (
+            not separator
+            or key in keys
+            or _TRACESTATE_KEY.fullmatch(key) is None
+            or not 0 < len(state) <= 256
+            or state.endswith(" ")
+            or any(character in ",=" or not 0x20 <= ord(character) <= 0x7E for character in state)
+        ):
+            return False
+        keys.add(key)
+    return True

--- a/rl_experience_transfer/src/rlxfer/transport.py
+++ b/rl_experience_transfer/src/rlxfer/transport.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Transport contracts and dependency-injected construction."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from importlib import metadata as importlib_metadata
+from types import MappingProxyType
+from typing import Any, Protocol
+
+from rlxfer.errors import CapabilityError
+from rlxfer.serialization import SerializedExperience
+
+
+class ReceiptState(str, Enum):
+    """Application delivery state, distinct from byte-transfer completion."""
+
+    ACCEPTED = "accepted"
+    ACKED = "acked"
+    NACKED = "nacked"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+
+    @property
+    def terminal(self) -> bool:
+        """Whether no further delivery-state transition is possible."""
+
+        return self not in {ReceiptState.ACCEPTED, ReceiptState.EXPIRED}
+
+
+@dataclass(frozen=True, slots=True)
+class TransportCapabilities:
+    """Features and limits advertised by a transport instance."""
+
+    name: str
+    zero_copy: bool = False
+    cpu_buffers: bool = True
+    accelerator_buffers: frozenset[str] = frozenset()
+    remote: bool = False
+    scatter_gather: bool = False
+    asynchronous: bool = False
+    acknowledgements: bool = True
+    persistence: bool = False
+    max_transfer_size: int | None = None
+    requires_registration: bool = False
+    delivery_guarantee: str = "at-least-once"
+
+
+@dataclass(frozen=True, slots=True)
+class TransferPlan:
+    """Transport-independent requirements decided before data movement."""
+
+    strategy: str = "metadata+buffers"
+    total_bytes: int = 0
+    buffer_count: int = 0
+    require_zero_copy: bool = False
+    require_remote: bool = False
+    require_async: bool = False
+    require_persistence: bool = False
+    device_types: frozenset[str] = frozenset({"cpu"})
+
+    def check(self, capabilities: TransportCapabilities) -> None:
+        """Fail before transfer when required capabilities are unavailable."""
+
+        missing: list[str] = []
+        if self.require_zero_copy and not capabilities.zero_copy:
+            missing.append("zero_copy")
+        if self.require_remote and not capabilities.remote:
+            missing.append("remote")
+        if self.require_async and not capabilities.asynchronous:
+            missing.append("asynchronous")
+        if self.require_persistence and not capabilities.persistence:
+            missing.append("persistence")
+        if "cpu" in self.device_types and not capabilities.cpu_buffers:
+            missing.append("cpu_buffers")
+        unsupported_devices = self.device_types - {"cpu"} - capabilities.accelerator_buffers
+        missing.extend(f"device:{device}" for device in sorted(unsupported_devices))
+        if (
+            capabilities.max_transfer_size is not None
+            and self.total_bytes > capabilities.max_transfer_size
+        ):
+            missing.append(f"max_transfer_size:{capabilities.max_transfer_size}")
+        if missing:
+            raise CapabilityError(
+                f"transport {capabilities.name!r} cannot satisfy: {', '.join(missing)}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class HealthStatus:
+    """Small health response suitable for readiness checks."""
+
+    healthy: bool
+    detail: str = "ok"
+    queue_depth: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptResult:
+    """Terminal or current state returned by receipt polling."""
+
+    state: ReceiptState
+    reason: str | None = None
+    attempts: int = 0
+
+
+WaitReceipt = Callable[[float | None], ReceiptResult]
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryReceipt:
+    """Receipt returned after a transport accepts an experience."""
+
+    receipt_id: str
+    experience_id: str
+    idempotency_key: str
+    accepted_at: float
+    _wait: WaitReceipt = field(repr=False, compare=False)
+
+    def wait(self, timeout: float | None = None) -> ReceiptResult:
+        """Wait for acknowledgement, rejection, or retry exhaustion."""
+
+        return self._wait(timeout)
+
+
+@dataclass(frozen=True, slots=True)
+class TransportDelivery:
+    """Opaque transport delivery passed to the consumer API."""
+
+    token: str
+    experience_id: str
+    idempotency_key: str
+    payload: SerializedExperience
+    attempt: int
+    published_at: float
+    max_retries: int = 3
+
+
+class ExperienceTransport(Protocol):
+    """Minimal control/data-plane contract implemented by every backend."""
+
+    @property
+    def capabilities(self) -> TransportCapabilities: ...
+
+    def publish(
+        self,
+        payload: SerializedExperience,
+        *,
+        experience_id: str,
+        idempotency_key: str,
+        timeout: float | None = None,
+        max_retries: int = 3,
+    ) -> DeliveryReceipt: ...
+
+    def receive(self, timeout: float | None = None) -> TransportDelivery | None: ...
+
+    def ack(self, token: str) -> None: ...
+
+    def nack(self, token: str, reason: str, *, retry: bool = True) -> None: ...
+
+    def reject(self, token: str, reason: str) -> None: ...
+
+    def cancel(self, receipt_id: str, reason: str = "cancelled") -> None: ...
+
+    def health(self) -> HealthStatus: ...
+
+    def close(self, timeout: float | None = None) -> None: ...
+
+
+TransportFactory = Callable[[Mapping[str, Any]], ExperienceTransport]
+
+
+@dataclass(frozen=True, slots=True)
+class TransportConfig:
+    """Name plus backend-owned options; the core never branches on the name."""
+
+    name: str
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+
+class TransportRegistry:
+    """Instance-scoped registry with optional Python entry-point discovery."""
+
+    def __init__(self, factories: Mapping[str, TransportFactory] | None = None) -> None:
+        self._factories = dict(factories or {})
+
+    def register(self, name: str, factory: TransportFactory) -> None:
+        if not name or name in self._factories:
+            raise ValueError(f"transport {name!r} is already registered or invalid")
+        self._factories[name] = factory
+
+    def discover(self, group: str = "rlxfer.transports") -> None:
+        for entry_point in importlib_metadata.entry_points(group=group):
+            self.register(entry_point.name, entry_point.load())
+
+    def create(self, config: TransportConfig) -> ExperienceTransport:
+        try:
+            factory = self._factories[config.name]
+        except KeyError as error:
+            available = ", ".join(sorted(self._factories)) or "none"
+            raise ValueError(
+                f"unknown transport {config.name!r}; registered transports: {available}"
+            ) from error
+        return factory(config.options)
+
+
+def default_registry() -> TransportRegistry:
+    """Return a new registry, avoiding process-global mutable registration state."""
+
+    factories: Mapping[str, TransportFactory] = MappingProxyType(
+        {
+            "fallback": _fallback_factory,
+            "filesystem": _filesystem_factory,
+            "memory": _memory_factory,
+            "nixl": _nixl_factory,
+        }
+    )
+    return TransportRegistry(factories)
+
+
+def _memory_factory(options: Mapping[str, Any]) -> ExperienceTransport:
+    from rlxfer.transports.memory import InMemoryTransport
+
+    return InMemoryTransport.from_options(options)
+
+
+def _fallback_factory(options: Mapping[str, Any]) -> ExperienceTransport:
+    from rlxfer.transports.fallback import FallbackTransport
+
+    return FallbackTransport.from_options(options)
+
+
+def _filesystem_factory(options: Mapping[str, Any]) -> ExperienceTransport:
+    from rlxfer.transports.filesystem import FileSystemTransport
+
+    return FileSystemTransport.from_options(options)
+
+
+def _nixl_factory(options: Mapping[str, Any]) -> ExperienceTransport:
+    from rlxfer.transports.nixl import NixlTransport
+
+    return NixlTransport.from_options(options)
+
+
+def create_transport(
+    config: TransportConfig, registry: TransportRegistry | None = None
+) -> ExperienceTransport:
+    """Construct a transport without exposing backend conditionals to callers."""
+
+    return (registry or default_registry()).create(config)

--- a/rl_experience_transfer/src/rlxfer/transports/__init__.py
+++ b/rl_experience_transfer/src/rlxfer/transports/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in experience transports."""
+
+from rlxfer.transports.fallback import FallbackTransport
+from rlxfer.transports.filesystem import FileSystemTransport
+from rlxfer.transports.memory import InMemoryTransport
+from rlxfer.transports.nixl import NixlTransport
+
+__all__ = ["FallbackTransport", "FileSystemTransport", "InMemoryTransport", "NixlTransport"]

--- a/rl_experience_transfer/src/rlxfer/transports/fallback.py
+++ b/rl_experience_transfer/src/rlxfer/transports/fallback.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Ordered transport fallback with routed receipts and delivery tokens."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from typing import Any
+
+from rlxfer.errors import (
+    BackpressureError,
+    CapabilityError,
+    ClosedError,
+    DeliveryError,
+    TransportError,
+)
+from rlxfer.serialization import SerializedExperience
+from rlxfer.transport import (
+    DeliveryReceipt,
+    ExperienceTransport,
+    HealthStatus,
+    TransportCapabilities,
+    TransportDelivery,
+)
+
+
+class FallbackTransport:
+    """Try healthy transports in order while preserving settlement routing."""
+
+    def __init__(
+        self,
+        transports: Sequence[ExperienceTransport],
+        *,
+        poll_interval: float = 0.05,
+        fallback_exceptions: Sequence[type[Exception]] = (
+            BackpressureError,
+            CapabilityError,
+            ClosedError,
+        ),
+    ) -> None:
+        if not transports or len({id(transport) for transport in transports}) != len(transports):
+            raise ValueError("fallback transports must be non-empty and unique")
+        if poll_interval <= 0:
+            raise ValueError("poll_interval must be positive")
+        if not fallback_exceptions or any(
+            not isinstance(error, type) or not issubclass(error, Exception)
+            for error in fallback_exceptions
+        ):
+            raise ValueError("fallback_exceptions must contain exception types")
+        self._transports = tuple(transports)
+        self._poll_interval = poll_interval
+        self._fallback_exceptions = tuple(fallback_exceptions)
+        self._next_receive = 0
+
+    @classmethod
+    def from_options(cls, options: Mapping[str, Any]) -> FallbackTransport:
+        return cls(**dict(options))
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        """Report only capabilities guaranteed by every fallback path."""
+
+        capabilities = tuple(transport.capabilities for transport in self._transports)
+        finite_sizes = [
+            item.max_transfer_size for item in capabilities if item.max_transfer_size is not None
+        ]
+        accelerators = set(capabilities[0].accelerator_buffers)
+        for item in capabilities[1:]:
+            accelerators.intersection_update(item.accelerator_buffers)
+        names = ",".join(item.name for item in capabilities)
+        return TransportCapabilities(
+            name=f"fallback({names})",
+            zero_copy=all(item.zero_copy for item in capabilities),
+            cpu_buffers=all(item.cpu_buffers for item in capabilities),
+            accelerator_buffers=frozenset(accelerators),
+            remote=all(item.remote for item in capabilities),
+            scatter_gather=all(item.scatter_gather for item in capabilities),
+            asynchronous=all(item.asynchronous for item in capabilities),
+            acknowledgements=all(item.acknowledgements for item in capabilities),
+            persistence=all(item.persistence for item in capabilities),
+            max_transfer_size=min(finite_sizes) if finite_sizes else None,
+            requires_registration=any(item.requires_registration for item in capabilities),
+            delivery_guarantee="at-least-once",
+        )
+
+    def publish(
+        self,
+        payload: SerializedExperience,
+        *,
+        experience_id: str,
+        idempotency_key: str,
+        timeout: float | None = None,
+        max_retries: int = 3,
+    ) -> DeliveryReceipt:
+        failures: list[Exception] = []
+        deadline = None if timeout is None else time.monotonic() + timeout
+        for index, transport in enumerate(self._transports):
+            if not _healthy(transport):
+                continue
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            try:
+                receipt = transport.publish(
+                    payload,
+                    experience_id=experience_id,
+                    idempotency_key=idempotency_key,
+                    timeout=remaining,
+                    max_retries=max_retries,
+                )
+            except self._fallback_exceptions as error:
+                failures.append(error)
+                continue
+            return replace(receipt, receipt_id=_routed(index, receipt.receipt_id))
+        detail = ", ".join(type(error).__name__ for error in failures) or "no healthy transport"
+        raise TransportError(f"all fallback transports failed before acceptance: {detail}") from (
+            failures[-1] if failures else None
+        )
+
+    def receive(self, timeout: float | None = None) -> TransportDelivery | None:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            succeeded = False
+            failures: list[Exception] = []
+            for _ in self._transports:
+                index = self._next_receive
+                self._next_receive = (index + 1) % len(self._transports)
+                remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+                wait = (
+                    self._poll_interval
+                    if remaining is None
+                    else min(self._poll_interval, remaining)
+                )
+                try:
+                    delivery = self._transports[index].receive(wait)
+                    succeeded = True
+                except (TransportError, ClosedError) as error:
+                    failures.append(error)
+                    continue
+                if delivery is not None:
+                    return replace(delivery, token=_routed(index, delivery.token))
+            if not succeeded:
+                raise TransportError(
+                    "all fallback transports failed while receiving"
+                ) from failures[-1]
+            if deadline is not None and time.monotonic() >= deadline:
+                return None
+
+    def ack(self, token: str) -> None:
+        transport, inner = self._route(token)
+        transport.ack(inner)
+
+    def nack(self, token: str, reason: str, *, retry: bool = True) -> None:
+        transport, inner = self._route(token)
+        transport.nack(inner, reason, retry=retry)
+
+    def reject(self, token: str, reason: str) -> None:
+        transport, inner = self._route(token)
+        transport.reject(inner, reason)
+
+    def cancel(self, receipt_id: str, reason: str = "cancelled") -> None:
+        transport, inner = self._route(receipt_id)
+        transport.cancel(inner, reason)
+
+    def health(self) -> HealthStatus:
+        statuses = tuple(_health(transport) for transport in self._transports)
+        unhealthy = [
+            self._transports[index].capabilities.name
+            for index, status in enumerate(statuses)
+            if not status.healthy
+        ]
+        return HealthStatus(
+            any(status.healthy for status in statuses),
+            "ok" if not unhealthy else f"unhealthy: {', '.join(unhealthy)}",
+            sum(status.queue_depth for status in statuses),
+        )
+
+    def close(self, timeout: float | None = None) -> None:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        failure: Exception | None = None
+        for transport in self._transports:
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            try:
+                transport.close(remaining)
+            except Exception as error:
+                failure = failure or error
+        if failure is not None:
+            raise TransportError("one or more fallback transports failed to close") from failure
+
+    def _route(self, value: str) -> tuple[ExperienceTransport, str]:
+        prefix, separator, inner = value.partition(":")
+        if not separator or not inner or not prefix.isdigit():
+            raise DeliveryError("fallback route is malformed")
+        try:
+            index = int(prefix)
+            if not 0 <= index < len(self._transports):
+                raise IndexError(index)
+            return self._transports[index], inner
+        except (ValueError, IndexError) as error:
+            raise DeliveryError("fallback route is unknown") from error
+
+
+def _routed(index: int, value: str) -> str:
+    return f"{index}:{value}"
+
+
+def _healthy(transport: ExperienceTransport) -> bool:
+    return _health(transport).healthy
+
+
+def _health(transport: ExperienceTransport) -> HealthStatus:
+    try:
+        return transport.health()
+    except Exception as error:
+        return HealthStatus(False, type(error).__name__)

--- a/rl_experience_transfer/src/rlxfer/transports/filesystem.py
+++ b/rl_experience_transfer/src/rlxfer/transports/filesystem.py
@@ -1,0 +1,494 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Persistent local transport with atomic filesystem queue transitions."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import shutil
+import time
+import uuid
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from rlxfer.errors import BackpressureError, ClosedError, DeliveryError
+from rlxfer.serialization import (
+    BufferSegment,
+    SerializationLimits,
+    SerializedExperience,
+    validate_transfer_limits,
+)
+from rlxfer.transport import (
+    DeliveryReceipt,
+    HealthStatus,
+    ReceiptResult,
+    ReceiptState,
+    TransportCapabilities,
+    TransportDelivery,
+)
+
+
+class FileSystemTransport:
+    """Multiprocess, persistent, at-least-once transport for one local host."""
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        max_queue: int = 128,
+        lease_timeout: float = 300.0,
+        poll_interval: float = 0.01,
+        limits: SerializationLimits | None = None,
+    ) -> None:
+        if max_queue < 1:
+            raise ValueError("max_queue must be positive")
+        if lease_timeout <= 0 or poll_interval <= 0:
+            raise ValueError("lease_timeout and poll_interval must be positive")
+        self._root = Path(path).expanduser().resolve()
+        self._max_queue = max_queue
+        self._lease_timeout = lease_timeout
+        self._poll_interval = poll_interval
+        self._limits = limits or SerializationLimits()
+        self._closed = False
+        for name in ("pending", "inflight", "receipts", "idempotency", "tmp"):
+            (self._root / name).mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._lock_path = self._root / ".lock"
+        self._lock_path.touch(exist_ok=True)
+        self._recover_stale()
+
+    @classmethod
+    def from_options(cls, options: Mapping[str, Any]) -> FileSystemTransport:
+        return cls(**dict(options))
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(
+            name="filesystem",
+            remote=False,
+            asynchronous=True,
+            acknowledgements=True,
+            persistence=True,
+            max_transfer_size=(
+                self._limits.max_metadata_bytes + self._limits.max_total_tensor_bytes
+            ),
+            delivery_guarantee="at-least-once",
+        )
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        with self._lock_path.open("rb") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock, fcntl.LOCK_UN)
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ClosedError("filesystem transport is closed")
+
+    def _depth(self) -> int:
+        return sum(1 for _ in (self._root / "pending").iterdir()) + sum(
+            1 for _ in (self._root / "inflight").iterdir()
+        )
+
+    @staticmethod
+    def _index_name(idempotency_key: str) -> str:
+        import hashlib
+
+        return hashlib.sha256(idempotency_key.encode()).hexdigest() + ".json"
+
+    @staticmethod
+    def _record_id(value: object) -> str:
+        if not isinstance(value, str):
+            raise DeliveryError("filesystem record ID must be a UUID hex string")
+        try:
+            parsed = uuid.UUID(hex=value)
+        except ValueError as error:
+            raise DeliveryError("filesystem record ID must be a UUID hex string") from error
+        if parsed.hex != value:
+            raise DeliveryError("filesystem record ID must be a canonical UUID hex string")
+        return value
+
+    @staticmethod
+    def _write_private(path: Path, data: bytes) -> None:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _write_json(self, target: Path, value: Mapping[str, Any]) -> None:
+        temporary = self._root / "tmp" / f"{uuid.uuid4().hex}.json"
+        try:
+            self._write_private(
+                temporary,
+                json.dumps(value, separators=(",", ":"), sort_keys=True).encode(),
+            )
+            os.replace(temporary, target)
+            self._fsync_directory(target.parent)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _write_receipt(self, record_id: str, result: ReceiptResult) -> None:
+        self._write_json(
+            self._root / "receipts" / f"{record_id}.json",
+            {
+                "state": result.state.value,
+                "reason": result.reason,
+                "attempts": result.attempts,
+            },
+        )
+
+    def _read_manifest(self, directory: Path) -> dict[str, Any]:
+        path = directory / "manifest.json"
+        if path.stat().st_size > self._limits.max_metadata_bytes:
+            raise DeliveryError("filesystem manifest exceeds metadata size limit")
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise DeliveryError("filesystem manifest must be a JSON object")
+        return value
+
+    @staticmethod
+    def _read_buffer(path: Path, expected_size: int) -> bytes:
+        if path.stat().st_size != expected_size:
+            raise DeliveryError("filesystem buffer size disagrees with its manifest")
+        return path.read_bytes()
+
+    @staticmethod
+    def _declared_size(item: object) -> int:
+        if not isinstance(item, dict):
+            return -1
+        value = item.get("nbytes")
+        return value if isinstance(value, int) and not isinstance(value, bool) else -1
+
+    def _recover_stale(self) -> None:
+        now = time.time()
+        with self._locked():
+            for directory in (self._root / "inflight").iterdir():
+                if now - directory.stat().st_mtime <= self._lease_timeout:
+                    continue
+                manifest = self._read_manifest(directory)
+                record_id = self._record_id(manifest.get("record_id"))
+                if (self._root / "receipts" / f"{record_id}.json").exists():
+                    shutil.rmtree(directory)
+                    continue
+                destination = self._root / "pending" / record_id
+                if destination.exists():
+                    shutil.rmtree(directory)
+                else:
+                    os.replace(directory, destination)
+            self._repair_indexes_locked()
+
+    def _repair_indexes_locked(self) -> None:
+        active: dict[str, dict[str, Any]] = {}
+        for queue_name in ("pending", "inflight"):
+            for directory in (self._root / queue_name).iterdir():
+                manifest = self._read_manifest(directory)
+                record_id = self._record_id(manifest.get("record_id"))
+                if queue_name == "pending" and directory.name != record_id:
+                    raise DeliveryError("pending directory and manifest record IDs differ")
+                idempotency_key = manifest.get("idempotency_key")
+                if not isinstance(idempotency_key, str) or not idempotency_key:
+                    raise DeliveryError("filesystem manifest idempotency key is invalid")
+                previous = active.setdefault(record_id, manifest)
+                if previous is not manifest:
+                    raise DeliveryError("duplicate active filesystem record ID")
+                index_path = self._root / "idempotency" / self._index_name(idempotency_key)
+                if not index_path.exists():
+                    self._write_json(
+                        index_path,
+                        {
+                            "record_id": record_id,
+                            "experience_id": str(manifest["experience_id"]),
+                            "published_at": float(manifest["published_at"]),
+                        },
+                    )
+                    continue
+                index = json.loads(index_path.read_text(encoding="utf-8"))
+                if self._record_id(index.get("record_id")) != record_id:
+                    raise DeliveryError("idempotency index points to another active record")
+
+        receipt_ids = {path.stem for path in (self._root / "receipts").glob("*.json")}
+        for index_path in (self._root / "idempotency").glob("*.json"):
+            index = json.loads(index_path.read_text(encoding="utf-8"))
+            record_id = self._record_id(index.get("record_id"))
+            if record_id not in active and record_id not in receipt_ids:
+                index_path.unlink()
+                self._fsync_directory(index_path.parent)
+
+    def publish(
+        self,
+        payload: SerializedExperience,
+        *,
+        experience_id: str,
+        idempotency_key: str,
+        timeout: float | None = None,
+        max_retries: int = 3,
+    ) -> DeliveryReceipt:
+        self._ensure_open()
+        if not experience_id or not idempotency_key:
+            raise ValueError("experience_id and idempotency_key are required")
+        if max_retries < 0:
+            raise ValueError("max_retries cannot be negative")
+        validate_transfer_limits(
+            metadata_bytes=len(payload.metadata),
+            tensor_sizes=(segment.nbytes for segment in payload.buffers),
+            limits=self._limits,
+        )
+        deadline = None if timeout is None else time.monotonic() + timeout
+        index_path = self._root / "idempotency" / self._index_name(idempotency_key)
+        record_id = uuid.uuid4().hex
+        published_at = time.time()
+        build = self._root / "tmp" / record_id
+        buffer_directory = build / "buffers"
+        buffer_directory.mkdir(mode=0o700, parents=True)
+        catalogs: list[dict[str, Any]] = []
+        try:
+            self._write_private(build / "metadata.json", payload.metadata)
+            for index, segment in enumerate(payload.buffers):
+                filename = f"{index:06d}.bin"
+                data = segment.materialize()
+                self._write_private(buffer_directory / filename, data)
+                catalog = segment.catalog_entry()
+                catalog["filename"] = filename
+                catalogs.append(catalog)
+            manifest: dict[str, Any] = {
+                "record_id": record_id,
+                "experience_id": experience_id,
+                "idempotency_key": idempotency_key,
+                "published_at": published_at,
+                "attempt": 1,
+                "max_retries": max_retries,
+                "buffers": catalogs,
+            }
+            self._write_private(
+                build / "manifest.json",
+                json.dumps(manifest, separators=(",", ":"), sort_keys=True).encode(),
+            )
+            self._fsync_directory(buffer_directory)
+            self._fsync_directory(build)
+            while True:
+                with self._locked():
+                    self._ensure_open()
+                    if index_path.exists():
+                        index = json.loads(index_path.read_text(encoding="utf-8"))
+                        indexed_record_id = self._record_id(index.get("record_id"))
+                        if index.get("experience_id") != experience_id:
+                            raise DeliveryError("idempotency key reused for another experience")
+                        shutil.rmtree(build)
+                        return self._receipt(
+                            indexed_record_id,
+                            experience_id,
+                            idempotency_key,
+                            float(index["published_at"]),
+                        )
+                    if self._depth() < self._max_queue:
+                        pending = self._root / "pending" / record_id
+                        os.replace(build, pending)
+                        self._fsync_directory(pending.parent)
+                        try:
+                            self._write_json(
+                                index_path,
+                                {
+                                    "record_id": record_id,
+                                    "experience_id": experience_id,
+                                    "published_at": published_at,
+                                },
+                            )
+                        except BaseException:
+                            shutil.rmtree(pending)
+                            self._fsync_directory(pending.parent)
+                            raise
+                        break
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise BackpressureError("filesystem queue is full")
+                time.sleep(self._sleep_duration(deadline))
+        except BaseException:
+            if build.exists():
+                shutil.rmtree(build)
+            raise
+        return self._receipt(record_id, experience_id, idempotency_key, published_at)
+
+    def _receipt(
+        self,
+        record_id: str,
+        experience_id: str,
+        idempotency_key: str,
+        published_at: float,
+    ) -> DeliveryReceipt:
+        return DeliveryReceipt(
+            receipt_id=record_id,
+            experience_id=experience_id,
+            idempotency_key=idempotency_key,
+            accepted_at=published_at,
+            _wait=lambda timeout: self._wait_receipt(record_id, timeout),
+        )
+
+    def _wait_receipt(self, record_id: str, timeout: float | None) -> ReceiptResult:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        path = self._root / "receipts" / f"{record_id}.json"
+        while not path.exists():
+            if deadline is not None and time.monotonic() >= deadline:
+                return ReceiptResult(ReceiptState.EXPIRED, "receipt wait timed out")
+            time.sleep(self._sleep_duration(deadline))
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return ReceiptResult(
+            ReceiptState(value["state"]), value.get("reason"), int(value["attempts"])
+        )
+
+    def _sleep_duration(self, deadline: float | None) -> float:
+        if deadline is None:
+            return self._poll_interval
+        return max(0.0, min(self._poll_interval, deadline - time.monotonic()))
+
+    def receive(self, timeout: float | None = None) -> TransportDelivery | None:
+        self._ensure_open()
+        self._recover_stale()
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            for pending in sorted((self._root / "pending").iterdir()):
+                token = uuid.uuid4().hex
+                inflight = self._root / "inflight" / token
+                with self._locked():
+                    try:
+                        os.replace(pending, inflight)
+                        os.utime(inflight)
+                    except FileNotFoundError:
+                        continue
+                try:
+                    manifest = self._read_manifest(inflight)
+                    if self._record_id(manifest.get("record_id")) != pending.name:
+                        raise DeliveryError("filesystem manifest record ID is invalid")
+                    manifest_buffers = manifest.get("buffers")
+                    if not isinstance(manifest_buffers, list):
+                        raise DeliveryError("filesystem buffer catalog must be a list")
+                    metadata_path = inflight / "metadata.json"
+                    validate_transfer_limits(
+                        metadata_bytes=metadata_path.stat().st_size,
+                        tensor_sizes=(self._declared_size(item) for item in manifest_buffers),
+                        limits=self._limits,
+                    )
+                    buffers = tuple(
+                        BufferSegment.from_catalog_entry(
+                            item,
+                            data=self._read_buffer(
+                                inflight / "buffers" / f"{index:06d}.bin",
+                                int(item["nbytes"]),
+                            ),
+                        )
+                        for index, item in enumerate(manifest_buffers)
+                        if isinstance(item, dict)
+                        if item.get("filename") == f"{index:06d}.bin"
+                    )
+                    if len(buffers) != len(manifest_buffers):
+                        raise DeliveryError("filesystem buffer filename is invalid")
+                    metadata = metadata_path.read_bytes()
+                except Exception as error:
+                    with self._locked():
+                        if inflight.exists():
+                            self._write_receipt(
+                                pending.name,
+                                ReceiptResult(
+                                    ReceiptState.REJECTED,
+                                    "filesystem delivery is corrupt",
+                                ),
+                            )
+                            shutil.rmtree(inflight)
+                    raise DeliveryError("filesystem delivery is corrupt") from error
+                return TransportDelivery(
+                    token=token,
+                    experience_id=str(manifest["experience_id"]),
+                    idempotency_key=str(manifest["idempotency_key"]),
+                    payload=SerializedExperience(
+                        metadata=metadata,
+                        buffers=buffers,
+                    ),
+                    attempt=int(manifest["attempt"]),
+                    published_at=float(manifest["published_at"]),
+                    max_retries=int(manifest["max_retries"]),
+                )
+            if deadline is not None and time.monotonic() >= deadline:
+                return None
+            time.sleep(self._sleep_duration(deadline))
+            self._ensure_open()
+
+    def _settle(self, token: str, state: ReceiptState, reason: str | None, retry: bool) -> None:
+        directory = self._root / "inflight" / token
+        with self._locked():
+            if not directory.exists():
+                raise DeliveryError("unknown or already-settled delivery token")
+            manifest = self._read_manifest(directory)
+            attempt = int(manifest["attempt"])
+            if retry and attempt <= int(manifest["max_retries"]):
+                manifest["attempt"] = attempt + 1
+                manifest["last_error"] = reason
+                self._write_json(directory / "manifest.json", manifest)
+                os.replace(
+                    directory,
+                    self._root / "pending" / str(manifest["record_id"]),
+                )
+                self._fsync_directory(self._root / "pending")
+                return
+            self._write_receipt(str(manifest["record_id"]), ReceiptResult(state, reason, attempt))
+            shutil.rmtree(directory)
+            self._fsync_directory(directory.parent)
+
+    def ack(self, token: str) -> None:
+        self._settle(token, ReceiptState.ACKED, None, False)
+
+    def nack(self, token: str, reason: str, *, retry: bool = True) -> None:
+        self._settle(token, ReceiptState.NACKED, reason, retry)
+
+    def reject(self, token: str, reason: str) -> None:
+        self._settle(token, ReceiptState.REJECTED, reason, False)
+
+    def cancel(self, receipt_id: str, reason: str = "cancelled") -> None:
+        """Atomically cancel a pending record without touching inflight data."""
+
+        receipt_id = self._record_id(receipt_id)
+        pending = self._root / "pending" / receipt_id
+        receipt = self._root / "receipts" / f"{receipt_id}.json"
+        with self._locked():
+            if receipt.exists():
+                return
+            if not pending.exists():
+                for inflight in (self._root / "inflight").iterdir():
+                    try:
+                        record_id = str(self._read_manifest(inflight)["record_id"])
+                    except Exception:
+                        continue
+                    if record_id == receipt_id:
+                        raise DeliveryError("cannot cancel an inflight delivery")
+                raise DeliveryError("unknown delivery receipt")
+            manifest = self._read_manifest(pending)
+            self._write_receipt(
+                receipt_id,
+                ReceiptResult(ReceiptState.CANCELLED, reason, int(manifest["attempt"])),
+            )
+            shutil.rmtree(pending)
+            self._fsync_directory(pending.parent)
+
+    def health(self) -> HealthStatus:
+        with self._locked():
+            return HealthStatus(
+                not self._closed,
+                "closed" if self._closed else "ok",
+                self._depth(),
+            )
+
+    def close(self, timeout: float | None = None) -> None:
+        del timeout
+        self._closed = True

--- a/rl_experience_transfer/src/rlxfer/transports/memory.py
+++ b/rl_experience_transfer/src/rlxfer/transports/memory.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded deterministic in-process transport."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from threading import Condition
+from typing import Any
+
+from rlxfer.errors import BackpressureError, ClosedError, DeliveryError, TransportError
+from rlxfer.serialization import (
+    SerializationLimits,
+    SerializedExperience,
+    validate_transfer_limits,
+)
+from rlxfer.transport import (
+    DeliveryReceipt,
+    HealthStatus,
+    ReceiptResult,
+    ReceiptState,
+    TransportCapabilities,
+    TransportDelivery,
+)
+
+
+@dataclass(slots=True)
+class _Record:
+    payload: SerializedExperience
+    experience_id: str
+    idempotency_key: str
+    published_at: float
+    max_retries: int
+    attempt: int = 1
+    state: ReceiptState = ReceiptState.ACCEPTED
+    reason: str | None = None
+    token: str | None = None
+
+
+class InMemoryTransport:
+    """Thread-safe at-least-once queue with explicit acknowledgement."""
+
+    def __init__(
+        self,
+        *,
+        max_queue: int = 128,
+        failure_at_publish: int | None = None,
+        failure_at_receive: int | None = None,
+        limits: SerializationLimits | None = None,
+    ) -> None:
+        if max_queue < 1:
+            raise ValueError("max_queue must be positive")
+        self._max_queue = max_queue
+        self._failure_at_publish = failure_at_publish
+        self._failure_at_receive = failure_at_receive
+        self._publish_count = 0
+        self._receive_count = 0
+        self._limits = limits or SerializationLimits()
+        self._records: dict[str, _Record] = {}
+        self._idempotency: dict[str, str] = {}
+        self._pending: deque[str] = deque()
+        self._inflight: dict[str, str] = {}
+        self._closed = False
+        self._condition = Condition()
+
+    @classmethod
+    def from_options(cls, options: Mapping[str, Any]) -> InMemoryTransport:
+        return cls(**dict(options))
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(
+            name="memory",
+            asynchronous=True,
+            acknowledgements=True,
+            max_transfer_size=(
+                self._limits.max_metadata_bytes + self._limits.max_total_tensor_bytes
+            ),
+            delivery_guarantee="at-least-once",
+        )
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ClosedError("in-memory transport is closed")
+
+    def _depth(self) -> int:
+        return len(self._pending) + len(self._inflight)
+
+    def publish(
+        self,
+        payload: SerializedExperience,
+        *,
+        experience_id: str,
+        idempotency_key: str,
+        timeout: float | None = None,
+        max_retries: int = 3,
+    ) -> DeliveryReceipt:
+        if not experience_id or not idempotency_key:
+            raise ValueError("experience_id and idempotency_key are required")
+        if max_retries < 0:
+            raise ValueError("max_retries cannot be negative")
+        validate_transfer_limits(
+            metadata_bytes=len(payload.metadata),
+            tensor_sizes=(segment.nbytes for segment in payload.buffers),
+            limits=self._limits,
+        )
+        deadline = None if timeout is None else time.monotonic() + timeout
+        with self._condition:
+            self._ensure_open()
+            existing_id = self._idempotency.get(idempotency_key)
+            if existing_id is not None:
+                if self._records[existing_id].experience_id != experience_id:
+                    raise DeliveryError("idempotency key reused for another experience")
+                return self._receipt(existing_id)
+            while self._depth() >= self._max_queue:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    raise BackpressureError("in-memory queue is full")
+                self._condition.wait(remaining)
+                self._ensure_open()
+            self._publish_count += 1
+            if self._failure_at_publish == self._publish_count:
+                raise TransportError("injected publish failure")
+            record_id = uuid.uuid4().hex
+            copied = SerializedExperience(
+                metadata=bytes(payload.metadata),
+                buffers=tuple(
+                    replace(segment, data=segment.materialize(), owner=None)
+                    for segment in payload.buffers
+                ),
+            )
+            self._records[record_id] = _Record(
+                payload=copied,
+                experience_id=experience_id,
+                idempotency_key=idempotency_key,
+                published_at=time.time(),
+                max_retries=max_retries,
+            )
+            self._idempotency[idempotency_key] = record_id
+            self._pending.append(record_id)
+            self._condition.notify_all()
+            return self._receipt(record_id)
+
+    def _receipt(self, record_id: str) -> DeliveryReceipt:
+        record = self._records[record_id]
+        return DeliveryReceipt(
+            receipt_id=record_id,
+            experience_id=record.experience_id,
+            idempotency_key=record.idempotency_key,
+            accepted_at=record.published_at,
+            _wait=lambda timeout: self._wait_receipt(record_id, timeout),
+        )
+
+    def _wait_receipt(self, record_id: str, timeout: float | None) -> ReceiptResult:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        with self._condition:
+            while not self._records[record_id].state.terminal:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    return ReceiptResult(
+                        ReceiptState.EXPIRED,
+                        "receipt wait timed out",
+                        self._records[record_id].attempt,
+                    )
+                self._condition.wait(remaining)
+            record = self._records[record_id]
+            return ReceiptResult(record.state, record.reason, record.attempt)
+
+    def receive(self, timeout: float | None = None) -> TransportDelivery | None:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        with self._condition:
+            self._ensure_open()
+            while not self._pending:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    return None
+                self._condition.wait(remaining)
+                self._ensure_open()
+            self._receive_count += 1
+            if self._failure_at_receive == self._receive_count:
+                raise TransportError("injected receive failure")
+            record_id = self._pending.popleft()
+            record = self._records[record_id]
+            token = uuid.uuid4().hex
+            record.token = token
+            self._inflight[token] = record_id
+            return TransportDelivery(
+                token=token,
+                experience_id=record.experience_id,
+                idempotency_key=record.idempotency_key,
+                payload=record.payload,
+                attempt=record.attempt,
+                published_at=record.published_at,
+                max_retries=record.max_retries,
+            )
+
+    def _pop_inflight(self, token: str) -> tuple[str, _Record]:
+        try:
+            record_id = self._inflight.pop(token)
+        except KeyError as error:
+            raise DeliveryError("unknown or already-settled delivery token") from error
+        return record_id, self._records[record_id]
+
+    def ack(self, token: str) -> None:
+        with self._condition:
+            _, record = self._pop_inflight(token)
+            record.state = ReceiptState.ACKED
+            record.payload = SerializedExperience(metadata=b"{}", buffers=())
+            self._condition.notify_all()
+
+    def nack(self, token: str, reason: str, *, retry: bool = True) -> None:
+        with self._condition:
+            record_id, record = self._pop_inflight(token)
+            record.reason = reason
+            record.token = None
+            if retry and record.attempt <= record.max_retries:
+                record.attempt += 1
+                record.state = ReceiptState.ACCEPTED
+                self._pending.append(record_id)
+            else:
+                record.state = ReceiptState.NACKED
+                record.payload = SerializedExperience(metadata=b"{}", buffers=())
+            self._condition.notify_all()
+
+    def reject(self, token: str, reason: str) -> None:
+        with self._condition:
+            _, record = self._pop_inflight(token)
+            record.reason = reason
+            record.state = ReceiptState.REJECTED
+            record.payload = SerializedExperience(metadata=b"{}", buffers=())
+            self._condition.notify_all()
+
+    def cancel(self, receipt_id: str, reason: str = "cancelled") -> None:
+        """Cancel a delivery that has not been handed to a consumer."""
+
+        with self._condition:
+            try:
+                record = self._records[receipt_id]
+            except KeyError as error:
+                raise DeliveryError("unknown delivery receipt") from error
+            if record.state.terminal:
+                return
+            if record.token is not None:
+                raise DeliveryError("cannot cancel an inflight delivery")
+            try:
+                self._pending.remove(receipt_id)
+            except ValueError as error:
+                raise DeliveryError("delivery is not pending") from error
+            record.reason = reason
+            record.state = ReceiptState.CANCELLED
+            record.payload = SerializedExperience(metadata=b"{}", buffers=())
+            self._condition.notify_all()
+
+    def health(self) -> HealthStatus:
+        with self._condition:
+            return HealthStatus(not self._closed, "closed" if self._closed else "ok", self._depth())
+
+    def close(self, timeout: float | None = None) -> None:
+        del timeout
+        with self._condition:
+            self._closed = True
+            self._condition.notify_all()

--- a/rl_experience_transfer/src/rlxfer/transports/nixl.py
+++ b/rl_experience_transfer/src/rlxfer/transports/nixl.py
@@ -1,0 +1,556 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Optional NIXL data plane with a filesystem control plane."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from importlib import import_module
+from pathlib import Path
+from threading import RLock
+from typing import Any
+
+from rlxfer.errors import (
+    DeliveryError,
+    MissingDependencyError,
+    TransferTimeoutError,
+    TransportError,
+)
+from rlxfer.observability import Metrics, NullMetrics
+from rlxfer.serialization import (
+    BufferSegment,
+    SerializationLimits,
+    SerializedExperience,
+    validate_metadata,
+    validate_transfer_limits,
+)
+from rlxfer.transport import (
+    DeliveryReceipt,
+    HealthStatus,
+    ReceiptResult,
+    ReceiptState,
+    TransportCapabilities,
+    TransportDelivery,
+)
+from rlxfer.transports.filesystem import FileSystemTransport
+
+
+@dataclass(slots=True)
+class _Source:
+    owners: tuple[Any, ...]
+    registrations: tuple[Any, ...]
+    receipt: DeliveryReceipt
+
+
+class NixlTransport:
+    """Pull-based NIXL transport retaining producer buffers until settlement.
+
+    The producer owns and keeps every registered source buffer immutable until the
+    delivery is acknowledged or rejected. The consumer owns destination buffers;
+    their NIXL registration ends after transfer completion, while their storage
+    remains alive through ``BufferSegment.owner``.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        agent_name: str | None = None,
+        backend: str = "UCX",
+        max_queue: int = 128,
+        transfer_timeout: float = 30.0,
+        poll_interval: float = 0.0005,
+        target_device: str | None = None,
+        allow_cpu_staging: bool = True,
+        metrics: Metrics | None = None,
+        limits: SerializationLimits | None = None,
+    ) -> None:
+        if transfer_timeout <= 0 or poll_interval <= 0:
+            raise ValueError("transfer_timeout and poll_interval must be positive")
+        try:
+            self._nixl = import_module("nixl")
+            self._torch = import_module("torch")
+        except ImportError as error:
+            raise MissingDependencyError(
+                "NIXL transport requires the optional 'nixl' and 'torch' packages"
+            ) from error
+        self._backend = backend.upper()
+        config = self._nixl.nixl_agent_config(backends=[self._backend])
+        self._agent = self._nixl.nixl_agent(agent_name or f"rlxfer-{uuid.uuid4().hex}", config)
+        if self._backend not in self._agent.backends:
+            raise TransportError(f"NIXL backend {self._backend!r} is unavailable")
+        self._limits = limits or SerializationLimits()
+        control_limits = replace(
+            self._limits,
+            max_metadata_bytes=self._limits.max_metadata_bytes * 2 + 1024 * 1024,
+        )
+        self._control = FileSystemTransport(
+            Path(path) / "control",
+            max_queue=max_queue,
+            poll_interval=0.01,
+            limits=control_limits,
+        )
+        self._transfer_timeout = transfer_timeout
+        self._poll_interval = poll_interval
+        self._target_device = target_device
+        self._allow_cpu_staging = allow_cpu_staging
+        self._metrics = metrics or NullMetrics()
+        self._sources: dict[str, _Source] = {}
+        self._receipts: dict[str, DeliveryReceipt] = {}
+        self._lock = RLock()
+        self._closing = False
+        self._closed = False
+
+    @classmethod
+    def from_options(cls, options: Mapping[str, Any]) -> NixlTransport:
+        return cls(**dict(options))
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        with self._lock:
+            memory_types = set(self._agent.get_backend_mem_types(self._backend))
+        accelerators = frozenset({"cuda"} if "VRAM_SEG" in memory_types else ())
+        return TransportCapabilities(
+            name=f"nixl:{self._backend.lower()}",
+            zero_copy=False,
+            cpu_buffers="DRAM_SEG" in memory_types,
+            accelerator_buffers=accelerators,
+            remote=True,
+            scatter_gather=True,
+            asynchronous=True,
+            acknowledgements=True,
+            persistence=False,
+            max_transfer_size=(
+                self._limits.max_metadata_bytes + self._limits.max_total_tensor_bytes
+            ),
+            requires_registration=True,
+            delivery_guarantee="at-least-once while the producer remains alive",
+        )
+
+    def _as_source_tensor(self, segment: BufferSegment) -> Any:
+        owner = segment.owner
+        if isinstance(owner, self._torch.Tensor):
+            tensor = owner.detach()
+        elif owner is not None:
+            try:
+                tensor = self._torch.as_tensor(owner)
+            except (TypeError, ValueError, RuntimeError):
+                tensor = self._torch.frombuffer(
+                    bytearray(segment.materialize()), dtype=self._torch.uint8
+                )
+        else:
+            tensor = self._torch.frombuffer(
+                bytearray(segment.materialize()), dtype=self._torch.uint8
+            )
+        tensor = tensor.contiguous()
+        if tensor.numel() * tensor.element_size() != segment.nbytes:
+            tensor = self._torch.frombuffer(
+                bytearray(segment.materialize()), dtype=self._torch.uint8
+            )
+        if tensor.device.type not in {"cpu", "cuda"}:
+            if not self._allow_cpu_staging:
+                raise TransportError(f"NIXL backend cannot register device {tensor.device.type!r}")
+            tensor = tensor.cpu().contiguous()
+        return tensor
+
+    @staticmethod
+    def _memory_type(tensor: Any) -> str:
+        return "VRAM" if tensor.device.type == "cuda" else "DRAM"
+
+    @staticmethod
+    def _descriptor(tensor: Any) -> tuple[int, int, int]:
+        device_id = int(tensor.get_device())
+        return (
+            int(tensor.data_ptr()),
+            int(tensor.numel() * tensor.element_size()),
+            max(0, device_id),
+        )
+
+    def _register(self, tensors: tuple[Any, ...]) -> tuple[Any, ...]:
+        groups: dict[tuple[str, str], list[Any]] = {}
+        for tensor in tensors:
+            groups.setdefault((self._memory_type(tensor), str(tensor.device)), []).append(tensor)
+        registrations: list[Any] = []
+        with self._lock:
+            try:
+                for group in groups.values():
+                    registrations.append(
+                        self._agent.register_memory(group, backends=[self._backend])
+                    )
+            except BaseException:
+                self._deregister(tuple(registrations))
+                raise
+        return tuple(registrations)
+
+    def _deregister(self, registrations: tuple[Any, ...]) -> None:
+        with self._lock:
+            for registration in reversed(registrations):
+                try:
+                    self._agent.deregister_memory(registration, backends=[self._backend])
+                except Exception:
+                    self._metrics.increment("cleanup_failures", attributes={"transport": "nixl"})
+
+    def _sync(self, tensors: tuple[Any, ...]) -> None:
+        devices = {str(tensor.device) for tensor in tensors if tensor.device.type == "cuda"}
+        for device in devices:
+            self._torch.cuda.synchronize(device)
+
+    def publish(
+        self,
+        payload: SerializedExperience,
+        *,
+        experience_id: str,
+        idempotency_key: str,
+        timeout: float | None = None,
+        max_retries: int = 3,
+    ) -> DeliveryReceipt:
+        with self._lock:
+            return self._publish_locked(
+                payload,
+                experience_id=experience_id,
+                idempotency_key=idempotency_key,
+                timeout=timeout,
+                max_retries=max_retries,
+            )
+
+    def _publish_locked(
+        self,
+        payload: SerializedExperience,
+        *,
+        experience_id: str,
+        idempotency_key: str,
+        timeout: float | None,
+        max_retries: int,
+    ) -> DeliveryReceipt:
+        if self._closed or self._closing:
+            raise TransportError("NIXL transport is closed")
+        validate_transfer_limits(
+            metadata_bytes=len(payload.metadata),
+            tensor_sizes=(segment.nbytes for segment in payload.buffers),
+            limits=self._limits,
+        )
+        expected = tuple(
+            segment
+            for segment in validate_metadata(payload.metadata, limits=self._limits)
+            if segment.data is None
+        )
+        if tuple((item.name, item.nbytes) for item in expected) != tuple(
+            (item.name, item.nbytes) for item in payload.buffers
+        ):
+            raise DeliveryError("NIXL payload buffers disagree with serializer metadata")
+        self._reap()
+        staging_started = time.perf_counter()
+        tensors = tuple(self._as_source_tensor(segment) for segment in payload.buffers)
+        self._sync(tensors)
+        self._metrics.observe("staging_copy_latency_seconds", time.perf_counter() - staging_started)
+        registration_started = time.perf_counter()
+        registrations = self._register(tensors)
+        self._metrics.observe(
+            "buffer_registration_latency_seconds",
+            time.perf_counter() - registration_started,
+        )
+        catalogs: list[dict[str, Any]] = []
+        for segment, tensor in zip(payload.buffers, tensors, strict=True):
+            address, nbytes, device_id = self._descriptor(tensor)
+            catalog = segment.catalog_entry()
+            catalog.update(
+                wire_device=str(tensor.device),
+                address=address,
+                region_size=nbytes,
+                device_id=device_id,
+                memory_type=self._memory_type(tensor),
+            )
+            catalogs.append(catalog)
+        control = {
+            "version": 1,
+            "backend": self._backend,
+            "agent_metadata": base64.b64encode(self._agent.get_agent_metadata()).decode("ascii"),
+            "metadata": base64.b64encode(payload.metadata).decode("ascii"),
+            "buffers": catalogs,
+        }
+        try:
+            receipt = self._control.publish(
+                SerializedExperience(
+                    metadata=json.dumps(control, separators=(",", ":"), sort_keys=True).encode(),
+                    buffers=(),
+                ),
+                experience_id=experience_id,
+                idempotency_key=idempotency_key,
+                timeout=timeout,
+                max_retries=max_retries,
+            )
+        except BaseException:
+            self._deregister(registrations)
+            raise
+        self._receipts.setdefault(receipt.receipt_id, receipt)
+        if (
+            receipt.wait(0.0).state is not ReceiptState.EXPIRED
+            or receipt.receipt_id in self._sources
+        ):
+            self._deregister(registrations)
+        else:
+            self._sources[receipt.receipt_id] = _Source(tensors, registrations, receipt)
+        self._metrics.increment("produced_batches")
+        self._metrics.increment("bytes_transferred", payload.nbytes)
+        return DeliveryReceipt(
+            receipt_id=receipt.receipt_id,
+            experience_id=receipt.experience_id,
+            idempotency_key=receipt.idempotency_key,
+            accepted_at=receipt.accepted_at,
+            _wait=lambda wait_timeout: self._wait_source(receipt.receipt_id, wait_timeout),
+        )
+
+    def _wait_source(self, record_id: str, timeout: float | None) -> ReceiptResult:
+        with self._lock:
+            try:
+                receipt = self._receipts[record_id]
+            except KeyError as error:
+                raise DeliveryError("unknown NIXL source receipt") from error
+        result = receipt.wait(timeout)
+        if result.state.terminal:
+            self._release_source(record_id)
+        return result
+
+    def _release_source(self, record_id: str) -> None:
+        with self._lock:
+            source = self._sources.pop(record_id, None)
+            if source is not None:
+                self._deregister(source.registrations)
+
+    def _reap(self) -> None:
+        with self._lock:
+            for record_id, source in tuple(self._sources.items()):
+                result = source.receipt.wait(0.0)
+                if result.state is not ReceiptState.EXPIRED:
+                    self._release_source(record_id)
+
+    def _target(self, item: Mapping[str, Any]) -> Any:
+        source_device = str(item["wire_device"])
+        requested = self._target_device or source_device
+        if requested.startswith("cuda") and not self._torch.cuda.is_available():
+            if not self._allow_cpu_staging:
+                raise TransportError("CUDA destination requested but CUDA is unavailable")
+            requested = "cpu"
+        return self._torch.empty(int(item["nbytes"]), dtype=self._torch.uint8, device=requested)
+
+    def _decode_control(self, payload: SerializedExperience) -> dict[str, Any]:
+        try:
+            value = json.loads(payload.metadata)
+        except (json.JSONDecodeError, UnicodeDecodeError, RecursionError) as error:
+            raise DeliveryError("invalid NIXL control metadata") from error
+        if not isinstance(value, dict) or value.get("version") != 1:
+            raise DeliveryError("unsupported NIXL control metadata version")
+        if value.get("backend") != self._backend or not isinstance(value.get("buffers"), list):
+            raise DeliveryError("incompatible NIXL backend or buffer catalog")
+        return value
+
+    def _validate_control_catalog(
+        self, metadata: bytes, items: Sequence[Mapping[str, Any]]
+    ) -> None:
+        expected = tuple(
+            segment
+            for segment in validate_metadata(metadata, limits=self._limits)
+            if segment.data is None
+        )
+        if len(expected) != len(items):
+            raise DeliveryError("NIXL and serializer buffer catalogs differ in length")
+        for segment, item in zip(expected, items, strict=True):
+            if any(item.get(key) != value for key, value in segment.catalog_entry().items()):
+                raise DeliveryError(
+                    f"NIXL catalog for buffer {segment.name!r} disagrees with metadata"
+                )
+            if (
+                item.get("region_size") != segment.nbytes
+                or isinstance(item.get("address"), bool)
+                or not isinstance(item.get("address"), int)
+                or int(item["address"]) <= 0
+                or isinstance(item.get("device_id"), bool)
+                or not isinstance(item.get("device_id"), int)
+                or int(item["device_id"]) < 0
+                or item.get("memory_type") not in {"DRAM", "VRAM"}
+            ):
+                raise DeliveryError(f"NIXL descriptor for buffer {segment.name!r} is invalid")
+
+    def _transfer_group(
+        self,
+        remote_name: str,
+        items: list[Mapping[str, Any]],
+        targets: list[Any],
+        deadline: float,
+    ) -> None:
+        source_type = str(items[0]["memory_type"])
+        remote = self._agent.get_xfer_descs(
+            [
+                (
+                    int(item["address"]),
+                    int(item["region_size"]),
+                    int(item["device_id"]),
+                )
+                for item in items
+            ],
+            source_type,
+        )
+        local = self._agent.get_xfer_descs(targets)
+        handle = self._agent.initialize_xfer(
+            "READ", local, remote, remote_name, backends=[self._backend]
+        )
+        try:
+            transfer_started = time.perf_counter()
+            state = self._agent.transfer(handle)
+            while state == "PROC":
+                if time.monotonic() >= deadline:
+                    raise TransferTimeoutError("NIXL transfer timed out")
+                time.sleep(self._poll_interval)
+                state = self._agent.check_xfer_state(handle)
+            if state != "DONE":
+                raise TransportError(f"NIXL transfer failed with state {state!r}")
+            self._metrics.observe(
+                "transfer_latency_seconds", time.perf_counter() - transfer_started
+            )
+        finally:
+            with suppress(Exception):
+                self._agent.release_xfer_handle(handle)
+
+    def receive(self, timeout: float | None = None) -> TransportDelivery | None:
+        with self._lock:
+            return self._receive_locked(timeout)
+
+    def _receive_locked(self, timeout: float | None) -> TransportDelivery | None:
+        if self._closed or self._closing:
+            raise TransportError("NIXL transport is closed")
+        control_delivery = self._control.receive(timeout)
+        if control_delivery is None:
+            return None
+        registrations: tuple[Any, ...] = ()
+        remote_name: str | None = None
+        try:
+            control = self._decode_control(control_delivery.payload)
+            items = [item for item in control["buffers"] if isinstance(item, dict)]
+            if len(items) != len(control["buffers"]):
+                raise DeliveryError("invalid NIXL buffer catalog entry")
+            metadata = base64.b64decode(control["metadata"], validate=True)
+            self._validate_control_catalog(metadata, items)
+            targets = tuple(self._target(item) for item in items)
+            registrations = self._register(targets)
+            if items:
+                remote_name = self._agent.add_remote_agent(
+                    base64.b64decode(control["agent_metadata"], validate=True)
+                )
+                grouped: dict[
+                    tuple[str, int, str, str],
+                    tuple[list[Mapping[str, Any]], list[Any]],
+                ] = {}
+                for item, target in zip(items, targets, strict=True):
+                    key = (
+                        str(item["memory_type"]),
+                        int(item["device_id"]),
+                        self._memory_type(target),
+                        str(target.device),
+                    )
+                    selected_items, selected_targets = grouped.setdefault(key, ([], []))
+                    selected_items.append(item)
+                    selected_targets.append(target)
+                deadline = time.monotonic() + self._transfer_timeout
+                for selected_items, selected_targets in grouped.values():
+                    self._transfer_group(
+                        remote_name,
+                        selected_items,
+                        selected_targets,
+                        deadline,
+                    )
+                self._sync(targets)
+            buffers = tuple(
+                BufferSegment.from_catalog_entry(item, owner=target)
+                for item, target in zip(items, targets, strict=True)
+            )
+            self._metrics.increment("consumed_batches")
+            return TransportDelivery(
+                token=control_delivery.token,
+                experience_id=control_delivery.experience_id,
+                idempotency_key=control_delivery.idempotency_key,
+                payload=SerializedExperience(
+                    metadata=metadata,
+                    buffers=buffers,
+                ),
+                attempt=control_delivery.attempt,
+                published_at=control_delivery.published_at,
+                max_retries=control_delivery.max_retries,
+            )
+        except BaseException as error:
+            self._metrics.increment("transfer_failures", attributes={"transport": "nixl"})
+            with suppress(Exception):
+                self._control.nack(
+                    control_delivery.token, f"NIXL receive failed: {error}", retry=True
+                )
+            raise
+        finally:
+            if remote_name is not None:
+                with suppress(Exception):
+                    self._agent.remove_remote_agent(remote_name)
+            self._deregister(registrations)
+
+    def ack(self, token: str) -> None:
+        with self._lock:
+            self._control.ack(token)
+            self._reap()
+
+    def nack(self, token: str, reason: str, *, retry: bool = True) -> None:
+        with self._lock:
+            self._control.nack(token, reason, retry=retry)
+            self._reap()
+
+    def reject(self, token: str, reason: str) -> None:
+        with self._lock:
+            self._control.reject(token, reason)
+            self._reap()
+
+    def cancel(self, receipt_id: str, reason: str = "cancelled") -> None:
+        """Cancel a pending pull before releasing its registered source buffers."""
+
+        with self._lock:
+            self._control.cancel(receipt_id, reason)
+            self._release_source(receipt_id)
+
+    def health(self) -> HealthStatus:
+        with self._lock:
+            self._reap()
+            control = self._control.health()
+            return HealthStatus(
+                not self._closed and not self._closing and control.healthy,
+                "closed" if self._closed or self._closing else control.detail,
+                control.queue_depth,
+            )
+
+    def close(self, timeout: float | None = None) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closing = True
+        deadline = time.monotonic() + max(0.0, timeout or 0.0)
+        while time.monotonic() < deadline:
+            self._reap()
+            with self._lock:
+                if not self._sources:
+                    break
+            time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
+        with self._lock:
+            source_ids = tuple(self._sources)
+        for record_id in source_ids:
+            try:
+                self.cancel(record_id, "producer shutdown")
+            except DeliveryError as error:
+                with self._lock:
+                    self._closing = False
+                raise TransferTimeoutError(
+                    "cannot close NIXL transport while a delivery is inflight"
+                ) from error
+        with self._lock:
+            self._control.close()
+            self._closed = True
+            self._closing = False

--- a/rl_experience_transfer/tests/test_adapters.py
+++ b/rl_experience_transfer/tests/test_adapters.py
@@ -1,0 +1,419 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from types import ModuleType
+from typing import Any
+
+import numpy as np
+import pytest
+
+from rlxfer.adapters import (
+    AdapterRegistry,
+    MilesAdapter,
+    MissingDependencyError,
+    NemoRLAdapter,
+    PrimeRLAdapter,
+    SlimeAdapter,
+    create_adapter,
+)
+from rlxfer.adapters.compat import verify_framework_version
+from rlxfer.compatibility import CompatibilityRequirements
+from rlxfer.errors import CompatibilityError
+from rlxfer.model import TensorPayload
+
+
+@pytest.mark.unit
+def test_adapter_registry_is_instance_scoped() -> None:
+    assert isinstance(create_adapter("nemo_rl"), NemoRLAdapter)
+    registry = AdapterRegistry()
+    registry.register("custom", SlimeAdapter)
+    adapter = create_adapter("custom", registry)
+    assert isinstance(adapter, SlimeAdapter)
+    assert adapter.adapter_version == "0.1.0"
+    with pytest.raises(ValueError, match="unknown adapter"):
+        create_adapter("custom")
+
+    with pytest.raises(CompatibilityError, match="outside adapter"):
+        verify_framework_version("slime", "9.0.0")
+
+
+def _install_module(monkeypatch: pytest.MonkeyPatch, name: str, **values: object) -> None:
+    module = ModuleType(name)
+    for key, value in values.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+@dataclass
+class _EncodedTensor:
+    dtype: str
+    shape: list[int]
+    data: bytes
+
+
+@dataclass
+class _RoutedExperts:
+    data: bytes
+    shape: list[int]
+    dtype: str
+
+
+@dataclass
+class _TrainingSample:
+    prompt_ids: list[int]
+    prompt_mask: list[bool]
+    completion_ids: list[int]
+    completion_mask: list[bool]
+    completion_logprobs: list[float]
+    completion_temperatures: list[float]
+    env_name: str
+    teacher_logprobs: list[float] | None = None
+    advantage: float | None = None
+    reward: float | None = None
+    mm_kwargs: dict[str, _EncodedTensor] | None = None
+    routed_experts: _RoutedExperts | None = None
+    mm_token_type_ids: list[int] | None = None
+    training_mode: str = "rl"
+
+
+@dataclass
+class _TrainingBatch:
+    examples: list[_TrainingSample]
+    step: int
+    run_idx: int | None = None
+
+
+def _install_prime(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_module(monkeypatch, "prime_rl", __version__="2873bf2")
+    _install_module(monkeypatch, "prime_rl.transport")
+    _install_module(
+        monkeypatch,
+        "prime_rl.transport.types",
+        EncodedTensor=_EncodedTensor,
+        RoutedExperts=_RoutedExperts,
+        TrainingSample=_TrainingSample,
+        TrainingBatch=_TrainingBatch,
+    )
+
+
+@pytest.mark.unit
+def test_prime_training_batch_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_prime(monkeypatch)
+    sample = _TrainingSample(
+        prompt_ids=[1, 2],
+        prompt_mask=[False, False],
+        completion_ids=[3, 4],
+        completion_mask=[True, True],
+        completion_logprobs=[-0.1, -0.2],
+        completion_temperatures=[0.8, 0.8],
+        env_name="math",
+        advantage=1.25,
+        reward=1.0,
+        mm_kwargs={"pixels": _EncodedTensor("uint8", [2], b"\x01\x02")},
+        routed_experts=_RoutedExperts(b"\x03", [1, 1, 1], "uint8"),
+    )
+    native = _TrainingBatch([sample], step=7, run_idx=2)
+
+    batch = PrimeRLAdapter().from_framework(native)
+
+    assert batch.metadata.producer_framework == "prime_rl"
+    assert batch.trajectories[0].tokens is not None
+    assert np.asarray(batch.trajectories[0].tokens.data).tolist() == [3, 4]
+    assert batch.trajectories[0].advantages is not None
+    assert batch.trajectories[0].advantages.shape == (2,)
+    restored = PrimeRLAdapter().to_framework(batch)
+    assert isinstance(restored, _TrainingBatch)
+    assert restored.step == 7
+    assert restored.examples[0].completion_ids == [3, 4]
+    assert isinstance(restored.examples[0].routed_experts, _RoutedExperts)
+    assert restored.examples[0].routed_experts.data == b"\x03"
+    assert restored.examples[0].mm_kwargs is not None
+    assert isinstance(restored.examples[0].mm_kwargs["pixels"], _EncodedTensor)
+    assert restored.examples[0].mm_kwargs["pixels"].data == b"\x01\x02"
+
+
+@pytest.mark.unit
+def test_prime_rejects_misaligned_completion(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_prime(monkeypatch)
+    sample = _TrainingSample(
+        prompt_ids=[1],
+        prompt_mask=[False],
+        completion_ids=[2, 3],
+        completion_mask=[True],
+        completion_logprobs=[-0.1, -0.2],
+        completion_temperatures=[1.0, 1.0],
+        env_name="test",
+    )
+    with pytest.raises(ValueError, match="completion_mask length"):
+        PrimeRLAdapter().from_framework(_TrainingBatch([sample], step=0))
+
+
+class _Status(Enum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    TRUNCATED = "truncated"
+
+
+@dataclass
+class _GroupedSample:
+    index: int | None = None
+    group_index: int | None = None
+    prompt: str = ""
+    tokens: list[int] = field(default_factory=list)
+    response: str = ""
+    response_length: int = 0
+    reward: float | None = None
+    loss_mask: list[int] | None = None
+    weight_versions: list[str] = field(default_factory=list)
+    rollout_log_probs: list[float] | None = None
+    teacher_log_probs: list[float] | None = None
+    status: _Status = _Status.PENDING
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> _GroupedSample:
+        state = dict(value)
+        state["status"] = _Status(state["status"])
+        accepted = cls.__dataclass_fields__
+        return cls(**{key: item for key, item in state.items() if key in accepted})
+
+
+@dataclass
+class _RolloutOutput:
+    samples: list[list[_GroupedSample]]
+    metrics: dict[str, Any] | None = None
+
+
+def _install_grouped(monkeypatch: pytest.MonkeyPatch, framework: str, version: str) -> None:
+    _install_module(monkeypatch, framework, __version__=version)
+    _install_module(monkeypatch, f"{framework}.utils")
+    _install_module(monkeypatch, f"{framework}.utils.types", Sample=_GroupedSample)
+    _install_module(monkeypatch, f"{framework}.rollout")
+    _install_module(
+        monkeypatch,
+        f"{framework}.rollout.base_types",
+        RolloutFnTrainOutput=_RolloutOutput,
+    )
+
+
+@pytest.mark.unit
+def test_slime_round_trip_retains_groups_and_miles_rejects_unknown_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_grouped(monkeypatch, "slime", "0.3.1")
+    _install_grouped(monkeypatch, "miles", "0.2.1")
+    first = _GroupedSample(
+        index=10,
+        group_index=2,
+        prompt="2+2?",
+        tokens=[10, 11, 12],
+        response="4",
+        response_length=1,
+        reward=1.0,
+        loss_mask=[1],
+        weight_versions=["3"],
+        rollout_log_probs=[-0.2],
+        status=_Status.COMPLETED,
+        metadata={"source": "real-shape-contract"},
+    )
+    second = _GroupedSample(
+        index=11,
+        group_index=3,
+        tokens=[20, 21],
+        response_length=1,
+        loss_mask=[1],
+        rollout_log_probs=[-0.3],
+        status=_Status.TRUNCATED,
+    )
+    native = _RolloutOutput([[first], [second]], metrics={"rollout": 2})
+
+    batch = SlimeAdapter().from_framework(native)
+
+    assert len(batch.trajectories) == 2
+    assert isinstance(batch.trajectories[0].tokens, TensorPayload)
+    assert np.asarray(batch.trajectories[0].tokens.data).tolist() == [12]
+    restored = SlimeAdapter().to_framework(batch)
+    assert isinstance(restored, _RolloutOutput)
+    assert [len(group) for group in restored.samples] == [1, 1]
+    assert restored.samples[0][0].status is _Status.COMPLETED
+    assert restored.metrics == {"rollout": 2}
+
+    with pytest.raises(ValueError, match="cross-framework slime -> miles conversion is unsafe"):
+        MilesAdapter().to_framework(batch)
+
+    semantics = {
+        "algorithm": "grpo",
+        "tokenizer_id": "tokenizer-v1",
+        "model_id": "model-v1",
+        "reward_definition": "math-v1",
+        "sequence_format": "prompt-response",
+        "padding": "right",
+        "chat_template": "chat-v1",
+        "truncation": "right",
+    }
+    for name, value in semantics.items():
+        setattr(batch.metadata, name, value)
+    requirements = CompatibilityRequirements(
+        consumer_framework="miles",
+        consumer_framework_version="0.2.1",
+        algorithm="grpo",
+        tokenizer_id="tokenizer-v1",
+        model_id="model-v1",
+        reward_definition="math-v1",
+        sequence_format="prompt-response",
+        padding="right",
+        chat_template="chat-v1",
+        truncation="right",
+    )
+    cross_framework = MilesAdapter(requirements).to_framework(batch)
+    assert isinstance(cross_framework, _RolloutOutput)
+
+
+@pytest.mark.unit
+def test_grouped_adapter_rejects_multidimensional_sample_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_grouped(monkeypatch, "slime", "0.3.1")
+    sample = _GroupedSample(tokens=np.ones((2, 2), dtype=np.int64), response_length=1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="tokens must be one-dimensional"):
+        SlimeAdapter().from_framework([[sample]])
+
+
+class _BatchedDataDict(dict[str, Any]):
+    pass
+
+
+@dataclass
+class _Completion:
+    message_log: list[dict[str, Any]]
+    env_extras: dict[str, Any] | None
+    truncated: bool
+    reward: float
+
+
+@dataclass
+class _PromptGroupRecord:
+    prompt_idx: int
+    prompt: list[dict[str, Any]]
+    extra_env_info: dict[str, Any] | None
+    metadata: dict[str, Any]
+    completions: list[_Completion]
+    rollout_metrics: dict[str, Any]
+
+
+def _install_nemo(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_module(monkeypatch, "nemo_rl", __version__="0.7.0")
+    _install_module(monkeypatch, "nemo_rl.distributed")
+    _install_module(
+        monkeypatch,
+        "nemo_rl.distributed.batched_data_dict",
+        BatchedDataDict=_BatchedDataDict,
+    )
+    _install_module(monkeypatch, "nemo_rl.experience")
+    _install_module(
+        monkeypatch,
+        "nemo_rl.experience.interfaces",
+        Completion=_Completion,
+        PromptGroupRecord=_PromptGroupRecord,
+    )
+
+
+@pytest.mark.unit
+def test_nemo_batched_data_dict_mapping_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_nemo(monkeypatch)
+    native = _BatchedDataDict(
+        input_ids=np.asarray([[1, 2, 3], [4, 5, 0]], dtype=np.int64),
+        input_lengths=np.asarray([3, 2], dtype=np.int32),
+        generation_logprobs=np.asarray([[-0.1, -0.2, -0.3], [-0.4, -0.5, 0.0]], dtype=np.float32),
+        token_mask=np.asarray([[1, 1, 1], [1, 1, 0]], dtype=np.bool_),
+    )
+
+    batch = NemoRLAdapter().from_framework((native, {"latency": 0.1}))
+
+    assert len(batch.trajectories) == 2
+    assert batch.tensors["input_ids"].dtype == "int64"
+    restored = NemoRLAdapter().to_framework(batch)
+    assert isinstance(restored, _BatchedDataDict)
+    np.testing.assert_array_equal(restored["input_ids"], native["input_ids"])
+    np.testing.assert_array_equal(restored["token_mask"], native["token_mask"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("input_ids", "input_lengths", "message"),
+    [
+        (np.asarray([[1, 2]]), np.asarray([-1]), "must be non-negative"),
+        (np.asarray([[1, 2]]), np.asarray([3]), "exceeds padded row width"),
+        (np.asarray([[1, 2]]), np.asarray([1.5]), "must be an integer"),
+        (np.asarray([[1, 2], [3, 4]]), np.asarray([2]), "must equal input_ids rows"),
+        (np.asarray([1, 2]), np.asarray([1, 1]), "one-dimensional rows"),
+    ],
+)
+def test_nemo_rejects_invalid_batch_lengths(
+    monkeypatch: pytest.MonkeyPatch,
+    input_ids: np.ndarray[Any, Any],
+    input_lengths: np.ndarray[Any, Any],
+    message: str,
+) -> None:
+    _install_nemo(monkeypatch)
+    with pytest.raises((TypeError, ValueError), match=message):
+        NemoRLAdapter().from_framework(
+            _BatchedDataDict(input_ids=input_ids, input_lengths=input_lengths)
+        )
+
+
+@pytest.mark.unit
+def test_nemo_prompt_group_record_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_nemo(monkeypatch)
+    completion = _Completion(
+        message_log=[
+            {
+                "role": "assistant",
+                "content": "four",
+                "token_ids": [4, 5],
+                "generation_logprobs": [-0.1, -0.2],
+            }
+        ],
+        env_extras={"turns": 1},
+        truncated=False,
+        reward=1.0,
+    )
+    native = _PromptGroupRecord(
+        prompt_idx=8,
+        prompt=[{"role": "user", "content": "2+2?"}],
+        extra_env_info=None,
+        metadata={"task": "math"},
+        completions=[completion],
+        rollout_metrics={"tokens": 2},
+    )
+
+    batch = NemoRLAdapter().from_framework(native)
+
+    assert batch.trajectories[0].response == "four"
+    restored = NemoRLAdapter().to_framework(batch)
+    assert isinstance(restored, _PromptGroupRecord)
+    assert isinstance(restored.completions[0], _Completion)
+    assert restored.completions[0].message_log[0]["token_ids"] == [4, 5]
+
+
+@pytest.mark.unit
+def test_missing_optional_dependency_is_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = NemoRLAdapter()
+    batch = adapter.from_framework(
+        {
+            "input_ids": np.asarray([[1]], dtype=np.int64),
+            "input_lengths": np.asarray([1], dtype=np.int32),
+        }
+    )
+
+    def missing_import(name: str) -> ModuleType:
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr("rlxfer.adapters.base.import_module", missing_import)
+    with pytest.raises(MissingDependencyError, match=r"rl-experience-transfer\[nemo-rl\]"):
+        adapter.to_framework(batch)

--- a/rl_experience_transfer/tests/test_api.py
+++ b/rl_experience_transfer/tests/test_api.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from typing import ClassVar
+
+import numpy as np
+import pytest
+
+from rlxfer.api import Delivery, ExperienceConsumer, ExperienceProducer
+from rlxfer.errors import CapabilityError, ClosedError, DeliveryError, IntegrityError
+from rlxfer.model import ExperienceBatch, ExperienceMetadata, TensorPayload, Trajectory
+from rlxfer.observability import InMemoryMetrics
+from rlxfer.serialization import JsonExperienceSerializer, SerializedExperience
+from rlxfer.transport import (
+    DeliveryReceipt,
+    HealthStatus,
+    ReceiptState,
+    TransferPlan,
+    TransportCapabilities,
+    TransportDelivery,
+)
+from rlxfer.transports.memory import InMemoryTransport
+
+
+def _trajectory() -> Trajectory:
+    return Trajectory(
+        prompt="2+2?",
+        response="4",
+        tokens=TensorPayload(np.asarray([4], dtype=np.int64)),
+        log_probs=TensorPayload(np.asarray([-0.2], dtype=np.float32)),
+        rewards={"task": 1.0},
+    )
+
+
+def _batch(*, idempotency_key: str | None = None) -> ExperienceBatch:
+    return ExperienceBatch(
+        metadata=ExperienceMetadata(
+            producer_id="rollout-1",
+            producer_framework="test",
+            producer_framework_version="1",
+            idempotency_key=idempotency_key,
+        ),
+        trajectories=(_trajectory(),),
+    )
+
+
+@pytest.mark.unit
+def test_publish_trajectory_receive_ack_and_metrics() -> None:
+    transport = InMemoryTransport()
+    producer_metrics = InMemoryMetrics()
+    consumer_metrics = InMemoryMetrics()
+    producer = ExperienceProducer(
+        transport,
+        metrics=producer_metrics,
+        producer_id="rollout-1",
+    )
+    consumer = ExperienceConsumer(transport, metrics=consumer_metrics)
+
+    receipt = producer.publish_trajectory(_trajectory())
+    delivery = consumer.receive(timeout=0.1)
+
+    assert isinstance(delivery, Delivery)
+    assert delivery.attempt == 1
+    assert delivery.to_framework() is delivery.batch
+    assert delivery.batch.metadata.producer_id == "rollout-1"
+    delivery.ack()
+    assert delivery.state == "acknowledged"
+    assert receipt.wait(0.1).state is ReceiptState.ACKED
+    with pytest.raises(DeliveryError, match="already acknowledged"):
+        delivery.ack()
+
+    producer_counters, _ = producer_metrics.snapshot()
+    consumer_counters, _ = consumer_metrics.snapshot()
+    assert producer_counters["produced_batches"] == 1
+    assert producer_counters["produced_trajectories"] == 1
+    assert producer_counters["bytes_transferred"] > 0
+    assert consumer_counters["received_batches"] == 1
+    assert consumer_counters["consumed_batches"] == 1
+    assert consumer_counters["consumed_trajectories"] == 1
+
+
+@pytest.mark.unit
+def test_nack_retry_and_permanent_rejection() -> None:
+    transport = InMemoryTransport()
+    producer = ExperienceProducer(transport)
+    consumer = ExperienceConsumer(transport)
+
+    retried_receipt = producer.publish_batch(_batch(), max_retries=2)
+    first = consumer.receive(0.1)
+    assert first is not None
+    first.nack("trainer temporarily unavailable")
+    assert first.state == "nacked"
+
+    second = consumer.receive(0.1)
+    assert second is not None
+    assert second.attempt == 2
+    second.ack()
+    result = retried_receipt.wait(0.1)
+    assert result.state is ReceiptState.ACKED
+    assert result.attempts == 2
+
+    rejected_receipt = producer.publish_batch(_batch())
+    rejected = consumer.receive(0.1)
+    assert rejected is not None
+    rejected.reject("algorithm is incompatible")
+    assert rejected_receipt.wait(0.1).state is ReceiptState.REJECTED
+
+
+class _NativeAdapter:
+    framework_name: ClassVar[str] = "native_test"
+
+    @property
+    def adapter_version(self) -> str:
+        return "test"
+
+    @property
+    def framework_version(self) -> str:
+        return "2"
+
+    def from_framework(self, native: object) -> ExperienceBatch:
+        if not isinstance(native, dict) or not isinstance(native.get("tokens"), list):
+            raise TypeError("native rollout must contain tokens")
+        tokens = np.asarray(native["tokens"], dtype=np.int64)
+        return ExperienceBatch(
+            metadata=ExperienceMetadata("native-worker", self.framework_name, "2"),
+            trajectories=(Trajectory(tokens=TensorPayload(tokens)),),
+            extensions={self.framework_name: {"kind": "native"}},
+        )
+
+    def to_framework(self, batch: ExperienceBatch) -> object:
+        tokens = batch.trajectories[0].tokens
+        assert tokens is not None
+        return {"tokens": np.asarray(tokens.data).tolist()}
+
+    def validate_compatible(self, batch: ExperienceBatch) -> None:
+        if self.framework_name not in batch.extensions:
+            raise ValueError("native extension is required")
+
+
+@pytest.mark.unit
+def test_optional_adapter_converts_native_rollout_and_training_input() -> None:
+    transport = InMemoryTransport()
+    adapter = _NativeAdapter()
+    producer = ExperienceProducer(transport, adapter=adapter)
+    consumer = ExperienceConsumer(transport, adapter=adapter)
+
+    receipt = producer.publish({"tokens": [7, 8]})
+    delivery = consumer.receive(0.1)
+
+    assert delivery is not None
+    assert delivery.to_framework() == {"tokens": [7, 8]}
+    delivery.ack()
+    assert receipt.wait(0.1).state is ReceiptState.ACKED
+
+
+@pytest.mark.unit
+def test_producer_checks_transfer_requirements_before_publish() -> None:
+    transport = InMemoryTransport()
+    producer = ExperienceProducer(
+        transport,
+        transfer_plan=TransferPlan(require_persistence=True),
+    )
+
+    with pytest.raises(CapabilityError, match="persistence"):
+        producer.publish(_batch())
+
+    assert transport.health().queue_depth == 0
+
+
+class _ReplayTransport:
+    def __init__(self, deliveries: list[TransportDelivery]) -> None:
+        self.deliveries = deque(deliveries)
+        self.acked: list[str] = []
+        self.nacked: list[str] = []
+        self.rejected: list[str] = []
+        self.cancelled: list[str] = []
+        self.closed = False
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(name="replay")
+
+    def publish(
+        self,
+        payload: SerializedExperience,
+        *,
+        experience_id: str,
+        idempotency_key: str,
+        timeout: float | None = None,
+        max_retries: int = 3,
+    ) -> DeliveryReceipt:
+        del payload, experience_id, idempotency_key, timeout, max_retries
+        raise AssertionError("replay transport is receive-only")
+
+    def receive(self, timeout: float | None = None) -> TransportDelivery | None:
+        del timeout
+        return self.deliveries.popleft() if self.deliveries else None
+
+    def ack(self, token: str) -> None:
+        self.acked.append(token)
+
+    def nack(self, token: str, reason: str, *, retry: bool = True) -> None:
+        del reason, retry
+        self.nacked.append(token)
+
+    def reject(self, token: str, reason: str) -> None:
+        del reason
+        self.rejected.append(token)
+
+    def cancel(self, receipt_id: str, reason: str = "cancelled") -> None:
+        del reason
+        self.cancelled.append(receipt_id)
+
+    def health(self) -> HealthStatus:
+        return HealthStatus(not self.closed)
+
+    def close(self, timeout: float | None = None) -> None:
+        del timeout
+        self.closed = True
+
+
+def _raw_delivery(
+    batch: ExperienceBatch,
+    token: str,
+    *,
+    experience_id: str | None = None,
+) -> TransportDelivery:
+    return TransportDelivery(
+        token=token,
+        experience_id=experience_id or batch.experience_id,
+        idempotency_key=batch.metadata.idempotency_key or batch.experience_id,
+        payload=JsonExperienceSerializer().serialize(batch),
+        attempt=1,
+        published_at=time.time(),
+    )
+
+
+@pytest.mark.unit
+def test_consumer_suppresses_already_acknowledged_duplicate() -> None:
+    batch = _batch(idempotency_key="same-request")
+    transport = _ReplayTransport([_raw_delivery(batch, "first"), _raw_delivery(batch, "duplicate")])
+    metrics = InMemoryMetrics()
+    consumer = ExperienceConsumer(transport, metrics=metrics)
+
+    first = consumer.receive(0.0)
+    assert first is not None
+    first.ack()
+    assert consumer.receive(0.0) is None
+
+    assert transport.acked == ["first", "duplicate"]
+    counters, _ = metrics.snapshot()
+    assert counters["received_batches"] == 1
+    assert counters["duplicate_deliveries"] == 1
+
+
+@pytest.mark.unit
+def test_invalid_envelope_is_rejected_before_delivery() -> None:
+    batch = _batch(idempotency_key="invalid-request")
+    transport = _ReplayTransport([_raw_delivery(batch, "invalid", experience_id="different-id")])
+    consumer = ExperienceConsumer(transport)
+
+    with pytest.raises(IntegrityError, match="experience IDs differ"):
+        consumer.receive(0.0)
+
+    assert transport.rejected == ["invalid"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_wrappers_and_context_shutdown() -> None:
+    transport = InMemoryTransport()
+    producer = ExperienceProducer(transport)
+    consumer = ExperienceConsumer(transport)
+
+    async with producer, consumer:
+        receipt = await producer.publish_async(_batch())
+        delivery = await consumer.receive_async(0.1)
+        assert delivery is not None
+        await delivery.ack_async()
+        assert receipt.wait(0.1).state is ReceiptState.ACKED
+
+    assert not transport.health().healthy
+    with pytest.raises(ClosedError):
+        producer.publish(_batch())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_receive_cancellation_and_cleanup() -> None:
+    transport = InMemoryTransport()
+    consumer = ExperienceConsumer(transport)
+    receive = asyncio.create_task(consumer.receive_async(10.0))
+    await asyncio.sleep(0)
+    receive.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await receive
+    await consumer.close_async()
+    assert not transport.health().healthy
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_producer_can_cancel_pending_publish() -> None:
+    transport = InMemoryTransport()
+    producer = ExperienceProducer(transport)
+    receipt = producer.publish(_batch())
+
+    await producer.cancel_async(receipt, "caller cancelled")
+
+    result = receipt.wait(0.1)
+    assert (result.state, result.reason) == (
+        ReceiptState.CANCELLED,
+        "caller cancelled",
+    )
+    assert transport.health().queue_depth == 0

--- a/rl_experience_transfer/tests/test_compatibility.py
+++ b/rl_experience_transfer/tests/test_compatibility.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from rlxfer.compatibility import (
+    CompatibilityRequirements,
+    check_compatibility,
+    ensure_compatible,
+)
+from rlxfer.errors import CompatibilityError
+from rlxfer.model import (
+    ExperienceBatch,
+    ExperienceMetadata,
+    PolicyVersion,
+    TensorPayload,
+    Trajectory,
+)
+
+
+def _batch(*, with_reference: bool = True) -> ExperienceBatch:
+    tokens = TensorPayload(np.array([1, 2, 3], dtype=np.int64))
+    reference = (
+        TensorPayload(np.array([-0.2, -0.3, -0.4], dtype=np.float32)) if with_reference else None
+    )
+    metadata = ExperienceMetadata(
+        producer_id="worker-1",
+        producer_framework="slime",
+        producer_framework_version="0.1",
+        policy_version=PolicyVersion(4, policy_id="actor", model_id="tiny"),
+        algorithm="grpo",
+        tokenizer_id="tokenizer-v1",
+        model_id="tiny",
+        reward_definition="unit-test-reward-v1",
+        sequence_format="prompt-response",
+        padding="right",
+        chat_template="chat-v1",
+        truncation="right:64",
+    )
+    return ExperienceBatch(
+        metadata=metadata,
+        trajectories=(Trajectory(tokens=tokens, reference_log_probs=reference),),
+    )
+
+
+def _requirements() -> CompatibilityRequirements:
+    return CompatibilityRequirements(
+        consumer_framework="miles",
+        consumer_framework_version="0.3",
+        algorithm="grpo",
+        tokenizer_id="tokenizer-v1",
+        model_id="tiny",
+        policy_version=PolicyVersion(4, policy_id="actor", model_id="tiny"),
+        reward_definition="unit-test-reward-v1",
+        sequence_format="prompt-response",
+        padding="right",
+        chat_template="chat-v1",
+        truncation="right:64",
+        requires_reference_log_probs=True,
+    )
+
+
+@pytest.mark.unit
+def test_matching_cross_framework_semantics_are_compatible() -> None:
+    report = check_compatibility(_batch(), _requirements())
+
+    assert report.compatible
+    assert report.issues == ()
+    ensure_compatible(_batch(), _requirements())
+
+
+@pytest.mark.unit
+def test_report_collects_every_mismatch_and_rejection_is_actionable() -> None:
+    requirements = CompatibilityRequirements(
+        consumer_framework="prime_rl",
+        consumer_framework_version="0.9",
+        algorithm="ppo",
+        tokenizer_id="other-tokenizer",
+        model_id="other-model",
+        policy_version=PolicyVersion(99),
+        reward_definition="other-reward",
+        sequence_format="response-only",
+        padding="left",
+        chat_template="other-chat",
+        truncation="left:32",
+        requires_reference_log_probs=True,
+    )
+    batch = _batch(with_reference=False)
+
+    report = check_compatibility(batch, requirements)
+
+    assert not report.compatible
+    assert {issue.field for issue in report.issues} == {
+        "algorithm",
+        "tokenizer_id",
+        "model_id",
+        "policy_version",
+        "reward_definition",
+        "sequence_format",
+        "padding",
+        "chat_template",
+        "truncation",
+        "reference_log_probs",
+    }
+    with pytest.raises(CompatibilityError) as caught:
+        report.raise_if_incompatible()
+    message = str(caught.value)
+    assert batch.experience_id in message
+    assert "action:" in message
+    assert "slime@0.1" in message
+    assert "prime_rl@0.9" in message
+
+
+@pytest.mark.unit
+def test_missing_required_producer_metadata_is_not_treated_as_wildcard() -> None:
+    batch = _batch()
+    batch.metadata.tokenizer_id = None
+
+    report = check_compatibility(batch, _requirements())
+
+    issue = next(item for item in report.issues if item.field == "tokenizer_id")
+    assert "did not declare" in issue.reason
+    assert "metadata.tokenizer_id" in issue.action
+
+
+@pytest.mark.unit
+def test_policy_staleness_is_bounded_and_requires_matching_identity() -> None:
+    requirements = replace(
+        _requirements(),
+        policy_version=PolicyVersion(6, policy_id="actor", model_id="tiny"),
+        max_policy_lag=2,
+    )
+    batch = _batch()
+    assert check_compatibility(batch, requirements).compatible
+
+    for policy, reason in (
+        (PolicyVersion(3, policy_id="actor", model_id="tiny"), "stale"),
+        (PolicyVersion(7, policy_id="actor", model_id="tiny"), "newer"),
+        (PolicyVersion(5, policy_id="other", model_id="tiny"), "identity"),
+    ):
+        batch.metadata.policy_version = policy
+        issue = next(
+            item
+            for item in check_compatibility(batch, requirements).issues
+            if item.field == "policy_version"
+        )
+        assert reason in issue.reason
+
+    with pytest.raises(ValueError, match="requires policy_version"):
+        CompatibilityRequirements("trainer", "1", max_policy_lag=1)
+
+    batch.metadata.policy_version = PolicyVersion(6, policy_id="actor", model_id="tiny")
+    batch.trajectories[0].policy_version = PolicyVersion(2, policy_id="actor", model_id="tiny")
+    assert any(
+        issue.field == "trajectories[0].policy_version"
+        for issue in check_compatibility(batch, requirements).issues
+    )

--- a/rl_experience_transfer/tests/test_contracts.py
+++ b/rl_experience_transfer/tests/test_contracts.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from rlxfer.api import ExperienceProducer
+from rlxfer.compatibility import CompatibilityRequirements
+from rlxfer.contracts import ConsumerContract, SchemaMigrationRegistry
+from rlxfer.errors import CompatibilityError, MigrationError
+from rlxfer.model import (
+    SCHEMA_VERSION,
+    ExperienceBatch,
+    ExperienceMetadata,
+    TensorPayload,
+    Trajectory,
+)
+from rlxfer.transports.memory import InMemoryTransport
+
+
+def _batch(version: str = SCHEMA_VERSION) -> ExperienceBatch:
+    return ExperienceBatch(
+        metadata=ExperienceMetadata("rollout", "test", "1", schema_version=version),
+        trajectories=(Trajectory(tokens=TensorPayload(np.arange(3, dtype=np.int64))),),
+    )
+
+
+def _contract(*required_fields: str) -> ConsumerContract:
+    return ConsumerContract(
+        CompatibilityRequirements("trainer", "1"),
+        required_fields=frozenset(required_fields),
+    )
+
+
+def _set_version(batch: ExperienceBatch, version: str) -> ExperienceBatch:
+    return replace(batch, metadata=replace(batch.metadata, schema_version=version))
+
+
+@pytest.mark.unit
+def test_contract_migrates_explicit_path_and_checks_nested_fields() -> None:
+    migrations = SchemaMigrationRegistry(
+        {
+            ("0.8", "0.9"): lambda batch: _set_version(batch, "0.9"),
+            ("0.9", SCHEMA_VERSION): lambda batch: _set_version(batch, SCHEMA_VERSION),
+        }
+    )
+
+    migrated = _contract("trajectories.tokens").negotiate(_batch("0.8"), migrations)
+
+    assert migrated.metadata.schema_version == SCHEMA_VERSION
+    assert migrated.experience_id == migrated.metadata.experience_id
+
+
+@pytest.mark.unit
+def test_contract_rejects_missing_fields_before_transport() -> None:
+    transport = InMemoryTransport()
+    producer = ExperienceProducer(transport, consumer_contract=_contract("trajectories.log_probs"))
+
+    with pytest.raises(CompatibilityError, match=r"trajectories\.log_probs"):
+        producer.publish(_batch())
+
+    assert transport.health().queue_depth == 0
+    ExperienceProducer(
+        transport,
+        consumer_contract=_contract("metadata.idempotency_key"),
+    ).publish(_batch(), idempotency_key="caller-key")
+    assert transport.health().queue_depth == 1
+
+
+@pytest.mark.unit
+def test_migration_requires_a_path_valid_version_and_stable_identity() -> None:
+    batch = _batch("0.9")
+    with pytest.raises(CompatibilityError, match="does not support schema"):
+        _contract().negotiate(batch)
+
+    migrations = SchemaMigrationRegistry()
+    with pytest.raises(MigrationError, match="no schema migration path"):
+        migrations.migrate(batch)
+
+    migrations.register(
+        "0.9",
+        SCHEMA_VERSION,
+        lambda value: replace(
+            _set_version(value, SCHEMA_VERSION),
+            metadata=replace(
+                value.metadata,
+                schema_version=SCHEMA_VERSION,
+                experience_id=ExperienceMetadata("other", "test", "1").experience_id,
+            ),
+        ),
+    )
+    with pytest.raises(MigrationError, match="changed experience_id"):
+        migrations.migrate(batch)

--- a/rl_experience_transfer/tests/test_e2e.py
+++ b/rl_experience_transfer/tests/test_e2e.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end matrices for public API reliability guarantees."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rlxfer import (
+    AuthenticatedExperienceSerializer,
+    CompatibilityRequirements,
+    ConsumerContract,
+    ExperienceBatch,
+    ExperienceConsumer,
+    ExperienceMetadata,
+    ExperienceProducer,
+    ExperienceSerializer,
+    JsonExperienceSerializer,
+    PolicyVersion,
+    ReceiptState,
+    SqliteDeliveryState,
+    TensorPayload,
+    TraceContext,
+    Trajectory,
+    trace_context_from,
+    with_trace_context,
+)
+from rlxfer.transport import ExperienceTransport
+from rlxfer.transports import FileSystemTransport, InMemoryTransport
+
+_TRACE = TraceContext("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+
+
+def _serializer(name: str) -> ExperienceSerializer:
+    if name == "authenticated":
+        return AuthenticatedExperienceSerializer(
+            {"test-key": b"k" * 32},
+            signing_key_id="test-key",
+        )
+    return JsonExperienceSerializer(checksum=True)
+
+
+def _transport(name: str, path: Path) -> ExperienceTransport:
+    return FileSystemTransport(path) if name == "filesystem" else InMemoryTransport()
+
+
+def _batch(key: str) -> ExperienceBatch:
+    policy = PolicyVersion(4, policy_id="actor", model_id="tiny")
+    return with_trace_context(
+        ExperienceBatch(
+            metadata=ExperienceMetadata(
+                "rollout",
+                "test",
+                "1",
+                idempotency_key=key,
+                policy_version=policy,
+            ),
+            trajectories=(
+                Trajectory(
+                    policy_version=policy,
+                    tokens=TensorPayload(np.asarray([3, 4], dtype=np.int64)),
+                    rewards={"task": 1.0},
+                ),
+            ),
+        ),
+        _TRACE,
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("transport_name", ["memory", "filesystem"])
+@pytest.mark.parametrize("serializer_name", ["json", "authenticated"])
+@pytest.mark.parametrize("outcome", ["ack", "retry_then_ack", "reject"])
+def test_delivery_lifecycle_matrix(
+    tmp_path: Path,
+    transport_name: str,
+    serializer_name: str,
+    outcome: str,
+) -> None:
+    """Exercise 2 transports x 2 security modes x 3 settlement paths."""
+
+    key = f"{transport_name}:{serializer_name}:{outcome}"
+    serializer = _serializer(serializer_name)
+    transport = _transport(transport_name, tmp_path / "queue")
+    state = SqliteDeliveryState(tmp_path / "delivery.sqlite")
+    contract = ConsumerContract(
+        CompatibilityRequirements(
+            "trainer",
+            "1",
+            policy_version=PolicyVersion(5, policy_id="actor", model_id="tiny"),
+            max_policy_lag=1,
+        ),
+        required_fields=frozenset({"extensions.w3c.trace_context.traceparent"}),
+    )
+    producer = ExperienceProducer(
+        transport,
+        serializer=serializer,
+        consumer_contract=contract,
+    )
+    consumer = ExperienceConsumer(
+        transport,
+        serializer=serializer,
+        consumer_contract=contract,
+        state_store=state,
+    )
+    try:
+        receipt = producer.publish(_batch(key), max_retries=1)
+        delivery = consumer.receive(1.0)
+        assert delivery is not None
+        assert trace_context_from(delivery.batch) == _TRACE
+        tokens = delivery.batch.trajectories[0].tokens
+        assert tokens is not None
+        np.testing.assert_array_equal(tokens.data, [3, 4])
+
+        if outcome == "retry_then_ack":
+            delivery.nack("temporary trainer pressure")
+            delivery = consumer.receive(1.0)
+            assert delivery is not None and delivery.attempt == 2
+            delivery.ack()
+        elif outcome == "reject":
+            delivery.reject("application rejected the experience")
+        else:
+            delivery.ack()
+        result = receipt.wait(1.0)
+    finally:
+        transport.close()
+
+    if outcome == "reject":
+        assert result.state is ReceiptState.REJECTED
+        assert not state.was_consumed(key)
+        assert state.dead_letters()[0].idempotency_key == key
+    else:
+        assert result.state is ReceiptState.ACKED
+        assert result.attempts == (2 if outcome == "retry_then_ack" else 1)
+        assert state.was_consumed(key)
+        assert state.dead_letters() == ()

--- a/rl_experience_transfer/tests/test_examples.py
+++ b/rl_experience_transfer/tests/test_examples.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Keep every dependency-light example executable."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.e2e
+@pytest.mark.multi_process
+@pytest.mark.parametrize(
+    "script",
+    ["basic.py", "cross_framework.py", "filesystem_process.py", "reliable_transfer.py"],
+)
+def test_dependency_light_example(script: str) -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, str(root / "examples" / script)],
+        cwd=root,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=20.0,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/rl_experience_transfer/tests/test_framework_integration.py
+++ b/rl_experience_transfer/tests/test_framework_integration.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pinned-source native conversion and framework-pipeline component tests."""
+
+from __future__ import annotations
+
+import os
+from itertools import product
+from pathlib import Path
+
+import pytest
+
+from examples.framework_pipeline import (
+    install_framework_source_shims,
+    run_framework_pipeline,
+)
+from examples.framework_roundtrip import (
+    FRAMEWORKS,
+    run_framework_case,
+    supports_conversion,
+)
+
+if os.environ.get("RLXFER_RUN_FRAMEWORK_INTEGRATION") != "1":
+    pytest.skip(
+        "set RLXFER_RUN_FRAMEWORK_INTEGRATION=1 in the isolated framework environment",
+        allow_module_level=True,
+    )
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.nemo_rl,
+    pytest.mark.prime_rl,
+    pytest.mark.slime,
+    pytest.mark.miles,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def source_import_shims() -> None:
+    """Bypass unrelated framework launch stacks while loading pinned native types."""
+
+    install_framework_source_shims()
+
+
+@pytest.mark.parametrize(
+    ("producer_framework", "consumer_framework"),
+    product(FRAMEWORKS, repeat=2),
+)
+def test_native_framework_conversion_matrix(
+    tmp_path: Path,
+    producer_framework: str,
+    consumer_framework: str,
+) -> None:
+    result = run_framework_case(producer_framework, consumer_framework, tmp_path / "queue")
+
+    assert result["result"] == "PASSED"
+    expected = (
+        "converted"
+        if supports_conversion(producer_framework, consumer_framework)
+        else ("rejected_as_unsafe")
+    )
+    assert result["expected_outcome"] == expected
+    if expected == "converted":
+        assert result["acknowledged"] is True
+        assert result["gradient_finite"] is True
+        assert result["gradient_present"] is True
+        assert result["parameter_changed"] is True
+    else:
+        assert result["rejection"]
+
+
+@pytest.mark.parametrize("framework", FRAMEWORKS)
+def test_framework_pipeline_components(tmp_path: Path, framework: str) -> None:
+    result = run_framework_pipeline(framework, tmp_path / framework)
+
+    assert result["result"] == "PASSED"
+    assert result["acknowledged"] is True
+    assert result["gradient_finite"] is True
+    assert result["gradient_present"] is True
+    assert result["parameter_changed"] is True
+    assert result["rollout_source"]
+    assert result["trainer_source"]

--- a/rl_experience_transfer/tests/test_model.py
+++ b/rl_experience_transfer/tests/test_model.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+from uuid import UUID
+
+import numpy as np
+import pytest
+
+from rlxfer.errors import SchemaValidationError
+from rlxfer.model import (
+    SCHEMA_VERSION,
+    Episode,
+    ExperienceBatch,
+    ExperienceMetadata,
+    PolicyVersion,
+    SampleIdentity,
+    TensorPayload,
+    Trajectory,
+    TransferDescriptor,
+    Transition,
+)
+from rlxfer.observability import InMemoryMetrics, structured_log
+
+
+def _metadata() -> ExperienceMetadata:
+    return ExperienceMetadata(
+        producer_id="rollout-1",
+        producer_framework="nemo_rl",
+        producer_framework_version="0.4",
+        policy_version=PolicyVersion(7, model_id="tiny-model"),
+    )
+
+
+def _trajectory(length: int = 4, sample_id: str | None = None) -> Trajectory:
+    identity = SampleIdentity(sample_id=sample_id) if sample_id is not None else SampleIdentity()
+    return Trajectory(
+        identity=identity,
+        policy_version=PolicyVersion(7, model_id="tiny-model"),
+        prompt="question",
+        response="answer",
+        tokens=TensorPayload(np.arange(length, dtype=np.int64)),
+        attention_mask=TensorPayload(np.ones(length, dtype=np.bool_)),
+        log_probs=TensorPayload(np.linspace(-1.0, -0.1, length, dtype=np.float32)),
+        rewards={"task": 1.0},
+        transitions=(Transition(observation={"step": 0}, action=1, reward=1.0),),
+    )
+
+
+@pytest.mark.unit
+def test_tensor_metadata_and_variable_length_batch_validate() -> None:
+    first = _trajectory(3)
+    second = _trajectory(5)
+    batch = ExperienceBatch(metadata=_metadata(), trajectories=(first, second))
+
+    batch.validate()
+
+    assert SCHEMA_VERSION == "1.0"
+    assert first.tokens is not None
+    assert first.tokens.shape == (3,)
+    assert first.tokens.dtype == "int64"
+    assert first.tokens.device == "cpu"
+    assert first.tokens.nbytes == 24
+    assert not hasattr(batch, "__dict__")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field_name", "false_value"),
+    [
+        ("stride", (99, 1)),
+        ("layout", "sparse"),
+        ("nbytes", 1),
+        ("device", "cuda:99"),
+    ],
+)
+def test_tensor_payload_rejects_metadata_that_disagrees_with_data(
+    field_name: str,
+    false_value: object,
+) -> None:
+    payload = TensorPayload(np.arange(6, dtype=np.float32).reshape(2, 3))
+    setattr(payload, field_name, false_value)
+
+    with pytest.raises(SchemaValidationError) as caught:
+        payload.validate()
+
+    assert caught.value.field == f"tensor.{field_name}"
+
+
+@pytest.mark.unit
+def test_nested_extensions_accept_json_and_wrapped_tensors() -> None:
+    extension_tensor = TensorPayload(np.array([1.5, 2.5], dtype=np.float32))
+    batch = ExperienceBatch(
+        metadata=_metadata(),
+        trajectories=(_trajectory(),),
+        payload={"nested": [1, {"tensor": extension_tensor}]},
+        extensions={"nemo_rl": {"loss_mask": extension_tensor, "flags": (True, None)}},
+    )
+
+    batch.validate()
+
+
+@pytest.mark.unit
+def test_alignment_error_carries_complete_framework_context() -> None:
+    trajectory = _trajectory(4)
+    trajectory.attention_mask = TensorPayload(np.ones(3, dtype=np.int64))
+    batch = ExperienceBatch(metadata=_metadata(), trajectories=(trajectory,))
+
+    with pytest.raises(SchemaValidationError) as caught:
+        batch.validate(consumer_framework="prime_rl", consumer_framework_version="0.2")
+
+    error = caught.value
+    assert error.field == "trajectories[0].attention_mask.shape"
+    assert error.expected == (4,)
+    assert error.actual == (3,)
+    assert error.producer_framework == "nemo_rl"
+    assert error.producer_framework_version == "0.4"
+    assert error.consumer_framework == "prime_rl"
+    assert error.consumer_framework_version == "0.2"
+    assert error.experience_id == batch.experience_id
+    assert "nemo_rl@0.4" in str(error)
+    assert "prime_rl@0.2" in str(error)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [("experience_id", "not-a-uuid"), ("schema_version", "2.0")],
+)
+def test_metadata_rejects_invalid_uuid_or_schema(field_name: str, field_value: str) -> None:
+    metadata = _metadata()
+    setattr(metadata, field_name, field_value)
+    batch = ExperienceBatch(metadata=metadata, trajectories=(_trajectory(),))
+
+    with pytest.raises(SchemaValidationError) as caught:
+        batch.validate()
+
+    assert caught.value.field == f"metadata.{field_name}"
+
+
+@pytest.mark.unit
+def test_extension_namespace_and_nested_raw_array_are_rejected() -> None:
+    batch = ExperienceBatch(
+        metadata=_metadata(),
+        trajectories=(_trajectory(),),
+        extensions={"not a namespace": {"raw": np.ones(1)}},
+    )
+    with pytest.raises(SchemaValidationError, match="namespace"):
+        batch.validate()
+
+    batch.extensions = {"slime": {"raw": np.ones(1)}}
+    with pytest.raises(SchemaValidationError, match="TensorPayload"):
+        batch.validate()
+
+
+@pytest.mark.unit
+def test_duplicate_sample_ids_and_invalid_episode_are_rejected() -> None:
+    duplicated = str(UUID("89cb7285-3459-4c62-801d-e812f67a69f8"))
+    batch = ExperienceBatch(
+        metadata=_metadata(),
+        trajectories=(_trajectory(sample_id=duplicated), _trajectory(sample_id=duplicated)),
+    )
+    with pytest.raises(SchemaValidationError, match="unique sample ID"):
+        batch.validate()
+
+    empty_episode = Episode(trajectories=())
+    with pytest.raises(SchemaValidationError, match="at least one trajectory"):
+        ExperienceBatch(metadata=_metadata(), episodes=(empty_episode,)).validate()
+
+
+@pytest.mark.unit
+def test_transfer_descriptor_validates_catalog_and_size() -> None:
+    descriptor = TransferDescriptor(
+        experience_id=_metadata().experience_id,
+        tensor_names=("tokens", "mask"),
+        byte_sizes={"tokens": 16, "mask": 2},
+        metadata_bytes=100,
+        checksums={"tokens": "sha256:123"},
+    )
+
+    descriptor.validate()
+    assert descriptor.total_bytes == 118
+
+    descriptor.byte_sizes.pop("mask")
+    with pytest.raises(SchemaValidationError) as caught:
+        descriptor.validate()
+    assert caught.value.field == "byte_sizes"
+
+
+@pytest.mark.unit
+def test_metrics_and_structured_logging_never_expose_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    metrics = InMemoryMetrics()
+    metrics.increment("produced_batches", attributes={"transport": "memory"})
+    metrics.observe("transfer_latency", 0.25)
+    counters, observations = metrics.snapshot()
+    assert counters == {"produced_batches{transport=memory}": 1}
+    assert observations == {"transfer_latency": (0.25,)}
+
+    logger = logging.getLogger("rlxfer-test")
+    with caplog.at_level(logging.INFO, logger="rlxfer-test"):
+        structured_log(
+            logger,
+            "batch_produced",
+            experience_id="safe-id",
+            prompt="secret prompt",
+            tokens=[1, 2, 3],
+            nested={"response_text": "secret answer"},
+        )
+    fields = cast(dict[str, object], vars(caplog.records[-1])["rlxfer"])
+    assert fields["experience_id"] == "safe-id"
+    assert fields["prompt"] == "<redacted>"
+    assert fields["tokens"] == "<redacted>"
+    assert fields["nested"] == {"response_text": "<redacted>"}
+    assert "secret" not in str(fields)

--- a/rl_experience_transfer/tests/test_nixl.py
+++ b/rl_experience_transfer/tests/test_nixl.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests against real NIXL Python bindings; no mocked NIXL objects."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from rlxfer.errors import DeliveryError
+from rlxfer.model import ExperienceBatch, ExperienceMetadata, TensorPayload
+from rlxfer.serialization import AuthenticatedExperienceSerializer, JsonExperienceSerializer
+from rlxfer.transport import ReceiptState
+from rlxfer.transports.nixl import NixlTransport
+
+pytest.importorskip("nixl")
+torch: Any = pytest.importorskip("torch")
+
+
+def _cpu_batch() -> ExperienceBatch:
+    return ExperienceBatch(
+        metadata=ExperienceMetadata("nixl-producer", "test", "1"),
+        tensors={
+            "tokens": TensorPayload(np.arange(40, dtype=np.int64).reshape(5, 8)),
+            "advantages": TensorPayload(np.linspace(-1, 1, 40, dtype=np.float32)),
+        },
+    )
+
+
+def _consume_nixl(path: str, output: Any) -> None:
+    started = time.perf_counter()
+    consumer = NixlTransport(path, agent_name="nixl-consumer-process")
+    delivery = consumer.receive(10.0)
+    if delivery is None:
+        output.put({"error": "receive timed out"})
+        return
+    restored = JsonExperienceSerializer().deserialize(delivery.payload)
+    tokens = cast(np.ndarray[Any, Any], restored.tensors["tokens"].data)
+    advantages = cast(np.ndarray[Any, Any], restored.tensors["advantages"].data)
+    consumer.ack(delivery.token)
+    consumer.close()
+    output.put(
+        {
+            "tokens": tokens.tolist(),
+            "advantages": advantages.tobytes(),
+            "elapsed": time.perf_counter() - started,
+        }
+    )
+
+
+@pytest.mark.nixl
+@pytest.mark.integration
+@pytest.mark.multi_process
+def test_real_nixl_multiprocess_cpu_scatter_gather(tmp_path: Path) -> None:
+    batch = _cpu_batch()
+    serializer = JsonExperienceSerializer()
+    producer = NixlTransport(tmp_path, agent_name="nixl-producer-process")
+    started = time.perf_counter()
+    receipt = producer.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="real-nixl-cpu",
+    )
+
+    context = multiprocessing.get_context("spawn")
+    output = context.Queue()
+    process = context.Process(target=_consume_nixl, args=(str(tmp_path), output))
+    process.start()
+    process.join(20.0)
+    assert process.exitcode == 0
+    result = output.get(timeout=1.0)
+    assert "error" not in result
+    assert result["tokens"] == np.arange(40, dtype=np.int64).reshape(5, 8).tolist()
+    assert result["advantages"] == np.linspace(-1, 1, 40, dtype=np.float32).tobytes()
+    assert receipt.wait(2.0).state is ReceiptState.ACKED
+    assert time.perf_counter() - started < 20.0
+    producer.close()
+
+
+@pytest.mark.nixl
+@pytest.mark.integration
+def test_real_nixl_rejects_bad_descriptor_and_cleans_up(tmp_path: Path) -> None:
+    batch = _cpu_batch()
+    producer = NixlTransport(tmp_path, agent_name="nixl-failure-producer")
+    consumer = NixlTransport(tmp_path, agent_name="nixl-failure-consumer")
+    receipt = producer.publish(
+        JsonExperienceSerializer().serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="real-nixl-failure",
+        max_retries=0,
+    )
+    pending = next((tmp_path / "control" / "pending").iterdir())
+    control_path = pending / "metadata.json"
+    control = json.loads(control_path.read_text(encoding="utf-8"))
+    control["buffers"][0]["region_size"] += 1
+    control_path.write_text(json.dumps(control), encoding="utf-8")
+
+    with pytest.raises(DeliveryError, match="descriptor"):
+        consumer.receive(1.0)
+    assert receipt.wait(1.0).state is ReceiptState.NACKED
+    assert producer.health().queue_depth == 0
+    consumer.close()
+    producer.close()
+
+
+@pytest.mark.nixl
+@pytest.mark.integration
+def test_real_nixl_cancel_releases_pending_source(tmp_path: Path) -> None:
+    batch = _cpu_batch()
+    producer = NixlTransport(tmp_path, agent_name="nixl-cancel-producer")
+    receipt = producer.publish(
+        JsonExperienceSerializer().serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="real-nixl-cancel",
+    )
+
+    producer.cancel(receipt.receipt_id, "caller cancelled")
+
+    result = receipt.wait(1.0)
+    assert (result.state, result.reason) == (
+        ReceiptState.CANCELLED,
+        "caller cancelled",
+    )
+    assert producer.health().queue_depth == 0
+    producer.close()
+
+
+@pytest.mark.nixl
+@pytest.mark.integration
+def test_real_nixl_concurrent_duplicate_publish_is_idempotent(tmp_path: Path) -> None:
+    batch = _cpu_batch()
+    producer = NixlTransport(tmp_path, agent_name="nixl-concurrent-producer")
+    consumer = NixlTransport(tmp_path, agent_name="nixl-concurrent-consumer")
+    payload = JsonExperienceSerializer().serialize(batch)
+
+    def publish(_: int) -> Any:
+        return producer.publish(
+            payload,
+            experience_id=batch.experience_id,
+            idempotency_key="real-nixl-concurrent",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        receipts = list(pool.map(publish, range(2)))
+
+    assert receipts[0].receipt_id == receipts[1].receipt_id
+    delivery = consumer.receive(2.0)
+    assert delivery is not None
+    consumer.ack(delivery.token)
+    assert receipts[0].wait(1.0).state is ReceiptState.ACKED
+    assert receipts[1].wait(1.0).state is ReceiptState.ACKED
+    assert consumer.receive(0.0) is None
+    assert not producer.capabilities.zero_copy
+    consumer.close()
+    producer.close()
+
+
+@pytest.mark.nixl
+@pytest.mark.integration
+def test_real_nixl_transfers_authenticated_payload(tmp_path: Path) -> None:
+    batch = _cpu_batch()
+    serializer = AuthenticatedExperienceSerializer({"test": b"k" * 32}, signing_key_id="test")
+    producer = NixlTransport(tmp_path, agent_name="nixl-auth-producer")
+    consumer = NixlTransport(tmp_path, agent_name="nixl-auth-consumer")
+    receipt = producer.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="real-nixl-auth",
+    )
+
+    delivery = consumer.receive(2.0)
+    assert delivery is not None
+    assert serializer.deserialize(delivery.payload).experience_id == batch.experience_id
+    consumer.ack(delivery.token)
+    assert receipt.wait(1.0).state is ReceiptState.ACKED
+    consumer.close()
+    producer.close()
+
+
+@pytest.mark.nixl
+@pytest.mark.integration
+@pytest.mark.requires_gpu
+def test_real_nixl_cuda_buffer(tmp_path: Path) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    tokens = torch.arange(64, dtype=torch.int64, device="cuda:0").reshape(8, 8)
+    batch = ExperienceBatch(
+        metadata=ExperienceMetadata("nixl-cuda", "test", "1"),
+        tensors={"tokens": TensorPayload(tokens)},
+    )
+    serializer = JsonExperienceSerializer(cpu_staging=False, preserve_device=True)
+    producer = NixlTransport(tmp_path, agent_name="nixl-cuda-producer")
+    consumer = NixlTransport(tmp_path, agent_name="nixl-cuda-consumer")
+    receipt = producer.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="real-nixl-cuda",
+    )
+    delivery = consumer.receive(5.0)
+    assert delivery is not None
+    restored = serializer.deserialize(delivery.payload)
+    received = restored.tensors["tokens"].data
+    assert isinstance(received, torch.Tensor)
+    assert received.device.type == "cuda"
+    assert torch.equal(received, tokens)
+    consumer.ack(delivery.token)
+    assert receipt.wait(1.0).state is ReceiptState.ACKED
+    consumer.close()
+    producer.close()
+
+
+@pytest.mark.nixl
+@pytest.mark.integration
+@pytest.mark.requires_gpu
+def test_real_nixl_multi_gpu_batch(tmp_path: Path) -> None:
+    if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+        pytest.skip("two CUDA devices are unavailable")
+    first = torch.arange(32, dtype=torch.int64, device="cuda:0")
+    second = torch.linspace(-1, 1, 32, dtype=torch.float32, device="cuda:1")
+    batch = ExperienceBatch(
+        metadata=ExperienceMetadata("nixl-multi-gpu", "test", "1"),
+        tensors={"tokens": TensorPayload(first), "advantages": TensorPayload(second)},
+    )
+    serializer = JsonExperienceSerializer(cpu_staging=False, preserve_device=True)
+    producer = NixlTransport(tmp_path, agent_name="nixl-multi-gpu-producer")
+    consumer = NixlTransport(tmp_path, agent_name="nixl-multi-gpu-consumer")
+    receipt = producer.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="real-nixl-multi-gpu",
+    )
+    delivery = consumer.receive(5.0)
+    assert delivery is not None
+    restored = serializer.deserialize(delivery.payload)
+    assert torch.equal(restored.tensors["tokens"].data, first)
+    assert torch.equal(restored.tensors["advantages"].data, second)
+    consumer.ack(delivery.token)
+    assert receipt.wait(1.0).state is ReceiptState.ACKED
+    consumer.close()
+    producer.close()

--- a/rl_experience_transfer/tests/test_package.py
+++ b/rl_experience_transfer/tests/test_package.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import rlxfer
+
+
+@pytest.mark.unit
+def test_package_imports() -> None:
+    assert rlxfer.__version__ == "0.1.0"
+    public_contracts = {
+        "AuthenticatedExperienceSerializer",
+        "BufferManager",
+        "ConsumerContract",
+        "DeliveryStateStore",
+        "DeliveryReceipt",
+        "ExperienceAdapter",
+        "ExperienceSerializer",
+        "ExperienceTransport",
+        "FallbackTransport",
+        "SchemaMigrationRegistry",
+        "SqliteDeliveryState",
+        "TraceContext",
+        "TransferPlan",
+        "TransportRegistry",
+    }
+    assert public_contracts <= set(rlxfer.__all__)
+    for name in public_contracts:
+        assert getattr(rlxfer, name).__name__ == name

--- a/rl_experience_transfer/tests/test_reliability.py
+++ b/rl_experience_transfer/tests/test_reliability.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rlxfer.api import ExperienceConsumer, ExperienceProducer
+from rlxfer.compatibility import CompatibilityRequirements
+from rlxfer.contracts import ConsumerContract
+from rlxfer.errors import IntegrityError, SerializationError, TransportError
+from rlxfer.model import (
+    ExperienceBatch,
+    ExperienceMetadata,
+    PolicyVersion,
+    TensorPayload,
+    Trajectory,
+)
+from rlxfer.serialization import (
+    AuthenticatedExperienceSerializer,
+    JsonExperienceSerializer,
+    validate_metadata,
+)
+from rlxfer.state import SqliteDeliveryState
+from rlxfer.tracing import TraceContext, trace_context_from, with_trace_context
+from rlxfer.transport import ReceiptState
+from rlxfer.transports.fallback import FallbackTransport
+from rlxfer.transports.memory import InMemoryTransport
+
+
+def _batch(*, key: str = "stable-key") -> ExperienceBatch:
+    return ExperienceBatch(
+        metadata=ExperienceMetadata("rollout", "test", "1", idempotency_key=key),
+        trajectories=(
+            Trajectory(
+                prompt="sensitive prompt",
+                tokens=TensorPayload(np.arange(4, dtype=np.int64)),
+            ),
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_authenticated_serializer_covers_metadata_and_external_buffers() -> None:
+    serializer = AuthenticatedExperienceSerializer({"current": b"k" * 32}, signing_key_id="current")
+    batch = _batch()
+    encoded = serializer.serialize(batch)
+
+    assert validate_metadata(encoded.metadata)
+    assert serializer.deserialize(encoded).experience_id == batch.experience_id
+    with pytest.raises(SerializationError, match="unknown or missing fields"):
+        JsonExperienceSerializer().deserialize(encoded)
+
+    segment = encoded.buffers[0]
+    raw = segment.materialize()
+    tampered = replace(segment, data=bytes([raw[0] ^ 1]) + raw[1:], owner=None)
+    with pytest.raises(IntegrityError, match="authentication failed"):
+        serializer.deserialize(replace(encoded, buffers=(tampered,)))
+
+    document = json.loads(encoded.metadata)
+    document["authentication"]["key_id"] = "rotated"
+    changed_key_id = json.dumps(document, separators=(",", ":"), sort_keys=True).encode()
+    rotating = AuthenticatedExperienceSerializer(
+        {"current": b"k" * 32, "rotated": b"k" * 32}, signing_key_id="current"
+    )
+    with pytest.raises(IntegrityError, match="authentication failed"):
+        rotating.deserialize(replace(encoded, metadata=changed_key_id))
+
+    unsigned = JsonExperienceSerializer().serialize(_batch())
+    with pytest.raises(IntegrityError, match="requires a signature"):
+        serializer.deserialize(unsigned)
+
+
+@pytest.mark.unit
+def test_trace_context_survives_safe_serialization() -> None:
+    context = TraceContext(
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        "vendor=value",
+    )
+    batch = _batch()
+    traced = with_trace_context(batch, context)
+    restored = JsonExperienceSerializer().deserialize(JsonExperienceSerializer().serialize(traced))
+
+    assert trace_context_from(batch) is None
+    assert trace_context_from(restored) == context
+    with pytest.raises(ValueError, match="traceparent"):
+        TraceContext("00-00000000000000000000000000000000-0000000000000000-00")
+    with pytest.raises(ValueError, match="tracestate"):
+        TraceContext(context.traceparent, "vendor=one,vendor=two")
+
+
+@pytest.mark.integration
+def test_sqlite_state_suppresses_restart_duplicates_and_records_dead_letters(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "delivery-state.sqlite"
+    first_transport = InMemoryTransport()
+    first_receipt = ExperienceProducer(first_transport).publish(_batch())
+    first = ExperienceConsumer(first_transport, state_store=SqliteDeliveryState(path)).receive(0.1)
+    assert first is not None
+    first.ack()
+    assert first_receipt.wait(0.1).state is ReceiptState.ACKED
+
+    replay_transport = InMemoryTransport()
+    replay_receipt = ExperienceProducer(replay_transport).publish(_batch())
+    restarted = ExperienceConsumer(replay_transport, state_store=SqliteDeliveryState(path))
+    assert restarted.receive(0.01) is None
+    assert replay_receipt.wait(0.1).state is ReceiptState.ACKED
+
+    rejected_transport = InMemoryTransport()
+    rejected_receipt = ExperienceProducer(rejected_transport).publish(_batch(key="rejected"))
+    state = SqliteDeliveryState(path)
+    rejected = ExperienceConsumer(rejected_transport, state_store=state).receive(0.1)
+    assert rejected is not None
+    rejected.reject("incompatible policy")
+
+    assert rejected_receipt.wait(0.1).state is ReceiptState.REJECTED
+    assert [(letter.idempotency_key, letter.reason) for letter in state.dead_letters()] == [
+        ("rejected", "incompatible policy")
+    ]
+    assert b"sensitive prompt" not in path.read_bytes()
+
+    exhausted_transport = InMemoryTransport()
+    exhausted_receipt = ExperienceProducer(exhausted_transport).publish(
+        _batch(key="exhausted"), max_retries=0
+    )
+    exhausted = ExperienceConsumer(exhausted_transport, state_store=state).receive(0.1)
+    assert exhausted is not None
+    exhausted.nack("retry budget exhausted")
+    assert exhausted_receipt.wait(0.1).state is ReceiptState.NACKED
+    assert state.dead_letters()[0].idempotency_key == "exhausted"
+
+
+@pytest.mark.integration
+def test_reliability_features_compose_end_to_end(tmp_path: Path) -> None:
+    context = TraceContext("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    batch = _batch(key="composed")
+    batch.metadata.policy_version = PolicyVersion(4, policy_id="actor", model_id="tiny")
+    batch = with_trace_context(batch, context)
+    contract = ConsumerContract(
+        CompatibilityRequirements(
+            "trainer",
+            "1",
+            policy_version=PolicyVersion(5, policy_id="actor", model_id="tiny"),
+            max_policy_lag=1,
+        ),
+        required_fields=frozenset({"extensions.w3c.trace_context.traceparent"}),
+    )
+    transport = FallbackTransport(
+        (InMemoryTransport(failure_at_publish=1), InMemoryTransport()),
+        fallback_exceptions=(TransportError,),
+    )
+    serializer = AuthenticatedExperienceSerializer({"test": b"k" * 32}, signing_key_id="test")
+    state = SqliteDeliveryState(tmp_path / "composed.sqlite")
+
+    receipt = ExperienceProducer(
+        transport, serializer=serializer, consumer_contract=contract
+    ).publish(batch)
+    delivery = ExperienceConsumer(
+        transport,
+        serializer=serializer,
+        consumer_contract=contract,
+        state_store=state,
+    ).receive(0.1)
+
+    assert delivery is not None and trace_context_from(delivery.batch) == context
+    delivery.ack()
+    assert receipt.wait(0.1).state is ReceiptState.ACKED
+    assert state.was_consumed("composed")

--- a/rl_experience_transfer/tests/test_serialization.py
+++ b/rl_experience_transfer/tests/test_serialization.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from rlxfer.errors import IntegrityError, SerializationError
+from rlxfer.model import ExperienceBatch, ExperienceMetadata, TensorPayload
+from rlxfer.serialization import (
+    JsonExperienceSerializer,
+    SerializationLimits,
+    SerializedExperience,
+    validate_metadata,
+)
+
+
+def _batch(array: np.ndarray[tuple[int, ...], np.dtype[np.generic]]) -> ExperienceBatch:
+    return ExperienceBatch(
+        metadata=ExperienceMetadata(
+            producer_id="rollout-1",
+            producer_framework="nemo_rl",
+            producer_framework_version="0.test",
+            experience_id="01031b86-18f3-4de1-97bc-a7aece118d41",
+            created_at=1.0,
+        ),
+        tensors={"tokens": TensorPayload(array, name="tokens")},
+        extensions={
+            "nemo_rl": {
+                "nested": [{"loss_mask": TensorPayload(np.array([1, 0, 1], dtype=np.uint8))}]
+            }
+        },
+    )
+
+
+@pytest.mark.unit
+def test_external_tensor_round_trip_is_byte_exact_and_deterministic() -> None:
+    array = np.arange(24, dtype=np.int16).reshape(4, 6)[:, ::2]
+    serializer = JsonExperienceSerializer(inline_threshold=0)
+
+    first = serializer.serialize(_batch(array))
+    second = serializer.serialize(_batch(array))
+    restored = serializer.deserialize(first)
+
+    assert first.metadata == second.metadata
+    assert len(first.buffers) == 2
+    assert first.buffers[0].path == ("tensors", "tokens", "data")
+    assert first.buffers[0].shape == array.shape
+    assert first.buffers[0].stride == (3, 1)
+    assert first.buffers[0].dtype == array.dtype.str
+    assert first.buffers[0].materialize() == array.tobytes(order="C")
+
+    tokens = restored.tensors["tokens"]
+    assert isinstance(tokens.data, np.ndarray)
+    assert tokens.data.dtype == array.dtype
+    assert tokens.data.shape == array.shape
+    assert tokens.data.tobytes() == array.tobytes(order="C")
+    assert np.array_equal(tokens.data, array)
+    assert tokens.stride == (3, 1)
+    assert tokens.layout == "strided"
+    assert tokens.data.strides == (6, 2)
+    assert tokens.data.flags.c_contiguous
+    nested = restored.extensions["nemo_rl"]
+    assert isinstance(nested, dict)
+    nested_tensor = nested["nested"][0]["loss_mask"]
+    assert isinstance(nested_tensor, TensorPayload)
+    assert isinstance(nested_tensor.data, np.ndarray)
+    assert np.array_equal(nested_tensor.data, np.array([1, 0, 1], dtype=np.uint8))
+
+
+@pytest.mark.unit
+def test_small_tensor_is_inline_and_metadata_can_be_prevalidated() -> None:
+    serializer = JsonExperienceSerializer(inline_threshold=1024)
+    encoded = serializer.serialize(_batch(np.array([[3.5, -1.0]], dtype=np.float32)))
+
+    assert encoded.buffers == ()
+    descriptors = validate_metadata(encoded.metadata)
+    assert len(descriptors) == 2
+    assert descriptors[0].data is not None
+    assert descriptors[0].wire_device == "cpu"
+    restored = serializer.deserialize(encoded)
+    restored_data = restored.tensors["tokens"].data
+    assert isinstance(restored_data, np.ndarray)
+    assert np.array_equal(
+        restored_data,
+        np.array([[3.5, -1.0]], dtype=np.float32),
+    )
+
+
+@pytest.mark.unit
+def test_checksum_corruption_is_rejected_before_batch_construction() -> None:
+    serializer = JsonExperienceSerializer(inline_threshold=0)
+    encoded = serializer.serialize(_batch(np.arange(4, dtype=np.int64)))
+    segment = encoded.buffers[0]
+    corrupted = bytes([segment.materialize()[0] ^ 0xFF]) + segment.materialize()[1:]
+    payload = SerializedExperience(
+        metadata=encoded.metadata,
+        buffers=(replace(segment, data=corrupted, owner=None), *encoded.buffers[1:]),
+    )
+
+    with pytest.raises(IntegrityError, match="checksum mismatch"):
+        serializer.deserialize(payload)
+
+
+@pytest.mark.unit
+def test_malformed_catalog_size_and_schema_are_rejected() -> None:
+    serializer = JsonExperienceSerializer(inline_threshold=1024)
+    encoded = serializer.serialize(_batch(np.arange(4, dtype=np.int32)))
+    document = json.loads(encoded.metadata)
+    document["tensors"][0]["nbytes"] += 1
+    malformed = json.dumps(document, separators=(",", ":"), sort_keys=True).encode()
+
+    with pytest.raises(IntegrityError, match="catalog size mismatch"):
+        validate_metadata(malformed)
+
+    document["tensors"][0]["nbytes"] -= 1
+    document["schema_version"] = "99.0"
+    malformed = json.dumps(document, separators=(",", ":"), sort_keys=True).encode()
+    with pytest.raises(SerializationError, match="unsupported schema version"):
+        serializer.deserialize(SerializedExperience(malformed))
+
+
+@pytest.mark.unit
+def test_external_catalog_and_supplied_segment_must_agree() -> None:
+    serializer = JsonExperienceSerializer(inline_threshold=0)
+    encoded = serializer.serialize(_batch(np.arange(4, dtype=np.float64)))
+    segment = encoded.buffers[0]
+    payload = SerializedExperience(
+        metadata=encoded.metadata,
+        buffers=(replace(segment, original_device="xpu:0"), *encoded.buffers[1:]),
+    )
+
+    with pytest.raises(IntegrityError, match="metadata disagrees with catalog"):
+        serializer.deserialize(payload)
+
+
+@pytest.mark.unit
+def test_numpy_stride_uses_element_units_and_normalizes_wire_layout() -> None:
+    array = np.arange(30, dtype=np.float32).reshape(5, 6)[:, ::2]
+    payload = TensorPayload(array)
+    serializer = JsonExperienceSerializer()
+
+    assert payload.stride == (6, 2)
+    encoded = serializer.serialize(_batch(array))
+    restored = serializer.deserialize(encoded).tensors["tokens"]
+
+    assert encoded.buffers[0].stride == (3, 1)
+    assert isinstance(restored.data, np.ndarray)
+    assert restored.stride == (3, 1)
+    assert tuple(size // restored.data.itemsize for size in restored.data.strides) == (3, 1)
+    assert restored.layout == "strided"
+    assert np.array_equal(restored.data, array)
+
+
+@pytest.mark.unit
+def test_metadata_byte_depth_and_item_limits_apply_in_both_directions() -> None:
+    encoded = JsonExperienceSerializer().serialize(_batch(np.arange(4, dtype=np.int16)))
+
+    byte_limited = JsonExperienceSerializer(
+        limits=replace(SerializationLimits(), max_metadata_bytes=len(encoded.metadata) - 1)
+    )
+    with pytest.raises(SerializationError, match=r"metadata size .* exceeds byte limit"):
+        byte_limited.deserialize(encoded)
+    with pytest.raises(SerializationError, match=r"metadata size .* exceeds byte limit"):
+        byte_limited.serialize(_batch(np.arange(4, dtype=np.int16)))
+
+    nested: object = "leaf"
+    for _ in range(20):
+        nested = [nested]
+    deep_batch = _batch(np.arange(4, dtype=np.int16))
+    deep_batch.extensions = {"nemo_rl": {"nested": nested}}
+    depth_limited = JsonExperienceSerializer(limits=replace(SerializationLimits(), max_depth=12))
+    with pytest.raises(SerializationError, match="nesting depth exceeds limit"):
+        depth_limited.serialize(deep_batch)
+
+    document = json.loads(encoded.metadata)
+    root = document["root"]
+    for _ in range(20):
+        root = {"$type": "list", "items": [root]}
+    document["root"] = root
+    deep_metadata = json.dumps(document, separators=(",", ":"), sort_keys=True).encode()
+    with pytest.raises(SerializationError, match="nesting depth exceeds limit"):
+        depth_limited.deserialize(SerializedExperience(deep_metadata))
+
+    item_limited = JsonExperienceSerializer(limits=replace(SerializationLimits(), max_items=20))
+    with pytest.raises(SerializationError, match="item count exceeds limit"):
+        item_limited.serialize(_batch(np.arange(4, dtype=np.int16)))
+    with pytest.raises(SerializationError, match="item count exceeds limit"):
+        item_limited.deserialize(encoded)
+
+
+@pytest.mark.unit
+def test_tensor_count_and_byte_limits_apply_before_restore() -> None:
+    batch = _batch(np.arange(4, dtype=np.int16))
+    defaults = SerializationLimits()
+
+    with pytest.raises(SerializationError, match="tensor count exceeds limit"):
+        JsonExperienceSerializer(limits=replace(defaults, max_tensor_count=1)).serialize(batch)
+    with pytest.raises(SerializationError, match="per-tensor byte limit"):
+        JsonExperienceSerializer(limits=replace(defaults, max_tensor_bytes=7)).serialize(batch)
+    with pytest.raises(SerializationError, match=r"total tensor size .* exceeds byte limit"):
+        JsonExperienceSerializer(
+            limits=replace(defaults, max_tensor_bytes=16, max_total_tensor_bytes=10)
+        ).serialize(batch)
+
+    encoded = JsonExperienceSerializer().serialize(batch)
+    with pytest.raises(SerializationError, match="tensor count exceeds limit"):
+        JsonExperienceSerializer(limits=replace(defaults, max_tensor_count=1)).deserialize(encoded)
+
+
+@pytest.mark.unit
+def test_non_contiguous_torch_stride_is_normalized_when_torch_is_available() -> None:
+    torch = pytest.importorskip("torch")
+    tensor = torch.arange(30, dtype=torch.int64).reshape(5, 6)[:, ::2]
+    batch = _batch(np.arange(1, dtype=np.int64))
+    batch.tensors = {"tokens": TensorPayload(tensor)}
+    serializer = JsonExperienceSerializer()
+
+    encoded = serializer.serialize(batch)
+    restored = serializer.deserialize(encoded).tensors["tokens"]
+
+    assert encoded.buffers[0].stride == (3, 1)
+    assert isinstance(restored.data, torch.Tensor)
+    assert restored.data.is_contiguous()
+    assert restored.data.stride() == (3, 1)
+    assert restored.stride == (3, 1)
+    assert restored.layout == "strided"
+    assert torch.equal(restored.data, tensor)

--- a/rl_experience_transfer/tests/test_transports.py
+++ b/rl_experience_transfer/tests/test_transports.py
@@ -1,0 +1,449 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reference transport behavior and multiprocess persistence tests."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import time
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from rlxfer.errors import (
+    BackpressureError,
+    CapabilityError,
+    DeliveryError,
+    SerializationError,
+    TransportError,
+)
+from rlxfer.model import ExperienceBatch, ExperienceMetadata, TensorPayload
+from rlxfer.serialization import JsonExperienceSerializer, SerializationLimits
+from rlxfer.transport import (
+    ExperienceTransport,
+    ReceiptState,
+    TransferPlan,
+    TransportConfig,
+    create_transport,
+)
+from rlxfer.transports.fallback import FallbackTransport
+from rlxfer.transports.filesystem import FileSystemTransport
+from rlxfer.transports.memory import InMemoryTransport
+
+
+def _batch() -> ExperienceBatch:
+    return ExperienceBatch(
+        metadata=ExperienceMetadata("producer", "test", "1"),
+        tensors={
+            "tokens": TensorPayload(np.arange(12, dtype=np.int64).reshape(3, 4)),
+            "rewards": TensorPayload(np.asarray([0.5, -1.0, 2.0], dtype=np.float32)),
+        },
+        extensions={"test": {"nested": [1, {"preserved": True}]}},
+    )
+
+
+def _consume_filesystem(path: str, output: Any) -> None:
+    transport = FileSystemTransport(path)
+    delivery = transport.receive(5.0)
+    if delivery is None:
+        output.put({"error": "receive timed out"})
+        return
+    batch = JsonExperienceSerializer().deserialize(delivery.payload)
+    output.put(
+        {
+            "tokens": cast(np.ndarray[Any, Any], batch.tensors["tokens"].data).tolist(),
+            "attempt": delivery.attempt,
+        }
+    )
+    transport.ack(delivery.token)
+    transport.close()
+
+
+@pytest.mark.unit
+def test_memory_round_trip_ack_and_duplicate() -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    payload = serializer.serialize(batch)
+    transport = InMemoryTransport(max_queue=2)
+
+    receipt = transport.publish(
+        payload,
+        experience_id=batch.experience_id,
+        idempotency_key="stable-key",
+    )
+    duplicate = transport.publish(
+        payload,
+        experience_id=batch.experience_id,
+        idempotency_key="stable-key",
+    )
+    assert duplicate.receipt_id == receipt.receipt_id
+
+    delivery = transport.receive(0.1)
+    assert delivery is not None
+    restored = serializer.deserialize(delivery.payload)
+    np.testing.assert_array_equal(restored.tensors["tokens"].data, batch.tensors["tokens"].data)
+    transport.ack(delivery.token)
+    assert receipt.wait(0.1).state is ReceiptState.ACKED
+
+
+@pytest.mark.unit
+def test_memory_retry_rejection_backpressure_and_capability() -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    payload = serializer.serialize(batch)
+    transport = InMemoryTransport(max_queue=1)
+    receipt = transport.publish(
+        payload,
+        experience_id=batch.experience_id,
+        idempotency_key="retry-key",
+        max_retries=1,
+    )
+    with pytest.raises(BackpressureError):
+        transport.publish(
+            payload,
+            experience_id=ExperienceMetadata("other", "test", "1").experience_id,
+            idempotency_key="blocked-key",
+            timeout=0.0,
+        )
+    delivery = transport.receive(0.1)
+    assert delivery is not None
+    transport.nack(delivery.token, "injected", retry=True)
+    retried = transport.receive(0.1)
+    assert retried is not None and retried.attempt == 2
+    transport.reject(retried.token, "malformed")
+    result = receipt.wait(0.1)
+    assert (result.state, result.reason, result.attempts) == (
+        ReceiptState.REJECTED,
+        "malformed",
+        2,
+    )
+    with pytest.raises(DeliveryError):
+        transport.ack(retried.token)
+    with pytest.raises(CapabilityError):
+        TransferPlan(require_persistence=True).check(transport.capabilities)
+
+
+@pytest.mark.unit
+def test_memory_failure_injection_leaves_queue_recoverable() -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    payload = serializer.serialize(batch)
+    publish_failure = InMemoryTransport(failure_at_publish=1)
+    with pytest.raises(TransportError, match="injected publish"):
+        publish_failure.publish(
+            payload,
+            experience_id=batch.experience_id,
+            idempotency_key="publish-failure",
+        )
+    assert publish_failure.health().queue_depth == 0
+
+    receive_failure = InMemoryTransport(failure_at_receive=1)
+    receipt = receive_failure.publish(
+        payload,
+        experience_id=batch.experience_id,
+        idempotency_key="receive-failure",
+    )
+    with pytest.raises(TransportError, match="injected receive"):
+        receive_failure.receive(0.1)
+    delivery = receive_failure.receive(0.1)
+    assert delivery is not None
+    receive_failure.ack(delivery.token)
+    assert receipt.wait(0.1).state is ReceiptState.ACKED
+
+
+@pytest.mark.unit
+def test_fallback_routes_delivery_and_does_not_retry_ambiguous_errors_by_default() -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    payload = serializer.serialize(batch)
+    primary = InMemoryTransport(failure_at_publish=1)
+    secondary = InMemoryTransport()
+
+    safe = FallbackTransport((primary, secondary))
+    with pytest.raises(TransportError, match="injected publish"):
+        safe.publish(payload, experience_id=batch.experience_id, idempotency_key="safe")
+    assert secondary.health().queue_depth == 0
+
+    enabled = create_transport(
+        TransportConfig(
+            "fallback",
+            {
+                "transports": (InMemoryTransport(failure_at_publish=1), secondary),
+                "fallback_exceptions": [TransportError],
+            },
+        )
+    )
+    assert isinstance(enabled, FallbackTransport)
+    receipt = enabled.publish(
+        payload,
+        experience_id=batch.experience_id,
+        idempotency_key="fallback",
+    )
+    delivery = enabled.receive(0.1)
+    assert delivery is not None
+    assert receipt.receipt_id.startswith("1:") and delivery.token.startswith("1:")
+    enabled.ack(delivery.token)
+    assert receipt.wait(0.1).state is ReceiptState.ACKED
+
+
+@pytest.mark.unit
+def test_reference_transports_enforce_transfer_size_limits(tmp_path: Path) -> None:
+    payload = JsonExperienceSerializer().serialize(_batch())
+    limits = replace(
+        SerializationLimits(),
+        max_tensor_bytes=64,
+        max_total_tensor_bytes=128,
+    )
+    transports: list[ExperienceTransport] = [
+        InMemoryTransport(limits=limits),
+        FileSystemTransport(tmp_path, limits=limits),
+    ]
+
+    for index, transport in enumerate(transports):
+        assert transport.capabilities.max_transfer_size == (
+            limits.max_metadata_bytes + limits.max_total_tensor_bytes
+        )
+        with pytest.raises(SerializationError, match="per-tensor byte limit"):
+            transport.publish(
+                payload,
+                experience_id=_batch().experience_id,
+                idempotency_key=f"limited-{index}",
+            )
+        assert transport.health().queue_depth == 0
+
+
+@pytest.mark.unit
+def test_memory_cancel_only_applies_before_delivery() -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    payload = serializer.serialize(batch)
+    transport = InMemoryTransport()
+    pending = transport.publish(
+        payload,
+        experience_id=batch.experience_id,
+        idempotency_key="cancel-pending",
+    )
+    transport.cancel(pending.receipt_id, "not needed")
+    assert pending.wait(0.1).state is ReceiptState.CANCELLED
+    assert transport.receive(0.0) is None
+
+    inflight = transport.publish(
+        payload,
+        experience_id=batch.experience_id,
+        idempotency_key="cancel-inflight",
+    )
+    assert transport.receive(0.1) is not None
+    with pytest.raises(DeliveryError, match="inflight"):
+        transport.cancel(inflight.receipt_id)
+
+
+@pytest.mark.integration
+@pytest.mark.multi_process
+def test_filesystem_multiprocess_byte_exact(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    producer = FileSystemTransport(tmp_path)
+    receipt = producer.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="multiprocess-key",
+    )
+
+    context = multiprocessing.get_context("spawn")
+    output = context.Queue()
+    process = context.Process(target=_consume_filesystem, args=(str(tmp_path), output))
+    process.start()
+    process.join(10.0)
+    assert process.exitcode == 0
+    assert output.get(timeout=1.0) == {
+        "tokens": np.arange(12, dtype=np.int64).reshape(3, 4).tolist(),
+        "attempt": 1,
+    }
+    assert receipt.wait(1.0).state is ReceiptState.ACKED
+    assert producer.health().queue_depth == 0
+
+
+@pytest.mark.integration
+def test_filesystem_recovers_stale_inflight(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    transport = FileSystemTransport(tmp_path, lease_timeout=0.01)
+    transport.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="recovery-key",
+    )
+    abandoned = transport.receive(0.1)
+    assert abandoned is not None
+    inflight = next((tmp_path / "inflight").iterdir())
+    old = time.time() - 10.0
+    os.utime(inflight, (old, old))
+
+    recovered = FileSystemTransport(tmp_path, lease_timeout=0.01).receive(0.1)
+    assert recovered is not None
+    assert recovered.experience_id == batch.experience_id
+    FileSystemTransport(tmp_path).ack(recovered.token)
+
+
+@pytest.mark.integration
+def test_filesystem_claim_refreshes_an_old_pending_lease(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    owner = FileSystemTransport(tmp_path, lease_timeout=1.0)
+    owner.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="old-pending",
+    )
+    pending = next((tmp_path / "pending").iterdir())
+    old = time.time() - 10.0
+    os.utime(pending, (old, old))
+
+    active = owner.receive(0.1)
+    assert active is not None
+    contender = FileSystemTransport(tmp_path, lease_timeout=1.0)
+
+    assert contender.receive(0.0) is None
+    owner.ack(active.token)
+
+
+@pytest.mark.integration
+def test_filesystem_publish_rolls_back_failed_index_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    transport = FileSystemTransport(tmp_path)
+    original = transport._write_json
+
+    def fail_index(target: Path, value: Mapping[str, Any]) -> None:
+        if target.parent.name == "idempotency":
+            raise OSError("injected index failure")
+        original(target, value)
+
+    monkeypatch.setattr(transport, "_write_json", fail_index)
+    with pytest.raises(OSError, match="injected index failure"):
+        transport.publish(
+            serializer.serialize(batch),
+            experience_id=batch.experience_id,
+            idempotency_key="index-failure",
+        )
+
+    assert not any((tmp_path / "pending").iterdir())
+    assert transport.health().queue_depth == 0
+
+
+@pytest.mark.integration
+def test_filesystem_repairs_missing_idempotency_index(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    first = FileSystemTransport(tmp_path)
+    receipt = first.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="repair-index",
+    )
+    next((tmp_path / "idempotency").iterdir()).unlink()
+
+    recovered = FileSystemTransport(tmp_path)
+    duplicate = recovered.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="repair-index",
+    )
+
+    assert duplicate.receipt_id == receipt.receipt_id
+    assert recovered.health().queue_depth == 1
+
+
+@pytest.mark.integration
+def test_filesystem_multiproducer_bound_is_atomic(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+
+    def publish(index: int) -> str:
+        batch = _batch()
+        transport = FileSystemTransport(tmp_path, max_queue=1, poll_interval=0.001)
+        try:
+            transport.publish(
+                serializer.serialize(batch),
+                experience_id=batch.experience_id,
+                idempotency_key=f"concurrent-{index}",
+                timeout=0.02,
+            )
+        except BackpressureError:
+            return "blocked"
+        return "accepted"
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        outcomes = list(pool.map(publish, range(8)))
+
+    assert outcomes.count("accepted") == 1
+    assert outcomes.count("blocked") == 7
+    assert FileSystemTransport(tmp_path, max_queue=1).health().queue_depth == 1
+
+
+@pytest.mark.integration
+def test_filesystem_corrupt_partial_delivery_is_rejected_and_removed(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    transport = FileSystemTransport(tmp_path)
+    receipt = transport.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="corrupt-key",
+    )
+    pending = next((tmp_path / "pending").iterdir())
+    next((pending / "buffers").iterdir()).unlink()
+
+    with pytest.raises(DeliveryError, match="corrupt"):
+        transport.receive(0.1)
+    assert receipt.wait(0.1).state is ReceiptState.REJECTED
+    assert transport.health().queue_depth == 0
+
+
+@pytest.mark.integration
+def test_filesystem_rejects_manifest_path_escape(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    transport = FileSystemTransport(tmp_path)
+    receipt = transport.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="path-escape",
+    )
+    pending = next((tmp_path / "pending").iterdir())
+    manifest_path = pending / "manifest.json"
+    manifest = cast(dict[str, Any], json.loads(manifest_path.read_text()))
+    manifest["buffers"][0]["filename"] = "../../outside"
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(DeliveryError, match="corrupt"):
+        transport.receive(0.1)
+
+    assert receipt.wait(0.1).state is ReceiptState.REJECTED
+    assert not (tmp_path / "outside").exists()
+
+
+@pytest.mark.integration
+def test_filesystem_cancel_pending_delivery(tmp_path: Path) -> None:
+    serializer = JsonExperienceSerializer()
+    batch = _batch()
+    transport = FileSystemTransport(tmp_path)
+    receipt = transport.publish(
+        serializer.serialize(batch),
+        experience_id=batch.experience_id,
+        idempotency_key="cancel-filesystem",
+    )
+
+    transport.cancel(receipt.receipt_id, "shutdown")
+
+    result = receipt.wait(0.1)
+    assert (result.state, result.reason) == (ReceiptState.CANCELLED, "shutdown")
+    assert transport.health().queue_depth == 0

--- a/rl_experience_transfer/uv.lock
+++ b/rl_experience_transfer/uv.lock
@@ -1,0 +1,997 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/a9/11851c3e02a3fea2ddc9932d1fdc7d2edaeecc0d2e11bc5f2a7fde2b0934/ast_serialize-0.8.0.tar.gz", hash = "sha256:6c37c43e4004dfb42d321ddedc569dc17ff4259296f3af577c9ea46a809bc010", size = 845638, upload-time = "2026-08-07T11:29:02.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/16/6e520b57cd8c75914b38c670ad4593d13c22911e4306cc7165dab8b0789b/ast_serialize-0.8.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:3d822605fa7bb326ef868d25fafced7fc660fa46d9b90c02ea86d5e2f5d325f7", size = 863924, upload-time = "2026-08-07T11:27:34.579Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e1/48802de9b22a2bcad42ec80601a17e3f69172fe4f590e6311bcc2b323aeb/ast_serialize-0.8.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:2efa40b068197d5efb62655b43baadb842ed71c4958cccd3e8b86a35726f0119", size = 1177662, upload-time = "2026-08-07T11:27:36.196Z" },
+    { url = "https://files.pythonhosted.org/packages/38/d4/323438db76bded3a1f3523a3167b8325916b2ddceb2107a330c6ec9fcf4d/ast_serialize-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:db1b957291bca08c7e72f43a12357b2948e20775d970e3fc3dac0aa3160ab725", size = 1167072, upload-time = "2026-08-07T11:27:37.646Z" },
+    { url = "https://files.pythonhosted.org/packages/77/82/53c5400b54144b56de8ed7f957fd1ccd97e42482009292ab46121d15f8dd/ast_serialize-0.8.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdc0d5b18ff8fb364e87923e47c0a91d0d69dbcaeaa274591f7fd26892cc3a3a", size = 1225497, upload-time = "2026-08-07T11:27:39.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5f/36c07327a8b91303fbf1382c7c3e8a2902072dbe1b9546138a5288e75ff0/ast_serialize-0.8.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9da7330f3e235bf7da89b8d39205c6350fc0c08a85379743f2df9fff87d6d980", size = 1227101, upload-time = "2026-08-07T11:27:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/48/5adf5c67addc7ddb328122208c6d375a84cf154984f412b4087330a157bd/ast_serialize-0.8.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3186969ee66a9863b00acc6523ace44c56974eecb348a7ea4b228d9f0b80e19", size = 1424001, upload-time = "2026-08-07T11:27:42.708Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a1/70074dd3869d2b0e934f91891d8d6b734361cd3b80f85ca7ece2e668ecdd/ast_serialize-0.8.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40a57b73731be45da4fa41430c4d5dc94a24b3a4faba7b9e069978c0402064ea", size = 1245545, upload-time = "2026-08-07T11:27:44.4Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/53b9c0a8a6399950c2e3546bdfab96d2b299d5b114b47eb94fd3c49c4054/ast_serialize-0.8.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b9da3ef807eda752502446dfecea3b381c4900b7e27a5d5f4f899eb39951", size = 1248961, upload-time = "2026-08-07T11:27:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/13/3651d3812548a2bda15e26e5dd51aadb48cf682d0865370255fcf0e367dd/ast_serialize-0.8.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:293cc1c5bfa741f8e3fbe8175b9c07beee487c9a6fdbb25a5acad9f1df2d30a9", size = 1243877, upload-time = "2026-08-07T11:27:47.325Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a0/521f0bf000f675e9312a4aae2c8ba7a992405d072a85c485e08fd59433b9/ast_serialize-0.8.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0910c3442a75216dde0f102d854ba2aaa71d2482e0ee213630b9bf29584fba3", size = 1293903, upload-time = "2026-08-07T11:27:49.264Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7e/402fc902568aa2ee65865a3e151f000db0153da8ce6b1be4c9c349025f8d/ast_serialize-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:43dd6d596879bb1cb8a12cc9dae7bb10090a39a35883026c24f82488a195619a", size = 1401070, upload-time = "2026-08-07T11:27:50.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/7c/97d4b66c057f1706fc8be6dd532cc77c988794357c8f4ffdb6adabb39562/ast_serialize-0.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8c9d537f59e936392cfd3597789d1390304dd659efc3c486ce7f40fb6b8a9f53", size = 1502602, upload-time = "2026-08-07T11:27:52.364Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6f/72cc3b71562001bba46e898ccfbf1844f7939b3e28912736206102f2e5a8/ast_serialize-0.8.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f0190a33d7f97c65e9069f7a7f40499eea6b5cbe260c558378109caf20ce934b", size = 1495848, upload-time = "2026-08-07T11:27:53.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/53/d6f629d1e49308b2f363dae028baa213ec222c9106fa1f7f0d1f7b41499a/ast_serialize-0.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:77308ae6c5cf5264cc0f01a7c556ec77a9e68eb1f61b093534d698139fdc3b14", size = 1556556, upload-time = "2026-08-07T11:27:55.342Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/22/340f35dd8dfc6d412d53dc20699ca014b8d228db923e8ed4759c512b162c/ast_serialize-0.8.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8d53a23f27e1ed3a36b2d26fd2a1a6228c8e85a1ed62ff7cdb44bd610769f20a", size = 1417822, upload-time = "2026-08-07T11:27:56.712Z" },
+    { url = "https://files.pythonhosted.org/packages/11/29/6dde5c13fbebc051d3a6df4ec0a6fd1d5359333cc1193f7f609f3410b4d8/ast_serialize-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ffa5e7cb08f96fed9121f77b224151e41caf88feab9d652bb46c78202b6fbeda", size = 1445153, upload-time = "2026-08-07T11:27:58.275Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c5/f473a8ed030f7a0ca24b9849cca184677a50c053867a7b808c2e1289bbd3/ast_serialize-0.8.0-cp314-cp314t-win32.whl", hash = "sha256:fa70ed4dea0bb18b30a1789c77baa701d0ef30c474f2ccabdea61e25623a8827", size = 1063711, upload-time = "2026-08-07T11:27:59.793Z" },
+    { url = "https://files.pythonhosted.org/packages/23/63/39e171fcd38ca057c2e1979d5ee81ac7a3502784abe3d83df7454f7a0978/ast_serialize-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d8b3c8eee4c1baef9d4e84d2a59a805501617127be42615cb48970b15b0892b6", size = 1103740, upload-time = "2026-08-07T11:28:01.405Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1c/d00762b399e7726d68d0a088cc946e3a4c60f1c6176f557608f672f627f3/ast_serialize-0.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:ac4f0a83c55a9b782f79ad55a5247b7db123c1db405959791c2ef886e9710c9f", size = 1076021, upload-time = "2026-08-07T11:28:02.947Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/11/911210c3c78923273a9211a2b6cfc4c8aa723b30dab3e1c8d19afb983b40/ast_serialize-0.8.0-cp315-abi3.abi3t-macosx_10_12_x86_64.whl", hash = "sha256:86b8a1e6d90467345356098b040150e82fbc26d24a7a202224b13dc1f6264ca0", size = 1177715, upload-time = "2026-08-07T11:28:04.654Z" },
+    { url = "https://files.pythonhosted.org/packages/77/89/6282881c8587606638db153cbe21e1e0c4d1f3970dee1aa0610a1c62a026/ast_serialize-0.8.0-cp315-abi3.abi3t-macosx_11_0_arm64.whl", hash = "sha256:39e92ff8e8cb45947fe9007174b2950e1fb098e6abd00266a13cd3bcf6675068", size = 1169347, upload-time = "2026-08-07T11:28:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/97/78/a9f846a03a340ff3728c915f23338ca742742f3292700559cdb3ad999b1e/ast_serialize-0.8.0-cp315-abi3.abi3t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c85d8d18db5b2dfcb3b7e38a4d600ca35504c0ed8a6f75cd1c811e4ffe248a15", size = 1225916, upload-time = "2026-08-07T11:28:07.654Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/15/aba6ef8a988a6eceb6f0359589aac509e29ae2dba67fd9bfd5af0c3f13e7/ast_serialize-0.8.0-cp315-abi3.abi3t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9830ff7e764f74d9eefb01170c61a9f0fd2c027dac5fcb72e064decd57d56371", size = 1227135, upload-time = "2026-08-07T11:28:09.504Z" },
+    { url = "https://files.pythonhosted.org/packages/94/29/3f63d696ea7c5b8abadcecc3505be51bd900daaccc522ed8322fa5b05a93/ast_serialize-0.8.0-cp315-abi3.abi3t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6479d9722a4cd21b578f5478074c41e6169f04811996ec881655560f703a5bba", size = 1425040, upload-time = "2026-08-07T11:28:11.044Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5d/0aac338604ff59df5774d4304307898982252f325ff7cafe31d52fedcb65/ast_serialize-0.8.0-cp315-abi3.abi3t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a63bed264e818cd83eec11feed0f50aa162542b91132ef58afebc857182763a5", size = 1246278, upload-time = "2026-08-07T11:28:12.519Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ca/9f1ef795bb724719532bd86dbec11e5b66857d3fbe9b6772baec0191a6ed/ast_serialize-0.8.0-cp315-abi3.abi3t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d187197d234aa45d6cfa2b096be5f666e8cc2e7eb3722d0ab8926293cf5720c", size = 1250029, upload-time = "2026-08-07T11:28:13.896Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/25/5e061372d2ed953b9ba3b9c4f73de3b8e9234cda3f6c088db4686801d0e1/ast_serialize-0.8.0-cp315-abi3.abi3t-manylinux_2_31_riscv64.whl", hash = "sha256:2d39a56282cfcc0d8eeea37267c754be59c98d48505c23b1dae5c6011f3813dd", size = 1243575, upload-time = "2026-08-07T11:28:15.37Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c1/ae7da218053120635a4ca802366c69f707203641af95372eeb83f70dfd52/ast_serialize-0.8.0-cp315-abi3.abi3t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f7cc5f10386994c0f4844f1e6d6a97127e9b478660eb6dec2b257644f0acab64", size = 1294396, upload-time = "2026-08-07T11:28:16.813Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/89/271d1f49c5269fcddcc789ea3f25be401f6723fc1138aeda539f4d05516d/ast_serialize-0.8.0-cp315-abi3.abi3t-musllinux_1_2_aarch64.whl", hash = "sha256:6102f2f985c2e542be85cd857678ec9356fefa792b93cadfadd31139f5696f27", size = 1401987, upload-time = "2026-08-07T11:28:18.333Z" },
+    { url = "https://files.pythonhosted.org/packages/55/be/4e7d77fcf571ac7cb5cf7115a20c36642bd7d29473b45dfaaefeb9618f90/ast_serialize-0.8.0-cp315-abi3.abi3t-musllinux_1_2_armv7l.whl", hash = "sha256:3a8660fe66667b76a6e9dccd1d33e66b229fde3b308db991c041609226c005b6", size = 1502904, upload-time = "2026-08-07T11:28:20.039Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ae/ed1de2db7e019d4236fbc164ffa5ef9a6022a300a342bbf142d21b7c141e/ast_serialize-0.8.0-cp315-abi3.abi3t-musllinux_1_2_i686.whl", hash = "sha256:e7266307e5fba39836edb79def8608887af48820508bff3c5f2941e1e04d1534", size = 1496967, upload-time = "2026-08-07T11:28:21.734Z" },
+    { url = "https://files.pythonhosted.org/packages/92/89/5fea507fae5c5f18b7dc7f95e5c00956574b8c717b8fd2049c504fab0b18/ast_serialize-0.8.0-cp315-abi3.abi3t-musllinux_1_2_ppc64le.whl", hash = "sha256:4ca7e6fd1ad845d1cc649dc2ecd499db2f8f46af5bf8da7b70dd858774cc038b", size = 1559041, upload-time = "2026-08-07T11:28:23.194Z" },
+    { url = "https://files.pythonhosted.org/packages/42/71/478d69df21b64e064554a68134c94be304270316ca676a94e63c389a636a/ast_serialize-0.8.0-cp315-abi3.abi3t-musllinux_1_2_riscv64.whl", hash = "sha256:2880350b13d3eae69a0d70bc1fb6c9bfaca4dbd0e20ba8cd1aa483080b56ff06", size = 1417367, upload-time = "2026-08-07T11:28:24.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2d/8962dc8d5b3a9dc27b36f9db199afa25264c741505469d9ec10ffbfd2ba7/ast_serialize-0.8.0-cp315-abi3.abi3t-musllinux_1_2_x86_64.whl", hash = "sha256:ab0f9a59f7d63d0d441b56b9a818b273705264352d5115cfee12e940e816d958", size = 1446178, upload-time = "2026-08-07T11:28:26.152Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/22/14d2ad4fd1d1bcd0dc687ca268e0630069f45162496260c0efb70ee0ea72/ast_serialize-0.8.0-cp315-abi3.abi3t-win32.whl", hash = "sha256:0485a25ef519c62e749ee3c1ad8070e591b380d67226349eb5a70b228dc1ac4a", size = 1063811, upload-time = "2026-08-07T11:28:27.864Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1d/84a327c0202a41aa5fdba3ade33904d6d8f3b9e6806fa83568d835395850/ast_serialize-0.8.0-cp315-abi3.abi3t-win_amd64.whl", hash = "sha256:bd84d60bca7079e741be4ac5dbe237751a59d7f6f9f0126b11880d63822cbe16", size = 1105518, upload-time = "2026-08-07T11:28:29.691Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/92/74556dec52fde85a2ad84ed159991b916241043788609c15d8b77e14570b/ast_serialize-0.8.0-cp315-abi3.abi3t-win_arm64.whl", hash = "sha256:057769b5921336eb2d9124f2a731b42ed05ffdac559b840dbdf6f3937cf153dc", size = 1076319, upload-time = "2026-08-07T11:28:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/5d/c650b1f2cc1e75193358da95a080261422e8cd10b66d7370b1688c9915c5/ast_serialize-0.8.0-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:a02cbed7d8bfdcdee88edaac12bd50d53d9953aaa2e1852ef078625be5f1c0b5", size = 852914, upload-time = "2026-08-07T11:28:32.929Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e3/6142e920fec6ef7bccabd8c24ed8ed99f8bdc6cb8b065e1df7c6a3b2d667/ast_serialize-0.8.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e1bd223df0f6c96b396975fa604cb33bce53d9b4a0185490be4c4a289f7c9c87", size = 1184007, upload-time = "2026-08-07T11:28:34.654Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/6e8be8df02b35d85e2b8809f7f1cfa290bdf5882b55127a539d049482db0/ast_serialize-0.8.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ddd3b61f45c132da66c5476b281891e08c1fd87fbdabe8a6973e1622efc85f06", size = 1177588, upload-time = "2026-08-07T11:28:36.318Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/80/7e0fd2e2e2aba257820db4a8657c4c356844d36b914b20a4af294bcfb902/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f9caa63fad8241257ae401b5ff0a64026c6adb36b8e86cbe8782d9ea505daf6", size = 1234575, upload-time = "2026-08-07T11:28:37.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/3bae0af06f9b1bae3001c44d64215f5b567877e7aae9ffd45db11c3a7647/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3926fa117b5e65019853a2969966d11c7175af377a3425991f3fe73784412405", size = 1236015, upload-time = "2026-08-07T11:28:39.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c4/ce2d41a1bc22508e82618901f7e10f2a5e2f9556553fea90624daf9875e2/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:485f1113af805e9e170b95ef993ca3fbd4f89c04bab25c58b4fc632d854801ab", size = 1432808, upload-time = "2026-08-07T11:28:40.664Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/90/f5058f209756dd70e958b7538aaa82d25d24944baf9ec8ae6f27b06fcacc/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ccebbed24f1281062d5852353c72c47502955926cfcb8345ffb3a44d87ff3d3", size = 1256251, upload-time = "2026-08-07T11:28:42.223Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/32/7f77ea87fa0836daab706ed5cb7f903bb25fa26a77439011aee626af11d8/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:252f883290d1cdb728eb7fe1d9a7221b88af5a329aae0bc91ddee4dafb820331", size = 1258574, upload-time = "2026-08-07T11:28:43.751Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5a/75b82ad2725b5e8e8c742732f9e76c6738a292d0709e1f60d10a973730b4/ast_serialize-0.8.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:96abc072ad29db8d02194afd47d68987322622787daceae82398d7b69f3ba2e6", size = 1254075, upload-time = "2026-08-07T11:28:45.28Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/8c20ed4eea805516a3fd23dd4a721ce28c64f50f0e4b359969f60a8c97a6/ast_serialize-0.8.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9118ad3e369727060b2696fc4078f250ecffca4248ba87f537f55cea9f9dce06", size = 1301018, upload-time = "2026-08-07T11:28:46.851Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/9f14430f12fe830b656fb38f8e2e05ee13b02a88967660bef46af0ab22a8/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f359df4bd921918af8bebd142a376c77511d7151cc8ba852760b587b5a4a54f3", size = 1409951, upload-time = "2026-08-07T11:28:48.312Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3d/084882eca93c842bd4262591a071ec7f825340644035e51501208cc5a8d4/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e94f9121d13fa36cbf21314783c77d05ae3a0868decd18cf5233fdcc6de49ac8", size = 1509544, upload-time = "2026-08-07T11:28:49.847Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/73/ea84852096c2036c61cc0b2f97b90242207419f534dc671060ee1c8e05cb/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:54f95b486018d262bcb387a9afd96f0da74508b442762b80c769454a6fbb3ee3", size = 1505671, upload-time = "2026-08-07T11:28:51.239Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/88/287b9a5300c1f2f651d259f670931b63110adc265b7613c885b44c5bc53d/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c38b915511e32bc718c49dbce98ff9af36bac0ad6a604f58000cd5e3aecdba7", size = 1563685, upload-time = "2026-08-07T11:28:53.112Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/1bc3a79afcf0c2a8d2c37182d0d659d1545a9d7f7f6dc9cf3e63d6c17135/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:9a2ef9cf12f2de4f1028c42c1dd7d775255e0fb3e5bb48896c97e35ef52366fe", size = 1427977, upload-time = "2026-08-07T11:28:54.418Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cd/440c798957e14e31776bfeb024d8fafe0bb1d5b89c51c2f067e69938f7b0/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f18048fe9f6dd266bd577cdec48bdcecb74faaa01fe941324435483b013ed2a", size = 1454335, upload-time = "2026-08-07T11:28:55.968Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/587eb36dcc240a54c8660f599464516b469ecad96f0dbdb6bccbedb50745/ast_serialize-0.8.0-cp39-abi3-win32.whl", hash = "sha256:31883542dd6c94d178f5db3d32fbd69c5eb88b3a7c018e7ac8cc0c45195ddbed", size = 1068858, upload-time = "2026-08-07T11:28:57.541Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/3e887bbd92164e183cb6e412c6a3e9198ddd446d7fe405958293ef5ef49c/ast_serialize-0.8.0-cp39-abi3-win_amd64.whl", hash = "sha256:861794565b06337005c1447ef23103a3d5a627d08bdc827870d00d0b28ef5f51", size = 1111839, upload-time = "2026-08-07T11:28:59Z" },
+    { url = "https://files.pythonhosted.org/packages/25/6c/b400476d3ceba681ab929787edc9554f6d88fcc69435eb681b00fc0457a5/ast_serialize-0.8.0-cp39-abi3-win_arm64.whl", hash = "sha256:b2a5978662fd4db463dfb4b974d2b10ac6430b98f5333aabc7051909df3561d0", size = 1083655, upload-time = "2026-08-07T11:29:00.349Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/9b/356320fbae2ac8467e21c5e73e1389c80468e4998c62cc7d3536cc51b614/librt-0.15.0.tar.gz", hash = "sha256:4e66cbe84437497d951b799d3e1551291b6fb3d643820a7014b3655d57a59162", size = 214338, upload-time = "2026-08-07T10:49:42.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/12/e2e9ca532cf5a0e08c9489826c4a35c6958c92ba0313fda70e8c6c3912be/librt-0.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e1a49adf16a7c9d9646816c2946135527197b6fcf4347c7b8b761cf1bfbf4489", size = 148673, upload-time = "2026-08-07T10:46:22.569Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/7c/02005e23478bd5950618d9712e0fd2b4c511657857f3efd8ba6a5feabcdd/librt-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81a398f45b45a59200e13cd5ad1ae1d3f44334de98b148331afe2cdfee701c52", size = 153547, upload-time = "2026-08-07T10:46:23.931Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/90/d8848a735f5642077fc4b3b4bebcdb08edf10178e3add45597f5201a368f/librt-0.15.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4eafbaff06b9563f8b1c850621ce51605de05208e09d4d71ce490bc972b7b9e8", size = 494355, upload-time = "2026-08-07T10:46:25.122Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/0b/8604f41ea02feace490e9e405a338a15f9905369f55b239a9ce31c946f24/librt-0.15.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:b0411b4066db926b80258c60dcb0e6db4c9cee312eab45b7e8866b17ddf9ada1", size = 485459, upload-time = "2026-08-07T10:46:26.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ac/84153bda1ce0da609182527ab92b40d961809e544eefdc5a1c2422971416/librt-0.15.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:febb1ce6cac545a54e6b769982824e955a700fdd9fbf3a08a3d82c990968b57d", size = 498398, upload-time = "2026-08-07T10:46:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3a/5ca6cd282b2c244bec8ec84102e09773264e9c02891d56ab3a8f0e4d7083/librt-0.15.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b230acc1c3bfe2d6f2627ba2b95dc92e58aa494600e9722d0e6ccbc931e59702", size = 515474, upload-time = "2026-08-07T10:46:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d3/bd34110234779eb843c6ed66aba7c9b2091d3dd85989f1fb9922f564cb7a/librt-0.15.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6da110e5f314c19ab8478464d02ae18808ae73d522c15260fa4918acdcd64da9", size = 509484, upload-time = "2026-08-07T10:46:30.124Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/43c3f7f071d71631a7daa3b835ef2168ea39f20692d81464d4e47fbaa6d6/librt-0.15.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:eab9208b00ca55bf75983ec99f7bf13acc746a36102e98953addaad7f7ea1e1b", size = 532534, upload-time = "2026-08-07T10:46:31.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/1c/b854adf036ea817c40408873a5b794d65a91d9f0f39826f2ad2a2d5d7f48/librt-0.15.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6c013cd3a1721e69e14380ada97eaa4b7b0cdf1c6b96fa765d4ea47c875088db", size = 537087, upload-time = "2026-08-07T10:46:32.734Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5c/c9a890e244e7dd725d3bd8b560e41f0aec787eaf343b46956a290ab7b841/librt-0.15.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:567b1c430f8bd560e689421468278ac5941bab4a05303b5d95b6ae10db03f451", size = 536575, upload-time = "2026-08-07T10:46:33.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c5/c8e70b60b704299555f55db468eb46b1c81bfc60201ffbfe20407d89870c/librt-0.15.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:29c4cab9df457b19672c39be7f384ebb2bc925c4e2684b8780c222b43eb36389", size = 517142, upload-time = "2026-08-07T10:46:35.577Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d1/767a90c41f5d381b3195bc88ac0ec4afda35777c9c781e1f9848fedd965e/librt-0.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bccbd8e5b0bffb7106cf18eb1baa3d7194b1cebb3b4b1cdbd4bdb19382a6ee6c", size = 558714, upload-time = "2026-08-07T10:46:36.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b4/3c0624b8dc8301ab808f2b3a910995bcabe28df070fb9a0e5505ae997dae/librt-0.15.0-cp310-cp310-win32.whl", hash = "sha256:8ae493ed5f659a7761c43d42f183db514536073ded9bcf671d2d1df47e29a07e", size = 104426, upload-time = "2026-08-07T10:46:38.594Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/e91c0382304bedb2db9c6801897319a9dcb68daac5e975819b562362f20d/librt-0.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:bc25fb356d0c7810bb49ff3df908ad1fda6995d660ab099ded69244ed7ab6053", size = 125057, upload-time = "2026-08-07T10:46:40.052Z" },
+    { url = "https://files.pythonhosted.org/packages/59/52/06790ced2ac7117f890c21bda43c39c958ec82aa665c0718e821d33ff939/librt-0.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:823b92cf3c18ecd08afc70c42473888b41b6e8ef5046f3b82c05c154a2fa3d22", size = 148039, upload-time = "2026-08-07T10:46:41.165Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1d/8e150b7fc449a1f33c8a760965cc1f43b14fc1577d9d0b50ab2701420e74/librt-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c70bc1b602cf59917e8f0c7a2cbc8bcc6fbc14d5486136b00707a79619121d63", size = 153067, upload-time = "2026-08-07T10:46:42.418Z" },
+    { url = "https://files.pythonhosted.org/packages/51/87/a162bc5a66a35599dc619ecb215145f4de7d68e886b479b6d12593139f7c/librt-0.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:814ff83a25b5fce8b9c80c4dd803153fb5c5599fc74db9e022466938368957ef", size = 493087, upload-time = "2026-08-07T10:46:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/3a/aeea1fc620cf48060d3065b37614edbf97043c099d0f50782bc8ca61d897/librt-0.15.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:57f5eeb6ad4c180de583b1038e61fe5fbd9796bb69a8a1c1a0c7ddbec4c8c60f", size = 485608, upload-time = "2026-08-07T10:46:45.038Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ff/fe571ad416f0856fd0d5578ffc2e6dc531891e586e36b647bcf50569cab8/librt-0.15.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82909c8f7eb9952656b65d3147afde4cf8e6d5a991eebc86418b5e65843b0ab8", size = 498723, upload-time = "2026-08-07T10:46:46.35Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e1/7a65eb5dedb1f00aebd948cdd8e17add48bf066cab3514e9daf84ab45a6c/librt-0.15.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f779070399f991400fc451719e0ea388eb7de313388bada2c127a35de05f798a", size = 516002, upload-time = "2026-08-07T10:46:47.599Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/59832b0ebfbd08c2742e6ece372ceb53f18bf1faef5d33c8daf3abebf749/librt-0.15.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bac89069bc496ebdf4f79ebb57bbd10d0b214c8454225deb672d91002bd17e18", size = 508607, upload-time = "2026-08-07T10:46:48.873Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/37fa73f3b43ebd8259f91ae9102a15e5a54e65d581e48dea72df3e81d7a4/librt-0.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e0d00c708fb2f5822b152429b1ac80a58dbbbc3f6c232c4d13a3f7fcf2ea5b4c", size = 530422, upload-time = "2026-08-07T10:46:50.45Z" },
+    { url = "https://files.pythonhosted.org/packages/26/02/e046c6fe7a5881ac34623242192f484426ba8a75595fd18f22c53a3f530f/librt-0.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6c6624fe268625869485553dd7cc1daf30d22558215bb2a4ff16f67a9801a31a", size = 534303, upload-time = "2026-08-07T10:46:51.693Z" },
+    { url = "https://files.pythonhosted.org/packages/95/32/d5e6d861ab0366f3edf74f887ab0c9eb9f535aaf01d32b80b4f734daa179/librt-0.15.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f56b397858a23dacf35ede366ed2212fdc03a6a57a1ad36468ad6e9dc5fac091", size = 536084, upload-time = "2026-08-07T10:46:52.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/de/d69d725513fe53fc90c6d7a1f86e4428939bad2fb905b17fe4c18d413dde/librt-0.15.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:4388184646efe2054911c5b00a1077d6d1ee86a95b7e8ba96dc7850a809f3f40", size = 514307, upload-time = "2026-08-07T10:46:54.194Z" },
+    { url = "https://files.pythonhosted.org/packages/36/93/f8aded0d6682b4f25820fa86e0690f87f01df9fd7bd09ddb04d9167ad021/librt-0.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:97335f59082f9fe2ce6c2a9cc6433a0114bbb6cd4d5c09dd76c95c68b9f9a8b0", size = 557686, upload-time = "2026-08-07T10:46:55.443Z" },
+    { url = "https://files.pythonhosted.org/packages/74/09/ffeb6bdeb6cd862b4272fddc8ad05f938dd25d020ed517e631813917d80a/librt-0.15.0-cp311-cp311-win32.whl", hash = "sha256:83380ffde38062a2e9bb55d83e74474f6614665528b98a6928720fc006dfffbb", size = 104917, upload-time = "2026-08-07T10:46:56.605Z" },
+    { url = "https://files.pythonhosted.org/packages/96/28/7e2313a3ffbf0b4de7ba3da58a09e488507b4bd1ea2b5e69378354a23415/librt-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:f75720477ee05d509a310e856cacc8d909adc182f7b91193c207bcc26d7ee6db", size = 125886, upload-time = "2026-08-07T10:46:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9e/04b8c3cde014ef255ee785730425268354543acc38902093a40afa0dc164/librt-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:256237037a3ab001ae8d9803b2d43562a4c3aa38739843694349e4d5ebb0fd56", size = 111885, upload-time = "2026-08-07T10:46:58.787Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/39/99c25030e782bdfb7a21be8c05254806a2e4bbb05c8d50c2a2130acbfa05/librt-0.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e87bc679f86a99aa3b26e3c78eeb821a247c9a28eae48eaafcc32c3bf4c3bb9e", size = 151021, upload-time = "2026-08-07T10:47:00.057Z" },
+    { url = "https://files.pythonhosted.org/packages/14/43/f4b1bd1b2888798a1409808889a25ea1ba49eaabce7d681ed27734c2df9d/librt-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:71599e011ac880e8e45d46047d714871894c7d4ab6f25626f8d4f89da21f368d", size = 155267, upload-time = "2026-08-07T10:47:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/db/3ad9c965c72f1e1d6beeec44ec10a54e17be8ae042fbb4baade16cbadced/librt-0.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c802434092b769b1d613ed2e13fac15fbfce1934a74bd10283b03c0fae231cd1", size = 503136, upload-time = "2026-08-07T10:47:02.45Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/07/5888a6d76acd62ebce66c61b74d94e9370b9c32929f111e487bb6546f8ed/librt-0.15.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5500eeae393a184d14e1f35645962c27129d20c81afa4069e6ef826ebc2b3aaa", size = 496670, upload-time = "2026-08-07T10:47:03.675Z" },
+    { url = "https://files.pythonhosted.org/packages/29/39/ab57cc2f5b276156da02bb7f5a8921bada1cb1993ffec99acf811c602c23/librt-0.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6ecfc32dfb46fb7b565bcd6abf9412acf978775a998273d22888a6d7953730dd", size = 513688, upload-time = "2026-08-07T10:47:04.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b9/bdbb0b648b5c2befb031f4c6f3b1dd857415e8fb492a25a3c764a6681e6c/librt-0.15.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cc46cfd15022e35084355478c9ac809d90b1152222706ac9a7655ec21df6fa", size = 531904, upload-time = "2026-08-07T10:47:06.211Z" },
+    { url = "https://files.pythonhosted.org/packages/93/26/473c2e4b6c104e9e58e27ce95fc8005c8bd4fc36cae4f254371125a92db8/librt-0.15.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d5f51401d102c885b9ca509e62c79b1dbff286e1b9b047fde6f763780789356d", size = 524427, upload-time = "2026-08-07T10:47:07.592Z" },
+    { url = "https://files.pythonhosted.org/packages/26/60/03b3abb82b41714671b907bf6989b228e31e6a8af52dec82b5b0728dc250/librt-0.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cc30523e3f1a23fb7511cc659834a0d01a1042bb9de359bc1c131cc4ec6c9656", size = 543155, upload-time = "2026-08-07T10:47:08.866Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0e/9bb1f0a4affbd0a1888f4f79dc03ed2a299d9a2c26c59ab2a97dcbf11903/librt-0.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:59fe030d8ae4a57e3fb7756bf35a858de74e04066fc8555c53d0af979132af81", size = 546890, upload-time = "2026-08-07T10:47:10.327Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/84/6937a280d461f7de6e031ffb02edc2b7c3c90d49d630565ce8ff27cbc5f2/librt-0.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5a6526a2a956bbb1e4ae3568c82e650fc99119c66bb011ea60715744955a2b4d", size = 555163, upload-time = "2026-08-07T10:47:11.798Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/95/2a2853c1ee014bf102116e7f897a04beeaeb2461b45b79af98bdfb95f1ef/librt-0.15.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:85ea21ec6730194d67156b0e0b5430ccb1d61f8b8b907e39b37f9812b74a13f0", size = 535812, upload-time = "2026-08-07T10:47:13.279Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/4c/cf9601c1b4c5f09280acd5d83abdb2e68527a2be8257136eb42304218622/librt-0.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1e47b8ba865d7ede071a91a7163073bbaeb72541f1ef8a07d512c45c7b5007f2", size = 573688, upload-time = "2026-08-07T10:47:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/47/6d/9ac7cbec46189a7625af4b5acbd25f10d827f4141b2002181848c8418923/librt-0.15.0-cp312-cp312-win32.whl", hash = "sha256:a5207ec414d1c4a2a7231b2086970dc036f94293cdf338190984958a013a42f1", size = 106138, upload-time = "2026-08-07T10:47:15.973Z" },
+    { url = "https://files.pythonhosted.org/packages/38/d0/2ae99c83be86ce23f925ac1aeeedc777e97f427c4a8d190c70d0a16e9a87/librt-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:73b30cfa976659b3917c8f6153bdb0591c6a9ec6583599fd24a689b690622022", size = 126974, upload-time = "2026-08-07T10:47:17.049Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ef/dd24f9635c730b86b87587967dda7516b1845e8b17684603d31607fed598/librt-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:a54cf9e0ef47b96af580849db5471142200568ce1e02cbf416addab551369570", size = 112292, upload-time = "2026-08-07T10:47:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/42/467b53a601b406ccd7b97c1fd54b59cb34f9185ad5ce7e9d5c3c4e8961c8/librt-0.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:db13ca398005abcbe538deda87b686d9bd08b7001cf40c4c06b444960ae10a26", size = 151029, upload-time = "2026-08-07T10:47:19.312Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/e6/36c2299b7a94b84fdd01220d8a777a71be5be0925bb0dbdf71c0a06a34d9/librt-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa1f1995789dca3698bc550aaceb09a51bd5df0a057ff84ff15296cd1975b801", size = 155194, upload-time = "2026-08-07T10:47:20.398Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/ed5071f9325845e670bd36012757419767fbf56af77ed483077b9e4db541/librt-0.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55456ea87d8df21808446d03817be2f65e20391c1c615d9187440dff28cd08dc", size = 502568, upload-time = "2026-08-07T10:47:21.652Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/6450c67c3615d87704bcbc21323fafc69c799b06a044c447529f725d4b01/librt-0.15.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5a86a5a08c2235316bdb359d5dbb6ce0abfca7fac06363103e2c5af571d92f95", size = 496153, upload-time = "2026-08-07T10:47:22.925Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d6/5f52b722bc75076954b3bfd49be15ea362df4d580c6fb315d0f617100d30/librt-0.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e56b6a368529bed262da40ce13f8fef590db0479819cca84f16a1f01ac356d0b", size = 513336, upload-time = "2026-08-07T10:47:24.213Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e2/c08fd1d36ce63ea5a12b85c5d37f4550b5f86a692167e41e5a74222607ae/librt-0.15.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:234d8d394721fa0d786af15ebf1f3fb7f3ed82fd1cd0cde45c2f247b5d4281d2", size = 531661, upload-time = "2026-08-07T10:47:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d8/d9482fcbeb177b9eb87bb3899eeb3b42be690313c652f9e146b1d0681fb2/librt-0.15.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d8363d7accb0286ac3a0e633f396e93800dafb8150494505daf9515bbda591f3", size = 524487, upload-time = "2026-08-07T10:47:26.79Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cc/075171517b41f861753034fbb151b42cfc83bcc853849f24f5e66fd60ccf/librt-0.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0f0ee3644d951f31055ad07d77d92520e84505dd7a432cc4cd501dd70ee06785", size = 543201, upload-time = "2026-08-07T10:47:27.999Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/03/42c2330f37eeb475b6affeedd06518f60035f323af3a839335e3fc9fef2d/librt-0.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2cfd1a81a648806e6a7717be4cc4d1bb392fa229752bf8444ba365e381e984d6", size = 546467, upload-time = "2026-08-07T10:47:29.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1e/1ad4c5638f7e64d8560328bd25c54b409a661bdb6ff254b38ff90744288d/librt-0.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a6cd22c9da0d866558e46a041f1cc0c2bbb26b61b137b2347fa834c332e1d101", size = 555139, upload-time = "2026-08-07T10:47:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/49/41/39fa7d15db1204cd1cbe6514680fbdc243adf754a0885061308f43afc013/librt-0.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:6d5225ef8801e4ea5e482fa9b5dfb891dd9ef6f6d870f1f25d449ca2c70ac218", size = 536050, upload-time = "2026-08-07T10:47:32.222Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/c6dcf0dd8e26dc0c9a499a2abab8646c86dcaf9ecea9524cb46d3686331a/librt-0.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d28a05796b99f749bf8794f17ba9ba1612d0076b802e9cfc62c554634e9ce3b", size = 573700, upload-time = "2026-08-07T10:47:33.527Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9b/ab54c71a7918a7c34fa5327fb61390a77446a07a146fbfb1165250a61035/librt-0.15.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:2067ff438048cead9d223ca5675bae2a25e520a7c3e6c1498bf9c6892d22caab", size = 82194, upload-time = "2026-08-07T10:47:34.835Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b2/4f9a243bb892395f3becb80789ade13771701091f9f07ab8230247953ba8/librt-0.15.0-cp313-cp313-win32.whl", hash = "sha256:1cd3b721f24c206398b9e26da3c3a9c011e6e89d06f318ba8ebefc30f1003890", size = 106231, upload-time = "2026-08-07T10:47:36.251Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/af/64aff4885a40b93132382f2c314647d722574605416504379184ef3045ea/librt-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:f395a4a9a03ac062dbe9a9f82e0c720502e590a38feee6a757bc82e9c63afbd8", size = 126996, upload-time = "2026-08-07T10:47:37.453Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/335bccf6c7cb9028cb0b54aead27d9ece3f01f83bc6baa2abace5da655c1/librt-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:0a15cb554761247d84a3ec0cbdf4078d70725384f0e4662c0fa3b26266eb60ad", size = 112188, upload-time = "2026-08-07T10:47:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/93/949053fb462eecc4a9a5ee770a81f4b40be7b79538b245545d4aebc6b58b/librt-0.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f5de7feedc56337a088eb15cd9fafa9938367362221d8cc62c642b7f94821993", size = 149833, upload-time = "2026-08-07T10:47:39.86Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ca/8281aa6cd560a3420e4497729f6b704b53be3eeaaef82d5aeadddaf7441f/librt-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c0eb900c0e91f4aebe680845242e614f1864edfd44106380d0752ac29522bf8", size = 154088, upload-time = "2026-08-07T10:47:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/02/1a1662dceaba6a086360891448d5ce9a7d3555976cae59a31a39d744b9c7/librt-0.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8c9a650a188e38bac005048cbe6342e81407782944d01934540ab75e417df21", size = 494215, upload-time = "2026-08-07T10:47:42.388Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/99211619dc656370a3740c33d2b0b6d5a3fb1e73689314f6ed477a397dc4/librt-0.15.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:92bfed8deec93df30286b9fe9e3b1dd17329cc076a192b4ee5ec223841d54953", size = 491173, upload-time = "2026-08-07T10:47:43.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/aa/5448d0b05f4579b635d3899176817ebf561af0e57bacd425b5b1887264c1/librt-0.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec4b19788f835711a2072f9dbe6b03b3bf32ed1f0fb30cf399bdd59d9f0c33fa", size = 505512, upload-time = "2026-08-07T10:47:45.314Z" },
+    { url = "https://files.pythonhosted.org/packages/95/82/01940e40b83c43a546c4a3c896cf34ca272a9690899d55914e4827b3dcce/librt-0.15.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4c7bacb70930f3d0a56f4ecf1be474a1f0d941b01dd73b756f3c256d42cb879", size = 523073, upload-time = "2026-08-07T10:47:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/759c0030f3ee371439eb26de34fc745807caf0abb878af7af4b8b7c3dd3d/librt-0.15.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e79f05e4a08b4d880342673312bbc895b56df7765605796f15902eb5367d3ae", size = 515080, upload-time = "2026-08-07T10:47:48.319Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/27/894e072228fcb159703c655da69f8cd10dbed489c36e3df7dd032a2483be/librt-0.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a417149c0cba4d50b61e992e5a15e69eaf96746609b461cc4ed168aeef6b79dd", size = 534164, upload-time = "2026-08-07T10:47:49.875Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a3/0078e91c1f36f8815db17827de15650b9a3fe56c55fbf998c854b34e40d3/librt-0.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:da7a94d6a3411f579d72aa3e3bc5fbca7ed4549f3dbd7e5de3aa567333374285", size = 540616, upload-time = "2026-08-07T10:47:51.408Z" },
+    { url = "https://files.pythonhosted.org/packages/86/33/81a29b796dd52a45e9ef7974c7732926e8f10f15b8d2be505665979f896d/librt-0.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:856f743ae607f2c1380eccb566c0038a9fb3eabf0fc2be2704d76d9f73557239", size = 545890, upload-time = "2026-08-07T10:47:52.818Z" },
+    { url = "https://files.pythonhosted.org/packages/05/82/8be1baa1350e5d30cfd70ae79d0a6f4dc5862ef47f7bb2808aabc9bb86e5/librt-0.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:779a6e7c894737e5983e7790a9c78c4000c30e23c9aada08081bdbea53b0fa60", size = 523287, upload-time = "2026-08-07T10:47:54.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4f/d1be6a01a35c20ef734e0e44113f87d4af756a9354a89dcfbe3b4f8af5e1/librt-0.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96bb17dbe8bab3c0954fbebfc69ed395599de75b6bbc35e3270a878e15d4dd65", size = 565868, upload-time = "2026-08-07T10:47:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/67/88/649cfa33f5825927b160610f670bdab012a64d627eddb94fa795ea4292fd/librt-0.15.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:7220697efaa6e5348fc3d18ee7f8563d4bfecd9872b37ffb915bfc1d08840622", size = 81619, upload-time = "2026-08-07T10:47:56.886Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/8e88a8d5e48fc8d1a817787fb6811dfff6499acd6c8683dd83934aa6ede0/librt-0.15.0-cp314-cp314-win32.whl", hash = "sha256:f54598964d357b1c5ab77cf5d92f21e598fe0e23cdbe9618480807f81b4eba15", size = 100138, upload-time = "2026-08-07T10:47:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/80/92/20fd6c4b6a1b1a564b076d55cd3d427d8428217d7638dc25a654cc4791d4/librt-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3ff5893a2c23d886aa9ce786de5ac6ddc74aeeaf90743682b74d920e117d2e28", size = 121258, upload-time = "2026-08-07T10:47:59.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/28/6af430b44d9ebb897b865a3c363b6dcace51357be2347cc0f8f869656a86/librt-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:3722a099730704c9a3d70c879fc0f51daec25fe5f1555672d97bc595abeafb95", size = 106467, upload-time = "2026-08-07T10:48:01.097Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/b42bb798942ced219f6d63b27e07f91237887a8d0bd0921666db79a13790/librt-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:38c0c7d4b6fc06c3324b3f9162c8391bfc4fd9dde53afe1033ce7edb48d5a714", size = 159523, upload-time = "2026-08-07T10:48:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/75/03/1b53cd4ef904e73b1d828a5f90143bf94a2967d7cfff0b9ccf93e12aa9b4/librt-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8b2fdd7ead3c995c37940a790690660d0ca006c302db26cc51933f6766866fc3", size = 161638, upload-time = "2026-08-07T10:48:03.725Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c4/9f9c9fba097d49e9e694c2b4dc331df31884645ecbc58a93b4b5fc69d2c5/librt-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fde98cf1fc4bac144ce23c2c4c017b924ba714509ea9334977b0b27050c837d", size = 701795, upload-time = "2026-08-07T10:48:05.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/05/0966840bda0380c8ae167b9043c6230202941cc90ea29c48e096964c765e/librt-0.15.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:e3b461183c5fa7681b48560f91515f53a953122fb30c71e07abc67d7ddf58c38", size = 682147, upload-time = "2026-08-07T10:48:06.555Z" },
+    { url = "https://files.pythonhosted.org/packages/18/af/1c47ca573c30ea47d195aec26133af522fea1104afaace028d7b32247ea8/librt-0.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4bbcc257e3babea20a91715c361b24554ec4e8f51aa578568afc230799fe1a19", size = 696397, upload-time = "2026-08-07T10:48:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/1aed6223d4f9f9d1171a8596ff100ea4c3f7699fea7a4ba657c3e60daa6c/librt-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b845b8d48088fad0cadc84be4b8fda63203be7e9237b71015b3925443c1f35ab", size = 722542, upload-time = "2026-08-07T10:48:09.569Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/22/9e3a929aea456c97d69e6ef3884efea56d4807f97399471cc946baebd8af/librt-0.15.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b30e600e8f337b9bd7f39b86d9fdfedc73cc46e3d0f745931a23a234220bb7e2", size = 729709, upload-time = "2026-08-07T10:48:11.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1b/c327ef6018e3a9ca0b8e7c5eddeeb331ba8f9b76c24e126d37d0f6d62faf/librt-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:64b0c8c35aa4c4ed79896359f3e0b285cbe4e610042106500da4811c322cc108", size = 752891, upload-time = "2026-08-07T10:48:12.558Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d1/d5f1ea02c56930087009e39db9b70660a663e76c730b27b925d786718457/librt-0.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0da0d94cb802f32a0524653e7201f2cef72d5f700a5407678f5290483d4fcd08", size = 745301, upload-time = "2026-08-07T10:48:14.55Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3c/5f7c585d15ebb2250c73e7c0ee4e9e47be72c65d520c07ddbcdc62037674/librt-0.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4a6369168d371207339b1e50d4532b06a7121586141f82599505a3f315751d47", size = 747921, upload-time = "2026-08-07T10:48:16.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/52/1443a446486eba966bcbca1696b472e4f210320ec42f490a47f48fbf0fdc/librt-0.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c434e072557ade9cbc642d052c89d031efe47d5c9614523619d0d74a02378e81", size = 727561, upload-time = "2026-08-07T10:48:18.089Z" },
+    { url = "https://files.pythonhosted.org/packages/79/91/2270a9380f11725cf83ce1925a5e32dd1dde2be9bba597f25c10a38644e7/librt-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7eec6a42018bc1d45763b1c162d3d2bf7c3b9a1b0ed30d3e91dcba390efefcc", size = 774417, upload-time = "2026-08-07T10:48:19.611Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/f4b1548d4f5b99186737fe27aec238e9823e8d5d23bf4df007c030689dc5/librt-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:6912fa5e635d74529ac7cdb1bdf6ca3af4453da8d1edbe0110ee1cb4ad407ebf", size = 104381, upload-time = "2026-08-07T10:48:21.048Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/134afad262def1de04c0843c376d02135f1168af43f22e09a52bd8394727/librt-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8e11699ed745931c395acd3621b07062e0f840efa6935aad87a64ed0995f0915", size = 127034, upload-time = "2026-08-07T10:48:22.561Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5f/1b6846b20572bd699c9e9ec321a5f781845bee477df2aa2a43b28bc40119/librt-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5d2a91724463bfed4f573cd7a9fdc856d2e230d0c0e5a61416a93481dccd8605", size = 110827, upload-time = "2026-08-07T10:48:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/44/4de9f4ddadb009a55c7758eb5736d62534a7daaf27bd71bc50e64b606b06/librt-0.15.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:8443e38dcfcfdbcf5add5118c623efd788d65ac2e25756d6251a54a06a4d0aca", size = 149843, upload-time = "2026-08-07T10:48:25.148Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/eb/5d9ab71e30119c44094e0275f38b47dd327aea0f843a080396677029d508/librt-0.15.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:6d15a29033c57490cfe2069097c6fc4049e4e65ffbb749be7dc453b7c4c68965", size = 154510, upload-time = "2026-08-07T10:48:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/8505d1b8f5e8c19587bd03f7429993b3e9ce5c06819d856bfb11d919374c/librt-0.15.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2c05c729b589e734c09578bf5964be48a911765484840d017bbc84f49d4c4ad", size = 497543, upload-time = "2026-08-07T10:48:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9a/3a8390775cb095765aded027ac9c63e7c8ea74e731498607544c6505de0e/librt-0.15.0-cp315-cp315-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:fa60887537e1d0cd2d9982269d33a709bf54b195cd2b9364fc0a758022af5bd9", size = 480452, upload-time = "2026-08-07T10:48:29.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/40/258a4a7117ee915d66de5cd9b8ade65a440993161107ce3a686f1859955c/librt-0.15.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d8bc24219b24c0af375718942ab75e3544b2763085f40f965be4326734ae8328", size = 507768, upload-time = "2026-08-07T10:48:31.007Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c6/2f4dd296c97a0b85b98894519b279408ec9dd602d4f692b1ea0e25dee670/librt-0.15.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86a21a7bd3fe3a419512ef424cc1c020f6771d0b29cfddff36d1635a855e63f0", size = 525122, upload-time = "2026-08-07T10:48:32.7Z" },
+    { url = "https://files.pythonhosted.org/packages/49/dd/29eab42be13b2bf0ea8cb227135a45d44693e30a7e8b92871981ff56b82b/librt-0.15.0-cp315-cp315-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dbab647e88d90b3167b91efe7091e248653688ed4337e4f90907a722c7361bb9", size = 520371, upload-time = "2026-08-07T10:48:34.294Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/4bad71adeca8fe208b775c2a35417fa5a2584c8f4791daaf89a89450fea1/librt-0.15.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:d8edcf6f550e918dca779c069b9e156385c60b406f99fc7641f32c52f7193659", size = 537258, upload-time = "2026-08-07T10:48:35.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/63/59dba6143fdcc7240c54458b629f3250000a61b8945890fc9efd451b19c5/librt-0.15.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:8b62076030baa2d8b1501a46bf0e19c27a489aa90671c55665bff7887f7660b0", size = 527432, upload-time = "2026-08-07T10:48:37.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/21/21a24c6a2327d8362580efebe77286bf47b0f4062ec5ea41766e609d3c7d/librt-0.15.0-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:d00d20d1818e82a07a0ee0aa89a98b17ed7916b92441090b683719cb20a59b6d", size = 548108, upload-time = "2026-08-07T10:48:39.384Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6d/fc68c89a7971418b41f9a873623ff935cb864097544c6a2f8ce491c8ef5d/librt-0.15.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:4e6ee93fc3cf848dcbf0cce2eca73d8e7dcd0cc2b6df3a529d57750b30a4c55c", size = 529681, upload-time = "2026-08-07T10:48:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7e/c2d98766124400d722063a630b0fde38a9fc768705d37eecca15c47dc192/librt-0.15.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:32896a0af72508ea979e0acb4e4c04cbeeae04938167950d535c83c45597167d", size = 567736, upload-time = "2026-08-07T10:48:43.124Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6c/f8c34a95e3a515c6e1c192b89511e7253c89a7760c6b500d57ffdb8d2dc8/librt-0.15.0-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:ec3ba415afaf951f6951b1dd16d3c8e4f540065fc382d7e70b823a79567ca374", size = 81673, upload-time = "2026-08-07T10:48:44.645Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9e/e23fa8e78679ec45728188650b39e8ff476c83b691c96f749217df3b1b7c/librt-0.15.0-cp315-cp315-win32.whl", hash = "sha256:d2813ba2503764f0450680c533d13df7cff9b49df1411062eded5f67db4195b9", size = 100081, upload-time = "2026-08-07T10:48:46.171Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/dc/3eb4c5e297343f0620a55532cd7c8d764d3001fa2159212dadf480464827/librt-0.15.0-cp315-cp315-win_amd64.whl", hash = "sha256:b87d67e33afaf265262f2a66db578284b88ee2e6fcd224579cb5c15518677ad8", size = 121228, upload-time = "2026-08-07T10:48:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/97/70/43abce19f04e49762f8ec834c8fafee13cc40fd6b94a72a24e534febfcd0/librt-0.15.0-cp315-cp315-win_arm64.whl", hash = "sha256:713bd7df21170b982e729e46870f31d6b437bd1a9b4648cffb529bd3c2ec5c4b", size = 106487, upload-time = "2026-08-07T10:48:49.095Z" },
+    { url = "https://files.pythonhosted.org/packages/de/15/83f2deddb9368b8951ec8c9477269b5b9b8bd9bbf15e57402d0f38817dca/librt-0.15.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:3de789c82752730f94782a5ee518baf9c05edf85733aeaf73bb6e518755cdf54", size = 159448, upload-time = "2026-08-07T10:48:50.649Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bf/043097353f9b3c73b583d07f6b8e552795463f4bfc8caf85e42eee50c26a/librt-0.15.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:e0b5deec9a8664eb722c797241970fd4aa1894d25fda36a1ddac0f7407606bd6", size = 161686, upload-time = "2026-08-07T10:48:52.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2a/8ae77f9719d42ce71cd708560a3557b38ac3c17a0383e57f87084de45bbe/librt-0.15.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5563302a8359bc2295bb7084d1a8ed1519df96afb30eb2aa4e0bff7b54228988", size = 710668, upload-time = "2026-08-07T10:48:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/61/34/c0436ea134deb9a0d6da80a396a2739a81cb31e0418f7227239e23140898/librt-0.15.0-cp315-cp315t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:22d6263b9d39d7bbb286fa791945646e3218f1be2d693e36fb630f1d0e59cd13", size = 679396, upload-time = "2026-08-07T10:48:55.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/001e0d99aa9250d5cd5715a9081291a20656083459f9019cda15255329e1/librt-0.15.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:39ffd14646190c454f0d86e0d256b33f00a87a26ab410e619773b841d0e41416", size = 704313, upload-time = "2026-08-07T10:48:57.46Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/53/b34fa9d0ff00f136f4d58ebb4c411ff634baed1eb412bb602a2bc8dcafcb/librt-0.15.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c47318cd3a61401452de11282242937e3e057c4fd3dbaf601e269d0928a06c0a", size = 729847, upload-time = "2026-08-07T10:48:59.231Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ac/fa4d7a424665040e95baf480a6d523446057684b6758624c85338e8a23b2/librt-0.15.0-cp315-cp315t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a56a1d4f859a82ca5b99fc4b82c9b027b15e3c455c5cd99e7d0719f27bb20b6c", size = 742736, upload-time = "2026-08-07T10:49:01.151Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/e17a9bb5de6fb8c3186ed1a7d68d21618b027ac2d3633e03d3b6109c67ae/librt-0.15.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:077471b3182db4e17c36ae91555f36a4d2c00080b267f749bcad34a478a9a302", size = 763454, upload-time = "2026-08-07T10:49:03.039Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/ecd02cd30935b931b9cdbfed6ab5a099c51b280b4e7baa274da80978ed27/librt-0.15.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:411ca4d1b905b860ceba7570dd6717a71dedaddcc4b0f77ece710aa41ee11f8d", size = 743296, upload-time = "2026-08-07T10:49:04.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b5/b3c2b8353ce820a4854f78d19321344242f89fa71c975b71132ba9bf242a/librt-0.15.0-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:1256589e0b0adb31751d685a68bce29d73407ddf4ef05d4188f49d5dcf9566d9", size = 756217, upload-time = "2026-08-07T10:49:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/52/6cc22542ba59146b05cca2a656f9ff8bb67e38e63d12c3b0cc183d837bf1/librt-0.15.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:f42b74a53e5f26a0ba0007411a7455b66c67ce4022a39cc1f56fc4efd65bcbab", size = 741934, upload-time = "2026-08-07T10:49:08.839Z" },
+    { url = "https://files.pythonhosted.org/packages/40/32/a04b72b1aa86e3be23b2ecff8c1aad2dcc955bd3956d6d26e7e34267e57a/librt-0.15.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:291bf73caf78b9e88d6fae9bfd693207ff7d832e2fdbe2cf8e746bc13f5f892b", size = 783763, upload-time = "2026-08-07T10:49:10.661Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f0/89eb11dffbe9279ff37144dec786927314502ae0b114f1449dc78c458aab/librt-0.15.0-cp315-cp315t-win32.whl", hash = "sha256:c16d15ee371643ab48dc8248a3e680ebbeca573a13af2c3dd0c985b142d77162", size = 104313, upload-time = "2026-08-07T10:49:12.305Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4a/1f1978c200f563beda63c36adff2d65bbecb81e365e8e69e572f5f70fbc6/librt-0.15.0-cp315-cp315t-win_amd64.whl", hash = "sha256:dbd605739f228912dc49027cb764456b9757750bdc2b6b7773164db7096c6fd1", size = 126889, upload-time = "2026-08-07T10:49:13.881Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a6/800800bfed7b1fb10fc3f3d557785c3854e80d3f7a9800d784b176a1fc2d/librt-0.15.0-cp315-cp315t-win_arm64.whl", hash = "sha256:84d244b00604d17df3fc7736c327892d6bba66181254aa4087be807b6c342bdc", size = 110700, upload-time = "2026-08-07T10:49:15.499Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/09/f2f5f45dae0c9a0891e4751a73312730e009395102e5d72a22a976cca41f/mypy-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1fa8d916ac3b705af733c4c1e6c9ebe38fd0d52beb15b105c3e8355b55e6ecdc", size = 14927774, upload-time = "2026-07-13T11:28:38.224Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b9/345367effd3a6877275a94d481614bfca983f45e028c6290e2cc54603811/mypy-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28e1e2af8cd8fff551fd30f2fe4b03fb76764ac8b1ba6c6a1bd00ad32b412db3", size = 14000127, upload-time = "2026-07-13T11:30:19.57Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6c/a10b7a7b9f0a755fb94e27ae834d4cea9ad6c5221f9325eef8f182641feb/mypy-2.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e77244df3843048c3f927182916730e40c124cbaa43905c1fb86cb382aa0805", size = 14229437, upload-time = "2026-07-13T11:28:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/bd/a26a602acb1bbf849fa4bdac4bc657ee2f11c0c2a764a2cc87a5304e865c/mypy-2.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9559ab18a9c9957dfa3004ab57cd4bac5f26a724329a9584e583367f0c2e1117", size = 15171457, upload-time = "2026-07-13T11:29:01.834Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/124f462bef69bcbc90b9358088460b6091954a3e004852fcd9948db617a5/mypy-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09abd66d8685e73f8f7d17b847c3e104d9a7b164a8706ea87d6c96a3d45816d5", size = 15478281, upload-time = "2026-07-13T11:32:23.413Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/8bdca6a8ac8d856d82ed049144af2721245a135c2e8001d3890c93975852/mypy-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e91adad1ca81742ac7ef9893959911df867752206b37135185e88dfb3c89494", size = 11148008, upload-time = "2026-07-13T11:34:17.332Z" },
+    { url = "https://files.pythonhosted.org/packages/83/41/490eea348e60ba50decec20bc750605444149a5d7a8cc560042f90ba2c75/mypy-2.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:6f99ec626e3c3a2f7c0b22c5b90ddb5dabb1c18729c971e9bdaca1f1766d2cee", size = 10142329, upload-time = "2026-07-13T11:32:52.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b9/d75b3082b05f1b3028828aeb18e74ae5ab0a0936051bbf1f32f59f654747/mypy-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329", size = 14838725, upload-time = "2026-07-13T11:32:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/50/79a65c6ea6e115bc73296038a4543b2d5c91f07912b918a2c616a2514bba/mypy-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f", size = 13911128, upload-time = "2026-07-13T11:32:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/90/48/e11ed7716c26953ca321f726e452e374dbf81a6f2b8b212ec02af29b6b8f/mypy-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a", size = 14146742, upload-time = "2026-07-13T11:33:03.313Z" },
+    { url = "https://files.pythonhosted.org/packages/06/72/6807565b1c4861ef66f7fdd98b51c61556356eab80235717b46c53bb8627/mypy-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982e3d53dd23d0a4cef67dd66791fdbede0cf38f9eb617bf47663554c51e1e36", size = 15081418, upload-time = "2026-07-13T11:31:13.899Z" },
+    { url = "https://files.pythonhosted.org/packages/00/80/1ea14c5d80e589e415973db3e47c78c2219a305b808b2b506395342c1d79/mypy-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85c5385b93012ffa3b31479ab579aef5415f4f3a32c6cf1ae07a984d2a0ff461", size = 15328164, upload-time = "2026-07-13T11:31:35.723Z" },
+    { url = "https://files.pythonhosted.org/packages/37/28/8223157404a3d51920078459c37f80fbdc590e1d8ea049dc5ce48643022a/mypy-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:13b1b16e2fa39f3b2e33fb1c468abc7a69369fa2e886b4b87b5afc81472325cd", size = 11136472, upload-time = "2026-07-13T11:27:37.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cc/ea27e5959c5f258585a756b252031f3b313583d81b5064b2bebc41d3706b/mypy-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5cd2f027a972a4a5f2278a11fac9747f5f81a53a30b714d74950b6807e55568", size = 10135800, upload-time = "2026-07-13T11:30:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ae/f7d056eb0294586a572d0d0d89580ec633c064db520f11d37d5a2fb833bd/mypy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97", size = 14947298, upload-time = "2026-07-13T11:27:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/db3e7af01e7844d21662c6ddc1f7825ec7cb4053f0391ac02faf3638396f/mypy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac", size = 13950768, upload-time = "2026-07-13T11:27:57.726Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/fb/43c031f0190513d1ec248ed037eceb742ddd2a4d74bbf406658a28173837/mypy-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6", size = 14151586, upload-time = "2026-07-13T11:29:18.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c3/f8b2ffc60883084da91be51af58e88a7ffd4ff9795acb7d902ff88d31eb1/mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b", size = 15227411, upload-time = "2026-07-13T11:30:29.904Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2e/16b917fc7adcf03f1aadddfc93aab804ffb234b1ab09c0ffd6d92a5d34a2/mypy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2", size = 15478790, upload-time = "2026-07-13T11:33:14.686Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/88/aaa65a93c73d0cdae7e42f8adb302bf6885bb281302084f99d0290a35347/mypy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757", size = 11234919, upload-time = "2026-07-13T11:33:39.28Z" },
+    { url = "https://files.pythonhosted.org/packages/35/19/b40de63f1a80e63bc2d40f0679a6a8dbd34e95176c8122119bdf406aa552/mypy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1", size = 10201510, upload-time = "2026-07-13T11:31:52.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/58/fa0ae047da911f540284009b4f44b96fe09d83c076d7c103e9d645f46303/mypy-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea317b060ce83e26050f8f9e4d7d6bf44ed7597c8ff9990bccffbb9d1d8522db", size = 14941909, upload-time = "2026-07-13T11:32:34.332Z" },
+    { url = "https://files.pythonhosted.org/packages/15/14/2ba1d61452d7c2a7fe12741e8d374e52b183476b07aa7f9e2a0d02b0720a/mypy-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762", size = 13967581, upload-time = "2026-07-13T11:30:00.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5a/483fb9e5ffbbb1a28dccc7b0a13d141b17ac769b6c9f488c0a0c63698962/mypy-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de121747278144fc9ae7caa2e978cf5df12aebc82933182f5b3b86081a30baef", size = 14168807, upload-time = "2026-07-13T11:28:48.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/77/70d7a10732063beb74ad713682cf871e88f5c5fa39bfc8beff8a524bf9cb/mypy-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37fa4de896a84e2dc9200d91e614c22563b43d1a266789d4bbac7b22ebe6192b", size = 15200144, upload-time = "2026-07-13T11:31:25.283Z" },
+    { url = "https://files.pythonhosted.org/packages/56/72/766218ac783be4fdfcd699b90037b63017348a3e86fb2c1fbfb18302637d/mypy-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f1b3a98dfd21058bc759bb3337d5d1f61d0fdf9f3cf9c00f4291790fb5427bff", size = 15460389, upload-time = "2026-07-13T11:29:29.077Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4e/8a9db7411ecb8ec0cb1fd05dba432f28bafffcd38b4e887714a4a0506689/mypy-2.3.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:944c665d984157cb96a679dfb7a4a81dd1d36b24b9c284b699514e6e626b82d4", size = 7753664, upload-time = "2026-07-13T11:29:08.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4c/c3f8bfd6ed0e5e38b5a244403b27f821d433443df5a15a278417c10a3a3c/mypy-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:4359424140d985192c778c1ce2c114a10c1ca58a381ed79cfa70d37df94b299f", size = 11417237, upload-time = "2026-07-13T11:33:47.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/00/89a32eaf5ccf174bc4f90db0eaea5d70636c01b8d49f384bdab2e8834390/mypy-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:3dd0bed92c4bdec57c42505b96416fb9e6a5aa7be84d2809bcd5f2ecec2860d7", size = 10389252, upload-time = "2026-07-13T11:31:43.81Z" },
+    { url = "https://files.pythonhosted.org/packages/31/56/104f93d69aa9f339b6b9d3b0a7faa699b8b466c942cf3ae86cc2a2ec0915/mypy-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:691fdc37132b1ae628d834f672e74de83462d9fb4aff621835767fb43a8dd373", size = 16385495, upload-time = "2026-07-13T11:29:49.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/03/f1d2123313f55efafdd27706960f43a771c62f1b68426c76043f3ab9ebf3/mypy-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:aec15d465d477558fd842757b487849007311cf3897849cdda0e3162ac0ac556", size = 15098155, upload-time = "2026-07-13T11:30:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5d/d5f9200399b445e81726c4f23becee33f233aee81c72680b1ef3a258b641/mypy-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b352b7e49f5e6576009e8df730e1ff4f915cb565b851b396d2ffe2f5a6f5da88", size = 15514155, upload-time = "2026-07-13T11:34:38.569Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ce/69977c555f08faa3190cfde44189b89dbd56861b1ab97aa18fc5f3a2e4a3/mypy-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c6c6bf687b17f90dbfcad95b960d32eaa0154c00da45f03ab50bf8952e047fe", size = 16766351, upload-time = "2026-07-13T11:33:29.195Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/92/6648b6caa3ab9e00f9ac0c2a78307805f873dd48139b24a6f6f7c3667bbf/mypy-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4ed18f111bfe2d599bca7468e7f9251042c1c2118f762c8de2766a56d773c60", size = 17043490, upload-time = "2026-07-13T11:30:53.927Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ab/0dc91d80f3f016634c68d451f294a97320fe903a9b6f90b9e57b3f7f1717/mypy-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654", size = 12146869, upload-time = "2026-07-13T11:29:38.874Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/4c964d02634ba81f4d1c84838e5c5b18ab06d13ed568960f5d6318495ccc/mypy-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5", size = 10965113, upload-time = "2026-07-13T11:28:07.056Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "nixl"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nixl-cu12", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/95/b529f064bc588ecc720eeed19fa5cede0a94463cd0bc23614f29f3a653ad/nixl-0.7.1-py3-none-any.whl", hash = "sha256:94e986068ca97c68e0eac865ef488d1e1c685898cfd6794817dac48f6d559f99", size = 10422, upload-time = "2025-11-06T18:48:07.624Z" },
+]
+
+[[package]]
+name = "nixl-cu12"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "torch", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/70/dd2bb0c5886c484ec4a3061b8325e03c6e4b262a10e66d1b66663d2f7a1a/nixl_cu12-1.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:40804fadf847df8906f1a0249d9ced6574bbab25e72fd8914e4e0f5f26787519", size = 50055375, upload-time = "2026-04-14T19:38:09.997Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/05/a0931edcd73c8e2728e20fbb5417ac91fcf7733eeec72795b6d4c7767d66/nixl_cu12-1.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:44ac2eeecc1a27dbe54f1df8e3568e4d142f0a881afca9d15dff0bb75838594c", size = 51325625, upload-time = "2026-04-14T19:35:58.417Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/14dec58b10e55eb9477998bd9e12845b62fca9ed5e0f5360cfc2e2827b7f/nixl_cu12-1.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:cfeeac742a81545e7124d03dd6c7ce79bb9a70d679a22a8bd5c04fb9649034a2", size = 50059313, upload-time = "2026-04-14T19:38:36.653Z" },
+    { url = "https://files.pythonhosted.org/packages/94/61/29f9c3a004194a7763fb1c70775498145993bf1eb4ff9c7ee090f7f32153/nixl_cu12-1.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:85d3709edc6741023c4cfadc015bce822da7488bcc4cc6871cf7c078b5a719f9", size = 51330161, upload-time = "2026-04-14T19:36:25.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/37/070608eb04b27fc87f1a52e735bf444817cad9446495751678752fccc62e/nixl_cu12-1.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e2fef21327f5ddf715e00b73ab7e1eac8cf8a529d18590f010cbbc22792e71a6", size = 50066664, upload-time = "2026-04-14T19:39:03.182Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6e/eb1dbe741f5b5dbdda870fe2704216d442b3bca74bbd12657f811d3ba2f4/nixl_cu12-1.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0143bc14d7b969c7519639821c126d3ba47cbaf38281c5d85656a348f65e06a4", size = 51338889, upload-time = "2026-04-14T19:36:47.974Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9f/91208975cc6360938f7caf682ff0a3e967e7506f8047a540899ea0b50094/nixl_cu12-1.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a0fae78732a70d00c229c987917052f54c7ff581f83c772e05d546d211e6828d", size = 50066786, upload-time = "2026-04-14T19:39:22.758Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e8/7c25846466be395de9e3d549b7e982b498c97ce315d44ad60906eceaf354/nixl_cu12-1.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ceb3d6243d1f5333c6d505c645d9ae18f96f61ff644af3b275e9115e65012e8f", size = 51339049, upload-time = "2026-04-14T19:37:12.938Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/573c16ab5750c7482c21b9d087113c2a204c633b74899074cf8f3d161df1/nixl_cu12-1.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7548417b8089078689d8f3ee56dd174991c06c621d3440fb0c8a967e35e39ff6", size = 50068528, upload-time = "2026-04-14T19:39:47.362Z" },
+    { url = "https://files.pythonhosted.org/packages/73/39/b2b82cf481a13a3aafc1e3fd960d957c5590cd74b8ad6dba16aa3b114fc3/nixl_cu12-1.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:24c676c81f06dabb05e81ae17ee1236bfa9b6abbad3f4a37299b7658f4bfd782", size = 51339383, upload-time = "2026-04-14T19:37:42.451Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
+    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.3.20"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "rl-experience-transfer"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "nixl", marker = "sys_platform == 'linux'" },
+    { name = "nixl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "torch" },
+]
+nixl = [
+    { name = "nixl", marker = "sys_platform == 'linux'" },
+    { name = "nixl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "torch" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "nixl", marker = "sys_platform == 'linux' and extra == 'all'", specifier = "==0.7.1" },
+    { name = "nixl", marker = "sys_platform == 'linux' and extra == 'nixl'", specifier = "==0.7.1" },
+    { name = "nixl-cu12", marker = "sys_platform == 'linux' and extra == 'all'", specifier = "==1.0.1" },
+    { name = "nixl-cu12", marker = "sys_platform == 'linux' and extra == 'nixl'", specifier = "==1.0.1" },
+    { name = "numpy", specifier = ">=1.24,<2.3" },
+    { name = "torch", marker = "extra == 'all'", specifier = ">=2.9,<2.10" },
+    { name = "torch", marker = "extra == 'nixl'", specifier = ">=2.9,<2.10" },
+]
+provides-extras = ["nemo-rl", "prime-rl", "nixl", "slime", "miles", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.3.0" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "ruff", specifier = ">=0.16.1" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/56/9577683b23072075ed2e40d725c52c2019d71a972fab8e083763da8e707e/torch-2.9.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:1cc208435f6c379f9b8fdfd5ceb5be1e3b72a6bdf1cb46c0d2812aa73472db9e", size = 104207681, upload-time = "2025-11-12T15:19:56.48Z" },
+    { url = "https://files.pythonhosted.org/packages/38/45/be5a74f221df8f4b609b78ff79dc789b0cc9017624544ac4dd1c03973150/torch-2.9.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:9fd35c68b3679378c11f5eb73220fdcb4e6f4592295277fbb657d31fd053237c", size = 899794036, upload-time = "2025-11-12T15:21:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/67/95/a581e8a382596b69385a44bab2733f1273d45c842f5d4a504c0edc3133b6/torch-2.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:2af70e3be4a13becba4655d6cc07dcfec7ae844db6ac38d6c1dafeb245d17d65", size = 110969861, upload-time = "2025-11-12T15:21:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/51/1756dc128d2bf6ea4e0a915cb89ea5e730315ff33d60c1ff56fd626ba3eb/torch-2.9.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:a83b0e84cc375e3318a808d032510dde99d696a85fe9473fc8575612b63ae951", size = 74452222, upload-time = "2025-11-12T15:20:46.223Z" },
+    { url = "https://files.pythonhosted.org/packages/15/db/c064112ac0089af3d2f7a2b5bfbabf4aa407a78b74f87889e524b91c5402/torch-2.9.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:62b3fd888277946918cba4478cf849303da5359f0fb4e3bfb86b0533ba2eaf8d", size = 104220430, upload-time = "2025-11-12T15:20:31.705Z" },
+    { url = "https://files.pythonhosted.org/packages/56/be/76eaa36c9cd032d3b01b001e2c5a05943df75f26211f68fae79e62f87734/torch-2.9.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d033ff0ac3f5400df862a51bdde9bad83561f3739ea0046e68f5401ebfa67c1b", size = 899821446, upload-time = "2025-11-12T15:20:15.544Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cc/7a2949e38dfe3244c4df21f0e1c27bce8aedd6c604a587dd44fc21017cb4/torch-2.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:0d06b30a9207b7c3516a9e0102114024755a07045f0c1d2f2a56b1819ac06bcb", size = 110973074, upload-time = "2025-11-12T15:21:39.958Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/7d251155a783fb2c1bb6837b2b7023c622a2070a0a72726ca1df47e7ea34/torch-2.9.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:52347912d868653e1528b47cafaf79b285b98be3f4f35d5955389b1b95224475", size = 74463887, upload-time = "2025-11-12T15:20:36.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/27/07c645c7673e73e53ded71705045d6cb5bae94c4b021b03aa8d03eee90ab/torch-2.9.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da5f6f4d7f4940a173e5572791af238cb0b9e21b1aab592bd8b26da4c99f1cd6", size = 104126592, upload-time = "2025-11-12T15:20:41.62Z" },
+    { url = "https://files.pythonhosted.org/packages/19/17/e377a460603132b00760511299fceba4102bd95db1a0ee788da21298ccff/torch-2.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:27331cd902fb4322252657f3902adf1c4f6acad9dcad81d8df3ae14c7c4f07c4", size = 899742281, upload-time = "2025-11-12T15:22:17.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1a/64f5769025db846a82567fa5b7d21dba4558a7234ee631712ee4771c436c/torch-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:81a285002d7b8cfd3fdf1b98aa8df138d41f1a8334fd9ea37511517cedf43083", size = 110940568, upload-time = "2025-11-12T15:21:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ab/07739fd776618e5882661d04c43f5b5586323e2f6a2d7d84aac20d8f20bd/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:c0d25d1d8e531b8343bea0ed811d5d528958f1dcbd37e7245bc686273177ad7e", size = 74479191, upload-time = "2025-11-12T15:21:25.816Z" },
+    { url = "https://files.pythonhosted.org/packages/20/60/8fc5e828d050bddfab469b3fe78e5ab9a7e53dda9c3bdc6a43d17ce99e63/torch-2.9.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c29455d2b910b98738131990394da3e50eea8291dfeb4b12de71ecf1fdeb21cb", size = 104135743, upload-time = "2025-11-12T15:21:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/6d3f80e6918213babddb2a37b46dbb14c15b14c5f473e347869a51f40e1f/torch-2.9.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:524de44cd13931208ba2c4bde9ec7741fd4ae6bfd06409a604fc32f6520c2bc9", size = 899749493, upload-time = "2025-11-12T15:24:36.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/47/c7843d69d6de8938c1cbb1eba426b1d48ddf375f101473d3e31a5fc52b74/torch-2.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:545844cc16b3f91e08ce3b40e9c2d77012dd33a48d505aed34b7740ed627a1b2", size = 110944162, upload-time = "2025-11-12T15:21:53.151Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0e/2a37247957e72c12151b33a01e4df651d9d155dd74d8cfcbfad15a79b44a/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5be4bf7496f1e3ffb1dd44b672adb1ac3f081f204c5ca81eba6442f5f634df8e", size = 74830751, upload-time = "2025-11-12T15:21:43.792Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/7a18745edcd7b9ca2381aa03353647bca8aace91683c4975f19ac233809d/torch-2.9.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:30a3e170a84894f3652434b56d59a64a2c11366b0ed5776fab33c2439396bf9a", size = 104142929, upload-time = "2025-11-12T15:21:48.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/dd/f1c0d879f2863ef209e18823a988dc7a1bf40470750e3ebe927efdb9407f/torch-2.9.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8301a7b431e51764629208d0edaa4f9e4c33e6df0f2f90b90e261d623df6a4e2", size = 899748978, upload-time = "2025-11-12T15:23:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9f/6986b83a53b4d043e36f3f898b798ab51f7f20fdf1a9b01a2720f445043d/torch-2.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2e1c42c0ae92bf803a4b2409fdfed85e30f9027a66887f5e7dcdbc014c7531db", size = 111176995, upload-time = "2025-11-12T15:22:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/40/60/71c698b466dd01e65d0e9514b5405faae200c52a76901baf6906856f17e4/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:2c14b3da5df416cf9cb5efab83aa3056f5b8cd8620b8fde81b4987ecab730587", size = 74480347, upload-time = "2025-11-12T15:21:57.648Z" },
+    { url = "https://files.pythonhosted.org/packages/48/50/c4b5112546d0d13cc9eaa1c732b823d676a9f49ae8b6f97772f795874a03/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1edee27a7c9897f4e0b7c14cfc2f3008c571921134522d5b9b5ec4ebbc69041a", size = 74433245, upload-time = "2025-11-12T15:22:39.027Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c9/2628f408f0518b3bae49c95f5af3728b6ab498c8624ab1e03a43dd53d650/torch-2.9.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:19d144d6b3e29921f1fc70503e9f2fc572cde6a5115c0c0de2f7ca8b1483e8b6", size = 104134804, upload-time = "2025-11-12T15:22:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/5bc91d6d831ae41bf6e9e6da6468f25330522e92347c9156eb3f1cb95956/torch-2.9.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c432d04376f6d9767a9852ea0def7b47a7bbc8e7af3b16ac9cf9ce02b12851c9", size = 899747132, upload-time = "2025-11-12T15:23:36.068Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/e8d4e009e52b6b2cf1684bde2a6be157b96fb873732542fb2a9a99e85a83/torch-2.9.1-cp314-cp314-win_amd64.whl", hash = "sha256:d187566a2cdc726fc80138c3cdb260970fab1c27e99f85452721f7759bbd554d", size = 110934845, upload-time = "2025-11-12T15:22:48.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b2/2d15a52516b2ea3f414643b8de68fa4cb220d3877ac8b1028c83dc8ca1c4/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb10896a1f7fedaddbccc2017ce6ca9ecaaf990f0973bdfcf405439750118d2c", size = 74823558, upload-time = "2025-11-12T15:22:43.392Z" },
+    { url = "https://files.pythonhosted.org/packages/86/5c/5b2e5d84f5b9850cd1e71af07524d8cbb74cba19379800f1f9f7c997fc70/torch-2.9.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0a2bd769944991c74acf0c4ef23603b9c777fdf7637f115605a4b2d8023110c7", size = 104145788, upload-time = "2025-11-12T15:23:52.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8c/3da60787bcf70add986c4ad485993026ac0ca74f2fc21410bc4eb1bb7695/torch-2.9.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:07c8a9660bc9414c39cac530ac83b1fb1b679d7155824144a40a54f4a47bfa73", size = 899735500, upload-time = "2025-11-12T15:24:08.788Z" },
+    { url = "https://files.pythonhosted.org/packages/db/2b/f7818f6ec88758dfd21da46b6cd46af9d1b3433e53ddbb19ad1e0da17f9b/torch-2.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c88d3299ddeb2b35dcc31753305612db485ab6f1823e37fb29451c8b2732b87e", size = 111163659, upload-time = "2025-11-12T15:23:20.009Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/6e/676ab5019b4dde8b9b7bab71245102fc02778ef3df48218b298686b9ffd6/triton-3.5.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5fc53d849f879911ea13f4a877243afc513187bc7ee92d1f2c0f1ba3169e3c94", size = 170320692, upload-time = "2025-11-11T17:40:46.074Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/72/ec90c3519eaf168f22cb1757ad412f3a2add4782ad3a92861c9ad135d886/triton-3.5.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61413522a48add32302353fdbaaf92daaaab06f6b5e3229940d21b5207f47579", size = 170425802, upload-time = "2025-11-11T17:40:53.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
+    { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e6/c595c35e5c50c4bc56a7bac96493dad321e9e29b953b526bbbe20f9911d0/triton-3.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0637b1efb1db599a8e9dc960d53ab6e4637db7d4ab6630a0974705d77b14b60", size = 170480488, upload-time = "2025-11-11T17:41:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b5/b0d3d8b901b6a04ca38df5e24c27e53afb15b93624d7fd7d658c7cd9352a/triton-3.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac7f7d959ad0f48c0e97d6643a1cc0fd5786fe61cb1f83b537c6b2d54776478", size = 170582192, upload-time = "2025-11-11T17:41:23.963Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Summary

- add a standalone `rl-experience-transfer` Python package with a versioned canonical RL experience schema and typed producer/consumer lifecycle
- add safe JSON metadata and external tensor serialization, HMAC authentication, consumer contracts, schema migrations, W3C tracing, durable idempotency, retry handling, and content-free dead letters
- provide in-memory, persistent filesystem, NIXL, and conservative fallback transports
- add guarded adapters for NeMo RL, PRIME-RL, slime, and MILES
- add production-oriented documentation, runnable examples, packaging validation, and pinned native-framework CI coverage
- exercise real pinned-source rollout and training components on the fly in PR CI, with source-provenance assertions and explicit CPU-only stand-ins for external/GPU services

## Why

Rollout workers and trainers need to exchange experience without binding framework-native records directly to one transport or accepting unsafe cross-framework conversions. This package separates framework adapters, canonical schema, serialization, and transport concerns while preserving native fields in namespaced extensions and failing closed when lossless reconstruction is not possible.

## Framework conversion contract

| Producer | NeMo RL | PRIME-RL | slime | MILES |
|---|---|---|---|---|
| NeMo RL | Supported | Rejected | Rejected | Rejected |
| PRIME-RL | Rejected | Supported | Rejected | Rejected |
| slime | Rejected | Rejected | Supported | Supported with explicit requirements |
| MILES | Rejected | Rejected | Supported with explicit requirements | Supported |

- **Supported** means native rollout → canonical `ExperienceBatch` → transport → native training input.
- **Supported with explicit requirements** means the slime/MILES cross-conversion proceeds only when matching `CompatibilityRequirements` declare the algorithm, tokenizer, model, reward semantics, sequence format, padding, chat template, and truncation.
- **Rejected** means the target framework cannot reconstruct its required native fields losslessly without guessing. The remaining 10 native pairings fail closed with actionable errors and terminal rejected receipts.
- This restriction applies to native reconstruction; canonical `ExperienceBatch` transport remains framework-neutral.

The six supported paths are four framework self-roundtrips plus the two explicitly contracted cross-framework paths, slime → MILES and MILES → slime. Each reconstructs pinned-source native types, recanonicalizes them, runs a finite PyTorch backward pass, verifies an optimizer parameter change, and acknowledges delivery.

## On-the-fly framework pipeline CI

The PR workflow checks out each framework at its audited commit and imports the named components directly from that checkout. Every claimed component is source-provenance checked, so a local substitute cannot silently satisfy the test. Experience travels through `ExperienceProducer` → filesystem transport → `ExperienceConsumer`; the framework-owned loss runs backward, a CPU optimizer changes a parameter, and the delivery is acknowledged only after the update.

| Framework | Real pinned-source rollout boundary | Real pinned-source training component | Deliberate CPU-only stand-in |
|---|---|---|---|
| NeMo RL | `RolloutManager.generate_and_push` and `AsyncRolloutImpl` | `ClippedPGLossFn` with native `BatchedDataDict` | deterministic generation/environment and tiny policy |
| PRIME-RL | `TrainingBatchSender.send` / `TrainingBatchReceiver` with native `TrainingBatch` | `compute_loss` with `DefaultLossConfig` | synthetic native batch and tiny policy |
| slime | `call_rollout_fn` with native `RolloutFnTrainOutput` / `Sample` | `compute_policy_loss` | test-time rollout plugin and tiny policy |
| MILES | `call_rollout_fn` with native `RolloutFnTrainOutput` / `Sample` | `compute_policy_loss` | test-time rollout plugin and tiny policy |

These are real source-owned component integrations, not mocks of the named boundaries. The stand-ins replace external model servers, environments, and GPU/distributed engines, so this does **not** claim to run each framework's complete distributed trainer. The Actions job publishes this same component/result table to the GitHub job summary.

## Validation

- Python 3.10 core: 87 passed, 1 skipped, 7 deselected
- Python 3.12 core: 87 passed, 1 skipped, 7 deselected
- delivery lifecycle E2E: 12/12 passed across memory/filesystem, JSON/authenticated, and ack/retry/reject paths
- dependency-light examples: 4/4 passed
- pinned native conversion matrix: 16/16 passed
- pinned framework pipeline components: 4/4 passed
- complete framework integration suite: 20/20 passed (16 conversion cases + 4 pipeline component cases)
- real NIXL integration: 7/7 passed
- Ruff, formatting, strict mypy, lockfile validation, pre-commit, Cargo clippy, and Cargo check passed
- wheel and sdist builds, Twine validation, and isolated Python 3.10/3.12 installs passed

## Reliability and security notes

- delivery is at least once; the library does not claim distributed exactly-once execution
- pickle and executable metadata deserialization are not used
- HMAC authentication detects tampering but does not encrypt payloads
- complete framework trainers and accelerator workloads remain environment-specific gates; CI exercises real pinned-source component boundaries, native records, and CPU optimizer updates
