### PR TITLE
feat(huggingface): support pinned revisions for ModelExpress downloads

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -333,9 +333,11 @@ When a no-shared-storage client installs a snapshot over the file stream, it als
 
 #### Registry entry keys
 
-Registry backends key every record, lease, and claim on one string. That key is a [`EntryKey`](../modelexpress_server/src/registry/entry_key.rs) encoding of `model_name` + resolved revision + weight mode, formatted as `model@rev:<sha>` with a `#metadata` suffix for `ignore_weights` downloads. This is what keeps two revisions of one model from sharing a lease (and coalescing onto each other's download), and what keeps a metadata-only download from satisfying a later full-weight request with a weightless snapshot. An unpinned, full-weight entry encodes to the bare model name, so records written before revisions existed keep parsing.
+Registry backends key every record, lease, and claim on one string. That key is an [`EntryKey`](../modelexpress_server/src/registry/entry_key.rs) encoding of `model_name` + resolved revision + weight mode. This is what keeps two revisions of one model from sharing a lease (and coalescing onto each other's download), and what keeps a metadata-only download from satisfying a later full-weight request with a weightless snapshot.
 
-Cache eviction parses the key back to delete the right snapshot, and skips the filesystem delete while another entry — typically the metadata-only twin of the same commit — still references it.
+An unpinned, full-weight entry encodes to the bare model name, so records written before revisions existed keep parsing and providers without a revision concept keep the keys they have always used. Anything else encodes as `mx1:<revision>:<flags>:<model_name>`. The model name goes last because it is the only field with no character restrictions — a GCS object path accepts almost any byte, so a name containing the separator must not be able to impersonate the other fields and aim a delete at the wrong model.
+
+Cache eviction parses the key back to delete the right snapshot. It keeps the files while another entry still references the same commit, treating a revisionless entry as covering every snapshot of its model. When the evicted entry is the last one for its model the whole repository directory goes, so a snapshot kept alive by an earlier shared-file decision cannot outlive the last record pointing at it. Hugging Face snapshot entries are symlinks into `blobs/`, so a per-revision delete also reclaims the blobs no surviving snapshot references — otherwise it would free almost no disk.
 
 ### p2p.proto - P2pService
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,6 +98,7 @@ ModelExpress/
 │       ├── registry/
 │       │   ├── state.rs                # RegistryManager wrapper
 │       │   ├── backend.rs              # RegistryBackend trait + ModelRecord
+│       │   ├── entry_key.rs            # EntryKey: model + revision + weight mode
 │       │   ├── k8s_types.rs            # ModelCacheEntry CRD type
 │       │   └── backend/
 │       │       ├── redis.rs            # Redis registry backend
@@ -314,11 +315,25 @@ Four proto files define four services, all compiled via `tonic-build` in `modele
 | `EnsureModelDownloaded` | `ModelDownloadRequest` | stream `ModelStatusUpdate` | Trigger download, stream progress |
 | `StreamModelFiles` | `ModelFilesRequest` | stream `FileChunk` | Stream model file contents (1MB chunks) |
 | `ListModelFiles` | `ModelFilesRequest` | `ModelFileList` | List files with sizes |
-| `DeleteModel` | `DeleteModelRequest` | `DeleteModelResponse` | Remove a model record from the registry (used by `model clear`) |
+| `DeleteModel` | `DeleteModelRequest` | `DeleteModelResponse` | Remove a model's records from the registry (used by `model clear`) |
 
 Key message types: `ModelProvider` (HuggingFace, NGC, GCS), `ModelStatus` (Downloading, Downloaded, Error), `ModelStatusUpdate`, `FileChunk`.
 
 `EnsureModelDownloaded` verifies that a `DOWNLOADED` registry record still has its files on disk before honoring it as a cache hit. If the files are missing (for example after a `model clear` that only removed local storage), the stale record is deleted and the download is re-claimed so the model is actually re-fetched rather than returning a false success.
+
+#### Pinned revisions
+
+`ModelDownloadRequest` and `ModelFilesRequest` carry an optional `revision` (a branch, tag, or commit SHA); `ModelStatusUpdate` reports the `resolved_revision` the request landed on. Providers without a revision concept (NGC, GCS) reject a set `revision` and report none.
+
+The server resolves the revision to an immutable commit **before** claiming the download lease, then pins every Hub file request to that commit, so a tag that moves mid-download cannot mix commits into one snapshot. A requested revision that does not exist fails the request; it never falls back to the default revision. An unpinned request still resolves the default revision to a commit SHA and reports it, so callers always learn the exact commit they got. If the Hub is unreachable while resolving an *unpinned* request, the server falls back to the snapshot already in its cache, which keeps cache hits working during a Hub outage.
+
+`StreamModelFiles` and `ListModelFiles` resolve a requested revision against the local cache only — the model is already downloaded, so serving it must not depend on Hub reachability.
+
+#### Registry entry keys
+
+Registry backends key every record, lease, and claim on one string. That key is a [`EntryKey`](../modelexpress_server/src/registry/entry_key.rs) encoding of `model_name` + resolved revision + weight mode, formatted as `model@rev:<sha>` with a `#metadata` suffix for `ignore_weights` downloads. This is what keeps two revisions of one model from sharing a lease (and coalescing onto each other's download), and what keeps a metadata-only download from satisfying a later full-weight request with a weightless snapshot. An unpinned, full-weight entry encodes to the bare model name, so records written before revisions existed keep parsing.
+
+Cache eviction parses the key back to delete the right snapshot, and skips the filesystem delete while another entry — typically the metadata-only twin of the same commit — still references it.
 
 ### p2p.proto - P2pService
 
@@ -470,6 +485,8 @@ The `Client` struct in `modelexpress_client/src/lib.rs` wraps gRPC connections:
 | `delete_model(name, cache_dir)` | Delete cached model |
 | `validate_model(name, cache_dir)` | Validate cached model integrity |
 
+Each download entry point has a `_revision` variant — `request_model_revision`, `request_model_on_server_revision`, `request_model_with_smart_fallback_revision` — that takes an optional branch, tag, or commit SHA and returns a `ModelDownloadResult { path, resolved_revision }`. The non-`_revision` methods keep their existing signatures and delegate with no revision pinned.
+
 ### Download Strategies
 
 | Strategy | Behavior |
@@ -486,7 +503,7 @@ The `Cli` struct in `args.rs` embeds `ClientArgs` via `#[command(flatten)]`. Com
 |---------|---------|
 | `health` | Check server health |
 | `ping` | Ping server |
-| `model download <name>` | Download a model |
+| `model download <name>` | Download a model. `--revision <branch\|tag\|sha>` pins a revision; the resolved commit SHA is reported back |
 | `model list-files <name>` | List model files |
 | `model clear <name>` | Delete cached model |
 | `model validate <name>` | Validate model integrity |
@@ -516,6 +533,14 @@ pub trait ModelProviderTrait: Send + Sync {
     async fn download_model(&self, name: &str, cache_path: Option<PathBuf>, ignore_weights: bool) -> Result<PathBuf>;
     async fn delete_model(&self, name: &str, cache_dir: PathBuf) -> Result<()>;
     async fn get_model_path(&self, name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
+
+    // Revision-aware variants. The defaults reject a pinned revision and delegate to the
+    // methods above, so only providers that expose revisions need to implement them.
+    async fn download_model_revision(&self, name: &str, cache_path: Option<PathBuf>, ignore_weights: bool, revision: Option<&str>) -> Result<ModelDownloadOutcome>;
+    async fn resolve_revision(&self, name: &str, cache_dir: Option<PathBuf>, revision: Option<&str>) -> Result<Option<String>>;
+    async fn delete_model_revision(&self, name: &str, cache_dir: PathBuf, revision: Option<&str>) -> Result<()>;
+    async fn get_model_path_revision(&self, name: &str, cache_dir: PathBuf, revision: Option<&str>) -> Result<PathBuf>;
+
     fn provider_name(&self) -> &'static str;
     fn is_ignored(filename: &str) -> bool;
     fn is_image(path: &Path) -> bool;
@@ -523,8 +548,10 @@ pub trait ModelProviderTrait: Send + Sync {
 }
 ```
 
+`ModelDownloadOutcome` carries the snapshot `path` plus the `resolved_revision` the request landed on (`None` for providers with no revision concept).
+
 Three implementations:
-- `HuggingFaceProvider` - uses the `hf-hub` crate with high-CPU download mode.
+- `HuggingFaceProvider` - uses the `hf-hub` crate with high-CPU download mode. Implements the revision-aware methods: it resolves a branch, tag, or SHA through `/api/models/<repo>/revision/<rev>`, downloads every file from the resolved commit, and writes `refs/<requested-revision>` so the snapshot stays resolvable by the name the caller used. `delete_model_revision` removes a single snapshot, and drops the whole repository directory once its last snapshot is gone.
 - `NgcProvider` - downloads from NVIDIA NGC via the files-manifest endpoint `…/v2/org/{org}[/team/{team}]/{type}/{name}/{version}/files` (no `versions/` segment), which returns self-authenticating presigned URLs paired with relative paths for every file, for both V1 and V2 storage and both org and team scopes (so nested paths and downloads need no per-file URL construction or Authorization forwarding). Falls back to `checksums.blake3` manifest enumeration against the versioned `…/versions/{version}/files` endpoint (Bearer-authenticated `/files/{path}` downloads) when the listing returns 400/401, as some UAM-gated orgs (e.g. the `nim` catalog) do. Resolves the NGC API key from `NGC_API_KEY`, `NGC_CLI_API_KEY`, or `~/.ngc/config`.
 - `GcsProvider` - downloads objects under a full `gs://<bucket>/<object-prefix>` URL using Google Application Default Credentials. It writes a `.mx/manifest.json` cache manifest, verifies downloaded files with GCS CRC32C checksums, skips dotfiles, README, and images, and stores models under `<cache>/gcs/<bucket>/<object-prefix>`. See [`GCS_PROVIDER.md`](GCS_PROVIDER.md) for the detailed design.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -329,6 +329,8 @@ The server resolves the revision to an immutable commit **before** claiming the 
 
 `StreamModelFiles` and `ListModelFiles` resolve a requested revision against the local cache only — the model is already downloaded, so serving it must not depend on Hub reachability.
 
+When a no-shared-storage client installs a snapshot over the file stream, it also writes the provider's local revision bookkeeping (`ModelProviderTrait::record_local_revision`; for Hugging Face, `refs/<requested-revision>`). Without it the files would be on disk but `huggingface_hub` could not resolve them by branch or tag under `HF_HUB_OFFLINE=1`.
+
 #### Registry entry keys
 
 Registry backends key every record, lease, and claim on one string. That key is a [`EntryKey`](../modelexpress_server/src/registry/entry_key.rs) encoding of `model_name` + resolved revision + weight mode, formatted as `model@rev:<sha>` with a `#metadata` suffix for `ignore_weights` downloads. This is what keeps two revisions of one model from sharing a lease (and coalescing onto each other's download), and what keeps a metadata-only download from satisfying a later full-weight request with a weightless snapshot. An unpinned, full-weight entry encodes to the bare model name, so records written before revisions existed keep parsing.
@@ -540,6 +542,8 @@ pub trait ModelProviderTrait: Send + Sync {
     async fn resolve_revision(&self, name: &str, cache_dir: Option<PathBuf>, revision: Option<&str>) -> Result<Option<String>>;
     async fn delete_model_revision(&self, name: &str, cache_dir: PathBuf, revision: Option<&str>) -> Result<()>;
     async fn get_model_path_revision(&self, name: &str, cache_dir: PathBuf, revision: Option<&str>) -> Result<PathBuf>;
+    async fn record_local_revision(&self, name: &str, cache_dir: &Path, requested: Option<&str>, commit: &str) -> Result<()>;
+    fn supports_revisions(&self) -> bool;
 
     fn provider_name(&self) -> &'static str;
     fn is_ignored(filename: &str) -> bool;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -89,6 +89,14 @@ modelexpress-cli model download google-t5/t5-small \
   --provider hugging-face \
   --strategy server-only
 
+# Pin a branch, tag, or commit SHA (Hugging Face only). The commit SHA the request
+# resolved to is printed on success, so a frontend and its workers can be held to
+# one revision. A revision that does not exist fails; it never falls back to the
+# default revision.
+modelexpress-cli model download google-t5/t5-small --revision refs/pr/1
+modelexpress-cli model download google-t5/t5-small \
+  --revision df1b051c49625cf57a3d0d8d3863ed4d13564fe4
+
 # Download from Google Cloud Storage
 modelexpress-cli model download gs://my-bucket/models/qwen/rev-1 \
   --provider gcs

--- a/modelexpress_client/go/gen/modelexpress/model/model.pb.go
+++ b/modelexpress_client/go/gen/modelexpress/model/model.pb.go
@@ -236,6 +236,9 @@ type ModelDownloadRequest struct {
 	ModelName     string                 `protobuf:"bytes,1,opt,name=model_name,json=modelName,proto3" json:"model_name,omitempty"`
 	Provider      ModelProvider          `protobuf:"varint,2,opt,name=provider,proto3,enum=model_express.model.ModelProvider" json:"provider,omitempty"`
 	IgnoreWeights bool                   `protobuf:"varint,3,opt,name=ignore_weights,json=ignoreWeights,proto3" json:"ignore_weights,omitempty"`
+	// Optional branch, tag, or commit SHA. When unset the provider's default
+	// revision is used. Providers without a revision concept reject a set value.
+	Revision      *string `protobuf:"bytes,4,opt,name=revision,proto3,oneof" json:"revision,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -291,16 +294,26 @@ func (x *ModelDownloadRequest) GetIgnoreWeights() bool {
 	return false
 }
 
+func (x *ModelDownloadRequest) GetRevision() string {
+	if x != nil && x.Revision != nil {
+		return *x.Revision
+	}
+	return ""
+}
+
 // Streaming status update for model download progress
 type ModelStatusUpdate struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	ModelName string                 `protobuf:"bytes,1,opt,name=model_name,json=modelName,proto3" json:"model_name,omitempty"`
 	Status    ModelStatus            `protobuf:"varint,2,opt,name=status,proto3,enum=model_express.model.ModelStatus" json:"status,omitempty"`
 	// Optional message for additional context (e.g., progress info, error details)
-	Message       *string       `protobuf:"bytes,3,opt,name=message,proto3,oneof" json:"message,omitempty"`
-	Provider      ModelProvider `protobuf:"varint,4,opt,name=provider,proto3,enum=model_express.model.ModelProvider" json:"provider,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Message  *string       `protobuf:"bytes,3,opt,name=message,proto3,oneof" json:"message,omitempty"`
+	Provider ModelProvider `protobuf:"varint,4,opt,name=provider,proto3,enum=model_express.model.ModelProvider" json:"provider,omitempty"`
+	// Immutable commit SHA the request resolved to. Unset for providers that do
+	// not expose revisions.
+	ResolvedRevision *string `protobuf:"bytes,5,opt,name=resolved_revision,json=resolvedRevision,proto3,oneof" json:"resolved_revision,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ModelStatusUpdate) Reset() {
@@ -361,6 +374,13 @@ func (x *ModelStatusUpdate) GetProvider() ModelProvider {
 	return ModelProvider_HUGGING_FACE
 }
 
+func (x *ModelStatusUpdate) GetResolvedRevision() string {
+	if x != nil && x.ResolvedRevision != nil {
+		return *x.ResolvedRevision
+	}
+	return ""
+}
+
 // Request for streaming model files
 type ModelFilesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -375,6 +395,9 @@ type ModelFilesRequest struct {
 	// When true, weight files are skipped and only non-weight files
 	// (config, tokenizer, etc.) are streamed. Mirrors ModelDownloadRequest.
 	IgnoreWeights bool `protobuf:"varint,5,opt,name=ignore_weights,json=ignoreWeights,proto3" json:"ignore_weights,omitempty"`
+	// Optional branch, tag, or commit SHA identifying the cached snapshot to
+	// serve. When unset the most recent local snapshot is used.
+	Revision      *string `protobuf:"bytes,6,opt,name=revision,proto3,oneof" json:"revision,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -442,6 +465,13 @@ func (x *ModelFilesRequest) GetIgnoreWeights() bool {
 		return x.IgnoreWeights
 	}
 	return false
+}
+
+func (x *ModelFilesRequest) GetRevision() string {
+	if x != nil && x.Revision != nil {
+		return *x.Revision
+	}
+	return ""
 }
 
 // Selects files within a model directory
@@ -722,20 +752,24 @@ const file_model_proto_rawDesc = "" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x1d\n" +
 	"\amessage\x18\x02 \x01(\tH\x00R\amessage\x88\x01\x01B\n" +
 	"\n" +
-	"\b_message\"\x9c\x01\n" +
+	"\b_message\"\xca\x01\n" +
 	"\x14ModelDownloadRequest\x12\x1d\n" +
 	"\n" +
 	"model_name\x18\x01 \x01(\tR\tmodelName\x12>\n" +
 	"\bprovider\x18\x02 \x01(\x0e2\".model_express.model.ModelProviderR\bprovider\x12%\n" +
-	"\x0eignore_weights\x18\x03 \x01(\bR\rignoreWeights\"\xd7\x01\n" +
+	"\x0eignore_weights\x18\x03 \x01(\bR\rignoreWeights\x12\x1f\n" +
+	"\brevision\x18\x04 \x01(\tH\x00R\brevision\x88\x01\x01B\v\n" +
+	"\t_revision\"\x9f\x02\n" +
 	"\x11ModelStatusUpdate\x12\x1d\n" +
 	"\n" +
 	"model_name\x18\x01 \x01(\tR\tmodelName\x128\n" +
 	"\x06status\x18\x02 \x01(\x0e2 .model_express.model.ModelStatusR\x06status\x12\x1d\n" +
 	"\amessage\x18\x03 \x01(\tH\x00R\amessage\x88\x01\x01\x12>\n" +
-	"\bprovider\x18\x04 \x01(\x0e2\".model_express.model.ModelProviderR\bproviderB\n" +
+	"\bprovider\x18\x04 \x01(\x0e2\".model_express.model.ModelProviderR\bprovider\x120\n" +
+	"\x11resolved_revision\x18\x05 \x01(\tH\x01R\x10resolvedRevision\x88\x01\x01B\n" +
 	"\n" +
-	"\b_message\"\x85\x02\n" +
+	"\b_messageB\x14\n" +
+	"\x12_resolved_revision\"\xb3\x02\n" +
 	"\x11ModelFilesRequest\x12\x1d\n" +
 	"\n" +
 	"model_name\x18\x01 \x01(\tR\tmodelName\x12>\n" +
@@ -743,7 +777,9 @@ const file_model_proto_rawDesc = "" +
 	"\n" +
 	"chunk_size\x18\x03 \x01(\rR\tchunkSize\x12K\n" +
 	"\rfile_selector\x18\x04 \x01(\v2&.model_express.model.ModelFileSelectorR\ffileSelector\x12%\n" +
-	"\x0eignore_weights\x18\x05 \x01(\bR\rignoreWeights\")\n" +
+	"\x0eignore_weights\x18\x05 \x01(\bR\rignoreWeights\x12\x1f\n" +
+	"\brevision\x18\x06 \x01(\tH\x00R\brevision\x88\x01\x01B\v\n" +
+	"\t_revision\")\n" +
 	"\x11ModelFileSelector\x12\x14\n" +
 	"\x05paths\x18\x01 \x03(\tR\x05paths\"\xf7\x01\n" +
 	"\tFileChunk\x12#\n" +
@@ -838,7 +874,9 @@ func file_model_proto_init() {
 		return
 	}
 	file_model_proto_msgTypes[1].OneofWrappers = []any{}
+	file_model_proto_msgTypes[2].OneofWrappers = []any{}
 	file_model_proto_msgTypes[3].OneofWrappers = []any{}
+	file_model_proto_msgTypes[4].OneofWrappers = []any{}
 	file_model_proto_msgTypes[6].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/modelexpress_client/src/bin/modules/args.rs
+++ b/modelexpress_client/src/bin/modules/args.rs
@@ -81,6 +81,11 @@ pub enum ModelCommands {
         /// Download strategy
         #[arg(long, short = 's', value_enum, default_value = "smart-fallback")]
         strategy: DownloadStrategy,
+
+        /// Branch, tag, or commit SHA to download. Defaults to the provider's
+        /// default revision. Only providers with revisions (Hugging Face) accept this.
+        #[arg(long, short = 'r', value_name = "REVISION")]
+        revision: Option<String>,
     },
 
     /// Initialize model storage configuration

--- a/modelexpress_client/src/bin/modules/handlers.rs
+++ b/modelexpress_client/src/bin/modules/handlers.rs
@@ -5,7 +5,7 @@ use super::args::{DownloadStrategy, ModelCommands, OutputFormat};
 use super::output::{print_human_readable, print_output};
 use super::payload::read_payload;
 use colored::*;
-use modelexpress_client::{Client, ClientConfig, ModelProvider};
+use modelexpress_client::{Client, ClientConfig, ModelDownloadResult, ModelProvider};
 use modelexpress_common::{
     cache::{CacheConfig, CacheStats, ModelInfo, resolve_model_path},
     download,
@@ -156,12 +156,14 @@ pub async fn handle_model_command(
             model_name,
             provider,
             strategy,
+            revision,
         } => {
             download_model(
                 storage_path_override,
                 model_name,
                 provider,
                 strategy,
+                revision,
                 server_config,
                 format,
             )
@@ -205,6 +207,7 @@ async fn download_model(
     model_name: String,
     provider: ModelProvider,
     strategy: DownloadStrategy,
+    revision: Option<String>,
     config: ClientConfig,
     format: &OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -218,6 +221,9 @@ async fn download_model(
         println!("  {}: {}", "Model".cyan().bold(), model_name);
         println!("  {}: {}", "Provider".cyan().bold(), provider);
         println!("  {}: {:?}", "Strategy".cyan().bold(), strategy);
+        if let Some(revision) = &revision {
+            println!("  {}: {}", "Revision".cyan().bold(), revision);
+        }
         println!();
     }
 
@@ -238,6 +244,7 @@ async fn download_model(
         c
     });
 
+    let revision = revision.as_deref();
     let result = match strategy {
         DownloadStrategy::SmartFallback => {
             debug!("Using smart fallback strategy");
@@ -245,9 +252,14 @@ async fn download_model(
             if let Some(cache_config) = cache_config {
                 config.cache = cache_config;
             }
-            Client::request_model_with_smart_fallback(model_name.clone(), provider, config, false)
-                .await
-                .map(|_| ())
+            Client::request_model_with_smart_fallback_revision(
+                model_name.clone(),
+                provider,
+                config,
+                false,
+                revision,
+            )
+            .await
         }
         DownloadStrategy::ServerOnly => {
             debug!("Using server-only strategy");
@@ -257,20 +269,23 @@ async fn download_model(
                 Client::new(config.clone()).await?
             };
             client
-                .request_model(&model_name, provider, false)
+                .request_model_revision(&model_name, provider, false, revision)
                 .await
-                .map(|_| ())
         }
         DownloadStrategy::Direct => {
             debug!("Using direct download strategy");
-            download::download_model(
+            download::download_model_revision(
                 &model_name,
                 provider,
                 cache_config.map(|config| config.local_path),
                 false,
+                revision,
             )
             .await
-            .map(|_| ())
+            .map(|outcome| ModelDownloadResult {
+                path: Some(outcome.path),
+                resolved_revision: outcome.resolved_revision,
+            })
             .map_err(|e| {
                 modelexpress_common::Error::Generic(format!("Direct download failed: {e}")).into()
             })
@@ -278,13 +293,19 @@ async fn download_model(
     };
 
     match result {
-        Ok(()) => {
+        Ok(outcome) => {
             info!("Model download completed successfully: {}", model_name);
             let success_msg = format!("Model '{model_name}' downloaded successfully");
             match format {
                 OutputFormat::Human => {
                     println!("{}", "✅ SUCCESS".green().bold());
                     println!("  {success_msg}");
+                    if let Some(resolved) = &outcome.resolved_revision {
+                        println!("  {}: {}", "Resolved revision".cyan().bold(), resolved);
+                    }
+                    if let Some(path) = &outcome.path {
+                        println!("  {}: {}", "Path".cyan().bold(), path.display());
+                    }
                 }
                 _ => {
                     let output = serde_json::json!({
@@ -292,7 +313,9 @@ async fn download_model(
                         "message": success_msg,
                         "model_name": model_name,
                         "provider": provider.to_string(),
-                        "strategy": format!("{:?}", strategy)
+                        "strategy": format!("{:?}", strategy),
+                        "resolved_revision": outcome.resolved_revision,
+                        "path": outcome.path.as_ref().map(|path| path.display().to_string())
                     });
                     print_output(&output, format);
                 }

--- a/modelexpress_client/src/bin/modules/handlers.rs
+++ b/modelexpress_client/src/bin/modules/handlers.rs
@@ -282,10 +282,7 @@ async fn download_model(
                 revision,
             )
             .await
-            .map(|outcome| ModelDownloadResult {
-                path: Some(outcome.path),
-                resolved_revision: outcome.resolved_revision,
-            })
+            .map(ModelDownloadResult::from)
             .map_err(|e| {
                 modelexpress_common::Error::Generic(format!("Direct download failed: {e}")).into()
             })

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -39,6 +39,18 @@ use tonic::service::interceptor::InterceptedService;
 
 type AuthChannel = InterceptedService<Channel, AuthInterceptor>;
 
+/// What a completed model request resolved to.
+///
+/// Callers that need the frontend and the workers to agree on one commit use
+/// `resolved_revision`; it is `None` only for providers with no revision concept.
+/// `path` is the local snapshot directory, and is `None` when the client has no cache
+/// configured to resolve it against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelDownloadResult {
+    pub path: Option<PathBuf>,
+    pub resolved_revision: Option<String>,
+}
+
 /// The main client for interacting with the `modelexpress_server` via gRPC
 pub struct Client {
     health_client: HealthServiceClient<AuthChannel>,
@@ -363,12 +375,15 @@ impl Client {
 
     /// Stream model files from the server to the local cache.
     /// This is an internal helper used when shared storage is disabled.
+    ///
+    /// Returns the local snapshot directory the files were installed into.
     async fn stream_model_files_from_server(
         &mut self,
         model_name: &str,
         provider: ModelProvider,
         ignore_weights: bool,
-    ) -> CommonResult<()> {
+        revision: Option<&str>,
+    ) -> CommonResult<PathBuf> {
         let cache_config = self.cache_config.as_ref().ok_or_else(|| {
             modelexpress_common::Error::Server(
                 "Cache configuration is required for file streaming. Please ensure cache_config is set.".to_string()
@@ -395,6 +410,7 @@ impl Client {
             chunk_size,
             file_selector: None,
             ignore_weights,
+            revision: revision.map(String::from),
         });
 
         let mut stream = self
@@ -632,26 +648,54 @@ impl Client {
             files_received, bytes_received, model_name
         );
 
-        Ok(())
+        model_dir.ok_or_else(|| {
+            modelexpress_common::Error::Server(format!(
+                "Server streamed no model directory for model {model_name}"
+            ))
+            .into()
+        })
     }
 
-    /// Request a model on the server.
+    /// Request a model on the server at its default revision.
     pub async fn request_model_on_server(
         &mut self,
         model_name: impl Into<String>,
         provider: ModelProvider,
         ignore_weights: bool,
     ) -> CommonResult<()> {
+        self.request_model_on_server_revision(model_name, provider, ignore_weights, None)
+            .await
+            .map(|_| ())
+    }
+
+    /// Request a model on the server at a specific branch, tag, or commit SHA.
+    ///
+    /// Returns the immutable revision the server resolved the request to, or `None` for
+    /// providers that do not expose revisions.
+    pub async fn request_model_on_server_revision(
+        &mut self,
+        model_name: impl Into<String>,
+        provider: ModelProvider,
+        ignore_weights: bool,
+        revision: Option<&str>,
+    ) -> CommonResult<Option<String>> {
         let model_name = model_name.into();
-        info!(
-            "Requesting model: {} from provider: {:?}",
-            model_name, provider
-        );
+        match revision {
+            Some(revision) => info!(
+                "Requesting model: {} at revision {} from provider: {:?}",
+                model_name, revision, provider
+            ),
+            None => info!(
+                "Requesting model: {} from provider: {:?}",
+                model_name, provider
+            ),
+        }
 
         let grpc_request = tonic::Request::new(ModelDownloadRequest {
             model_name: model_name.clone(),
             provider: modelexpress_common::grpc::model::ModelProvider::from(provider) as i32,
             ignore_weights,
+            revision: revision.map(String::from),
         });
 
         let mut stream = self
@@ -660,12 +704,20 @@ impl Client {
             .await?
             .into_inner();
 
+        // The resolved revision is reported on every update; hold on to the last one
+        // seen so it is still available if the terminal update omits it.
+        let mut resolved_revision: Option<String> = None;
+
         // Process streaming updates until the download is complete
         while let Some(update_result) = stream.message().await? {
             let status: ModelStatus =
                 modelexpress_common::grpc::model::ModelStatus::try_from(update_result.status)
                     .unwrap_or(modelexpress_common::grpc::model::ModelStatus::Error)
                     .into();
+
+            if update_result.resolved_revision.is_some() {
+                resolved_revision = update_result.resolved_revision.clone();
+            }
 
             // Log progress messages if available
             if let Some(message) = &update_result.message {
@@ -678,7 +730,7 @@ impl Client {
             match status {
                 ModelStatus::DOWNLOADED => {
                     info!("Model {} is now available", model_name);
-                    return Ok(());
+                    return Ok(resolved_revision);
                 }
                 ModelStatus::ERROR => {
                     let error_message = update_result
@@ -712,9 +764,27 @@ impl Client {
         provider: ModelProvider,
         ignore_weights: bool,
     ) -> CommonResult<()> {
+        self.request_model_revision(model_name, provider, ignore_weights, None)
+            .await
+            .map(|_| ())
+    }
+
+    /// Request a model at a specific branch, tag, or commit SHA, reporting the snapshot
+    /// path and the immutable revision the request resolved to.
+    ///
+    /// When shared_storage is disabled, files are streamed from the server into the
+    /// local cache under that resolved revision.
+    pub async fn request_model_revision(
+        &mut self,
+        model_name: impl Into<String>,
+        provider: ModelProvider,
+        ignore_weights: bool,
+        revision: Option<&str>,
+    ) -> CommonResult<ModelDownloadResult> {
         let model_name = model_name.into();
 
-        self.request_model_on_server(&model_name, provider, ignore_weights)
+        let resolved_revision = self
+            .request_model_on_server_revision(&model_name, provider, ignore_weights, revision)
             .await?;
 
         info!("Model {} downloaded successfully via server", model_name);
@@ -725,16 +795,48 @@ impl Client {
             .as_ref()
             .is_some_and(|c| !c.shared_storage);
 
-        if needs_streaming {
+        let path = if needs_streaming {
             info!(
                 "Shared storage disabled, streaming files from server for model {}",
                 model_name
             );
-            self.stream_model_files_from_server(&model_name, provider, ignore_weights)
-                .await?;
-        }
+            Some(
+                self.stream_model_files_from_server(
+                    &model_name,
+                    provider,
+                    ignore_weights,
+                    resolved_revision.as_deref(),
+                )
+                .await?,
+            )
+        } else {
+            self.local_snapshot_path(&model_name, provider, resolved_revision.as_deref())
+        };
 
-        Ok(())
+        Ok(ModelDownloadResult {
+            path,
+            resolved_revision,
+        })
+    }
+
+    /// Best-effort local path of a downloaded snapshot. `None` when the cache layout
+    /// cannot be resolved or the directory is not present locally, which is the normal
+    /// case for a shared-storage client whose cache is not configured.
+    fn local_snapshot_path(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        revision: Option<&str>,
+    ) -> Option<PathBuf> {
+        let cache_dir = self
+            .cache_config
+            .as_ref()
+            .map(|config| config.local_path.clone())
+            .or_else(|| CacheConfig::discover().map(|config| config.local_path).ok())?;
+
+        resolve_model_path(&cache_dir, provider, model_name, revision)
+            .ok()
+            .filter(|path| path.exists())
     }
 
     /// Request a model with automatic server fallback, creating client connection only if needed.
@@ -746,25 +848,50 @@ impl Client {
         config: Config,
         ignore_weights: bool,
     ) -> CommonResult<()> {
+        Self::request_model_with_smart_fallback_revision(
+            model_name,
+            provider,
+            config,
+            ignore_weights,
+            None,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Revision-aware [`Client::request_model_with_smart_fallback`]. The direct-download
+    /// fallback honours the same revision, so a pinned request cannot silently land on a
+    /// different commit just because the server was unreachable.
+    pub async fn request_model_with_smart_fallback_revision(
+        model_name: impl Into<String>,
+        provider: ModelProvider,
+        config: Config,
+        ignore_weights: bool,
+        revision: Option<&str>,
+    ) -> CommonResult<ModelDownloadResult> {
         let model_name = model_name.into();
 
         match Client::new(config.clone()).await {
             Ok(mut client) => {
                 info!("Server connection established, downloading via server...");
                 client
-                    .request_model(&model_name, provider, ignore_weights)
+                    .request_model_revision(&model_name, provider, ignore_weights, revision)
                     .await
             }
             Err(e) => {
                 info!("Cannot connect to server ({}), downloading directly...", e);
-                download::download_model(
+                download::download_model_revision(
                     &model_name,
                     provider,
                     Some(config.cache.local_path.clone()),
                     ignore_weights,
+                    revision,
                 )
                 .await
-                .map(|_| ())
+                .map(|outcome| ModelDownloadResult {
+                    path: Some(outcome.path),
+                    resolved_revision: outcome.resolved_revision,
+                })
                 .map_err(|e| {
                     modelexpress_common::Error::Generic(format!("Direct download failed: {e}"))
                         .into()
@@ -951,6 +1078,7 @@ mod tests {
                 status: modelexpress_common::grpc::model::ModelStatus::Downloaded as i32,
                 message: None,
                 provider: modelexpress_common::grpc::model::ModelProvider::Gcs as i32,
+                resolved_revision: None,
             };
             Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
                 update,
@@ -964,6 +1092,82 @@ mod tests {
             Err(Status::unimplemented(
                 "stream_model_files is not used in this test",
             ))
+        }
+
+        async fn list_model_files(
+            &self,
+            _request: Request<ModelFilesRequest>,
+        ) -> Result<Response<ModelFileList>, Status> {
+            Err(Status::unimplemented(
+                "list_model_files is not used in this test",
+            ))
+        }
+
+        async fn delete_model(
+            &self,
+            _request: Request<DeleteModelRequest>,
+        ) -> Result<Response<DeleteModelResponse>, Status> {
+            Err(Status::unimplemented(
+                "delete_model is not used in this test",
+            ))
+        }
+    }
+
+    /// Resolves any requested revision to a fixed commit and streams one file from it,
+    /// recording the revision the client asked the streaming RPC for.
+    #[derive(Default)]
+    struct PinnedRevisionModelService {
+        streamed_revision: Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    const PINNED_TEST_COMMIT: &str = "abc123def456";
+
+    #[tonic::async_trait]
+    impl ModelService for PinnedRevisionModelService {
+        type EnsureModelDownloadedStream =
+            Pin<Box<dyn Stream<Item = Result<ModelStatusUpdate, Status>> + Send>>;
+        type StreamModelFilesStream = Pin<Box<dyn Stream<Item = Result<FileChunk, Status>> + Send>>;
+
+        async fn ensure_model_downloaded(
+            &self,
+            request: Request<ModelDownloadRequest>,
+        ) -> Result<Response<Self::EnsureModelDownloadedStream>, Status> {
+            let request = request.into_inner();
+            let update = ModelStatusUpdate {
+                model_name: request.model_name,
+                status: modelexpress_common::grpc::model::ModelStatus::Downloaded as i32,
+                message: None,
+                provider: request.provider,
+                resolved_revision: Some(PINNED_TEST_COMMIT.to_string()),
+            };
+            Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
+                update,
+            )]))))
+        }
+
+        async fn stream_model_files(
+            &self,
+            request: Request<ModelFilesRequest>,
+        ) -> Result<Response<Self::StreamModelFilesStream>, Status> {
+            *self
+                .streamed_revision
+                .lock()
+                .expect("Failed to lock streamed_revision") = request.into_inner().revision;
+
+            let data = b"{}".to_vec();
+            let chunk = FileChunk {
+                relative_path: "config.json".to_string(),
+                data: data.clone(),
+                offset: 0,
+                total_size: data.len() as u64,
+                is_last_chunk: true,
+                is_last_file: true,
+                commit_hash: Some(PINNED_TEST_COMMIT.to_string()),
+            };
+
+            Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
+                chunk,
+            )]))))
         }
 
         async fn list_model_files(
@@ -1001,6 +1205,7 @@ mod tests {
                 status: modelexpress_common::grpc::model::ModelStatus::Downloaded as i32,
                 message: None,
                 provider: request.provider,
+                resolved_revision: request.revision,
             };
             Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
                 update,
@@ -1347,7 +1552,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false, None)
             .await;
 
         server_handle.abort();
@@ -1384,7 +1589,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false, None)
             .await;
 
         server_handle.abort();
@@ -1431,7 +1636,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false, None)
             .await;
 
         server_handle.abort();
@@ -1478,7 +1683,7 @@ mod tests {
             .expect("Expected test client to connect");
 
         let result = client
-            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false)
+            .stream_model_files_from_server("test/model", ModelProvider::HuggingFace, false, None)
             .await;
 
         server_handle.abort();
@@ -1526,6 +1731,60 @@ mod tests {
                 .expect("Expected marker metadata")
                 .len(),
             0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_model_revision_installs_the_resolved_snapshot() {
+        let cache_dir = TempDir::new().expect("Failed to create temp dir");
+        let service = PinnedRevisionModelService::default();
+        let streamed_revision = service.streamed_revision.clone();
+        let (addr, server_handle) = spawn_model_service(service).await;
+
+        let mut config = ClientConfig::for_testing(format!("http://{addr}"));
+        config.cache.local_path = cache_dir.path().to_path_buf();
+        config.cache.shared_storage = false;
+
+        let mut client = Client::new(config)
+            .await
+            .expect("Expected test client to connect");
+
+        let outcome = client
+            .request_model_revision(
+                "test/model",
+                ModelProvider::HuggingFace,
+                false,
+                Some("v1.0"),
+            )
+            .await
+            .expect("Expected pinned model request to succeed");
+
+        server_handle.abort();
+        let _ = server_handle.await;
+
+        assert_eq!(
+            outcome.resolved_revision.as_deref(),
+            Some(PINNED_TEST_COMMIT)
+        );
+
+        // The file stream is requested by resolved commit, not by the tag the caller
+        // typed, so the snapshot on disk matches the revision that was reported back.
+        assert_eq!(
+            streamed_revision
+                .lock()
+                .expect("Failed to lock streamed_revision")
+                .as_deref(),
+            Some(PINNED_TEST_COMMIT)
+        );
+
+        let expected_dir = cache_dir
+            .path()
+            .join("models--test--model/snapshots")
+            .join(PINNED_TEST_COMMIT);
+        assert_eq!(outcome.path.as_deref(), Some(expected_dir.as_path()));
+        assert_eq!(
+            std::fs::read(expected_dir.join("config.json")).expect("Expected streamed file"),
+            b"{}"
         );
     }
 

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -15,6 +15,7 @@ use modelexpress_common::{
         },
     },
     models::{ModelStatus, Status},
+    providers::ModelDownloadOutcome,
 };
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
@@ -49,6 +50,16 @@ type AuthChannel = InterceptedService<Channel, AuthInterceptor>;
 pub struct ModelDownloadResult {
     pub path: Option<PathBuf>,
     pub resolved_revision: Option<String>,
+}
+
+impl From<ModelDownloadOutcome> for ModelDownloadResult {
+    /// A direct provider download always knows where it put the files.
+    fn from(outcome: ModelDownloadOutcome) -> Self {
+        Self {
+            path: Some(outcome.path),
+            resolved_revision: outcome.resolved_revision,
+        }
+    }
 }
 
 /// The main client for interacting with the `modelexpress_server` via gRPC
@@ -922,10 +933,7 @@ impl Client {
                     revision,
                 )
                 .await
-                .map(|outcome| ModelDownloadResult {
-                    path: Some(outcome.path),
-                    resolved_revision: outcome.resolved_revision,
-                })
+                .map(ModelDownloadResult::from)
                 .map_err(|e| {
                     modelexpress_common::Error::Generic(format!("Direct download failed: {e}"))
                         .into()

--- a/modelexpress_client/src/lib.rs
+++ b/modelexpress_client/src/lib.rs
@@ -800,15 +800,17 @@ impl Client {
                 "Shared storage disabled, streaming files from server for model {}",
                 model_name
             );
-            Some(
-                self.stream_model_files_from_server(
+            let dir = self
+                .stream_model_files_from_server(
                     &model_name,
                     provider,
                     ignore_weights,
                     resolved_revision.as_deref(),
                 )
-                .await?,
-            )
+                .await?;
+            self.finish_streamed_install(&model_name, provider, revision, &resolved_revision)
+                .await;
+            Some(dir)
         } else {
             self.local_snapshot_path(&model_name, provider, resolved_revision.as_deref())
         };
@@ -817,6 +819,38 @@ impl Client {
             path,
             resolved_revision,
         })
+    }
+
+    /// Complete the provider-specific cache bookkeeping for a snapshot that arrived over
+    /// the file stream instead of through the provider's own downloader — for Hugging
+    /// Face, the `refs/<revision>` entry that makes the snapshot resolvable by branch or
+    /// tag name offline.
+    ///
+    /// Failing here does not fail the request: every file is already on disk and
+    /// resolvable by commit SHA, which is what the caller was handed.
+    async fn finish_streamed_install(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        requested_revision: Option<&str>,
+        resolved_revision: &Option<String>,
+    ) {
+        let (Some(cache_config), Some(commit)) = (self.cache_config.as_ref(), resolved_revision)
+        else {
+            return;
+        };
+
+        if let Err(e) = download::get_provider(provider)
+            .record_local_revision(
+                model_name,
+                &cache_config.local_path,
+                requested_revision,
+                commit,
+            )
+            .await
+        {
+            debug!("Could not record the revision of {model_name} locally: {e}");
+        }
     }
 
     /// Best-effort local path of a downloaded snapshot. `None` when the cache layout
@@ -1785,6 +1819,15 @@ mod tests {
         assert_eq!(
             std::fs::read(expected_dir.join("config.json")).expect("Expected streamed file"),
             b"{}"
+        );
+
+        // The installed snapshot has to be a valid Hugging Face cache entry: without the
+        // ref, huggingface_hub cannot resolve the tag offline even though the files are
+        // all there.
+        assert_eq!(
+            std::fs::read_to_string(cache_dir.path().join("models--test--model/refs/v1.0"))
+                .expect("Expected the requested revision to be recorded"),
+            PINNED_TEST_COMMIT
         );
     }
 

--- a/modelexpress_common/proto/model.proto
+++ b/modelexpress_common/proto/model.proto
@@ -37,6 +37,9 @@ message ModelDownloadRequest {
   string model_name = 1;
   ModelProvider provider = 2;
   bool ignore_weights = 3;
+  // Optional branch, tag, or commit SHA. When unset the provider's default
+  // revision is used. Providers without a revision concept reject a set value.
+  optional string revision = 4;
 }
 
 // Streaming status update for model download progress
@@ -46,6 +49,9 @@ message ModelStatusUpdate {
   // Optional message for additional context (e.g., progress info, error details)
   optional string message = 3;
   ModelProvider provider = 4;
+  // Immutable commit SHA the request resolved to. Unset for providers that do
+  // not expose revisions.
+  optional string resolved_revision = 5;
 }
 
 // Enum representing the status of a model
@@ -75,6 +81,9 @@ message ModelFilesRequest {
   // When true, weight files are skipped and only non-weight files
   // (config, tokenizer, etc.) are streamed. Mirrors ModelDownloadRequest.
   bool ignore_weights = 5;
+  // Optional branch, tag, or commit SHA identifying the cached snapshot to
+  // serve. When unset the most recent local snapshot is used.
+  optional string revision = 6;
 }
 
 // Selects files within a model directory

--- a/modelexpress_common/src/download.rs
+++ b/modelexpress_common/src/download.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::models::ModelProvider;
-use crate::providers::{GcsProvider, HuggingFaceProvider, ModelProviderTrait, NgcProvider};
+use crate::providers::{
+    GcsProvider, HuggingFaceProvider, ModelDownloadOutcome, ModelProviderTrait, NgcProvider,
+};
 use anyhow::Result;
 use std::path::PathBuf;
 use tracing::{info, warn};
@@ -42,6 +44,53 @@ pub async fn download_model(
 
     provider_impl
         .download_model(model_name, cache_dir, ignore_weights)
+        .await
+}
+
+/// Download a model at a specific revision, reporting the revision it resolved to.
+///
+/// A `None` revision downloads the provider's default revision; providers that expose
+/// revisions still report the immutable revision they picked.
+pub async fn download_model_revision(
+    model_name: &str,
+    provider: ModelProvider,
+    cache_dir: Option<PathBuf>,
+    ignore_weights: bool,
+    revision: Option<&str>,
+) -> Result<ModelDownloadOutcome> {
+    let provider_impl = get_provider(provider);
+    match revision {
+        Some(revision) => info!(
+            "Downloading model '{}' at revision '{}' using provider: {}",
+            model_name,
+            revision,
+            provider_impl.provider_name()
+        ),
+        None => info!(
+            "Downloading model '{}' using provider: {}",
+            model_name,
+            provider_impl.provider_name()
+        ),
+    }
+
+    if ignore_weights {
+        warn!("`ignore_weights` is set to true. All the model weight files will be ignored!");
+    }
+
+    provider_impl
+        .download_model_revision(model_name, cache_dir, ignore_weights, revision)
+        .await
+}
+
+/// Resolve a requested revision to the provider's immutable identifier for it.
+pub async fn resolve_revision(
+    model_name: &str,
+    provider: ModelProvider,
+    cache_dir: Option<PathBuf>,
+    revision: Option<&str>,
+) -> Result<Option<String>> {
+    get_provider(provider)
+        .resolve_revision(model_name, cache_dir, revision)
         .await
 }
 

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -217,6 +217,7 @@ impl From<&models::ModelStatusResponse> for grpc::model::ModelStatusUpdate {
             status: grpc::model::ModelStatus::from(response.status) as i32,
             message: None,
             provider: grpc::model::ModelProvider::from(response.provider) as i32,
+            resolved_revision: None,
         }
     }
 }
@@ -351,6 +352,7 @@ mod tests {
             status: grpc::model::ModelStatus::Downloaded as i32,
             message: Some("Test message".to_string()),
             provider: grpc::model::ModelProvider::HuggingFace as i32,
+            resolved_revision: None,
         };
 
         let response: models::ModelStatusResponse = grpc_update.into();

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -4,6 +4,30 @@
 use anyhow::Result;
 use std::path::PathBuf;
 
+/// Result of a model download.
+///
+/// `resolved_revision` is the immutable revision the request resolved to (a commit SHA
+/// for Hugging Face). It is `None` for providers with no revision concept, so callers
+/// can tell "not applicable" apart from "unknown".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelDownloadOutcome {
+    /// Directory the model snapshot was downloaded into.
+    pub path: PathBuf,
+    /// Immutable revision the request resolved to, when the provider has one.
+    pub resolved_revision: Option<String>,
+}
+
+/// Reject a pinned revision for providers that do not support one, so every
+/// unsupported-provider error reads the same.
+pub fn reject_unsupported_revision(provider_name: &str, revision: Option<&str>) -> Result<()> {
+    match revision {
+        Some(revision) => anyhow::bail!(
+            "Provider '{provider_name}' does not support pinned revisions (requested '{revision}')"
+        ),
+        None => Ok(()),
+    }
+}
+
 /// Trait for model providers
 /// This trait provides the framework for supporting multiple model providers.
 #[async_trait::async_trait]
@@ -16,13 +40,76 @@ pub trait ModelProviderTrait: Send + Sync {
         ignore_weights: bool,
     ) -> Result<PathBuf>;
 
+    /// Download a model at a specific revision, reporting the revision it resolved to.
+    ///
+    /// Providers that expose revisions override this and treat [`Self::download_model`]
+    /// as the unpinned special case.
+    async fn download_model_revision(
+        &self,
+        model_name: &str,
+        cache_path: Option<PathBuf>,
+        ignore_weights: bool,
+        revision: Option<&str>,
+    ) -> Result<ModelDownloadOutcome> {
+        reject_unsupported_revision(self.provider_name(), revision)?;
+        let path = self
+            .download_model(model_name, cache_path, ignore_weights)
+            .await?;
+        Ok(ModelDownloadOutcome {
+            path,
+            resolved_revision: None,
+        })
+    }
+
+    /// Resolve a requested branch, tag, or revision identifier to an immutable one.
+    ///
+    /// A `None` request means "the provider's default revision". Providers with a
+    /// revision concept always return `Some`, including for the default revision, so
+    /// callers can pin cache and lease identity to it.
+    ///
+    /// This must never fall back to the default revision when the requested one does
+    /// not exist.
+    async fn resolve_revision(
+        &self,
+        _model_name: &str,
+        _cache_dir: Option<PathBuf>,
+        revision: Option<&str>,
+    ) -> Result<Option<String>> {
+        reject_unsupported_revision(self.provider_name(), revision)?;
+        Ok(None)
+    }
+
     /// Delete a model from the provider's cache
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
     async fn delete_model(&self, model_name: &str, cache_dir: PathBuf) -> Result<()>;
 
+    /// Delete a single revision of a model from the provider's cache.
+    /// A `None` revision deletes everything cached for the model.
+    async fn delete_model_revision(
+        &self,
+        model_name: &str,
+        cache_dir: PathBuf,
+        revision: Option<&str>,
+    ) -> Result<()> {
+        reject_unsupported_revision(self.provider_name(), revision)?;
+        self.delete_model(model_name, cache_dir).await
+    }
+
     /// Get the full path to the latest model snapshot if it exists
     /// Returns the path if found, or an error if not found
     async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf>;
+
+    /// Get the full path to a specific model revision, or to the latest snapshot when no
+    /// revision is requested. Returns an error if the revision is not cached.
+    async fn get_model_path_revision(
+        &self,
+        model_name: &str,
+        cache_dir: PathBuf,
+        revision: Option<&str>,
+    ) -> Result<PathBuf> {
+        reject_unsupported_revision(self.provider_name(), revision)?;
+        self.get_model_path(model_name, cache_dir).await
+    }
 
     /// Return the canonical model name for this provider.
     fn canonical_model_name(&self, model_name: &str) -> Result<String> {

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -87,6 +87,23 @@ pub trait ModelProviderTrait: Send + Sync {
         Ok(None)
     }
 
+    /// Record locally that the caller's `requested_revision` — or the provider's default
+    /// revision when `None` — names `commit`.
+    ///
+    /// A snapshot installed by streaming from the ModelExpress server never went through
+    /// this provider's downloader, so the cache bookkeeping the provider's own tooling
+    /// expects is missing. Providers with a revision concept implement this to complete
+    /// the install; the default is a no-op.
+    async fn record_local_revision(
+        &self,
+        _model_name: &str,
+        _cache_dir: &std::path::Path,
+        _requested_revision: Option<&str>,
+        _commit: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Delete a model from the provider's cache
     /// Returns Ok(()) if the model was successfully deleted or didn't exist
     async fn delete_model(&self, model_name: &str, cache_dir: PathBuf) -> Result<()>;

--- a/modelexpress_common/src/providers.rs
+++ b/modelexpress_common/src/providers.rs
@@ -61,6 +61,14 @@ pub trait ModelProviderTrait: Send + Sync {
         })
     }
 
+    /// Whether this provider has a revision concept at all.
+    ///
+    /// Lets callers reject a pinned revision as a bad request up front, rather than
+    /// discovering it as a resolution failure that reads like a missing revision.
+    fn supports_revisions(&self) -> bool {
+        false
+    }
+
     /// Resolve a requested branch, tag, or revision identifier to an immutable one.
     ///
     /// A `None` request means "the provider's default revision". Providers with a

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -5,7 +5,7 @@ use crate::{
     cache::{ModelInfo, ProviderCache, directory_size},
     constants, envs,
     models::ModelProvider,
-    providers::ModelProviderTrait,
+    providers::{ModelDownloadOutcome, ModelProviderTrait},
 };
 use anyhow::{Context, Result};
 use futures::StreamExt;
@@ -20,6 +20,9 @@ use tracing::{debug, info, warn};
 
 const HF_FALLBACK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const HF_FALLBACK_READ_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Revision used when a caller does not pin one. Matches hf-hub's own default branch.
+const DEFAULT_HF_REVISION: &str = "main";
 
 /// Check if offline mode is enabled via `HF_HUB_OFFLINE`.
 /// See [`crate::envs::hf_offline`] for the accepted truthy values.
@@ -65,6 +68,31 @@ impl HuggingFaceProviderCache {
 
     fn snapshots_dir(cache_root: &Path, model_name: &str) -> PathBuf {
         Self::repo_root(cache_root, model_name).join("snapshots")
+    }
+
+    fn refs_dir(cache_root: &Path, model_name: &str) -> PathBuf {
+        Self::repo_root(cache_root, model_name).join("refs")
+    }
+
+    /// Read the commit a cached `refs/<revision>` entry points at.
+    ///
+    /// Returns `None` when the ref does not exist, so callers can fall back to
+    /// treating the requested revision as a commit SHA.
+    fn read_ref(cache_root: &Path, model_name: &str, revision: &str) -> Option<String> {
+        let ref_path = Self::refs_dir(cache_root, model_name).join(revision);
+        let commit = fs::read_to_string(ref_path).ok()?;
+        let commit = commit.trim();
+        if commit.is_empty() {
+            None
+        } else {
+            Some(commit.to_string())
+        }
+    }
+
+    /// Map a requested revision to the commit that identifies its snapshot directory,
+    /// using only local cache state.
+    fn local_commit_for_revision(cache_root: &Path, model_name: &str, revision: &str) -> String {
+        Self::read_ref(cache_root, model_name, revision).unwrap_or_else(|| revision.to_string())
     }
 
     fn folder_name_to_model_id(folder_name: &str) -> String {
@@ -294,27 +322,107 @@ impl HuggingFaceProvider {
                 ));
             }
         }
-        Cache::new(cache_dir.to_path_buf())
-            .model(model_name.to_string())
-            .create_ref(commit_hash)
-            .with_context(|| {
-                format!("Failed to create Hugging Face cache ref for '{model_name}'")
-            })?;
-
         Ok(pointer_path)
     }
-}
 
-#[async_trait::async_trait]
-impl ModelProviderTrait for HuggingFaceProvider {
-    /// Attempt to download a model from Hugging Face.
-    /// Returns the directory it is in.
-    async fn download_model(
+    /// Point `refs/<revision>` at `commit_hash` so the snapshot stays resolvable by the
+    /// name the caller asked for (a branch, a tag, or the default revision).
+    fn create_revision_ref(
+        cache_dir: &Path,
+        model_name: &str,
+        revision: &str,
+        commit_hash: &str,
+    ) -> Result<()> {
+        Cache::new(cache_dir.to_path_buf())
+            .repo(Repo::with_revision(
+                model_name.to_string(),
+                RepoType::Model,
+                revision.to_string(),
+            ))
+            .create_ref(commit_hash)
+            .with_context(|| {
+                format!("Failed to create Hugging Face cache ref for '{model_name}@{revision}'")
+            })
+    }
+
+    /// Fetch repository metadata for a revision.
+    ///
+    /// A missing branch, tag, or commit surfaces as an error here; we never retry
+    /// against the default revision, so a typo can't silently download the wrong model.
+    async fn repo_info_at_revision(
+        model_name: &str,
+        revision: &str,
+        cache_dir: Option<&Path>,
+    ) -> Result<hf_hub::api::RepoInfo> {
+        let mut builder = ApiBuilder::from_env().with_token(envs::hf_token());
+        if let Some(cache_dir) = cache_dir {
+            builder = builder.with_cache_dir(cache_dir.to_path_buf());
+        }
+        let api = builder.build()?;
+        api.repo(Repo::with_revision(
+            model_name.to_string(),
+            RepoType::Model,
+            revision.to_string(),
+        ))
+        .info()
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to fetch model '{model_name}' at revision '{revision}' from HuggingFace. \
+                 Is this a valid HuggingFace ID and revision? Error: {e}"
+            )
+        })
+    }
+
+    /// Resolve a requested revision against the local cache only.
+    ///
+    /// Used in offline mode and by the file-serving paths, which must not reach out to
+    /// the Hub for a model that is already downloaded.
+    fn resolve_revision_offline(
+        cache_dir: &Path,
+        model_name: &str,
+        revision: Option<&str>,
+    ) -> Result<String> {
+        match revision {
+            Some(revision) => {
+                let commit = HuggingFaceProviderCache::local_commit_for_revision(
+                    cache_dir, model_name, revision,
+                );
+                let snapshot =
+                    HuggingFaceProviderCache::snapshots_dir(cache_dir, model_name).join(&commit);
+                if snapshot.is_dir() {
+                    Ok(commit)
+                } else {
+                    anyhow::bail!(
+                        "Revision '{revision}' of model '{model_name}' is not present in the cache"
+                    )
+                }
+            }
+            None => {
+                let latest =
+                    HuggingFaceProviderCache::latest_local_snapshot_path(cache_dir, model_name)?;
+                latest
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(String::from)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Cached snapshot path for '{model_name}' has no revision component"
+                        )
+                    })
+            }
+        }
+    }
+
+    /// Download every eligible file of `model_name` at `revision`, resolving the request
+    /// to an immutable commit first and fetching every file from that commit.
+    async fn download_at_revision(
         &self,
         model_name: &str,
         cache_dir: Option<PathBuf>,
         ignore_weights: bool,
-    ) -> Result<PathBuf> {
+        revision: Option<&str>,
+    ) -> Result<ModelDownloadOutcome> {
         let cache_dir = get_cache_dir(cache_dir);
         std::fs::create_dir_all(&cache_dir).map_err(|e| {
             anyhow::anyhow!("Failed to create cache directory {:?}: {}", cache_dir, e)
@@ -322,7 +430,13 @@ impl ModelProviderTrait for HuggingFaceProvider {
 
         if is_offline_mode() {
             info!("HF_HUB_OFFLINE is set, using cached model for '{model_name}'");
-            return self.get_model_path(model_name, cache_dir).await;
+            let resolved = Self::resolve_revision_offline(&cache_dir, model_name, revision)?;
+            let path =
+                HuggingFaceProviderCache::snapshots_dir(&cache_dir, model_name).join(&resolved);
+            return Ok(ModelDownloadOutcome {
+                path,
+                resolved_revision: Some(resolved),
+            });
         }
 
         let token = envs::hf_token();
@@ -341,24 +455,36 @@ impl ModelProviderTrait for HuggingFaceProvider {
             .with_cache_dir(cache_dir.clone())
             .build()?;
         let model_name = model_name.to_string();
+        let requested_revision = revision.unwrap_or(DEFAULT_HF_REVISION).to_string();
 
-        let repo = api.model(model_name.clone());
-
-        let info = repo.info().await.map_err(
-            |e| anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace. Is this a valid HuggingFace ID? Error: {e}"),
-        )?;
+        let info = api
+            .repo(Repo::with_revision(
+                model_name.clone(),
+                RepoType::Model,
+                requested_revision.clone(),
+            ))
+            .info()
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to fetch model '{model_name}' at revision '{requested_revision}' from \
+                     HuggingFace. Is this a valid HuggingFace ID and revision? Error: {e}"
+                )
+            })?;
         debug!("Got model info: {info:?}");
 
         if info.siblings.is_empty() {
             anyhow::bail!("Model '{model_name}' exists but contains no downloadable files.");
         }
 
+        // Every file is fetched from the resolved commit rather than from the requested
+        // branch or tag, so a revision that moves mid-download cannot mix commits into
+        // one snapshot.
         let pinned_repo = api.repo(Repo::with_revision(
             model_name.clone(),
             RepoType::Model,
             info.sha.clone(),
         ));
-        let mut p = PathBuf::new();
         let mut files_downloaded = false;
 
         for sib in info.siblings {
@@ -376,8 +502,8 @@ impl ModelProviderTrait for HuggingFaceProvider {
                 continue;
             }
 
-            let path = match repo.get(&sib.rfilename).await {
-                Ok(path) => path,
+            match pinned_repo.get(&sib.rfilename).await {
+                Ok(_) => {}
                 Err(e) if HuggingFaceProvider::is_missing_content_range_error(&e) => {
                     // hf-hub requires Content-Range for its size probe. Some HF mirrors return a
                     // complete 200 OK body instead, so retry this file without Range headers.
@@ -401,7 +527,7 @@ impl ModelProviderTrait for HuggingFaceProvider {
                             model_name = model_name,
                             e = e
                         )
-                    })?
+                    })?;
                 }
                 Err(e) => {
                     // HTTP 416 (Range Not Satisfiable) occurs for empty files (0 bytes)
@@ -422,9 +548,8 @@ impl ModelProviderTrait for HuggingFaceProvider {
                         e = e
                     ));
                 }
-            };
+            }
 
-            p = path;
             files_downloaded = true;
         }
 
@@ -435,12 +560,75 @@ impl ModelProviderTrait for HuggingFaceProvider {
             ));
         }
 
-        info!("Downloaded model files for {model_name}");
+        HuggingFaceProvider::create_revision_ref(
+            &cache_dir,
+            &model_name,
+            &requested_revision,
+            &info.sha,
+        )?;
 
-        match p.parent() {
-            Some(p) => Ok(p.to_path_buf()),
-            None => Err(anyhow::anyhow!("Invalid HF cache path: {}", p.display())),
+        info!(
+            "Downloaded model files for {model_name} at revision {}",
+            info.sha
+        );
+
+        Ok(ModelDownloadOutcome {
+            path: HuggingFaceProviderCache::snapshots_dir(&cache_dir, &model_name).join(&info.sha),
+            resolved_revision: Some(info.sha),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl ModelProviderTrait for HuggingFaceProvider {
+    /// Attempt to download a model from Hugging Face at its default revision.
+    /// Returns the directory it is in.
+    async fn download_model(
+        &self,
+        model_name: &str,
+        cache_dir: Option<PathBuf>,
+        ignore_weights: bool,
+    ) -> Result<PathBuf> {
+        self.download_at_revision(model_name, cache_dir, ignore_weights, None)
+            .await
+            .map(|outcome| outcome.path)
+    }
+
+    async fn download_model_revision(
+        &self,
+        model_name: &str,
+        cache_dir: Option<PathBuf>,
+        ignore_weights: bool,
+        revision: Option<&str>,
+    ) -> Result<ModelDownloadOutcome> {
+        self.download_at_revision(model_name, cache_dir, ignore_weights, revision)
+            .await
+    }
+
+    /// Resolve a branch, tag, or commit SHA to the immutable commit SHA it names.
+    ///
+    /// Offline, this only consults the local cache; a revision that is not cached is an
+    /// error rather than a fall back to whatever snapshot happens to be newest.
+    async fn resolve_revision(
+        &self,
+        model_name: &str,
+        cache_dir: Option<PathBuf>,
+        revision: Option<&str>,
+    ) -> Result<Option<String>> {
+        let cache_dir = get_cache_dir(cache_dir);
+
+        if is_offline_mode() {
+            return Self::resolve_revision_offline(&cache_dir, model_name, revision).map(Some);
         }
+
+        let info = Self::repo_info_at_revision(
+            model_name,
+            revision.unwrap_or(DEFAULT_HF_REVISION),
+            Some(&cache_dir),
+        )
+        .await?;
+
+        Ok(Some(info.sha))
     }
 
     /// Attempt to delete a model from Hugging Face cache
@@ -543,6 +731,63 @@ impl ModelProviderTrait for HuggingFaceProvider {
         Ok(())
     }
 
+    /// Delete a single cached revision, leaving the model's other revisions intact.
+    ///
+    /// Once the last snapshot is gone the whole repository directory is removed, which
+    /// also reclaims the blobs the snapshots pointed at.
+    async fn delete_model_revision(
+        &self,
+        model_name: &str,
+        cache_dir: PathBuf,
+        revision: Option<&str>,
+    ) -> Result<()> {
+        let Some(revision) = revision else {
+            return self.delete_model(model_name, cache_dir).await;
+        };
+
+        let commit =
+            HuggingFaceProviderCache::local_commit_for_revision(&cache_dir, model_name, revision);
+        let snapshot =
+            HuggingFaceProviderCache::snapshots_dir(&cache_dir, model_name).join(&commit);
+
+        if snapshot.exists() {
+            fs::remove_dir_all(&snapshot)
+                .with_context(|| format!("Failed to remove snapshot {}", snapshot.display()))?;
+            info!("Deleted snapshot {} for model '{model_name}'", commit);
+        } else {
+            info!("Snapshot {commit} for model '{model_name}' is not cached");
+        }
+
+        // Drop refs that named the removed snapshot so a later lookup cannot resolve a
+        // branch or tag to a directory that no longer exists.
+        let refs_dir = HuggingFaceProviderCache::refs_dir(&cache_dir, model_name);
+        if let Ok(entries) = fs::read_dir(&refs_dir) {
+            for entry in entries.filter_map(Result::ok) {
+                let path = entry.path();
+                if path.is_file()
+                    && fs::read_to_string(&path).is_ok_and(|target| target.trim() == commit)
+                    && let Err(e) = fs::remove_file(&path)
+                {
+                    warn!("Failed to remove stale ref {}: {e}", path.display());
+                }
+            }
+        }
+
+        let snapshots_dir = HuggingFaceProviderCache::snapshots_dir(&cache_dir, model_name);
+        let no_snapshots_left = fs::read_dir(&snapshots_dir)
+            .map(|mut entries| entries.next().is_none())
+            .unwrap_or(false);
+        if no_snapshots_left {
+            let repo_root = HuggingFaceProviderCache::repo_root(&cache_dir, model_name);
+            fs::remove_dir_all(&repo_root).with_context(|| {
+                format!("Failed to remove empty repository {}", repo_root.display())
+            })?;
+            info!("Removed empty repository directory for model '{model_name}'");
+        }
+
+        Ok(())
+    }
+
     /// Get the full path to the latest model snapshot if it exists.
     /// Returns the path if found, or an error if not found.
     async fn get_model_path(&self, model_name: &str, cache_dir: PathBuf) -> Result<PathBuf> {
@@ -575,6 +820,24 @@ impl ModelProviderTrait for HuggingFaceProvider {
         );
 
         Ok(latest_local_snapshot)
+    }
+
+    /// Resolve a cached snapshot directory without contacting the Hub.
+    ///
+    /// The file-serving paths use this: the model is already downloaded, so a requested
+    /// revision either has a snapshot on disk or the request is not serviceable.
+    async fn get_model_path_revision(
+        &self,
+        model_name: &str,
+        cache_dir: PathBuf,
+        revision: Option<&str>,
+    ) -> Result<PathBuf> {
+        let Some(revision) = revision else {
+            return self.get_model_path(model_name, cache_dir).await;
+        };
+
+        let commit = Self::resolve_revision_offline(&cache_dir, model_name, Some(revision))?;
+        Ok(HuggingFaceProviderCache::snapshots_dir(&cache_dir, model_name).join(commit))
     }
 
     fn provider_name(&self) -> &'static str {
@@ -725,18 +988,14 @@ mod tests {
             .mount(&server)
             .await;
 
+        // Downloads are pinned to the resolved commit, so both hf-hub's range probe and
+        // the full-body fallback hit the commit-pinned URL. A request against the branch
+        // would mean a file could come from a commit other than the one we report.
         Mock::given(method("GET"))
             .and(path_regex(r"^/test/model/resolve/main/LICENSE$"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("etag", "\"license-etag\"")
-                    .insert_header("x-repo-commit", "def5678")
-                    .insert_header("accept-ranges", "bytes")
-                    .insert_header("content-length", file_contents.len().to_string())
-                    .set_body_bytes(file_contents.to_vec()),
-            )
-            .expect(1)
-            .named("hf-hub range probe without content-range")
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .named("branch-resolved download must not happen")
             .mount(&server)
             .await;
 
@@ -750,8 +1009,8 @@ mod tests {
                     .insert_header("content-length", file_contents.len().to_string())
                     .set_body_bytes(file_contents.to_vec()),
             )
-            .expect(1)
-            .named("commit-pinned full-body fallback")
+            .expect(2)
+            .named("commit-pinned range probe, then full-body fallback")
             .mount(&server)
             .await;
 
@@ -1078,6 +1337,299 @@ mod tests {
                 .expect_err("Expected error")
                 .to_string()
                 .contains("not found in cache")
+        );
+    }
+
+    /// Stub the revision-metadata endpoint hf-hub queries for `revision`, reporting
+    /// `sha` as the commit that revision currently points at.
+    async fn mock_revision_info(server: &MockServer, revision: &str, sha: &str) {
+        Mock::given(method("GET"))
+            .and(path_regex(format!(
+                r"^/api/models/test/model/revision/{revision}$"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "test/model",
+                "sha": sha,
+                "siblings": [{"rfilename": "config.json"}]
+            })))
+            .mount(server)
+            .await;
+    }
+
+    /// Stub `config.json` under one specific revision path.
+    async fn mock_revision_file(server: &MockServer, revision: &str, sha: &str) {
+        Mock::given(method("GET"))
+            .and(path_regex(format!(
+                r"^/test/model/resolve/{revision}/config\.json$"
+            )))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .insert_header("etag", format!("\"{sha}\""))
+                    .insert_header("x-repo-commit", sha)
+                    .insert_header("accept-ranges", "bytes")
+                    .insert_header("content-length", "64")
+                    .insert_header("content-range", "bytes 0-63/64")
+                    .set_body_bytes(vec![0u8; 64]),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_download_at_explicit_commit_produces_that_snapshot() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let server = MockServer::start().await;
+
+        mock_revision_info(&server, "abc9999", "abc9999").await;
+        mock_revision_file(&server, "abc9999", "abc9999").await;
+
+        let _hf_endpoint_guard =
+            EnvVarGuard::set(&env_lock, crate::envs::HF_ENDPOINT, &server.uri());
+
+        let outcome = HuggingFaceProvider
+            .download_model_revision(
+                "test/model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                Some("abc9999"),
+            )
+            .await
+            .expect("Pinned download should succeed");
+
+        assert_eq!(outcome.resolved_revision.as_deref(), Some("abc9999"));
+        assert_eq!(
+            outcome.path,
+            temp_dir
+                .path()
+                .join("models--test--model/snapshots/abc9999")
+        );
+        assert!(outcome.path.join("config.json").exists());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_download_at_tag_fetches_every_file_from_the_resolved_commit() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let server = MockServer::start().await;
+
+        mock_revision_info(&server, "v1.0", "def5678").await;
+        mock_revision_file(&server, "def5678", "def5678").await;
+
+        // A tag can move between the metadata lookup and the file fetch, so downloading
+        // through the tag would risk mixing commits into one snapshot.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/test/model/resolve/v1\.0/config\.json$"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .named("tag-resolved download must not happen")
+            .mount(&server)
+            .await;
+
+        let _hf_endpoint_guard =
+            EnvVarGuard::set(&env_lock, crate::envs::HF_ENDPOINT, &server.uri());
+
+        let outcome = HuggingFaceProvider
+            .download_model_revision(
+                "test/model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                Some("v1.0"),
+            )
+            .await
+            .expect("Tag download should succeed");
+
+        assert_eq!(outcome.resolved_revision.as_deref(), Some("def5678"));
+        assert!(outcome.path.ends_with("snapshots/def5678"));
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("models--test--model/refs/v1.0"))
+                .expect("Expected the tag ref to point at the resolved commit"),
+            "def5678"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_unpinned_download_reports_the_default_revision_commit() {
+        let env_lock = acquire_env_mutex();
+        let mock_server = MockHFServer::new(&env_lock).await;
+
+        let outcome = HuggingFaceProvider
+            .download_model_revision(
+                "test/model",
+                Some(mock_server.cache_path.clone()),
+                false,
+                None,
+            )
+            .await
+            .expect("Unpinned download should succeed");
+
+        assert_eq!(outcome.resolved_revision.as_deref(), Some("def5678"));
+        assert!(outcome.path.ends_with("snapshots/def5678"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_missing_revision_fails_without_falling_back_to_the_default() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/api/models/test/model/revision/no-such-tag$"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        // The default revision resolves fine. Falling back to it would quietly hand the
+        // caller a different model than the one they pinned.
+        mock_revision_info(&server, "main", "def5678").await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/test/model/resolve/[^/]+/config\.json$"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .named("no file may be downloaded for a missing revision")
+            .mount(&server)
+            .await;
+
+        let _hf_endpoint_guard =
+            EnvVarGuard::set(&env_lock, crate::envs::HF_ENDPOINT, &server.uri());
+
+        let error = HuggingFaceProvider
+            .download_model_revision(
+                "test/model",
+                Some(temp_dir.path().to_path_buf()),
+                false,
+                Some("no-such-tag"),
+            )
+            .await
+            .expect_err("A missing revision must fail");
+
+        assert!(
+            error.to_string().contains("no-such-tag"),
+            "Error should name the requested revision, got: {error}"
+        );
+        assert!(
+            !temp_dir
+                .path()
+                .join("models--test--model/snapshots/def5678")
+                .exists(),
+            "The default revision must not have been downloaded"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_resolve_revision_offline_uses_refs_then_snapshot_directories() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let repo_root = temp_dir.path().join("models--test--model");
+        std::fs::create_dir_all(repo_root.join("snapshots/abc1234"))
+            .expect("Failed to create snapshot");
+        std::fs::create_dir_all(repo_root.join("refs")).expect("Failed to create refs");
+        std::fs::write(repo_root.join("refs/main"), "abc1234").expect("Failed to write ref");
+
+        let _offline_guard = EnvVarGuard::set(&env_lock, crate::envs::HF_HUB_OFFLINE, "1");
+        let cache_dir = Some(temp_dir.path().to_path_buf());
+        let provider = HuggingFaceProvider;
+
+        for revision in [None, Some("main"), Some("abc1234")] {
+            let resolved = provider
+                .resolve_revision("test/model", cache_dir.clone(), revision)
+                .await
+                .unwrap_or_else(|e| panic!("Expected {revision:?} to resolve offline: {e}"));
+            assert_eq!(resolved.as_deref(), Some("abc1234"));
+        }
+
+        assert!(
+            provider
+                .resolve_revision("test/model", cache_dir, Some("not-cached"))
+                .await
+                .is_err(),
+            "An uncached revision must not resolve to the newest local snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_model_revision_keeps_the_other_snapshots() {
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let repo_root = temp_dir.path().join("models--test--model");
+        for commit in ["abc1234", "def5678"] {
+            std::fs::create_dir_all(repo_root.join("snapshots").join(commit))
+                .expect("Failed to create snapshot");
+            std::fs::write(
+                repo_root.join("snapshots").join(commit).join("config.json"),
+                b"{}",
+            )
+            .expect("Failed to write config");
+        }
+        std::fs::create_dir_all(repo_root.join("refs")).expect("Failed to create refs");
+        std::fs::write(repo_root.join("refs/main"), "abc1234").expect("Failed to write ref");
+
+        let provider = HuggingFaceProvider;
+        provider
+            .delete_model_revision("test/model", temp_dir.path().to_path_buf(), Some("main"))
+            .await
+            .expect("Deleting one revision should succeed");
+
+        assert!(!repo_root.join("snapshots/abc1234").exists());
+        assert!(!repo_root.join("refs/main").exists());
+        assert!(repo_root.join("snapshots/def5678/config.json").exists());
+
+        provider
+            .delete_model_revision("test/model", temp_dir.path().to_path_buf(), Some("def5678"))
+            .await
+            .expect("Deleting the last revision should succeed");
+
+        assert!(
+            !repo_root.exists(),
+            "The repository directory should be removed once its last snapshot is gone"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_get_model_path_revision_never_reaches_the_hub() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let server = MockServer::start().await;
+
+        // Any request at all fails the test: serving an already-downloaded snapshot must
+        // not depend on the Hub being reachable.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/.*$"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .named("resolving a cached snapshot must not call the Hub")
+            .mount(&server)
+            .await;
+
+        let repo_root = temp_dir.path().join("models--test--model");
+        std::fs::create_dir_all(repo_root.join("snapshots/abc1234"))
+            .expect("Failed to create snapshot");
+
+        let _hf_endpoint_guard =
+            EnvVarGuard::set(&env_lock, crate::envs::HF_ENDPOINT, &server.uri());
+
+        let provider = HuggingFaceProvider;
+        let path = provider
+            .get_model_path_revision("test/model", temp_dir.path().to_path_buf(), Some("abc1234"))
+            .await
+            .expect("A cached revision should resolve");
+        assert_eq!(path, repo_root.join("snapshots/abc1234"));
+
+        assert!(
+            provider
+                .get_model_path_revision(
+                    "test/model",
+                    temp_dir.path().to_path_buf(),
+                    Some("missing")
+                )
+                .await
+                .is_err(),
+            "An uncached revision must not resolve"
         );
     }
 }

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -345,6 +345,52 @@ impl HuggingFaceProvider {
             })
     }
 
+    /// Delete blobs that no surviving snapshot references.
+    ///
+    /// Snapshot entries are symlinks into the repository's `blobs/` directory, so
+    /// deleting a snapshot removes the links but leaves the bytes behind. Without this,
+    /// evicting one revision of a multi-revision model reclaims essentially no disk.
+    ///
+    /// Best effort: a blob we cannot classify is kept. Leaking disk is recoverable,
+    /// deleting a blob another snapshot still points at is not.
+    fn reclaim_unreferenced_blobs(cache_dir: &Path, model_name: &str) {
+        let blobs_dir = HuggingFaceProviderCache::repo_root(cache_dir, model_name).join("blobs");
+        let Ok(blobs) = fs::read_dir(&blobs_dir) else {
+            return;
+        };
+
+        let mut referenced = HashSet::new();
+        let snapshots_dir = HuggingFaceProviderCache::snapshots_dir(cache_dir, model_name);
+        let Ok(snapshots) = fs::read_dir(&snapshots_dir) else {
+            // No snapshot directory to walk means we cannot prove a blob is unused.
+            return;
+        };
+        for snapshot in snapshots.filter_map(Result::ok) {
+            let Ok(entries) = fs::read_dir(snapshot.path()) else {
+                // An unreadable snapshot may reference anything, so keep every blob.
+                return;
+            };
+            for entry in entries.filter_map(Result::ok) {
+                if let Ok(target) = fs::canonicalize(entry.path()) {
+                    referenced.insert(target);
+                }
+            }
+        }
+
+        for blob in blobs.filter_map(Result::ok) {
+            let path = blob.path();
+            let is_unreferenced = fs::canonicalize(&path)
+                .map(|canonical| !referenced.contains(&canonical))
+                .unwrap_or(false);
+            if is_unreferenced {
+                match fs::remove_file(&path) {
+                    Ok(()) => debug!("Reclaimed unreferenced blob {}", path.display()),
+                    Err(e) => warn!("Failed to reclaim blob {}: {e}", path.display()),
+                }
+            }
+        }
+    }
+
     /// Fetch repository metadata for a revision.
     ///
     /// A missing branch, tag, or commit surfaces as an error here; we never retry
@@ -742,7 +788,12 @@ impl ModelProviderTrait for HuggingFaceProvider {
         revision: Option<&str>,
     ) -> Result<()> {
         let Some(revision) = revision else {
-            return self.delete_model(model_name, cache_dir).await;
+            // Remove the repository directory outright rather than going through
+            // `delete_model`, which enumerates the repo's files from the Hub and so
+            // frees nothing when the Hub is unreachable. Cache eviction has to reclaim
+            // disk without depending on the network, and dropping the directory also
+            // takes the blobs and refs that a file-by-file delete leaves behind.
+            return HuggingFaceProviderCache.clear_model(&cache_dir, model_name);
         };
 
         let commit =
@@ -783,6 +834,10 @@ impl ModelProviderTrait for HuggingFaceProvider {
                 format!("Failed to remove empty repository {}", repo_root.display())
             })?;
             info!("Removed empty repository directory for model '{model_name}'");
+        } else {
+            // Snapshot entries are symlinks into `blobs/`, so removing a snapshot frees
+            // almost none of its bytes. Reclaim the blobs no surviving snapshot points at.
+            HuggingFaceProvider::reclaim_unreferenced_blobs(&cache_dir, model_name);
         }
 
         Ok(())
@@ -873,6 +928,8 @@ mod tests {
     use super::*;
     use crate::test_support::{EnvVarGuard, acquire_env_mutex};
     use serde_json::json;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
     use std::sync::MutexGuard;
     use tempfile::TempDir;
     use tokio::time::Duration;
@@ -1608,6 +1665,67 @@ mod tests {
         assert!(
             !repo_root.exists(),
             "The repository directory should be removed once its last snapshot is gone"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_delete_model_revision_reclaims_only_unreferenced_blobs() {
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let repo_root = temp_dir.path().join("models--test--model");
+        let blobs = repo_root.join("blobs");
+        std::fs::create_dir_all(&blobs).expect("Failed to create blobs");
+
+        // `shared` is linked from both snapshots, `only-old` from just the one we delete.
+        for blob in ["shared", "only-old"] {
+            std::fs::write(blobs.join(blob), vec![0u8; 32]).expect("Failed to write blob");
+        }
+        for (commit, blob_names) in [
+            ("abc1234", vec!["shared", "only-old"]),
+            ("def5678", vec!["shared"]),
+        ] {
+            let snapshot = repo_root.join("snapshots").join(commit);
+            std::fs::create_dir_all(&snapshot).expect("Failed to create snapshot");
+            for blob in blob_names {
+                symlink(blobs.join(blob), snapshot.join(blob)).expect("Failed to link blob");
+            }
+        }
+
+        HuggingFaceProvider
+            .delete_model_revision("test/model", temp_dir.path().to_path_buf(), Some("abc1234"))
+            .await
+            .expect("Deleting one revision should succeed");
+
+        assert!(
+            blobs.join("shared").exists(),
+            "A blob the surviving snapshot links to must be kept"
+        );
+        assert!(
+            !blobs.join("only-old").exists(),
+            "A blob no snapshot links to any more must be reclaimed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_model_revision_without_a_revision_is_local_only() {
+        // Eviction has to reclaim disk without the Hub being reachable, so the
+        // delete-everything path must not enumerate files from the API.
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let repo_root = temp_dir.path().join("models--test--model");
+        let snapshot = repo_root.join("snapshots/abc1234");
+        std::fs::create_dir_all(&snapshot).expect("Failed to create snapshot");
+        std::fs::write(snapshot.join("config.json"), b"{}").expect("Failed to write config");
+        std::fs::create_dir_all(repo_root.join("blobs")).expect("Failed to create blobs");
+        std::fs::write(repo_root.join("blobs/blob1"), vec![0u8; 32]).expect("Failed to write blob");
+
+        HuggingFaceProvider
+            .delete_model_revision("test/model", temp_dir.path().to_path_buf(), None)
+            .await
+            .expect("Deleting the whole model should succeed");
+
+        assert!(
+            !repo_root.exists(),
+            "The repository directory should be gone"
         );
     }
 

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -840,6 +840,10 @@ impl ModelProviderTrait for HuggingFaceProvider {
         Ok(HuggingFaceProviderCache::snapshots_dir(&cache_dir, model_name).join(commit))
     }
 
+    fn supports_revisions(&self) -> bool {
+        true
+    }
+
     fn provider_name(&self) -> &'static str {
         "Hugging Face"
     }

--- a/modelexpress_common/src/providers/huggingface.rs
+++ b/modelexpress_common/src/providers/huggingface.rs
@@ -844,6 +844,24 @@ impl ModelProviderTrait for HuggingFaceProvider {
         true
     }
 
+    /// Write `refs/<revision>` for a snapshot that was installed by streaming rather
+    /// than downloaded through hf-hub, so `huggingface_hub` can resolve the snapshot by
+    /// branch or tag name — including with `HF_HUB_OFFLINE=1`.
+    async fn record_local_revision(
+        &self,
+        model_name: &str,
+        cache_dir: &Path,
+        requested_revision: Option<&str>,
+        commit: &str,
+    ) -> Result<()> {
+        Self::create_revision_ref(
+            cache_dir,
+            model_name,
+            requested_revision.unwrap_or(DEFAULT_HF_REVISION),
+            commit,
+        )
+    }
+
     fn provider_name(&self) -> &'static str {
         "Hugging Face"
     }

--- a/modelexpress_server/src/cache.rs
+++ b/modelexpress_server/src/cache.rs
@@ -364,13 +364,21 @@ impl CacheEvictionService {
         // Several entries can share one snapshot on disk — a metadata-only download and
         // a full-weight one of the same revision, for instance. Only remove the files
         // once the last entry referencing them goes away.
+        //
+        // An entry with no revision covers every snapshot of its model, so it shares
+        // files with all of them. That is how a record written before revisions existed
+        // behaves: evicting it must not delete the snapshot a revision-scoped entry is
+        // still using.
         let siblings = self.registry.get_models_by_last_used(None).await?;
         let snapshot_still_referenced = siblings.iter().any(|sibling| {
             if sibling.model_name == entry_key {
                 return false;
             }
             let other = EntryKey::parse(&sibling.model_name);
-            other.model_name == key.model_name && other.revision == key.revision
+            other.model_name == key.model_name
+                && (other.revision == key.revision
+                    || other.revision.is_none()
+                    || key.revision.is_none())
         });
 
         // Delete files from disk first. If this fails, we keep the registry record
@@ -725,5 +733,76 @@ mod tests {
         assert_eq!(stats.downloaded_models, 1);
         assert_eq!(stats.downloading_models, 1);
         assert_eq!(stats.error_models, 1);
+    }
+
+    fn downloaded_record(model_name: &str) -> ModelRecord {
+        let now = Utc::now();
+        ModelRecord {
+            model_name: model_name.to_string(),
+            provider: ModelProvider::HuggingFace,
+            status: ModelStatus::DOWNLOADED,
+            created_at: now,
+            last_used_at: now,
+            message: None,
+        }
+    }
+
+    /// Evict `entry_key` with `siblings` also in the registry, and report whether the
+    /// snapshot survived on disk.
+    async fn evict_and_report_files_kept(entry_key: &str, siblings: Vec<&'static str>) -> bool {
+        let evicted = entry_key.to_string();
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_get_model_record()
+            .once()
+            .returning(move |name| Ok(Some(downloaded_record(name))));
+        mock.expect_get_models_by_last_used()
+            .once()
+            .returning(move |_| {
+                let mut records = vec![downloaded_record(&evicted)];
+                records.extend(siblings.iter().map(|name| downloaded_record(name)));
+                Ok(records)
+            });
+        mock.expect_delete_model().once().returning(|_| Ok(()));
+
+        let (service, cache_dir) = service_with_mock(mock, CacheEvictionConfig::default());
+        let snapshot = cache_dir
+            .path()
+            .join("models--test--model/snapshots/abc123");
+        std::fs::create_dir_all(&snapshot).expect("Failed to create snapshot");
+        std::fs::write(snapshot.join("config.json"), b"{}").expect("Failed to write config");
+
+        service.evict_model(entry_key).await.expect("evict");
+        snapshot.exists()
+    }
+
+    #[tokio::test]
+    async fn test_evict_removes_the_snapshot_when_nothing_else_references_it() {
+        assert!(!evict_and_report_files_kept("test/model@rev:abc123", vec![]).await);
+    }
+
+    #[tokio::test]
+    async fn test_evict_keeps_files_shared_with_the_metadata_only_entry() {
+        assert!(
+            evict_and_report_files_kept(
+                "test/model@rev:abc123",
+                vec!["test/model@rev:abc123#metadata"]
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_evict_keeps_files_a_revision_scoped_entry_still_uses() {
+        // A pre-revision record covers every snapshot of its model, so evicting it must
+        // not delete the snapshot a revision-scoped entry points at.
+        assert!(evict_and_report_files_kept("test/model", vec!["test/model@rev:abc123"]).await);
+    }
+
+    #[tokio::test]
+    async fn test_evict_ignores_other_revisions_of_the_same_model() {
+        assert!(
+            !evict_and_report_files_kept("test/model@rev:abc123", vec!["test/model@rev:def456"])
+                .await
+        );
     }
 }

--- a/modelexpress_server/src/cache.rs
+++ b/modelexpress_server/src/cache.rs
@@ -361,40 +361,44 @@ impl CacheEvictionService {
 
         let key = EntryKey::parse(entry_key);
 
-        // Several entries can share one snapshot on disk — a metadata-only download and
-        // a full-weight one of the same revision, for instance. Only remove the files
-        // once the last entry referencing them goes away.
-        //
+        // Entries that outlive this one and belong to the same model. Which files we can
+        // delete depends entirely on what they still reference.
+        let siblings = self.registry.get_models_by_last_used(None).await?;
+        let survivors: Vec<EntryKey> = siblings
+            .iter()
+            .filter(|sibling| sibling.model_name != entry_key)
+            .map(|sibling| EntryKey::parse(&sibling.model_name))
+            .filter(|other| other.model_name == key.model_name)
+            .collect();
+
         // An entry with no revision covers every snapshot of its model, so it shares
         // files with all of them. That is how a record written before revisions existed
-        // behaves: evicting it must not delete the snapshot a revision-scoped entry is
-        // still using.
-        let siblings = self.registry.get_models_by_last_used(None).await?;
-        let snapshot_still_referenced = siblings.iter().any(|sibling| {
-            if sibling.model_name == entry_key {
-                return false;
-            }
-            let other = EntryKey::parse(&sibling.model_name);
-            other.model_name == key.model_name
-                && (other.revision == key.revision
-                    || other.revision.is_none()
-                    || key.revision.is_none())
+        // behaves: evicting it must not delete a snapshot a revision-scoped entry uses,
+        // and a revision-scoped evict must not delete files the legacy entry covers.
+        let snapshot_still_referenced = survivors.iter().any(|other| {
+            other.revision == key.revision || other.revision.is_none() || key.revision.is_none()
         });
 
         // Delete files from disk first. If this fails, we keep the registry record
         // so the next eviction cycle can retry.
-        if snapshot_still_referenced {
+        let delete_revision = if survivors.is_empty() {
+            // Nothing else references this model. Drop the whole cache entry rather than
+            // just this revision, so snapshots left behind by an earlier shared-file
+            // decision cannot outlive the last record pointing at them.
+            Some(None)
+        } else if snapshot_still_referenced {
             debug!(
                 "Keeping files for '{entry_key}': another registry entry still references \
                  the same snapshot"
             );
+            None
         } else {
+            Some(key.revision.as_deref())
+        };
+
+        if let Some(revision) = delete_revision {
             get_provider(record.provider)
-                .delete_model_revision(
-                    &key.model_name,
-                    self.cache_directory.clone(),
-                    key.revision.as_deref(),
-                )
+                .delete_model_revision(&key.model_name, self.cache_directory.clone(), revision)
                 .await
                 .map_err(|e| format!("failed to delete model files for '{entry_key}': {e}"))?;
         }
@@ -747,9 +751,16 @@ mod tests {
         }
     }
 
-    /// Evict `entry_key` with `siblings` also in the registry, and report whether the
-    /// snapshot survived on disk.
-    async fn evict_and_report_files_kept(entry_key: &str, siblings: Vec<&'static str>) -> bool {
+    fn key(revision: Option<&str>, metadata_only: bool) -> String {
+        EntryKey::new("test/model", revision.map(String::from), metadata_only).to_string()
+    }
+
+    /// Which snapshots of `test/model` survive evicting `entry_key` while `siblings`
+    /// remain in the registry. Two snapshots exist on disk: `abc123` and `def456`.
+    async fn evict_and_report_surviving_snapshots(
+        entry_key: &str,
+        siblings: Vec<String>,
+    ) -> Vec<String> {
         let evicted = entry_key.to_string();
         let mut mock = MockRegistryBackend::new();
         mock.expect_get_model_record()
@@ -765,29 +776,48 @@ mod tests {
         mock.expect_delete_model().once().returning(|_| Ok(()));
 
         let (service, cache_dir) = service_with_mock(mock, CacheEvictionConfig::default());
-        let snapshot = cache_dir
-            .path()
-            .join("models--test--model/snapshots/abc123");
-        std::fs::create_dir_all(&snapshot).expect("Failed to create snapshot");
-        std::fs::write(snapshot.join("config.json"), b"{}").expect("Failed to write config");
+        let snapshots_dir = cache_dir.path().join("models--test--model/snapshots");
+        for commit in ["abc123", "def456"] {
+            let snapshot = snapshots_dir.join(commit);
+            std::fs::create_dir_all(&snapshot).expect("Failed to create snapshot");
+            std::fs::write(snapshot.join("config.json"), b"{}").expect("Failed to write config");
+        }
 
         service.evict_model(entry_key).await.expect("evict");
-        snapshot.exists()
+
+        let mut surviving: Vec<String> = std::fs::read_dir(&snapshots_dir)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .map(|entry| entry.file_name().to_string_lossy().to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        surviving.sort();
+        surviving
     }
 
     #[tokio::test]
-    async fn test_evict_removes_the_snapshot_when_nothing_else_references_it() {
-        assert!(!evict_and_report_files_kept("test/model@rev:abc123", vec![]).await);
+    async fn test_evict_removes_only_its_own_snapshot() {
+        assert_eq!(
+            evict_and_report_surviving_snapshots(
+                &key(Some("abc123"), false),
+                vec![key(Some("def456"), false)]
+            )
+            .await,
+            vec!["def456".to_string()]
+        );
     }
 
     #[tokio::test]
     async fn test_evict_keeps_files_shared_with_the_metadata_only_entry() {
-        assert!(
-            evict_and_report_files_kept(
-                "test/model@rev:abc123",
-                vec!["test/model@rev:abc123#metadata"]
+        assert_eq!(
+            evict_and_report_surviving_snapshots(
+                &key(Some("abc123"), false),
+                vec![key(Some("abc123"), true), key(Some("def456"), false)]
             )
-            .await
+            .await,
+            vec!["abc123".to_string(), "def456".to_string()]
         );
     }
 
@@ -795,14 +825,21 @@ mod tests {
     async fn test_evict_keeps_files_a_revision_scoped_entry_still_uses() {
         // A pre-revision record covers every snapshot of its model, so evicting it must
         // not delete the snapshot a revision-scoped entry points at.
-        assert!(evict_and_report_files_kept("test/model", vec!["test/model@rev:abc123"]).await);
+        assert_eq!(
+            evict_and_report_surviving_snapshots("test/model", vec![key(Some("abc123"), false)])
+                .await,
+            vec!["abc123".to_string(), "def456".to_string()]
+        );
     }
 
     #[tokio::test]
-    async fn test_evict_ignores_other_revisions_of_the_same_model() {
+    async fn test_evict_of_the_last_entry_removes_every_snapshot() {
+        // Otherwise a snapshot kept alive by an earlier shared-file decision would
+        // outlive the last record that pointed at it, and never be reclaimed.
         assert!(
-            !evict_and_report_files_kept("test/model@rev:abc123", vec!["test/model@rev:def456"])
+            evict_and_report_surviving_snapshots(&key(Some("abc123"), false), vec![])
                 .await
+                .is_empty()
         );
     }
 }

--- a/modelexpress_server/src/cache.rs
+++ b/modelexpress_server/src/cache.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::registry::backend::ModelRecord;
+use crate::registry::entry_key::EntryKey;
 use crate::registry::state::RegistryManager;
 use modelexpress_common::config::DurationConfig;
 use modelexpress_common::download::get_provider;
@@ -343,28 +344,55 @@ impl CacheEvictionService {
         Ok(result)
     }
 
-    /// Evict a single model (remove from filesystem, then from database)
+    /// Evict a single entry (remove from filesystem, then from the registry).
+    ///
+    /// `entry_key` is a registry key, so it has to be parsed back into the model name
+    /// and revision the provider needs in order to delete the right snapshot.
     async fn evict_model(
         &self,
-        model_name: &str,
+        entry_key: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Look up the model record to determine the provider
         let record = self
             .registry
-            .get_model_record(model_name)
+            .get_model_record(entry_key)
             .await?
-            .ok_or_else(|| format!("model '{model_name}' not found in registry"))?;
+            .ok_or_else(|| format!("model '{entry_key}' not found in registry"))?;
+
+        let key = EntryKey::parse(entry_key);
+
+        // Several entries can share one snapshot on disk — a metadata-only download and
+        // a full-weight one of the same revision, for instance. Only remove the files
+        // once the last entry referencing them goes away.
+        let siblings = self.registry.get_models_by_last_used(None).await?;
+        let snapshot_still_referenced = siblings.iter().any(|sibling| {
+            if sibling.model_name == entry_key {
+                return false;
+            }
+            let other = EntryKey::parse(&sibling.model_name);
+            other.model_name == key.model_name && other.revision == key.revision
+        });
 
         // Delete files from disk first. If this fails, we keep the registry record
         // so the next eviction cycle can retry.
-        let provider = get_provider(record.provider);
-        provider
-            .delete_model(model_name, self.cache_directory.clone())
-            .await
-            .map_err(|e| format!("failed to delete model files for '{model_name}': {e}"))?;
+        if snapshot_still_referenced {
+            debug!(
+                "Keeping files for '{entry_key}': another registry entry still references \
+                 the same snapshot"
+            );
+        } else {
+            get_provider(record.provider)
+                .delete_model_revision(
+                    &key.model_name,
+                    self.cache_directory.clone(),
+                    key.revision.as_deref(),
+                )
+                .await
+                .map_err(|e| format!("failed to delete model files for '{entry_key}': {e}"))?;
+        }
 
         // Only remove from registry after successful filesystem deletion
-        self.registry.delete_model(model_name).await?;
+        self.registry.delete_model(entry_key).await?;
 
         Ok(())
     }

--- a/modelexpress_server/src/registry.rs
+++ b/modelexpress_server/src/registry.rs
@@ -7,8 +7,9 @@
 //! `backend` owns the `RegistryBackend` trait plus its Redis, Kubernetes CRD, and
 //! (behind the `memory-backend` feature) in-memory implementations. `state` wraps the
 //! backend in a lazy-connect manager used by `ModelDownloadTracker` and
-//! `CacheEvictionService`.
+//! `CacheEvictionService`. `entry_key` defines the identity every backend keys on.
 
 pub mod backend;
+pub mod entry_key;
 pub mod k8s_types;
 pub mod state;

--- a/modelexpress_server/src/registry/entry_key.rs
+++ b/modelexpress_server/src/registry/entry_key.rs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity of a single registry entry.
+//!
+//! Registry backends key every record, lease, and claim on one string. A model name
+//! alone is not a sufficient key:
+//!
+//! - two revisions of the same model must not share a download lease, or a request for
+//!   one revision would coalesce onto a download of the other;
+//! - a metadata-only download (`ignore_weights`) must not satisfy a later full-weight
+//!   request, which would hand back a snapshot with no weights in it.
+//!
+//! [`EntryKey`] folds those three components into the single string the backends want
+//! and parses it back, so cache eviction can still recover the model name and revision
+//! it needs in order to delete the right files.
+//!
+//! An unpinned, full-weight entry encodes to the bare model name, so providers without
+//! a revision concept keep the keys they have always used.
+
+use std::fmt::{Display, Formatter};
+
+/// Separates the model name from its resolved revision.
+const REVISION_SEPARATOR: &str = "@rev:";
+/// Marks an entry whose download skipped weight files.
+const METADATA_SUFFIX: &str = "#metadata";
+
+/// The components a registry key is built from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryKey {
+    /// Provider-canonical model name.
+    pub model_name: String,
+    /// Immutable revision the request resolved to, when the provider has one.
+    pub revision: Option<String>,
+    /// Whether the entry covers a weightless (config/tokenizer only) download.
+    pub metadata_only: bool,
+}
+
+impl EntryKey {
+    pub fn new(
+        model_name: impl Into<String>,
+        revision: Option<String>,
+        metadata_only: bool,
+    ) -> Self {
+        Self {
+            model_name: model_name.into(),
+            revision,
+            metadata_only,
+        }
+    }
+
+    /// Recover the components of an encoded key.
+    ///
+    /// A key that carries neither marker parses back to an unpinned, full-weight entry,
+    /// which is how records written before revisions existed are read.
+    pub fn parse(key: &str) -> Self {
+        let (body, metadata_only) = match key.strip_suffix(METADATA_SUFFIX) {
+            Some(body) => (body, true),
+            None => (key, false),
+        };
+
+        match body.rsplit_once(REVISION_SEPARATOR) {
+            Some((model_name, revision)) if !model_name.is_empty() && !revision.is_empty() => {
+                Self::new(model_name, Some(revision.to_string()), metadata_only)
+            }
+            _ => Self::new(body, None, metadata_only),
+        }
+    }
+
+    /// True when this entry belongs to `model_name`, whatever its revision or weight mode.
+    /// Drives "forget everything about this model" operations such as `model clear`.
+    pub fn belongs_to(&self, model_name: &str) -> bool {
+        self.model_name == model_name
+    }
+}
+
+impl Display for EntryKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.model_name)?;
+        if let Some(revision) = &self.revision {
+            write!(f, "{REVISION_SEPARATOR}{revision}")?;
+        }
+        if self.metadata_only {
+            f.write_str(METADATA_SUFFIX)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(key: EntryKey) {
+        assert_eq!(EntryKey::parse(&key.to_string()), key);
+    }
+
+    #[test]
+    fn unpinned_full_weight_entry_encodes_to_the_bare_model_name() {
+        let key = EntryKey::new("google-t5/t5-small", None, false);
+        assert_eq!(key.to_string(), "google-t5/t5-small");
+        roundtrip(key);
+    }
+
+    #[test]
+    fn every_component_survives_a_roundtrip() {
+        roundtrip(EntryKey::new(
+            "org/model",
+            Some("abc123".to_string()),
+            false,
+        ));
+        roundtrip(EntryKey::new("org/model", None, true));
+        roundtrip(EntryKey::new("org/model", Some("abc123".to_string()), true));
+        roundtrip(EntryKey::new("gs://bucket/org/model/rev-1", None, false));
+    }
+
+    #[test]
+    fn two_revisions_of_one_model_get_distinct_keys() {
+        let first = EntryKey::new("org/model", Some("abc123".to_string()), false).to_string();
+        let second = EntryKey::new("org/model", Some("def456".to_string()), false).to_string();
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn metadata_only_and_full_weight_entries_do_not_collide() {
+        let revision = Some("abc123".to_string());
+        assert_ne!(
+            EntryKey::new("org/model", revision.clone(), true).to_string(),
+            EntryKey::new("org/model", revision, false).to_string()
+        );
+    }
+
+    #[test]
+    fn a_legacy_key_parses_as_unpinned_and_full_weight() {
+        let parsed = EntryKey::parse("meta-llama/Llama-3.1-70B");
+        assert_eq!(parsed.model_name, "meta-llama/Llama-3.1-70B");
+        assert!(parsed.revision.is_none());
+        assert!(!parsed.metadata_only);
+    }
+
+    #[test]
+    fn belongs_to_ignores_revision_and_weight_mode() {
+        let key = EntryKey::new("org/model", Some("abc123".to_string()), true);
+        assert!(key.belongs_to("org/model"));
+        assert!(!key.belongs_to("org/other"));
+    }
+}

--- a/modelexpress_server/src/registry/entry_key.rs
+++ b/modelexpress_server/src/registry/entry_key.rs
@@ -17,13 +17,26 @@
 //!
 //! An unpinned, full-weight entry encodes to the bare model name, so providers without
 //! a revision concept keep the keys they have always used.
+//!
+//! # Encoding
+//!
+//! Anything else encodes as `mx1:<revision>:<flags>:<model_name>`. The model name goes
+//! last because it is the only field with no character restrictions — a GCS object path
+//! accepts almost any byte, so a name like `gs://bucket/models/foo:m:bar` must not be
+//! able to impersonate the other fields. Putting it last means nothing after it needs
+//! parsing, and the round trip is exact for any name.
+//!
+//! The revision field does have to avoid `:`, which holds because it is always a commit
+//! identifier: Git forbids `:` in ref names, and resolved revisions are commit SHAs.
 
 use std::fmt::{Display, Formatter};
 
-/// Separates the model name from its resolved revision.
-const REVISION_SEPARATOR: &str = "@rev:";
-/// Marks an entry whose download skipped weight files.
-const METADATA_SUFFIX: &str = "#metadata";
+/// Marks a key that carries a revision or weight mode. Versioned so the format can
+/// change without misreading old keys.
+const STRUCTURED_PREFIX: &str = "mx1:";
+/// Weight-mode field values.
+const METADATA_FLAG: &str = "m";
+const FULL_WEIGHT_FLAG: &str = "-";
 
 /// The components a registry key is built from.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,21 +62,36 @@ impl EntryKey {
         }
     }
 
+    /// Whether the key needs the structured form.
+    ///
+    /// A model name that happens to start with the prefix is encoded structurally even
+    /// when it carries no revision, so it can never be mistaken for a key we wrote.
+    fn needs_structured_form(&self) -> bool {
+        self.revision.is_some()
+            || self.metadata_only
+            || self.model_name.starts_with(STRUCTURED_PREFIX)
+    }
+
     /// Recover the components of an encoded key.
     ///
-    /// A key that carries neither marker parses back to an unpinned, full-weight entry,
-    /// which is how records written before revisions existed are read.
+    /// A key without the prefix parses back to an unpinned, full-weight entry, which is
+    /// how records written before revisions existed are read.
     pub fn parse(key: &str) -> Self {
-        let (body, metadata_only) = match key.strip_suffix(METADATA_SUFFIX) {
-            Some(body) => (body, true),
-            None => (key, false),
+        let Some(fields) = key.strip_prefix(STRUCTURED_PREFIX) else {
+            return Self::new(key, None, false);
         };
 
-        match body.rsplit_once(REVISION_SEPARATOR) {
-            Some((model_name, revision)) if !model_name.is_empty() && !revision.is_empty() => {
-                Self::new(model_name, Some(revision.to_string()), metadata_only)
-            }
-            _ => Self::new(body, None, metadata_only),
+        // `splitn(3)` leaves the model name — the only field that may contain `:` —
+        // untouched in the final part.
+        let mut parts = fields.splitn(3, ':');
+        match (parts.next(), parts.next(), parts.next()) {
+            (Some(revision), Some(flags), Some(model_name)) => Self::new(
+                model_name,
+                (!revision.is_empty()).then(|| revision.to_string()),
+                flags == METADATA_FLAG,
+            ),
+            // Not a key this module produced; treat it as a plain model name.
+            _ => Self::new(key, None, false),
         }
     }
 
@@ -76,14 +104,21 @@ impl EntryKey {
 
 impl Display for EntryKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.model_name)?;
-        if let Some(revision) = &self.revision {
-            write!(f, "{REVISION_SEPARATOR}{revision}")?;
+        if !self.needs_structured_form() {
+            return f.write_str(&self.model_name);
         }
-        if self.metadata_only {
-            f.write_str(METADATA_SUFFIX)?;
-        }
-        Ok(())
+
+        let flags = if self.metadata_only {
+            METADATA_FLAG
+        } else {
+            FULL_WEIGHT_FLAG
+        };
+        write!(
+            f,
+            "{STRUCTURED_PREFIX}{}:{flags}:{}",
+            self.revision.as_deref().unwrap_or(""),
+            self.model_name
+        )
     }
 }
 
@@ -112,6 +147,44 @@ mod tests {
         roundtrip(EntryKey::new("org/model", None, true));
         roundtrip(EntryKey::new("org/model", Some("abc123".to_string()), true));
         roundtrip(EntryKey::new("gs://bucket/org/model/rev-1", None, false));
+    }
+
+    /// A GCS object path accepts almost any byte, so a model name is free to contain
+    /// whatever the encoding uses as structure. Misreading one would evict a different
+    /// model's files, so every shape has to round-trip exactly.
+    #[test]
+    fn a_model_name_cannot_impersonate_the_encoding() {
+        for name in [
+            "gs://bucket/models/foo:m:bar",
+            "gs://bucket/models/foo#metadata",
+            "gs://bucket/models/foo@rev:abc123",
+            "mx1:abc123:m:gs://bucket/models/foo",
+            "mx1:",
+            ":::",
+        ] {
+            roundtrip(EntryKey::new(name, None, false));
+            roundtrip(EntryKey::new(name, None, true));
+            roundtrip(EntryKey::new(name, Some("abc123".to_string()), false));
+        }
+    }
+
+    #[test]
+    fn a_name_that_looks_like_a_key_stays_distinct_from_the_key_it_mimics() {
+        // The literal name and the entry whose encoding it copies must not collide.
+        let mimic = EntryKey::new("mx1:abc123:m:org/model", None, false);
+        let real = EntryKey::new("org/model", Some("abc123".to_string()), true);
+        assert_ne!(mimic.to_string(), real.to_string());
+        assert_eq!(EntryKey::parse(&mimic.to_string()), mimic);
+        assert_eq!(EntryKey::parse(&real.to_string()), real);
+    }
+
+    #[test]
+    fn a_model_name_with_a_colon_keeps_its_revision_and_weight_mode() {
+        let key = EntryKey::new("ngc/org/model:1.0", Some("abc123".to_string()), true);
+        let parsed = EntryKey::parse(&key.to_string());
+        assert_eq!(parsed.model_name, "ngc/org/model:1.0");
+        assert_eq!(parsed.revision.as_deref(), Some("abc123"));
+        assert!(parsed.metadata_only);
     }
 
     #[test]

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -33,6 +33,10 @@ use tracing::{debug, error, info, warn};
 
 static START_TIME: std::sync::OnceLock<SystemTime> = std::sync::OnceLock::new();
 
+/// Ceiling on resolving a revision with the provider. This is a metadata lookup, not a
+/// download, so it should complete quickly or not at all.
+const REVISION_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Get the configured cache directory for model downloads
 fn get_server_cache_dir() -> Option<std::path::PathBuf> {
     // Try to get cache configuration
@@ -112,12 +116,13 @@ async fn resolve_target_revision(
         )));
     }
 
-    let error = match provider_impl
-        .resolve_revision(model_name, cache_dir.clone(), requested)
-        .await
-    {
-        Ok(resolved) => return Ok(resolved),
-        Err(e) => e,
+    // Resolution runs before the download lease is claimed, so an unresponsive provider
+    // would otherwise hold the RPC open indefinitely without any download in progress.
+    let resolve = provider_impl.resolve_revision(model_name, cache_dir.clone(), requested);
+    let error = match tokio::time::timeout(REVISION_RESOLVE_TIMEOUT, resolve).await {
+        Ok(Ok(resolved)) => return Ok(resolved),
+        Ok(Err(e)) => e,
+        Err(_) => anyhow::anyhow!("timed out after {}s", REVISION_RESOLVE_TIMEOUT.as_secs()),
     };
 
     if requested.is_some() {
@@ -1263,12 +1268,17 @@ mod tests {
     }
 
     /// Claim, touch, and report a cache hit for `target`, asserting the registry was
-    /// keyed on `expected_key` rather than on the bare model name.
-    async fn assert_claims_on_key(target: DownloadTarget, expected_key: &'static str) {
+    /// keyed on the target's entry key rather than on the bare model name.
+    async fn assert_claims_on_entry_key(target: DownloadTarget) {
+        let expected_key = target.entry_key();
+        assert_ne!(
+            expected_key, target.model_name,
+            "This target must not reduce to the bare model name, or the test proves nothing"
+        );
         let mut mock = crate::registry::backend::MockRegistryBackend::new();
         mock.expect_try_claim_for_download()
             .with(
-                mockall::predicate::eq(expected_key),
+                mockall::predicate::eq(expected_key.clone()),
                 mockall::predicate::eq(ModelProvider::HuggingFace),
                 mockall::predicate::always(),
                 mockall::predicate::always(),
@@ -1313,13 +1323,10 @@ mod tests {
         std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
         std::fs::write(model_dir.join("config.json"), b"{}").expect("Failed to write config");
 
-        assert_claims_on_key(
-            DownloadTarget {
-                revision: Some("abc123".to_string()),
-                ..test_target("test/model")
-            },
-            "test/model@rev:abc123",
-        )
+        assert_claims_on_entry_key(DownloadTarget {
+            revision: Some("abc123".to_string()),
+            ..test_target("test/model")
+        })
         .await;
     }
 
@@ -1340,13 +1347,10 @@ mod tests {
 
         // A metadata-only entry must not be the same registry record as a full-weight
         // one, or a weightless snapshot would satisfy a request that needs weights.
-        assert_claims_on_key(
-            DownloadTarget {
-                ignore_weights: true,
-                ..test_target("test/model")
-            },
-            "test/model#metadata",
-        )
+        assert_claims_on_entry_key(DownloadTarget {
+            ignore_weights: true,
+            ..test_target("test/model")
+        })
         .await;
     }
 

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -101,7 +101,19 @@ async fn resolve_target_revision(
     cache_dir: Option<PathBuf>,
     requested: Option<&str>,
 ) -> Result<Option<String>, Status> {
-    let error = match download::resolve_revision(model_name, provider, cache_dir.clone(), requested)
+    let provider_impl = download::get_provider(provider);
+
+    // Pinning a revision on a provider that has none is a malformed request, not a
+    // revision that happens to be missing.
+    if requested.is_some() && !provider_impl.supports_revisions() {
+        return Err(Status::invalid_argument(format!(
+            "Provider '{}' does not support pinned revisions",
+            provider_impl.provider_name()
+        )));
+    }
+
+    let error = match provider_impl
+        .resolve_revision(model_name, cache_dir.clone(), requested)
         .await
     {
         Ok(resolved) => return Ok(resolved),
@@ -119,7 +131,7 @@ async fn resolve_target_revision(
          falling back to the cached snapshot"
     );
 
-    match download::get_provider(provider)
+    match provider_impl
         .get_model_path_revision(model_name, cache_dir.unwrap_or_default(), None)
         .await
         .ok()
@@ -1863,6 +1875,31 @@ mod tests {
             (Some("newer222".to_string()), b"new".to_vec()),
             "Without a revision the newest snapshot is served, so the pinned request above \
              really did select a different one"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ensure_model_downloaded_rejects_a_revision_on_a_provider_without_revisions() {
+        let service = test_model_service();
+        let request = Request::new(ModelDownloadRequest {
+            model_name: "gs://test-bucket/org/model/rev-1".to_string(),
+            provider: modelexpress_common::grpc::model::ModelProvider::Gcs as i32,
+            ignore_weights: false,
+            revision: Some("v1.0".to_string()),
+        });
+
+        let status = service
+            .ensure_model_downloaded(request)
+            .await
+            .map(|_| ())
+            .expect_err("A provider without revisions must reject a pinned revision");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(
+            status
+                .message()
+                .contains("does not support pinned revisions"),
+            "Unexpected message: {}",
+            status.message()
         );
     }
 

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::registry::backend::ClaimOutcome;
+use crate::registry::entry_key::EntryKey;
 use crate::registry::state::RegistryManager;
 use modelexpress_common::{
     cache::{CacheConfig, resolve_model_path},
@@ -52,14 +53,86 @@ async fn model_files_present(
     cache_dir: Option<std::path::PathBuf>,
     model_name: &str,
     provider: ModelProvider,
+    revision: Option<&str>,
 ) -> bool {
     let Some(cache_dir) = cache_dir else {
         return true;
     };
     download::get_provider(provider)
-        .get_model_path(model_name, cache_dir)
+        .get_model_path_revision(model_name, cache_dir, revision)
         .await
         .is_ok()
+}
+
+/// A model download request reduced to the identity the registry and the provider need.
+///
+/// `revision` is always the *resolved*, immutable revision (a commit SHA for Hugging
+/// Face), never the branch or tag the caller typed, so cache and lease identity cannot
+/// drift when a tag moves.
+#[derive(Debug, Clone)]
+pub struct DownloadTarget {
+    pub model_name: String,
+    pub provider: ModelProvider,
+    pub revision: Option<String>,
+    pub ignore_weights: bool,
+}
+
+impl DownloadTarget {
+    /// The single string every registry backend keys this download on.
+    fn entry_key(&self) -> String {
+        EntryKey::new(
+            self.model_name.clone(),
+            self.revision.clone(),
+            self.ignore_weights,
+        )
+        .to_string()
+    }
+}
+
+/// Resolve a requested revision to the immutable revision the download will use.
+///
+/// A revision the caller pinned explicitly must resolve or the request fails: silently
+/// serving the default revision instead would hand back a different model than asked
+/// for. For an unpinned request we fall back to whatever snapshot is already cached,
+/// so a Hub outage still serves models the server has downloaded before.
+async fn resolve_target_revision(
+    model_name: &str,
+    provider: ModelProvider,
+    cache_dir: Option<PathBuf>,
+    requested: Option<&str>,
+) -> Result<Option<String>, Status> {
+    let error = match download::resolve_revision(model_name, provider, cache_dir.clone(), requested)
+        .await
+    {
+        Ok(resolved) => return Ok(resolved),
+        Err(e) => e,
+    };
+
+    if requested.is_some() {
+        return Err(Status::not_found(format!(
+            "Failed to resolve revision for model '{model_name}': {error:#}"
+        )));
+    }
+
+    warn!(
+        "Failed to resolve the default revision for '{model_name}': {error:#}; \
+         falling back to the cached snapshot"
+    );
+
+    match download::get_provider(provider)
+        .get_model_path_revision(model_name, cache_dir.unwrap_or_default(), None)
+        .await
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(String::from)
+        }) {
+        Some(cached) => Ok(Some(cached)),
+        None => Err(Status::not_found(format!(
+            "Failed to resolve revision for model '{model_name}': {error:#}"
+        ))),
+    }
 }
 
 /// Health service implementation
@@ -247,6 +320,23 @@ impl ModelService for ModelServiceImpl {
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
         let ignore_weights = model_request.ignore_weights;
 
+        // Resolve before claiming: the registry keys the download lease on the resolved
+        // revision, so two revisions of one model never coalesce onto a single claim.
+        let revision = resolve_target_revision(
+            &model_name,
+            provider,
+            get_server_cache_dir(),
+            model_request.revision.as_deref(),
+        )
+        .await?;
+
+        let target = DownloadTarget {
+            model_name: model_name.clone(),
+            provider,
+            revision: revision.clone(),
+            ignore_weights,
+        };
+
         // Spawn a task to handle the streaming download updates
         let tracker = self.tracker.clone();
         tokio::spawn(async move {
@@ -256,9 +346,7 @@ impl ModelService for ModelServiceImpl {
             // duplicate that update or, worse, emit `status=ERROR` on a model we're
             // about to retry and trip the client-lib's terminal-error bailout before
             // the retry completion broadcast arrives.
-            let final_status = tracker
-                .ensure_model_downloaded(&model_name, provider, &tx, ignore_weights)
-                .await;
+            let final_status = tracker.ensure_model_downloaded(&target, &tx).await;
 
             // Send final status update
             let final_update = ModelStatusUpdate {
@@ -272,6 +360,7 @@ impl ModelService for ModelServiceImpl {
                     ModelStatus::DOWNLOADING => Some("Download still in progress".to_string()),
                 },
                 provider: grpc_provider as i32,
+                resolved_revision: revision,
             };
 
             let _ = tx.send(Ok(final_update)).await;
@@ -312,9 +401,14 @@ impl ModelService for ModelServiceImpl {
         let cache_dir = get_server_cache_dir()
             .ok_or_else(|| Status::internal("Server cache directory not configured"))?;
 
-        // Get the model path using the provider from the request
+        // Get the model path using the provider from the request. A requested revision
+        // selects that exact snapshot instead of whichever one is newest on disk.
         let model_path = provider_impl
-            .get_model_path(&model_name, cache_dir.clone())
+            .get_model_path_revision(
+                &model_name,
+                cache_dir.clone(),
+                files_request.revision.as_deref(),
+            )
             .await
             .map_err(|e| Status::not_found(format!("Model not found: {e}")))?;
 
@@ -497,7 +591,7 @@ impl ModelService for ModelServiceImpl {
 
         // Get the model path using the provider from the request
         let model_path = provider_impl
-            .get_model_path(&model_name, cache_dir)
+            .get_model_path_revision(&model_name, cache_dir, files_request.revision.as_deref())
             .await
             .map_err(|e| Status::not_found(format!("Model not found: {e}")))?;
 
@@ -544,13 +638,18 @@ impl ModelService for ModelServiceImpl {
         let model_name = download::canonical_model_name(&delete_request.model_name, provider)
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
 
+        // A model can hold several entries at once (one per revision, and separate ones
+        // for metadata-only downloads). `model clear` means "forget this model", so drop
+        // all of them rather than only the unpinned full-weight entry.
         let tracker = self.tracker.clone();
-        tracker.delete_status(&model_name).await;
-        info!("Deleted registry record for model '{model_name}'");
+        let removed = tracker.delete_model_entries(&model_name).await;
+        info!("Deleted {removed} registry record(s) for model '{model_name}'");
 
         Ok(Response::new(DeleteModelResponse {
             success: true,
-            message: Some(format!("Model '{model_name}' removed from registry")),
+            message: Some(format!(
+                "Model '{model_name}' removed from registry ({removed} record(s))"
+            )),
         }))
     }
 }
@@ -558,6 +657,30 @@ impl ModelService for ModelServiceImpl {
 /// Type alias for the complex waiting channels type
 type WaitingChannels =
     Arc<Mutex<HashMap<String, Vec<tokio::sync::mpsc::Sender<Result<ModelStatusUpdate, Status>>>>>>;
+
+/// What a status update is routed by and what it reports.
+///
+/// Waiters are registered under the registry entry key, which carries the revision and
+/// weight mode, while the update itself reports the plain model name the caller asked
+/// for plus the revision it resolved to.
+struct UpdateIdentity<'a> {
+    entry_key: &'a str,
+    model_name: &'a str,
+    provider: ModelProvider,
+    resolved_revision: Option<&'a str>,
+}
+
+impl UpdateIdentity<'_> {
+    fn status_update(&self, status: ModelStatus, message: Option<String>) -> ModelStatusUpdate {
+        ModelStatusUpdate {
+            model_name: self.model_name.to_string(),
+            status: modelexpress_common::grpc::model::ModelStatus::from(status) as i32,
+            message,
+            provider: GrpcModelProvider::from(self.provider) as i32,
+            resolved_revision: self.resolved_revision.map(String::from),
+        }
+    }
+}
 
 /// Tracks the status of model downloads through the distributed registry backend.
 #[derive(Clone)]
@@ -617,14 +740,22 @@ impl ModelDownloadTracker {
             error!("Failed to update model status in registry: {e}");
             return;
         }
-        self.notify_waiters(model_name, status, provider, message);
+        self.notify_waiters(
+            UpdateIdentity {
+                entry_key: &model_name,
+                model_name: &model_name,
+                provider,
+                resolved_revision: None,
+            },
+            status,
+            message,
+        );
     }
 
     fn notify_waiters(
         &self,
-        model_name: String,
+        identity: UpdateIdentity<'_>,
         status: ModelStatus,
-        provider: ModelProvider,
         message: Option<String>,
     ) {
         let mut waiting = match self.waiting_channels.lock() {
@@ -634,18 +765,13 @@ impl ModelDownloadTracker {
                 poisoned.into_inner()
             }
         };
-        if let Some(channels) = waiting.get(&model_name) {
-            let update = ModelStatusUpdate {
-                model_name: model_name.clone(),
-                status: modelexpress_common::grpc::model::ModelStatus::from(status) as i32,
-                message,
-                provider: GrpcModelProvider::from(provider) as i32,
-            };
+        if let Some(channels) = waiting.get(identity.entry_key) {
+            let update = identity.status_update(status, message);
             for channel in channels {
                 let _ = channel.try_send(Ok(update.clone()));
             }
             if status == ModelStatus::DOWNLOADED || status == ModelStatus::ERROR {
-                waiting.remove(&model_name);
+                waiting.remove(identity.entry_key);
             }
         }
     }
@@ -692,21 +818,50 @@ impl ModelDownloadTracker {
         waiting.remove(model_name);
     }
 
+    /// Deletes every registry entry belonging to `model_name`, whatever revision or
+    /// weight mode each entry covers. Returns how many records were removed.
+    pub async fn delete_model_entries(&self, model_name: &str) -> usize {
+        let records = match self.registry.get_models_by_last_used(None).await {
+            Ok(records) => records,
+            Err(e) => {
+                error!("Failed to list registry records for '{model_name}': {e}");
+                // Fall back to the unpinned full-weight key so the common case still
+                // clears rather than failing outright.
+                self.delete_status(model_name).await;
+                return 0;
+            }
+        };
+
+        let mut removed: usize = 0;
+        for record in records {
+            if EntryKey::parse(&record.model_name).belongs_to(model_name) {
+                self.delete_status(&record.model_name).await;
+                removed = removed.saturating_add(1);
+            }
+        }
+        removed
+    }
+
     /// Spawn a background task that actually downloads the model, updating the tracker on
     /// success or failure. Extracted here so the claim and retry paths share the code.
-    fn spawn_download_task(
-        &self,
-        model_name: String,
-        provider: ModelProvider,
-        ignore_weights: bool,
-        retry: bool,
-        claim_id: String,
-    ) {
+    fn spawn_download_task(&self, target: DownloadTarget, retry: bool, claim_id: String) {
         let tracker = self.clone();
         tokio::spawn(async move {
+            let entry_key = target.entry_key();
+            let DownloadTarget {
+                model_name,
+                provider,
+                revision,
+                ignore_weights,
+            } = target;
             let cache_dir = get_server_cache_dir();
-            let download =
-                download::download_model(&model_name, provider, cache_dir, ignore_weights);
+            let download = download::download_model_revision(
+                &model_name,
+                provider,
+                cache_dir,
+                ignore_weights,
+                revision.as_deref(),
+            );
             tokio::pin!(download);
             let start = tokio::time::Instant::now()
                 .checked_add(DOWNLOAD_HEARTBEAT_INTERVAL)
@@ -719,7 +874,7 @@ impl ModelDownloadTracker {
                         match tracker
                             .registry
                             .refresh_download_claim(
-                                &model_name,
+                                &entry_key,
                                 provider,
                                 &claim_id,
                                 DOWNLOAD_LEASE_DURATION,
@@ -763,11 +918,20 @@ impl ModelDownloadTracker {
 
             match tracker
                 .registry
-                .finish_download_claim(&model_name, provider, &claim_id, status, message.clone())
+                .finish_download_claim(&entry_key, provider, &claim_id, status, message.clone())
                 .await
             {
                 Ok(true) => {
-                    tracker.notify_waiters(model_name.clone(), status, provider, message);
+                    tracker.notify_waiters(
+                        UpdateIdentity {
+                            entry_key: &entry_key,
+                            model_name: &model_name,
+                            provider,
+                            resolved_revision: revision.as_deref(),
+                        },
+                        status,
+                        message,
+                    );
                 }
                 Ok(false) => {
                     warn!("Ignoring completion for {model_name}: lease ownership was lost");
@@ -780,13 +944,26 @@ impl ModelDownloadTracker {
     }
 
     /// Initiates a download for a model and streams status updates.
+    ///
+    /// All registry operations key on the target's entry key rather than its model name,
+    /// so a second revision (or a full-weight request behind a metadata-only one) claims
+    /// its own lease instead of coalescing onto an unrelated download.
     pub async fn ensure_model_downloaded(
         &self,
-        model_name: &str,
-        provider: ModelProvider,
+        target: &DownloadTarget,
         tx: &tokio::sync::mpsc::Sender<Result<ModelStatusUpdate, Status>>,
-        ignore_weights: bool,
     ) -> ModelStatus {
+        let entry_key = target.entry_key();
+        let entry_key = entry_key.as_str();
+        let model_name = target.model_name.as_str();
+        let provider = target.provider;
+        let identity = UpdateIdentity {
+            entry_key,
+            model_name,
+            provider,
+            resolved_revision: target.revision.as_deref(),
+        };
+
         // Atomically try to claim this model for download. The `ClaimOutcome` tells us
         // whether THIS replica won the claim or is observing someone else's claim —
         // status alone (`DOWNLOADING`) can't distinguish those cases across replicas.
@@ -802,39 +979,41 @@ impl ModelDownloadTracker {
             attempt = attempt.saturating_add(1);
             match self
                 .registry
-                .try_claim_for_download(model_name, provider, &claim_id, DOWNLOAD_LEASE_DURATION)
+                .try_claim_for_download(entry_key, provider, &claim_id, DOWNLOAD_LEASE_DURATION)
                 .await
             {
                 Ok(ClaimOutcome::Claimed) => break (ModelStatus::DOWNLOADING, true),
                 Ok(ClaimOutcome::AlreadyExists(existing)) => {
                     if existing == ModelStatus::DOWNLOADED
                         && attempt < MAX_CLAIM_ATTEMPTS
-                        && !model_files_present(get_server_cache_dir(), model_name, provider).await
+                        && !model_files_present(
+                            get_server_cache_dir(),
+                            model_name,
+                            provider,
+                            target.revision.as_deref(),
+                        )
+                        .await
                     {
                         error!(
                             "Registry reports model '{model_name}' as DOWNLOADED but its files \
                              are missing from the cache; clearing the stale record and \
                              re-downloading"
                         );
-                        self.delete_status(model_name).await;
+                        self.delete_status(entry_key).await;
                         continue;
                     }
                     if existing == ModelStatus::DOWNLOADED {
                         // Returning an existing downloaded model is a cache hit for LRU purposes.
-                        self.touch_and_log(model_name).await;
+                        self.touch_and_log(entry_key).await;
                     }
                     break (existing, false);
                 }
                 Err(e) => {
                     error!("Failed to claim model for download: {e}");
-                    let error_update = ModelStatusUpdate {
-                        model_name: model_name.to_string(),
-                        status: modelexpress_common::grpc::model::ModelStatus::from(
-                            ModelStatus::ERROR,
-                        ) as i32,
-                        message: Some("Registry error occurred".to_string()),
-                        provider: GrpcModelProvider::from(provider) as i32,
-                    };
+                    let error_update = identity.status_update(
+                        ModelStatus::ERROR,
+                        Some("Registry error occurred".to_string()),
+                    );
                     let _ = tx.send(Ok(error_update)).await;
                     return ModelStatus::ERROR;
                 }
@@ -849,21 +1028,17 @@ impl ModelDownloadTracker {
         let (effective_status, is_retry_owner) = if status == ModelStatus::ERROR {
             let won = match self
                 .registry
-                .try_reset_error_for_retry(model_name, provider, &claim_id, DOWNLOAD_LEASE_DURATION)
+                .try_reset_error_for_retry(entry_key, provider, &claim_id, DOWNLOAD_LEASE_DURATION)
                 .await
             {
                 Ok(won) => won,
                 Err(e) => {
                     error!("Failed to CAS status for retry: {e}");
                     let _ = tx
-                        .send(Ok(ModelStatusUpdate {
-                            model_name: model_name.to_string(),
-                            status: modelexpress_common::grpc::model::ModelStatus::from(
-                                ModelStatus::ERROR,
-                            ) as i32,
-                            message: Some("Registry error occurred during retry".to_string()),
-                            provider: GrpcModelProvider::from(provider) as i32,
-                        }))
+                        .send(Ok(identity.status_update(
+                            ModelStatus::ERROR,
+                            Some("Registry error occurred during retry".to_string()),
+                        )))
                         .await;
                     return ModelStatus::ERROR;
                 }
@@ -873,36 +1048,28 @@ impl ModelDownloadTracker {
             (status, false)
         };
 
-        let update = ModelStatusUpdate {
-            model_name: model_name.to_string(),
-            status: modelexpress_common::grpc::model::ModelStatus::from(effective_status) as i32,
-            message: match (status, effective_status) {
+        let update = identity.status_update(
+            effective_status,
+            match (status, effective_status) {
                 (_, ModelStatus::DOWNLOADED) => Some("Model already downloaded".to_string()),
                 (ModelStatus::ERROR, _) => Some("Previous download failed, retrying".to_string()),
                 (_, ModelStatus::DOWNLOADING) => Some("Model download in progress".to_string()),
                 // effective can never be ERROR: ERROR observations are CAS'd above.
                 (_, ModelStatus::ERROR) => Some("Download error".to_string()),
             },
-            provider: GrpcModelProvider::from(provider) as i32,
-        };
+        );
         let _ = tx.send(Ok(update)).await;
 
         if effective_status == ModelStatus::DOWNLOADING {
             // Every caller is a waiter — whether we own the download or not, we still
             // need a channel so the completion broadcast reaches this stream.
-            self.add_waiting_channel(model_name, tx.clone());
+            self.add_waiting_channel(entry_key, tx.clone());
 
             // Spawn the download only on the replica that won the claim (fresh
             // download) or won the ERROR-retry CAS. Everyone else waits.
             if is_owner || is_retry_owner {
                 let retry = status == ModelStatus::ERROR;
-                self.spawn_download_task(
-                    model_name.to_string(),
-                    provider,
-                    ignore_weights,
-                    retry,
-                    claim_id,
-                );
+                self.spawn_download_task(target.clone(), retry, claim_id);
                 claim_id = uuid::Uuid::new_v4().to_string();
             }
 
@@ -910,22 +1077,11 @@ impl ModelDownloadTracker {
                 tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                 match self
                     .registry
-                    .try_claim_for_download(
-                        model_name,
-                        provider,
-                        &claim_id,
-                        DOWNLOAD_LEASE_DURATION,
-                    )
+                    .try_claim_for_download(entry_key, provider, &claim_id, DOWNLOAD_LEASE_DURATION)
                     .await
                 {
                     Ok(ClaimOutcome::Claimed) => {
-                        self.spawn_download_task(
-                            model_name.to_string(),
-                            provider,
-                            ignore_weights,
-                            false,
-                            claim_id,
-                        );
+                        self.spawn_download_task(target.clone(), false, claim_id);
                         claim_id = uuid::Uuid::new_v4().to_string();
                     }
                     Ok(ClaimOutcome::AlreadyExists(current_status))
@@ -1024,6 +1180,16 @@ mod tests {
         ModelDownloadTracker::new(registry)
     }
 
+    /// Unpinned, full-weight target: its entry key is the bare model name.
+    fn test_target(model_name: &str) -> DownloadTarget {
+        DownloadTarget {
+            model_name: model_name.to_string(),
+            provider: ModelProvider::HuggingFace,
+            revision: None,
+            ignore_weights: false,
+        }
+    }
+
     #[tokio::test]
     async fn test_tracker_get_status_missing_returns_none() {
         let mut mock = crate::registry::backend::MockRegistryBackend::new();
@@ -1078,10 +1244,98 @@ mod tests {
 
         assert_eq!(
             tracker
-                .ensure_model_downloaded("test/model", ModelProvider::HuggingFace, &tx, false,)
+                .ensure_model_downloaded(&test_target("test/model"), &tx)
                 .await,
             ModelStatus::DOWNLOADED
         );
+    }
+
+    /// Claim, touch, and report a cache hit for `target`, asserting the registry was
+    /// keyed on `expected_key` rather than on the bare model name.
+    async fn assert_claims_on_key(target: DownloadTarget, expected_key: &'static str) {
+        let mut mock = crate::registry::backend::MockRegistryBackend::new();
+        mock.expect_try_claim_for_download()
+            .with(
+                mockall::predicate::eq(expected_key),
+                mockall::predicate::eq(ModelProvider::HuggingFace),
+                mockall::predicate::always(),
+                mockall::predicate::always(),
+            )
+            .once()
+            .returning(|_, _, _, _| Ok(ClaimOutcome::AlreadyExists(ModelStatus::DOWNLOADED)));
+        mock.expect_touch_model()
+            .with(mockall::predicate::eq(expected_key))
+            .once()
+            .returning(|_| Ok(()));
+
+        let tracker = tracker_with_mock(mock);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+
+        assert_eq!(
+            tracker.ensure_model_downloaded(&target, &tx).await,
+            ModelStatus::DOWNLOADED
+        );
+
+        // Clients see the model name they asked for, not the internal registry key.
+        let update = rx
+            .recv()
+            .await
+            .expect("Expected a status update")
+            .expect("Expected an ok status update");
+        assert_eq!(update.model_name, target.model_name);
+        assert_eq!(update.resolved_revision, target.revision);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_tracker_scopes_the_lease_to_the_resolved_revision() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let _cache_dir_guard = EnvVarGuard::set(
+            &env_lock,
+            "MODEL_EXPRESS_CACHE_DIRECTORY",
+            temp_dir.path().to_str().expect("Expected temp dir path"),
+        );
+        let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
+        let model_dir = temp_dir.path().join("models--test--model/snapshots/abc123");
+        std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+        std::fs::write(model_dir.join("config.json"), b"{}").expect("Failed to write config");
+
+        assert_claims_on_key(
+            DownloadTarget {
+                revision: Some("abc123".to_string()),
+                ..test_target("test/model")
+            },
+            "test/model@rev:abc123",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_tracker_separates_metadata_only_from_full_weight_downloads() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let _cache_dir_guard = EnvVarGuard::set(
+            &env_lock,
+            "MODEL_EXPRESS_CACHE_DIRECTORY",
+            temp_dir.path().to_str().expect("Expected temp dir path"),
+        );
+        let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
+        let model_dir = temp_dir.path().join("models--test--model/snapshots/abc123");
+        std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+        std::fs::write(model_dir.join("config.json"), b"{}").expect("Failed to write config");
+
+        // A metadata-only entry must not be the same registry record as a full-weight
+        // one, or a weightless snapshot would satisfy a request that needs weights.
+        assert_claims_on_key(
+            DownloadTarget {
+                ignore_weights: true,
+                ..test_target("test/model")
+            },
+            "test/model#metadata",
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1440,6 +1694,7 @@ mod tests {
                 paths: vec!["config.json".to_string(), "subdir/nested.txt".to_string()],
             }),
             ignore_weights: false,
+            revision: None,
         });
 
         let response = service
@@ -1477,7 +1732,8 @@ mod tests {
             !model_files_present(
                 Some(cache_dir.clone()),
                 "test/model",
-                ModelProvider::HuggingFace
+                ModelProvider::HuggingFace,
+                None
             )
             .await
         );
@@ -1487,7 +1743,13 @@ mod tests {
         std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
         std::fs::write(model_dir.join("config.json"), b"{}").expect("Failed to write config");
         assert!(
-            model_files_present(Some(cache_dir), "test/model", ModelProvider::HuggingFace).await
+            model_files_present(
+                Some(cache_dir),
+                "test/model",
+                ModelProvider::HuggingFace,
+                None
+            )
+            .await
         );
     }
 
@@ -1495,7 +1757,7 @@ mod tests {
     async fn test_model_files_present_assumes_present_without_cache_dir() {
         // With no configured cache directory we cannot verify, so we must not force a
         // re-download loop: assume the files are present.
-        assert!(model_files_present(None, "test/model", ModelProvider::HuggingFace).await);
+        assert!(model_files_present(None, "test/model", ModelProvider::HuggingFace, None).await);
     }
 
     #[tokio::test]
@@ -1525,6 +1787,7 @@ mod tests {
                 paths: vec!["config.json".to_string()],
             }),
             ignore_weights: false,
+            revision: None,
         });
 
         let response = service
@@ -1541,6 +1804,100 @@ mod tests {
         assert_eq!(chunks[0].relative_path, "config.json");
         assert_eq!(chunks[0].commit_hash.as_deref(), Some("abc123"));
         assert!(chunks[0].is_last_file);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_stream_model_files_serves_the_requested_revision() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let _cache_dir_guard = EnvVarGuard::set(
+            &env_lock,
+            "MODEL_EXPRESS_CACHE_DIRECTORY",
+            temp_dir.path().to_str().expect("Expected temp dir path"),
+        );
+        let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
+
+        // Two revisions cached side by side. Without a requested revision the newest
+        // snapshot wins, so asking for the older one proves the request is honored.
+        let write_snapshot = |commit: &str, body: &[u8]| {
+            let model_dir = temp_dir
+                .path()
+                .join("models--test--model/snapshots")
+                .join(commit);
+            std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+            std::fs::write(model_dir.join("config.json"), body).expect("Failed to write config");
+        };
+        write_snapshot("older111", b"old");
+        // Snapshot ordering is by directory timestamp, so the two have to be distinct.
+        tokio::time::sleep(tokio::time::Duration::from_millis(1100)).await;
+        write_snapshot("newer222", b"new");
+
+        let stream_revision = async |revision: Option<&str>| {
+            let request = Request::new(ModelFilesRequest {
+                model_name: "test/model".to_string(),
+                provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
+                chunk_size: 1024,
+                file_selector: None,
+                ignore_weights: false,
+                revision: revision.map(String::from),
+            });
+            let chunks: Vec<_> = test_model_service()
+                .stream_model_files(request)
+                .await
+                .expect("Expected stream response")
+                .into_inner()
+                .map(|chunk| chunk.expect("Expected chunk"))
+                .collect()
+                .await;
+            assert_eq!(chunks.len(), 1);
+            (chunks[0].commit_hash.clone(), chunks[0].data.clone())
+        };
+
+        assert_eq!(
+            stream_revision(Some("older111")).await,
+            (Some("older111".to_string()), b"old".to_vec())
+        );
+        assert_eq!(
+            stream_revision(None).await,
+            (Some("newer222".to_string()), b"new".to_vec()),
+            "Without a revision the newest snapshot is served, so the pinned request above \
+             really did select a different one"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_stream_model_files_rejects_an_uncached_revision() {
+        let env_lock = acquire_env_mutex();
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let _cache_dir_guard = EnvVarGuard::set(
+            &env_lock,
+            "MODEL_EXPRESS_CACHE_DIRECTORY",
+            temp_dir.path().to_str().expect("Expected temp dir path"),
+        );
+        let _offline_guard = EnvVarGuard::set(&env_lock, "HF_HUB_OFFLINE", "1");
+
+        let model_dir = temp_dir.path().join("models--test--model/snapshots/abc123");
+        std::fs::create_dir_all(&model_dir).expect("Failed to create model dir");
+        std::fs::write(model_dir.join("config.json"), b"{}").expect("Failed to write config");
+
+        let service = test_model_service();
+        let request = Request::new(ModelFilesRequest {
+            model_name: "test/model".to_string(),
+            provider: modelexpress_common::grpc::model::ModelProvider::HuggingFace as i32,
+            chunk_size: 1024,
+            file_selector: None,
+            ignore_weights: false,
+            revision: Some("not-cached".to_string()),
+        });
+
+        let status = service
+            .stream_model_files(request)
+            .await
+            .map(|_| ())
+            .expect_err("An uncached revision must not fall back to another snapshot");
+        assert_eq!(status.code(), tonic::Code::NotFound);
     }
 
     #[tokio::test]
@@ -1569,6 +1926,7 @@ mod tests {
                 paths: vec!["config.json".to_string(), "missing.json".to_string()],
             }),
             ignore_weights: false,
+            revision: None,
         });
 
         let result = service.stream_model_files(request).await;
@@ -1590,6 +1948,7 @@ mod tests {
             chunk_size: 0,
             file_selector: None,
             ignore_weights: false,
+            revision: None,
         });
 
         let result = service.list_model_files(request).await;
@@ -1608,6 +1967,7 @@ mod tests {
             chunk_size: 1024,
             file_selector: None,
             ignore_weights: false,
+            revision: None,
         });
 
         let result = service.stream_model_files(request).await;
@@ -1624,6 +1984,7 @@ mod tests {
             model_name: "test/model".to_string(),
             provider: 99,
             ignore_weights: false,
+            revision: None,
         });
 
         let result = service.ensure_model_downloaded(request).await;
@@ -1643,6 +2004,7 @@ mod tests {
             chunk_size: 0,
             file_selector: None,
             ignore_weights: false,
+            revision: None,
         });
 
         let result = service.list_model_files(request).await;
@@ -1662,6 +2024,7 @@ mod tests {
             chunk_size: 1024,
             file_selector: None,
             ignore_weights: false,
+            revision: None,
         });
 
         let result = service.stream_model_files(request).await;
@@ -1695,6 +2058,7 @@ mod tests {
             chunk_size: 1024,
             file_selector: None,
             ignore_weights: false,
+            revision: None,
         });
 
         let response = service
@@ -1737,6 +2101,7 @@ mod tests {
             chunk_size: 1024,
             file_selector: None,
             ignore_weights: false,
+            revision: None,
         });
 
         let response = service


### PR DESCRIPTION
Closes #586

## Summary

Callers can request a Hugging Face model at a branch, tag, or commit SHA, and always learn the immutable commit the request resolved to, so a frontend and its workers can be held to one model revision.

- `ModelDownloadRequest` / `ModelFilesRequest` carry an optional `revision`; `ModelStatusUpdate` reports `resolved_revision`.
- `ModelProviderTrait` gains revision-aware variants alongside the existing methods. Their defaults reject a pinned revision and delegate, so only Hugging Face implements them; NGC and GCS return a clear `InvalidArgument`.
- Client and CLI expose `--revision` and return the snapshot path plus the resolved revision. The pre-existing signatures are unchanged and delegate with nothing pinned, so no downstream Rust caller breaks.

## Two bugs this fixes along the way

**Files could come from a commit other than the one reported.** `HuggingFaceProvider::download_model` called `repo.info()` to get `info.sha` but then downloaded through `repo.get()`, which resolves against `main`. A branch moving mid-download could scatter files across commits while we reported a single SHA. Every file is now fetched from the resolved commit.

**A metadata-only download satisfied a later full-weight request.** `ignore_weights` downloads marked the model `DOWNLOADED` under the same registry key as a full download, so the next full-weight request got a cache hit on a snapshot with no weights in it.

## Registry entry keys

Registry backends key every record, lease, and claim on a single string, and a model name alone is not a sufficient key for either of the above. Records, leases, and claims now key on an `EntryKey` encoding model + resolved revision + weight mode, formatted `model@rev:<sha>` with a `#metadata` suffix for `ignore_weights`.

An unpinned, full-weight entry encodes to the bare model name, so records written before this change keep parsing, and providers without a revision concept keep the keys they have always used. No Redis schema or CRD change is needed: the K8s CR-name sanitizer already hashes the original string.

Cache eviction parses the key back to delete the right snapshot, and skips the filesystem delete while another entry still references the same commit.

## Three judgment calls worth review

- **Revision resolution happens before the lease claim**, which adds one HF metadata call per download request — the lease has to be keyed on the resolved revision. When resolution fails for an *unpinned* request, the server falls back to the snapshot already in its cache; otherwise a Hub outage would break cache hits that work today. A *pinned* request always fails hard, since falling back would hand back a different model than the one asked for.
- **Streamed snapshots now get a `refs/<revision>` entry** (`ModelProviderTrait::record_local_revision`). Without it the acceptance item "installs a valid HF-compatible snapshot" was not really met: the files were all present but `huggingface_hub` could not resolve them by branch under `HF_HUB_OFFLINE=1`. This is also the piece #569's cold-start flow depends on.
- **Eviction treats a revisionless entry as sharing files with every revision of its model.** After an upgrade an old bare-name record co-exists with new revision-scoped ones; without this it would delete their snapshot on its way out, costing a re-download.

## Acceptance criteria

Each item from #586 has a test:

| Criterion | Test |
|---|---|
| Cold-cache download with an explicit commit SHA | `test_download_at_explicit_commit_produces_that_snapshot` |
| Tag or branch resolves to a SHA; all files from that SHA | `test_download_at_tag_fetches_every_file_from_the_resolved_commit` |
| Unpinned download returns the default revision's SHA | `test_unpinned_download_reports_the_default_revision_commit` |
| Two revisions do not share a cache/lease entry | `test_tracker_scopes_the_lease_to_the_resolved_revision`, `entry_key` tests |
| Metadata-only vs full-weight distinguished | `test_tracker_separates_metadata_only_from_full_weight_downloads` |
| No-shared-storage streaming installs a valid snapshot and reports the same SHA | `test_request_model_revision_installs_the_resolved_snapshot`, `test_stream_model_files_serves_the_requested_revision` |
| A nonexistent revision fails and never falls back | `test_missing_revision_fails_without_falling_back_to_the_default`, `test_stream_model_files_rejects_an_uncached_revision` |

## Testing

`cargo test --workspace` (489 tests), `cargo clippy --workspace --all-targets` clean, `pre-commit run --all-files` clean. The HF tests are wiremock-backed and need no network. Docs updated in `docs/ARCHITECTURE.md` and `docs/CLI.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Download models using a branch, tag, or commit revision.
  - Reports the resolved immutable commit SHA and installed path.
  - Supports revision-aware downloads, file access, caching, and deletion.
  - Enables offline use of previously cached revisions.
  - Distinguishes registry entries by model, revision, and weight mode.

- **Bug Fixes**
  - Prevents pinned downloads from silently falling back to the default revision.
  - Preserves shared cached snapshots during cleanup.

- **Documentation**
  - Added guidance and examples for revision pinning in the CLI and architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->