### PR TITLE
fix(vmm): request FABRIC handle type so arena memory is MNNVL-exportable

### DIFF
--- a/modelexpress_client/python/modelexpress/vmm/backend.py
+++ b/modelexpress_client/python/modelexpress/vmm/backend.py
@@ -81,6 +81,8 @@ class CudaVmmBackend:
     def __init__(self, device: int = 0) -> None:
         self._cu = _import_cuda()
         self._device = device
+        # None = not yet probed; True/False = FABRIC export usable on this host.
+        self._fabric_supported = None
         self._ensure_context()
         self._granularity = self._compute_granularity()
         logger.debug(
@@ -124,8 +126,44 @@ class CudaVmmBackend:
             raise ValueError(
                 f"size {size} is not a multiple of granularity {self._granularity}"
             )
-        prop = self._allocation_prop()
-        handle = self._call("cuMemCreate", self._cu.cuMemCreate(size, prop, 0))
+        # Probe FABRIC once; hosts that reject it fall back to a plain alloc.
+        handle = None
+        if self._fabric_supported is not False:
+            fabric = self._fabric_handle_type()
+            if fabric is not None:
+                try:
+                    handle = self._call(
+                        "cuMemCreate",
+                        self._cu.cuMemCreate(
+                            size, self._allocation_prop(fabric), 0
+                        ),
+                    )
+                    if self._fabric_supported is None:
+                        self._fabric_supported = True
+                        logger.info(
+                            "VMM arena: FABRIC-exportable allocations enabled"
+                        )
+                except CudaBackendError as exc:
+                    # Only a platform-level refusal means FABRIC is unavailable;
+                    # anything else (OOM, bad device) must not disable it.
+                    if (
+                        self._fabric_supported is None
+                        and exc.result_code in self._fabric_unsupported_codes()
+                    ):
+                        self._fabric_supported = False
+                        logger.warning(
+                            "VMM arena: FABRIC handle type unsupported (%s); "
+                            "falling back to non-exportable allocations -- "
+                            "MNNVL cuda_ipc peer-to-peer will NOT be available",
+                            exc,
+                        )
+                    else:
+                        raise
+        if handle is None:
+            prop = self._allocation_prop()
+            handle = self._call(
+                "cuMemCreate", self._cu.cuMemCreate(size, prop, 0)
+            )
         try:
             self._call("cuMemMap", self._cu.cuMemMap(va, size, 0, handle, 0))
             try:
@@ -242,7 +280,7 @@ class CudaVmmBackend:
                 "creating CudaVmmBackend"
             )
 
-    def _allocation_prop(self):
+    def _allocation_prop(self, handle_type=None):
         prop = self._cu.CUmemAllocationProp()
         prop.type = self._cu.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
         prop.location.type = (
@@ -252,7 +290,31 @@ class CudaVmmBackend:
         # GPUDirect RDMA capable so NIXL/UCX can register the resulting
         # range with the HCA without bouncing through host memory.
         prop.allocFlags.gpuDirectRDMACapable = 1
+        # Without this the allocation has no exportable handle types, so
+        # cuMemExportToShareableHandle(FABRIC) fails and MNNVL P2P is impossible.
+        if handle_type is not None:
+            prop.requestedHandleTypes = handle_type
         return prop
+
+    def _fabric_handle_type(self):
+        """CU_MEM_HANDLE_TYPE_FABRIC, or None if unavailable in this build."""
+        try:
+            return self._cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        except AttributeError:
+            logger.warning(
+                "cuda-python bindings expose no CU_MEM_HANDLE_TYPE_FABRIC; "
+                "arena memory will not be MNNVL-exportable (need >= 12.4)"
+            )
+            return None
+
+    def _fabric_unsupported_codes(self):
+        """CUresults that mean the platform cannot do FABRIC handles."""
+        codes = []
+        for name in ("CUDA_ERROR_NOT_SUPPORTED", "CUDA_ERROR_NOT_PERMITTED"):
+            code = getattr(self._cu.CUresult, name, None)
+            if code is not None:
+                codes.append(code)
+        return tuple(codes)
 
     def _access_desc(self):
         access = self._cu.CUmemAccessDesc()

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -57,7 +57,8 @@ metrics = [
 # Required for the VmmArena allocator (CudaVmmBackend uses cuMem* APIs).
 # The pure-Python VmmArena tests don't need it; CudaVmmBackend does.
 vmm = [
-    "cuda-python>=12.0",
+    # 12.4 is the first release exposing CU_MEM_HANDLE_TYPE_FABRIC.
+    "cuda-python>=12.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
`CudaVmmBackend._allocation_prop()` never set `prop.requestedHandleTypes`, so
every `cuMemCreate` in the VMM arena produced an allocation with no exportable
handle types. `uct_cuda_ipc_mem_reg`'s
`cuMemExportToShareableHandle(CU_MEM_HANDLE_TYPE_FABRIC)` therefore fails, and
peer-to-peer over the UCX `cuda_ipc` transport is impossible for arena-backed
memory on multi-node NVLINK (MNNVL) systems.

Measured on GB300 (2 nodes on one MNNVL fabric, 512 MB tensor), replaying what
`uct_cuda_ipc_mem_reg` does:

                                     | arena (before) | default allocator
    cuPointerGetAttribute(14)        | 0x0            | 0x8 (FABRIC)
    cuMemRetainAllocationHandle      | rc=0           | rc=0
    cuMemExportToShareableHandle     | rc=1 FAILED    | rc=0 OK

With this change the arena reports `0x8` and the export returns `rc=0`.

The fabric handle type is probed once and the outcome cached: platforms that
reject it fall back to a plain allocation with a warning rather than failing
the load, so non-fabric hosts are unaffected.

Verified end to end with Kimi-K3 at TP8 across two GB300 nodes: 2712 tensors /
206.38 GB per rank transferred in ~1.0 s at 1.6-2.36 Tbps, versus a disk load
of 334-454 s. Without the change the transfer cannot start at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA virtual memory allocation compatibility on systems that do not support FABRIC handles.
  * Added automatic fallback to standard memory allocation when FABRIC-exportable memory is unavailable.
  * Preserved clear error reporting when FABRIC allocation fails after support has been detected.

* **Improvements**
  * Cached hardware capability checks to provide more reliable and efficient memory allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->