### PR TITLE
fix(nixl): validate arena coverage before single-MR registration

### DIFF
--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -280,7 +280,11 @@ class NixlTransferManager:
         self._tensor_descriptors = tensor_descriptors
         return tensor_descriptors
 
-    def register_tensors(self, tensors: dict[str, torch.Tensor]) -> bytes:
+    def register_tensors(
+        self,
+        tensors: dict[str, torch.Tensor],
+        force_per_tensor: bool = False,
+    ) -> bytes:
         """
         Register tensors with NIXL for RDMA access.
 
@@ -318,7 +322,7 @@ class NixlTransferManager:
 
         # Phase 1: Discover CUDA allocation boundaries (if pool reg enabled)
         alloc_discovery_start = time.perf_counter()
-        if _pool_reg_enabled():
+        if _pool_reg_enabled() and not force_per_tensor:
             if self._accelerator_backend.supports_pool_reg():
                 allocations = self._find_cuda_allocations(tensor_descriptors)
             else:
@@ -426,6 +430,30 @@ class NixlTransferManager:
                 self._accelerator_backend.name,
             )
             return self.register_tensors(tensors)
+
+        # NIXL resolves descriptors by containment, so one tensor outside
+        # [base, base+used) fails prep_xfer_dlist for the whole transfer.
+        uncovered = [
+            d
+            for d in tensor_descriptors
+            if d.addr < base or (d.addr + d.size) > (base + used)
+        ]
+        if uncovered:
+            logger.warning(
+                "register_arena: %d of %d tensors lie outside the arena range "
+                "[0x%x, 0x%x); falling back to per-tensor registration. "
+                "First uncovered: %s at 0x%x (%d bytes)",
+                len(uncovered),
+                len(tensor_descriptors),
+                base,
+                base + used,
+                uncovered[0].name,
+                uncovered[0].addr,
+                uncovered[0].size,
+            )
+            # Bypass pool reg: it resolves the same per-handle bounds we just
+            # found insufficient.
+            return self.register_tensors(tensors, force_per_tensor=True)
 
         nixl_reg_start = time.perf_counter()
         self._agent.register_memory(

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -216,18 +216,55 @@ class TestRawDescriptorMemType:
         )
 
     def test_arena_registration_uses_vram_segment(self):
+        # The arena range must actually cover the tensor, as a real arena does.
+        tensor = torch.zeros(1)
+        base = tensor.data_ptr()
+        used = tensor.numel() * tensor.element_size()
+
+        class FakeArena:
+            def registered_range(self):
+                return base, used
+
+        mgr = self._make_manager()
+        assert mgr.register_arena(FakeArena(), {"w": tensor}) == b"metadata"
+
+        mgr._agent.register_memory.assert_called_once_with(
+            [(base, used, 0, "")],
+            mem_type=NIXL_ACCELERATOR_MEM_TYPE,
+            backends=["UCX"],
+        )
+
+    def test_arena_registration_falls_back_when_tensor_uncovered(self):
+        # A tensor outside [base, base+used) must not be served by the single MR.
         class FakeArena:
             def registered_range(self):
                 return 0x1000, 0x2000
 
+        tensor = torch.zeros(4, dtype=torch.float32)
         mgr = self._make_manager()
-        assert mgr.register_arena(FakeArena(), {"w": torch.zeros(1)}) == b"metadata"
+        assert mgr.register_arena(FakeArena(), {"w": tensor}) == b"metadata"
 
-        mgr._agent.register_memory.assert_called_once_with(
-            [(0x1000, 0x2000, 0, "")],
-            mem_type=NIXL_ACCELERATOR_MEM_TYPE,
-            backends=["UCX"],
-        )
+        args, kwargs = mgr._agent.register_memory.call_args
+        assert args[0][0] is tensor
+        assert kwargs == {"backends": ["UCX"]}
+
+    def test_arena_fallback_bypasses_pool_registration(self, monkeypatch):
+        # Pool reg resolves the same per-handle bounds, so the fallback must
+        # register per tensor even when MX_POOL_REG=1.
+        monkeypatch.setenv("MX_POOL_REG", "1")
+
+        class FakeArena:
+            def registered_range(self):
+                return 0x1000, 0x2000
+
+        tensor = torch.zeros(4, dtype=torch.float32)
+        mgr = self._make_manager()
+        assert mgr.register_arena(FakeArena(), {"w": tensor}) == b"metadata"
+
+        # Per-tensor, not the pool-reg alloc tuples.
+        args, kwargs = mgr._agent.register_memory.call_args
+        assert args[0][0] is tensor
+        assert kwargs == {"backends": ["UCX"]}
 
     def test_receive_transfer_descriptors_use_vram_segment(self, monkeypatch):
         monkeypatch.setattr(torch.cuda, "set_device", lambda *args, **kwargs: None)


### PR DESCRIPTION
`register_arena()` registers one MR over the arena's `[base, base+used)` bump
range, but never checks that every tensor actually lies inside it. NIXL resolves
transfer descriptors by *containment* (`nixlSecDescList::getCoveringIndex` ->
`nixlBasicDesc::covers`), so a single uncovered tensor makes the whole
`prep_xfer_dlist` fail with `NIXL_ERR_NOT_FOUND` -- not just that one
descriptor. The receive then fails with no indication of which tensor was at
fault.

This is reachable whenever a tensor is allocated outside the arena's
`use_arena` scope -- for example buffers created after load by post-processing,
which do not come from the arena's bump allocator.

Observed on GB300 with Kimi-K3 at TP8: the arena registered cleanly as
1 region / 208.40 GB and the consumer reached
`Receiving 2712 tensors from source (P2P)`, then failed in `prep_xfer_dlist`
with `NIXL_ERR_NOT_FOUND` and no further detail. Per-tensor registration
(2712 regions, 1:1 with the descriptors) transfers correctly, which is what
isolated the coverage gap.

Containment resolution itself was verified against the installed nixl wheel:
a descriptor inside a registered region resolves, 512 sub-descriptors inside a
single region resolve, and a descriptor overrunning the region end or with a
mismatched devId returns NotFound.

This adds an up-front coverage check that falls back to per-tensor registration
and names the first uncovered tensor, turning a silent whole-transfer failure
into a warning plus a working (if less compact) registration. It does not
change behaviour when the arena does cover every tensor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tensor registration reliability by validating that all tensors fit within the registered memory range.
  * Automatically falls back to individual tensor registration when tensors extend beyond that range.
  * Added diagnostic logging to help identify registration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->