### PR TITLE
fix(weight_transfer): register local destination memory on the trainer-pull path

### DIFF
--- a/modelexpress_client/python/modelexpress/load_strategy/trainer_pull_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/trainer_pull_strategy.py
@@ -31,7 +31,14 @@ from typing import TYPE_CHECKING, Any
 
 from ..adapter import EngineAdapter, StrategyFailed
 from ..nixl_transfer import is_nixl_available
-from .base import LoadContext, LoadResult, LoadStrategy, _as_load_result, _init_nixl_manager
+from .base import (
+    LoadContext,
+    LoadResult,
+    LoadStrategy,
+    _as_load_result,
+    _init_nixl_manager,
+    register_tensors,
+)
 from .. import envs
 from ..weight_transfer.protocol.serialization import decode_trainer_table
 from ..weight_transfer.roles.pull import PullRole
@@ -130,6 +137,11 @@ class TrainerPullStrategy(LoadStrategy):
                 "trainer-pull",
                 accelerator_backend=ctx.accelerator_backend,
             )
+
+        # A NIXL READ needs its local destination inside a registered region.
+        # Every other strategy in the chain registers here; this one never did,
+        # so prep_xfer_dlist on the local side failed with NIXL_ERR_NOT_FOUND.
+        register_tensors(result, ctx)
 
         planner = (
             ServerPlanner(mx_client=ctx.mx_client)

--- a/modelexpress_client/python/modelexpress/load_strategy/trainer_pull_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/trainer_pull_strategy.py
@@ -143,6 +143,18 @@ class TrainerPullStrategy(LoadStrategy):
         # so prep_xfer_dlist on the local side failed with NIXL_ERR_NOT_FOUND.
         register_tensors(result, ctx)
 
+        # register_tensors is deliberately best-effort: at the other call sites a
+        # failure only costs P2P *serving*, so degrading is right. Here the
+        # registered region is the destination of an inbound READ, so without it
+        # every transfer fails at prep and falls silently through to disk. Turn
+        # that into a strategy failure the fallback chain can act on.
+        if ctx.nixl_manager is None or not ctx.nixl_manager.tensor_descriptors:
+            raise StrategyFailed(
+                "NIXL registration did not complete; trainer pull has no local "
+                "destination to read into",
+                mutated=False,
+            )
+
         planner = (
             ServerPlanner(mx_client=ctx.mx_client)
             if _use_server_planner()

--- a/modelexpress_client/python/tests/test_trainer_pull_strategy.py
+++ b/modelexpress_client/python/tests/test_trainer_pull_strategy.py
@@ -104,3 +104,64 @@ class TestTrainerPullIsAvailable:
         with patch.dict("os.environ", {"MX_WEIGHT_SYNC_SERVER": "mx:8080"}, clear=True):
             with patch(f"{_MODULE}.is_nixl_available", return_value=True):
                 assert strategy.is_available(ctx) is False
+
+
+class TestTrainerPullRequiresRegistration:
+    """register_tensors is best-effort at every other call site, and that is right
+    there: a failure only costs P2P serving.  On this path the registered region is
+    the destination of an inbound READ, so a silent skip means every transfer fails
+    at prep with NIXL_ERR_NOT_FOUND and falls through to disk looking successful.
+    """
+
+    def _load(self, tensor_descriptors):
+        ctx = _make_load_context()
+        ctx.nixl_manager = MagicMock()
+        ctx.nixl_manager.tensor_descriptors = tensor_descriptors
+        strategy = _make_strategy()
+        result = LoadResult(value=MagicMock(), model=MagicMock())
+
+        with (
+            patch.object(strategy, "_fetch_table", return_value=MagicMock()),
+            patch(f"{_MODULE}.register_tensors"),
+            patch(f"{_MODULE}.PullRole") as pull_role,
+            patch(f"{_MODULE}.LocalPlanner"),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            return strategy.load(result, ctx), pull_role
+
+    def test_load_fails_when_registration_left_no_descriptors(self):
+        """The whole point: refuse rather than read into unregistered memory."""
+        from modelexpress.adapter import StrategyFailed
+
+        import pytest
+
+        with pytest.raises(StrategyFailed) as excinfo:
+            self._load({})
+
+        assert excinfo.value.mutated is False
+
+    def test_load_fails_when_nixl_manager_is_absent(self):
+        from modelexpress.adapter import StrategyFailed
+
+        import pytest
+
+        ctx = _make_load_context()
+        ctx.nixl_manager = None
+        strategy = _make_strategy()
+        result = LoadResult(value=MagicMock(), model=MagicMock())
+
+        with (
+            patch.object(strategy, "_fetch_table", return_value=MagicMock()),
+            patch(f"{_MODULE}._init_nixl_manager", return_value=None),
+            patch(f"{_MODULE}.register_tensors"),
+            patch(f"{_MODULE}.PullRole"),
+            patch(f"{_MODULE}.LocalPlanner"),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            with pytest.raises(StrategyFailed):
+                strategy.load(result, ctx)
+
+    def test_load_proceeds_once_descriptors_exist(self):
+        """The guard must not fire on the healthy path."""
+        _result, pull_role = self._load({"weight": object()})
+        assert pull_role.called


### PR DESCRIPTION
TrainerPullStrategy never registered its local destination memory with NIXL. A NIXL READ requires the local destination to sit inside a registered region, so prep_xfer_dlist on the local side could not resolve and the transfer failed with NIXL_ERR_NOT_FOUND. The failure is silent from the caller's point of view: the strategy falls back to rdma and then to instant_tensor, so what looks like a successful weight load has quietly gone to disk instead of over the fabric. Every other strategy in the chain (default, gds, instant_tensor, model_streamer, rdma) already makes this call in the same place; this path was the only one that never did.

The second commit closes the gap that leaves. register_tensors is deliberately best-effort and swallows failures, which is correct at its other call sites, where a miss costs only P2P serving capability. On the trainer-pull path the registered region is the destination of an inbound READ, so a skip means the same silent fall-through to disk. It now raises StrategyFailed(mutated=False) when no descriptors exist after registration. The mutated flag matters on its own: letting the condition reach PullRole.initialize would surface it as mutated=True and claim the model may be half-written when nothing has been touched.

I'd rather not mirror the registration preconditions into is_available() as well, which was the other half of the automated review suggestion. The two copies would drift, and the guard covers the case at the point where it matters.

Measured on real hardware against a live trainer holding 399 registered tensors, 16.38 GB total. Before the change the READ fails at prep on both current main and on the consolidation branch in #588. After it, main completes the transfer in 0.576s at 227.4 Gbps and #588 completes it in 0.577s at 226.9 Gbps, which is the single-QP ceiling for a 400 Gb/s link.

The original defect is not reachable from the mocked suite, which passes with and without the registration call, because it only appears once there is a real NIXL agent on the far side and memory actually has to be registered. It was found with a scratch end-to-end harness that is not in the repo, and getting that harness or an equivalent into CI is worth doing separately. The precondition guard added in the second commit is reachable, and is covered in both branches plus the healthy path; those tests were verified to fail when the guard is removed.

Signed-off-by: Nicolas 'Pixel' Noble <nicolas@nobis-crew.org>