### PR TITLE
feat(refit): add Redis-backed lifecycle control plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,14 @@ jobs:
           --test registry_backend_redis \
           -- --include-ignored --test-threads=1
 
+    - name: Run Refit service Redis integration tests
+      env:
+        REDIS_URL: redis://localhost:6379
+      run: |
+        cargo test -p model-express-workspace-tests \
+          --test refit_service_redis \
+          -- --include-ignored --test-threads=1
+
     - name: Run integration test script
       env:
         MX_METADATA_BACKEND: redis

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,6 +2400,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "tonic 0.13.1",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
 ]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -390,10 +390,11 @@ Weight bytes and full tensor manifests remain on trainer or generator workers.
 | `DeleteVersionLease` | Release a generator's protection of the version shards |
 
 The final missing source slot atomically changes the version to `READY`.
-`WeightVersionShard` remains the name of the per-worker manifest publication:
-`shard_id` identifies that physical publication, while `source_slot_id`
-identifies the required, version-scoped source contribution it covers. The
-trainer coordinator chooses the opaque slots—for example,
+`WeightVersionShard` remains the name of the per-worker manifest publication.
+Its identity is `(version_id, worker_id, source_slot_id)`: `source_slot_id`
+identifies the required, version-scoped source contribution it covers, and
+`worker_id` identifies the publishing process. The trainer coordinator chooses
+the opaque slots—for example,
 `publisher:global-rank:12` for a selected Megatron publisher. Multiple
 publications may advertise the same source slot, including a replacement worker
 or a generator that becomes a peer source. Deployments configured with

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,6 +95,12 @@ ModelExpress/
 │       │   └── backend/
 │       │       ├── redis.rs            # P2P Redis backend
 │       │       └── kubernetes.rs       # P2P Kubernetes CRD backend
+│       ├── refit.rs                     # Refit module exports
+│       ├── refit/
+│       │   ├── service.rs               # Backend-neutral Refit gRPC service
+│       │   ├── backend.rs               # RefitBackend contract and factory
+│       │   └── backend/
+│       │       └── redis.rs             # Redis backend and atomic Lua scripts
 │       ├── registry/
 │       │   ├── state.rs                # RegistryManager wrapper
 │       │   ├── backend.rs              # RegistryBackend trait + ModelRecord
@@ -293,7 +299,7 @@ All cargo dependencies are declared in the root `Cargo.toml`. Sub-crates use wor
 
 ## gRPC Services
 
-Four proto files define four services, all compiled via `tonic-build` in `modelexpress_common/build.rs`:
+Six proto files define the server's gRPC services, all compiled via `tonic-build` in `modelexpress_common/build.rs`:
 
 ### health.proto - HealthService
 
@@ -345,6 +351,59 @@ Per-worker gRPC service started when `MX_P2P_METADATA=1`, or unconditionally whe
 
 See [`metadata.md`](metadata.md) for the full metadata architecture including storage schemas and coordination protocol.
 
+### refit.proto - RefitService (Redis only)
+
+`RefitService` is a new RL-specific control plane. It does not reuse or modify the
+legacy `WeightSyncService`. The initial slice stores worker registrations,
+immutable weight versions, and compact physical shard publications in Redis.
+Weight bytes and full tensor manifests remain on trainer or generator workers.
+
+| RPC | Purpose |
+|-----|---------|
+| `RegisterWorker` | Register or refresh one TTL-bound worker process |
+| `CreateWeightVersion` | Idempotently create one immutable `STAGING` version |
+| `GetWeightVersion` | Read the version and its lifecycle state |
+| `DeleteWeightVersion` | Move a `READY` version to `RELEASING`; existing leases remain valid |
+| `CreateWeightVersionShard` | Publish one worker manifest for a required source slot |
+| `ListWeightVersionShards` | List the version's physical source publications |
+| `DeleteWeightVersionShard` | Evict one source shard after release when no lease protects the version |
+| `RegisterVersionLease` | Acquire protection while a version is `READY`, or renew the same owner's existing protection while it is `READY` or `RELEASING` |
+| `DeleteVersionLease` | Release a generator's protection of the version shards |
+
+The final missing source slot atomically changes the version to `READY`.
+`WeightVersionShard` remains the name of the per-worker manifest publication:
+`shard_id` identifies that physical publication, while `source_slot_id`
+identifies the required, version-scoped source contribution it covers. The
+trainer coordinator chooses the opaque slots—for example,
+`publisher:global-rank:12` for a selected Megatron publisher. Multiple
+publications may advertise the same source slot, including a replacement worker
+or a generator that becomes a peer source. Deployments configured with
+Kubernetes or the test-only memory backend do not expose `RefitService` yet.
+
+`RegisterWorker` is also the heartbeat API. `worker_id` is a fresh process
+incarnation identity, so a restarted worker registers a new ID instead of
+fencing an old registration. The registration expires with its TTL; source
+planning and source discovery will use that liveness when selecting a
+publication.
+
+Cross-key compare-and-set operations live in documented Redis scripts
+under `modelexpress_server/src/refit/backend/redis/scripts/`. Redis executes
+each script atomically. The `refit_service_redis` test drives the public gRPC
+API through two server replicas and covers concurrent version creation,
+concurrent final source-slot publication, idempotent and conflicting replay,
+replacement-source publication, lease-protected release, and safe shard
+eviction. CI runs this test against Redis 7.
+
+A future Kubernetes backend can preserve this gRPC contract, but it cannot
+translate each Redis key into an independent CRD and retain the same atomic
+guarantees. Lease creation and shard deletion race across resources. The
+Kubernetes implementation therefore needs one version-scoped coordination
+object as the serialization boundary, updated with `resourceVersion`
+compare-and-swap; shard and lease objects can remain child records.
+`RefitService` depends on the domain-level `RefitBackend` contract, with Redis
+implemented under `refit/backend/redis.rs`. Kubernetes remains a separate
+end-to-end backend slice implementing the same transaction boundaries.
+
 ## Rust Server
 
 ### Startup Flow
@@ -357,7 +416,7 @@ See [`metadata.md`](metadata.md) for the full metadata architecture including st
 6. Start `CacheEvictionService` background task (reads the same registry)
 7. Connect to the P2P metadata backend (`MX_METADATA_BACKEND`, Redis or Kubernetes CRD)
 8. Start reaper background task for stale source detection and GC
-9. Register 4 gRPC services with tonic (max message size: 100MB)
+9. Register the configured gRPC services with tonic (max message size: 100MB)
 10. Listen on configured address (default `0.0.0.0:8001`)
 11. Graceful shutdown on CTRL+C (signals cache eviction service and reaper)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -390,6 +390,9 @@ Weight bytes and full tensor manifests remain on trainer or generator workers.
 | `DeleteVersionLease` | Release a generator's protection of the version shards |
 
 The final missing source slot atomically changes the version to `READY`.
+`WeightVersion.uid` is MX's opaque identity. `version_number` is the optional
+framework-provided numeric label used for correlation; MX does not use it as an
+identity or ordering key.
 `WeightVersionShard` remains the name of the per-worker manifest publication.
 Its identity is `(version_id, worker_id, source_slot_id)`: `source_slot_id`
 identifies the required, version-scoped source contribution it covers, and

--- a/modelexpress_common/build.rs
+++ b/modelexpress_common/build.rs
@@ -13,6 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "proto/model.proto",
                 "proto/p2p.proto",
                 "proto/weight_sync.proto",
+                "proto/refit.proto",
             ],
             &["proto"],
         )?;

--- a/modelexpress_common/proto/refit.proto
+++ b/modelexpress_common/proto/refit.proto
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package model_express.refit;
+
+// Control-plane metadata for RL weight publication. Weight bytes and full
+// manifests remain on trainer and generator workers.
+service RefitService {
+  // External APIs: called by the RL framework orchestrator.
+  rpc CreateWeightVersion(CreateWeightVersionRequest) returns (WeightVersion);
+  rpc GetWeightVersion(GetWeightVersionRequest) returns (WeightVersion);
+  rpc DeleteWeightVersion(DeleteWeightVersionRequest) returns (WeightVersion);
+
+  // Internal APIs: called by ModelExpress worker clients, not by the RL
+  // framework orchestrator.
+  rpc RegisterWorker(RegisterWorkerRequest) returns (WorkerRegistration);
+  rpc CreateWeightVersionShard(CreateWeightVersionShardRequest) returns (CreateWeightVersionShardResponse);
+  rpc ListWeightVersionShards(ListWeightVersionShardsRequest) returns (ListWeightVersionShardsResponse);
+  rpc DeleteWeightVersionShard(DeleteWeightVersionShardRequest) returns (DeleteWeightVersionShardResponse);
+  // A live lease protects every shard while a generator installs the version.
+  // Re-registering the same lease owner renews its expiry.
+  rpc RegisterVersionLease(RegisterVersionLeaseRequest) returns (VersionLease);
+  rpc DeleteVersionLease(DeleteVersionLeaseRequest) returns (DeleteVersionLeaseResponse);
+}
+
+enum WorkerRole {
+  WORKER_ROLE_UNSPECIFIED = 0;
+  WORKER_ROLE_TRAINER = 1;
+  WORKER_ROLE_GENERATOR = 2;
+}
+
+enum WeightPayloadFormat {
+  WEIGHT_PAYLOAD_FORMAT_UNSPECIFIED = 0;
+  WEIGHT_PAYLOAD_FORMAT_FULL_TENSOR = 1;
+  WEIGHT_PAYLOAD_FORMAT_XOR_DELTA = 2;
+}
+
+enum WeightVersionState {
+  WEIGHT_VERSION_STATE_UNSPECIFIED = 0;
+  WEIGHT_VERSION_STATE_STAGING = 1;
+  WEIGHT_VERSION_STATE_READY = 2;
+  WEIGHT_VERSION_STATE_RELEASING = 3;
+}
+
+message WorkerRegistration {
+  // Fresh identity for this concrete process lifetime. A restarted worker
+  // receives a new worker_id rather than fencing a prior registration.
+  string worker_id = 1;
+  reserved 2, 3;
+  WorkerRole role = 4;
+  string model_name = 5;
+  string endpoint = 6;
+  uint64 expires_at_unix_ms = 7;
+}
+
+message RegisterWorkerRequest {
+  WorkerRegistration worker = 1;
+  uint32 ttl_seconds = 2;
+}
+
+message WeightVersion {
+  // Server-generated 8-character lowercase hexadecimal ID.
+  string version_id = 1;
+  string model_name = 2;
+  optional uint64 sequence = 3;
+  string idempotency_key = 4;
+  WeightPayloadFormat payload_format = 5;
+  string base_version_id = 6;
+  // Required version-scoped source contributions. Physical source workers are
+  // not baked in; the trainer coordinator supplies opaque IDs such as a
+  // selected publisher global rank.
+  repeated string expected_source_slots = 7;
+  string layout_signature = 8;
+  WeightVersionState state = 9;
+  uint64 created_at_unix_ms = 10;
+}
+
+message CreateWeightVersionRequest {
+  string model_name = 1;
+  optional uint64 sequence = 2;
+  string idempotency_key = 3;
+  WeightPayloadFormat payload_format = 4;
+  string base_version_id = 5;
+  repeated string expected_source_slots = 6;
+}
+
+message GetWeightVersionRequest {
+  string version_id = 1;
+}
+
+message DeleteWeightVersionRequest {
+  string version_id = 1;
+}
+
+message WeightVersionShard {
+  string version_id = 1;
+  // Unique physical publication of one worker's complete manifest.
+  string shard_id = 2;
+  // Required version-scoped source contribution covered by this publication.
+  string source_slot_id = 3;
+  string worker_id = 4;
+  reserved 5, 6;
+  uint64 tensor_count = 7;
+  uint64 total_bytes = 8;
+  string manifest_digest = 9;
+  string manifest_endpoint = 10;
+  string transport = 11;
+}
+
+message CreateWeightVersionShardRequest {
+  WeightVersionShard shard = 1;
+}
+
+message CreateWeightVersionShardResponse {
+  WeightVersionShard shard = 1;
+  WeightVersion version = 2;
+}
+
+message ListWeightVersionShardsRequest {
+  string version_id = 1;
+}
+
+message ListWeightVersionShardsResponse {
+  repeated WeightVersionShard shards = 1;
+}
+
+message DeleteWeightVersionShardRequest {
+  string version_id = 1;
+  string shard_id = 2;
+  string worker_id = 3;
+  reserved 4, 5;
+}
+
+message DeleteWeightVersionShardResponse {
+  bool deleted = 1;
+}
+
+message VersionLease {
+  // Server-generated 8-character lowercase hexadecimal ID.
+  string lease_id = 1;
+  string version_id = 2;
+  string worker_id = 3;
+  reserved 4, 5;
+  uint64 expires_at_unix_ms = 6;
+}
+
+message RegisterVersionLeaseRequest {
+  string version_id = 1;
+  string worker_id = 2;
+  reserved 3, 4;
+  uint32 ttl_seconds = 5;
+}
+
+message DeleteVersionLeaseRequest {
+  string version_id = 1;
+  string lease_id = 2;
+  string worker_id = 3;
+  reserved 4, 5;
+}
+
+message DeleteVersionLeaseResponse {
+  bool deleted = 1;
+}

--- a/modelexpress_common/proto/refit.proto
+++ b/modelexpress_common/proto/refit.proto
@@ -48,11 +48,10 @@ message WorkerRegistration {
   // Fresh identity for this concrete process lifetime. A restarted worker
   // receives a new worker_id rather than fencing a prior registration.
   string worker_id = 1;
-  reserved 2, 3;
-  WorkerRole role = 4;
-  string model_name = 5;
-  string endpoint = 6;
-  uint64 expires_at_unix_ms = 7;
+  WorkerRole role = 2;
+  string model_name = 3;
+  string endpoint = 4;
+  uint64 expires_at_unix_ms = 5;
 }
 
 message RegisterWorkerRequest {
@@ -67,11 +66,15 @@ message WeightVersion {
   optional uint64 sequence = 3;
   string idempotency_key = 4;
   WeightPayloadFormat payload_format = 5;
-  string base_version_id = 6;
+  // Present only for XOR_DELTA; identifies the base WeightVersion to which the
+  // delta is applied.
+  optional string base_version_id = 6;
   // Required version-scoped source contributions. Physical source workers are
   // not baked in; the trainer coordinator supplies opaque IDs such as a
   // selected publisher global rank.
   repeated string expected_source_slots = 7;
+  // Adapter-defined fingerprint of the model parameter layout, used to detect
+  // incompatible source manifests.
   string layout_signature = 8;
   WeightVersionState state = 9;
   uint64 created_at_unix_ms = 10;
@@ -82,7 +85,8 @@ message CreateWeightVersionRequest {
   optional uint64 sequence = 2;
   string idempotency_key = 3;
   WeightPayloadFormat payload_format = 4;
-  string base_version_id = 5;
+  // Required only for XOR_DELTA; omitted for FULL_TENSOR.
+  optional string base_version_id = 5;
   repeated string expected_source_slots = 6;
 }
 
@@ -96,17 +100,15 @@ message DeleteWeightVersionRequest {
 
 message WeightVersionShard {
   string version_id = 1;
-  // Unique physical publication of one worker's complete manifest.
-  string shard_id = 2;
   // Required version-scoped source contribution covered by this publication.
-  string source_slot_id = 3;
-  string worker_id = 4;
-  reserved 5, 6;
-  uint64 tensor_count = 7;
-  uint64 total_bytes = 8;
-  string manifest_digest = 9;
-  string manifest_endpoint = 10;
-  string transport = 11;
+  string source_slot_id = 2;
+  // Together with version_id and source_slot_id, identifies this publication.
+  string worker_id = 3;
+  uint64 tensor_count = 4;
+  uint64 total_bytes = 5;
+  string manifest_digest = 6;
+  string manifest_endpoint = 7;
+  string transport = 8;
 }
 
 message CreateWeightVersionShardRequest {
@@ -128,9 +130,8 @@ message ListWeightVersionShardsResponse {
 
 message DeleteWeightVersionShardRequest {
   string version_id = 1;
-  string shard_id = 2;
+  string source_slot_id = 2;
   string worker_id = 3;
-  reserved 4, 5;
 }
 
 message DeleteWeightVersionShardResponse {
@@ -142,22 +143,19 @@ message VersionLease {
   string lease_id = 1;
   string version_id = 2;
   string worker_id = 3;
-  reserved 4, 5;
-  uint64 expires_at_unix_ms = 6;
+  uint64 expires_at_unix_ms = 4;
 }
 
 message RegisterVersionLeaseRequest {
   string version_id = 1;
   string worker_id = 2;
-  reserved 3, 4;
-  uint32 ttl_seconds = 5;
+  uint32 ttl_seconds = 3;
 }
 
 message DeleteVersionLeaseRequest {
   string version_id = 1;
   string lease_id = 2;
   string worker_id = 3;
-  reserved 4, 5;
 }
 
 message DeleteVersionLeaseResponse {

--- a/modelexpress_common/proto/refit.proto
+++ b/modelexpress_common/proto/refit.proto
@@ -60,10 +60,11 @@ message RegisterWorkerRequest {
 }
 
 message WeightVersion {
-  // Server-generated 8-character lowercase hexadecimal ID.
-  string version_id = 1;
+  // MX-generated opaque identity for this WeightVersion.
+  string uid = 1;
   string model_name = 2;
-  optional uint64 sequence = 3;
+  // Framework-provided version number for correlation and observability only.
+  optional uint64 version_number = 3;
   string idempotency_key = 4;
   WeightPayloadFormat payload_format = 5;
   // Present only for XOR_DELTA; identifies the base WeightVersion to which the
@@ -82,7 +83,7 @@ message WeightVersion {
 
 message CreateWeightVersionRequest {
   string model_name = 1;
-  optional uint64 sequence = 2;
+  optional uint64 version_number = 2;
   string idempotency_key = 3;
   WeightPayloadFormat payload_format = 4;
   // Required only for XOR_DELTA; omitted for FULL_TENSOR.
@@ -91,11 +92,11 @@ message CreateWeightVersionRequest {
 }
 
 message GetWeightVersionRequest {
-  string version_id = 1;
+  string uid = 1;
 }
 
 message DeleteWeightVersionRequest {
-  string version_id = 1;
+  string uid = 1;
 }
 
 message WeightVersionShard {

--- a/modelexpress_common/src/lib.rs
+++ b/modelexpress_common/src/lib.rs
@@ -37,6 +37,9 @@ pub mod grpc {
     pub mod weight_sync {
         tonic::include_proto!("weight_sync");
     }
+    pub mod refit {
+        tonic::include_proto!("model_express.refit");
+    }
 }
 
 /// Defines the shared response format between server and client (legacy HTTP)

--- a/modelexpress_server/src/lib.rs
+++ b/modelexpress_server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod backend_config;
 pub mod cache;
 pub mod config;
 pub mod p2p;
+pub mod refit;
 pub mod registry;
 pub mod server;
 pub mod services;

--- a/modelexpress_server/src/refit.rs
+++ b/modelexpress_server/src/refit.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! RL refit control-plane service and metadata backends.
+
+pub mod backend;
+pub mod service;

--- a/modelexpress_server/src/refit/backend.rs
+++ b/modelexpress_server/src/refit/backend.rs
@@ -54,9 +54,9 @@ pub trait RefitBackend: Send + Sync {
         request: &CreateWeightVersionRequest,
     ) -> RefitResult<WeightVersion>;
 
-    async fn get_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion>;
+    async fn get_weight_version(&self, uid: &str) -> RefitResult<WeightVersion>;
 
-    async fn delete_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion>;
+    async fn delete_weight_version(&self, uid: &str) -> RefitResult<WeightVersion>;
 
     async fn create_weight_version_shard(
         &self,

--- a/modelexpress_server/src/refit/backend.rs
+++ b/modelexpress_server/src/refit/backend.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend abstraction for RL refit control-plane metadata.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modelexpress_common::grpc::refit::{
+    CreateWeightVersionRequest, DeleteVersionLeaseRequest, DeleteWeightVersionShardRequest,
+    RegisterVersionLeaseRequest, VersionLease, WeightVersion, WeightVersionShard,
+    WorkerRegistration,
+};
+
+use crate::backend_config::BackendConfig;
+
+pub mod redis;
+
+pub type RefitResult<T> = Result<T, RefitBackendError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RefitBackendError {
+    #[error("{0}")]
+    InvalidArgument(String),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("{0}")]
+    FailedPrecondition(String),
+    #[error("{0}")]
+    AlreadyExists(String),
+    #[error("{0}")]
+    ResourceExhausted(String),
+    #[error("{0}")]
+    Internal(String),
+    #[error("{0}")]
+    Unavailable(String),
+}
+
+/// Atomic domain operations required by `RefitService`.
+///
+/// Each method is one backend transaction boundary. Redis implements these
+/// operations with Lua; a Kubernetes implementation can use a version-scoped
+/// coordination CR and `resourceVersion` compare-and-swap.
+#[async_trait]
+pub trait RefitBackend: Send + Sync {
+    async fn register_worker(
+        &self,
+        worker: WorkerRegistration,
+        ttl_seconds: u32,
+    ) -> RefitResult<WorkerRegistration>;
+
+    async fn create_weight_version(
+        &self,
+        request: &CreateWeightVersionRequest,
+    ) -> RefitResult<WeightVersion>;
+
+    async fn get_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion>;
+
+    async fn delete_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion>;
+
+    async fn create_weight_version_shard(
+        &self,
+        shard: WeightVersionShard,
+    ) -> RefitResult<(WeightVersionShard, WeightVersion)>;
+
+    async fn list_weight_version_shards(
+        &self,
+        version_id: &str,
+    ) -> RefitResult<Vec<WeightVersionShard>>;
+
+    async fn delete_weight_version_shard(
+        &self,
+        request: &DeleteWeightVersionShardRequest,
+    ) -> RefitResult<bool>;
+
+    async fn register_version_lease(
+        &self,
+        request: &RegisterVersionLeaseRequest,
+    ) -> RefitResult<VersionLease>;
+
+    async fn delete_version_lease(&self, request: &DeleteVersionLeaseRequest) -> RefitResult<bool>;
+}
+
+/// Construct the configured Refit backend.
+///
+/// Refit is not exposed for backends that do not yet implement its atomic
+/// lifecycle contract.
+pub async fn create_backend(config: &BackendConfig) -> RefitResult<Option<Arc<dyn RefitBackend>>> {
+    match config {
+        BackendConfig::Redis { url } => Ok(Some(Arc::new(
+            redis::RedisRefitBackend::connect(url).await?,
+        ))),
+        BackendConfig::Kubernetes { .. } => Ok(None),
+        #[cfg(feature = "memory-backend")]
+        BackendConfig::Memory => Ok(None),
+    }
+}

--- a/modelexpress_server/src/refit/backend/redis.rs
+++ b/modelexpress_server/src/refit/backend/redis.rs
@@ -116,17 +116,16 @@ where
 }
 
 fn version_from_hash(fields: HashMap<String, String>) -> RefitResult<WeightVersion> {
-    let sequence =
-        match hash_field(&fields, "sequence")? {
-            "" => None,
-            value => Some(value.parse().map_err(|error| {
-                RefitBackendError::Internal(format!("invalid sequence: {error}"))
-            })?),
-        };
+    let version_number = match hash_field(&fields, "version_number")? {
+        "" => None,
+        value => Some(value.parse().map_err(|error| {
+            RefitBackendError::Internal(format!("invalid version_number: {error}"))
+        })?),
+    };
     Ok(WeightVersion {
-        version_id: hash_field(&fields, "version_id")?.to_string(),
+        uid: hash_field(&fields, "uid")?.to_string(),
         model_name: hash_field(&fields, "model_name")?.to_string(),
-        sequence,
+        version_number,
         idempotency_key: hash_field(&fields, "idempotency_key")?.to_string(),
         payload_format: parse_hash_field(&fields, "payload_format")?,
         base_version_id: match hash_field(&fields, "base_version_id")? {
@@ -181,7 +180,7 @@ impl RedisRefitBackend {
     async fn create_version_once(
         &self,
         request: &CreateWeightVersionRequest,
-        version_id: &str,
+        uid: &str,
     ) -> RefitResult<String> {
         let expected_source_slots =
             serde_json::to_string(&request.expected_source_slots).map_err(|error| {
@@ -190,17 +189,17 @@ impl RedisRefitBackend {
         let script = Script::new(CREATE_VERSION_LUA);
         let mut invocation = script.prepare_invoke();
         invocation
-            .key(version_key(version_id))
+            .key(version_key(uid))
             .key(idempotency_key(
                 &request.model_name,
                 &request.idempotency_key,
             ))
-            .key(expected_source_slots_key(version_id))
-            .arg(version_id)
+            .key(expected_source_slots_key(uid))
+            .arg(uid)
             .arg(&request.model_name)
             .arg(
                 request
-                    .sequence
+                    .version_number
                     .map_or_else(String::new, |value| value.to_string()),
             )
             .arg(&request.idempotency_key)
@@ -261,20 +260,20 @@ impl RefitBackend for RedisRefitBackend {
         request: &CreateWeightVersionRequest,
     ) -> RefitResult<WeightVersion> {
         for _ in 0..5 {
-            let version_id: String = Uuid::new_v4()
+            let uid: String = Uuid::new_v4()
                 .simple()
                 .to_string()
                 .chars()
                 .take(8)
                 .collect();
-            let result = self.create_version_once(request, &version_id).await?;
+            let result = self.create_version_once(request, &uid).await?;
             if result == "CREATED" {
-                return self.get_weight_version(&version_id).await;
+                return self.get_weight_version(&uid).await;
             }
-            if let Some(existing_id) = result.strip_prefix("EXISTING:") {
-                let existing = self.get_weight_version(existing_id).await?;
+            if let Some(existing_uid) = result.strip_prefix("EXISTING:") {
+                let existing = self.get_weight_version(existing_uid).await?;
                 if existing.model_name == request.model_name
-                    && existing.sequence == request.sequence
+                    && existing.version_number == request.version_number
                     && existing.payload_format == request.payload_format
                     && existing.base_version_id == request.base_version_id
                     && existing.expected_source_slots == request.expected_source_slots
@@ -296,31 +295,29 @@ impl RefitBackend for RedisRefitBackend {
         ))
     }
 
-    async fn get_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion> {
+    async fn get_weight_version(&self, uid: &str) -> RefitResult<WeightVersion> {
         let mut redis = self.redis.clone();
-        let fields: HashMap<String, String> = redis
-            .hgetall(version_key(version_id))
-            .await
-            .map_err(redis_error)?;
+        let fields: HashMap<String, String> =
+            redis.hgetall(version_key(uid)).await.map_err(redis_error)?;
         if fields.is_empty() {
             return Err(RefitBackendError::NotFound(format!(
-                "weight version {version_id:?} was not found"
+                "weight version UID {uid:?} was not found"
             )));
         }
         version_from_hash(fields)
     }
 
-    async fn delete_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion> {
+    async fn delete_weight_version(&self, uid: &str) -> RefitResult<WeightVersion> {
         let mut redis = self.redis.clone();
         let result: String = Script::new(DELETE_VERSION_LUA)
-            .key(version_key(version_id))
+            .key(version_key(uid))
             .arg(i32::from(WeightVersionState::Releasing))
             .arg(i32::from(WeightVersionState::Ready))
             .invoke_async(&mut redis)
             .await
             .map_err(redis_error)?;
         match result.as_str() {
-            "OK" => self.get_weight_version(version_id).await,
+            "OK" => self.get_weight_version(uid).await,
             "VERSION_NOT_FOUND" => Err(RefitBackendError::NotFound(
                 "weight version was not found".to_string(),
             )),

--- a/modelexpress_server/src/refit/backend/redis.rs
+++ b/modelexpress_server/src/refit/backend/redis.rs
@@ -1,0 +1,578 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Redis implementation of the Refit control-plane backend.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use modelexpress_common::grpc::refit::{
+    CreateWeightVersionRequest, DeleteVersionLeaseRequest, DeleteWeightVersionShardRequest,
+    RegisterVersionLeaseRequest, VersionLease, WeightVersion, WeightVersionShard,
+    WeightVersionState, WorkerRegistration,
+};
+use prost::Message;
+use redis::aio::ConnectionManager;
+use redis::{AsyncCommands, Script};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::{RefitBackend, RefitBackendError, RefitResult};
+
+const CREATE_VERSION_LUA: &str = include_str!("redis/scripts/create_weight_version.lua");
+const REGISTER_WORKER_LUA: &str = include_str!("redis/scripts/register_worker.lua");
+const CREATE_SHARD_LUA: &str = include_str!("redis/scripts/create_weight_version_shard.lua");
+const DELETE_VERSION_LUA: &str = include_str!("redis/scripts/delete_weight_version.lua");
+const DELETE_SHARD_LUA: &str = include_str!("redis/scripts/delete_weight_version_shard.lua");
+const REGISTER_LEASE_LUA: &str = include_str!("redis/scripts/register_version_lease.lua");
+const DELETE_LEASE_LUA: &str = include_str!("redis/scripts/delete_version_lease.lua");
+
+fn version_key(version_id: &str) -> String {
+    format!("mx:refit:version:{version_id}")
+}
+
+fn shards_key(version_id: &str) -> String {
+    format!("mx:refit:version:{version_id}:shards")
+}
+
+fn coverage_key(version_id: &str) -> String {
+    format!("mx:refit:version:{version_id}:coverage")
+}
+
+fn expected_source_slots_key(version_id: &str) -> String {
+    format!("mx:refit:version:{version_id}:expected-source-slots")
+}
+
+fn worker_key(worker_id: &str) -> String {
+    format!("mx:refit:worker:{worker_id}")
+}
+
+fn leases_key(version_id: &str) -> String {
+    format!("mx:refit:version:{version_id}:leases")
+}
+
+fn lease_key(version_id: &str, lease_id: &str) -> String {
+    format!("mx:refit:version:{version_id}:lease:{lease_id}")
+}
+
+fn idempotency_key(model_name: &str, request_key: &str) -> String {
+    format!("mx:refit:version-request:{model_name}:{request_key}")
+}
+
+fn lease_id(version_id: &str, worker_id: &str) -> String {
+    let digest = Sha256::digest(format!("{version_id}\0{worker_id}").as_bytes());
+    let mut id = String::with_capacity(8);
+    for byte in &digest[..4] {
+        let _ = write!(id, "{byte:02x}");
+    }
+    id
+}
+
+fn now_unix_ms() -> RefitResult<u64> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| RefitBackendError::Internal(format!("system clock error: {error}")))?
+        .as_millis();
+    u64::try_from(millis)
+        .map_err(|_| RefitBackendError::Internal("system time does not fit in uint64".to_string()))
+}
+
+fn redis_error(error: redis::RedisError) -> RefitBackendError {
+    if error.is_io_error()
+        || error.is_cluster_error()
+        || matches!(
+            error.kind(),
+            redis::ErrorKind::BusyLoadingError
+                | redis::ErrorKind::MasterDown
+                | redis::ErrorKind::ClusterConnectionNotFound
+        )
+    {
+        RefitBackendError::Unavailable(error.to_string())
+    } else {
+        RefitBackendError::Internal(error.to_string())
+    }
+}
+
+fn hash_field<'a>(fields: &'a HashMap<String, String>, name: &str) -> RefitResult<&'a str> {
+    fields.get(name).map(String::as_str).ok_or_else(|| {
+        RefitBackendError::Internal(format!("Refit metadata record is missing {name}"))
+    })
+}
+
+fn parse_hash_field<T>(fields: &HashMap<String, String>, name: &str) -> RefitResult<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    hash_field(fields, name)?.parse().map_err(|error| {
+        RefitBackendError::Internal(format!("invalid {name} in Refit metadata: {error}"))
+    })
+}
+
+fn version_from_hash(fields: HashMap<String, String>) -> RefitResult<WeightVersion> {
+    let sequence =
+        match hash_field(&fields, "sequence")? {
+            "" => None,
+            value => Some(value.parse().map_err(|error| {
+                RefitBackendError::Internal(format!("invalid sequence: {error}"))
+            })?),
+        };
+    Ok(WeightVersion {
+        version_id: hash_field(&fields, "version_id")?.to_string(),
+        model_name: hash_field(&fields, "model_name")?.to_string(),
+        sequence,
+        idempotency_key: hash_field(&fields, "idempotency_key")?.to_string(),
+        payload_format: parse_hash_field(&fields, "payload_format")?,
+        base_version_id: hash_field(&fields, "base_version_id")?.to_string(),
+        expected_source_slots: serde_json::from_str(hash_field(&fields, "expected_source_slots")?)
+            .map_err(|error| {
+                RefitBackendError::Internal(format!("invalid expected_source_slots: {error}"))
+            })?,
+        layout_signature: hash_field(&fields, "layout_signature")?.to_string(),
+        state: parse_hash_field(&fields, "state")?,
+        created_at_unix_ms: parse_hash_field(&fields, "created_at_unix_ms")?,
+    })
+}
+
+fn lease_from_hash(fields: HashMap<String, String>) -> RefitResult<VersionLease> {
+    Ok(VersionLease {
+        lease_id: hash_field(&fields, "lease_id")?.to_string(),
+        version_id: hash_field(&fields, "version_id")?.to_string(),
+        worker_id: hash_field(&fields, "worker_id")?.to_string(),
+        expires_at_unix_ms: parse_hash_field(&fields, "expires_at_unix_ms")?,
+    })
+}
+
+#[derive(Clone)]
+pub struct RedisRefitBackend {
+    redis: ConnectionManager,
+}
+
+impl RedisRefitBackend {
+    pub async fn connect(redis_url: &str) -> RefitResult<Self> {
+        let client = redis::Client::open(redis_url).map_err(redis_error)?;
+        let redis = ConnectionManager::new(client).await.map_err(redis_error)?;
+        Ok(Self { redis })
+    }
+
+    async fn get_lease(&self, version_id: &str, lease_id: &str) -> RefitResult<VersionLease> {
+        let mut redis = self.redis.clone();
+        let fields: HashMap<String, String> = redis
+            .hgetall(lease_key(version_id, lease_id))
+            .await
+            .map_err(redis_error)?;
+        if fields.is_empty() {
+            return Err(RefitBackendError::NotFound(format!(
+                "version lease {lease_id:?} was not found"
+            )));
+        }
+        lease_from_hash(fields)
+    }
+
+    async fn create_version_once(
+        &self,
+        request: &CreateWeightVersionRequest,
+        version_id: &str,
+    ) -> RefitResult<String> {
+        let expected_source_slots =
+            serde_json::to_string(&request.expected_source_slots).map_err(|error| {
+                RefitBackendError::Internal(format!("encode expected_source_slots: {error}"))
+            })?;
+        let script = Script::new(CREATE_VERSION_LUA);
+        let mut invocation = script.prepare_invoke();
+        invocation
+            .key(version_key(version_id))
+            .key(idempotency_key(
+                &request.model_name,
+                &request.idempotency_key,
+            ))
+            .key(expected_source_slots_key(version_id))
+            .arg(version_id)
+            .arg(&request.model_name)
+            .arg(
+                request
+                    .sequence
+                    .map_or_else(String::new, |value| value.to_string()),
+            )
+            .arg(&request.idempotency_key)
+            .arg(request.payload_format)
+            .arg(&request.base_version_id)
+            .arg(expected_source_slots)
+            .arg(request.expected_source_slots.len())
+            .arg(i32::from(WeightVersionState::Staging))
+            .arg(now_unix_ms()?);
+        for source_slot_id in &request.expected_source_slots {
+            invocation.arg(source_slot_id);
+        }
+        let mut redis = self.redis.clone();
+        invocation
+            .invoke_async(&mut redis)
+            .await
+            .map_err(redis_error)
+    }
+}
+
+#[async_trait]
+impl RefitBackend for RedisRefitBackend {
+    async fn register_worker(
+        &self,
+        mut worker: WorkerRegistration,
+        ttl_seconds: u32,
+    ) -> RefitResult<WorkerRegistration> {
+        let mut redis = self.redis.clone();
+        let result: String = Script::new(REGISTER_WORKER_LUA)
+            .key(worker_key(&worker.worker_id))
+            .arg(&worker.worker_id)
+            .arg(worker.role)
+            .arg(&worker.model_name)
+            .arg(&worker.endpoint)
+            .arg(u64::from(ttl_seconds).saturating_mul(1000))
+            .invoke_async(&mut redis)
+            .await
+            .map_err(redis_error)?;
+        if result == "CONFLICT" {
+            return Err(RefitBackendError::AlreadyExists(
+                "worker_id is already registered with different metadata".to_string(),
+            ));
+        }
+        worker.expires_at_unix_ms = result
+            .strip_prefix("OK:")
+            .ok_or_else(|| {
+                RefitBackendError::Internal(format!("unexpected Redis response: {result}"))
+            })?
+            .parse()
+            .map_err(|error| {
+                RefitBackendError::Internal(format!("invalid expiry from Redis: {error}"))
+            })?;
+        Ok(worker)
+    }
+
+    async fn create_weight_version(
+        &self,
+        request: &CreateWeightVersionRequest,
+    ) -> RefitResult<WeightVersion> {
+        for _ in 0..5 {
+            let version_id: String = Uuid::new_v4()
+                .simple()
+                .to_string()
+                .chars()
+                .take(8)
+                .collect();
+            let result = self.create_version_once(request, &version_id).await?;
+            if result == "CREATED" {
+                return self.get_weight_version(&version_id).await;
+            }
+            if let Some(existing_id) = result.strip_prefix("EXISTING:") {
+                let existing = self.get_weight_version(existing_id).await?;
+                if existing.model_name == request.model_name
+                    && existing.sequence == request.sequence
+                    && existing.payload_format == request.payload_format
+                    && existing.base_version_id == request.base_version_id
+                    && existing.expected_source_slots == request.expected_source_slots
+                {
+                    return Ok(existing);
+                }
+                return Err(RefitBackendError::AlreadyExists(
+                    "idempotency_key was already used for a different WeightVersion".to_string(),
+                ));
+            }
+            if result != "COLLISION" {
+                return Err(RefitBackendError::Internal(format!(
+                    "unexpected Redis response: {result}"
+                )));
+            }
+        }
+        Err(RefitBackendError::ResourceExhausted(
+            "could not allocate a unique weight version ID".to_string(),
+        ))
+    }
+
+    async fn get_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion> {
+        let mut redis = self.redis.clone();
+        let fields: HashMap<String, String> = redis
+            .hgetall(version_key(version_id))
+            .await
+            .map_err(redis_error)?;
+        if fields.is_empty() {
+            return Err(RefitBackendError::NotFound(format!(
+                "weight version {version_id:?} was not found"
+            )));
+        }
+        version_from_hash(fields)
+    }
+
+    async fn delete_weight_version(&self, version_id: &str) -> RefitResult<WeightVersion> {
+        let mut redis = self.redis.clone();
+        let result: String = Script::new(DELETE_VERSION_LUA)
+            .key(version_key(version_id))
+            .arg(i32::from(WeightVersionState::Releasing))
+            .arg(i32::from(WeightVersionState::Ready))
+            .invoke_async(&mut redis)
+            .await
+            .map_err(redis_error)?;
+        match result.as_str() {
+            "OK" => self.get_weight_version(version_id).await,
+            "VERSION_NOT_FOUND" => Err(RefitBackendError::NotFound(
+                "weight version was not found".to_string(),
+            )),
+            "VERSION_NOT_READY" => Err(RefitBackendError::FailedPrecondition(
+                "only a READY weight version can be deleted".to_string(),
+            )),
+            _ => Err(RefitBackendError::Internal(format!(
+                "unexpected Redis response: {result}"
+            ))),
+        }
+    }
+
+    async fn create_weight_version_shard(
+        &self,
+        shard: WeightVersionShard,
+    ) -> RefitResult<(WeightVersionShard, WeightVersion)> {
+        let mut version = self.get_weight_version(&shard.version_id).await?;
+        let encoded = shard.encode_to_vec();
+        let mut redis = self.redis.clone();
+        let result: String = Script::new(CREATE_SHARD_LUA)
+            .key(version_key(&shard.version_id))
+            .key(worker_key(&shard.worker_id))
+            .key(shards_key(&shard.version_id))
+            .key(coverage_key(&shard.version_id))
+            .key(expected_source_slots_key(&shard.version_id))
+            .arg(&shard.shard_id)
+            .arg(encoded)
+            .arg(&version.model_name)
+            .arg(&shard.source_slot_id)
+            .arg(i32::from(WeightVersionState::Staging))
+            .arg(i32::from(WeightVersionState::Ready))
+            .invoke_async(&mut redis)
+            .await
+            .map_err(redis_error)?;
+        let state = match result.as_str() {
+            "VERSION_NOT_FOUND" => {
+                return Err(RefitBackendError::NotFound(
+                    "weight version was not found".to_string(),
+                ));
+            }
+            "WORKER_NOT_FOUND" => {
+                return Err(RefitBackendError::FailedPrecondition(
+                    "worker registration is missing or expired".to_string(),
+                ));
+            }
+            "MODEL_MISMATCH" => {
+                return Err(RefitBackendError::FailedPrecondition(
+                    "worker and weight version model_name differ".to_string(),
+                ));
+            }
+            "SOURCE_SLOT_NOT_REQUIRED" => {
+                return Err(RefitBackendError::InvalidArgument(
+                    "source_slot_id is not required by the weight version".to_string(),
+                ));
+            }
+            "VERSION_NOT_WRITABLE" => {
+                return Err(RefitBackendError::FailedPrecondition(
+                    "weight version does not accept shard publication".to_string(),
+                ));
+            }
+            "SHARD_CONFLICT" => {
+                return Err(RefitBackendError::AlreadyExists(
+                    "shard_id was already published with different metadata".to_string(),
+                ));
+            }
+            value => {
+                let Some(state) = value.strip_prefix("OK:") else {
+                    return Err(RefitBackendError::Internal(format!(
+                        "unexpected Redis response: {result}"
+                    )));
+                };
+                state.parse().map_err(|error| {
+                    RefitBackendError::Internal(format!("invalid publication state: {error}"))
+                })?
+            }
+        };
+        WeightVersionState::try_from(state).map_err(|_| {
+            RefitBackendError::Internal(format!("invalid publication state: {state}"))
+        })?;
+        version.state = state;
+        Ok((shard, version))
+    }
+
+    async fn list_weight_version_shards(
+        &self,
+        version_id: &str,
+    ) -> RefitResult<Vec<WeightVersionShard>> {
+        self.get_weight_version(version_id).await?;
+        let mut redis = self.redis.clone();
+        let encoded: Vec<Vec<u8>> = redis
+            .hvals(shards_key(version_id))
+            .await
+            .map_err(redis_error)?;
+        let mut shards = encoded
+            .into_iter()
+            .map(|bytes| {
+                WeightVersionShard::decode(bytes.as_slice()).map_err(|error| {
+                    RefitBackendError::Internal(format!(
+                        "invalid WeightVersionShard in Redis: {error}"
+                    ))
+                })
+            })
+            .collect::<RefitResult<Vec<_>>>()?;
+        shards.sort_by(|left, right| {
+            (&left.source_slot_id, &left.shard_id).cmp(&(&right.source_slot_id, &right.shard_id))
+        });
+        Ok(shards)
+    }
+
+    async fn delete_weight_version_shard(
+        &self,
+        request: &DeleteWeightVersionShardRequest,
+    ) -> RefitResult<bool> {
+        let mut redis = self.redis.clone();
+        let encoded: Option<Vec<u8>> = redis
+            .hget(shards_key(&request.version_id), &request.shard_id)
+            .await
+            .map_err(redis_error)?;
+        let encoded = encoded.ok_or_else(|| {
+            RefitBackendError::NotFound("weight version shard not found".to_string())
+        })?;
+        let shard = WeightVersionShard::decode(encoded.as_slice()).map_err(|error| {
+            RefitBackendError::Internal(format!("invalid WeightVersionShard in Redis: {error}"))
+        })?;
+        if shard.worker_id != request.worker_id {
+            return Err(RefitBackendError::FailedPrecondition(
+                "only the publishing worker can delete its shard".to_string(),
+            ));
+        }
+
+        let result: String = Script::new(DELETE_SHARD_LUA)
+            .key(version_key(&request.version_id))
+            .key(worker_key(&request.worker_id))
+            .key(shards_key(&request.version_id))
+            .key(leases_key(&request.version_id))
+            .arg(&request.shard_id)
+            .arg(encoded)
+            .arg(i32::from(WeightVersionState::Releasing))
+            .invoke_async(&mut redis)
+            .await
+            .map_err(redis_error)?;
+        match result.as_str() {
+            "DELETED" => Ok(true),
+            "VERSION_NOT_FOUND" => Err(RefitBackendError::NotFound(
+                "weight version was not found".to_string(),
+            )),
+            "VERSION_NOT_RELEASING" => Err(RefitBackendError::FailedPrecondition(
+                "weight version must be RELEASING before its shards can be deleted".to_string(),
+            )),
+            "WORKER_NOT_FOUND" => Err(RefitBackendError::FailedPrecondition(
+                "worker registration is missing or expired".to_string(),
+            )),
+            "SHARD_NOT_FOUND" => Err(RefitBackendError::NotFound(
+                "weight version shard not found".to_string(),
+            )),
+            "SHARD_CONFLICT" => Err(RefitBackendError::FailedPrecondition(
+                "weight version shard changed while it was being deleted".to_string(),
+            )),
+            "VERSION_LEASED" => Err(RefitBackendError::FailedPrecondition(
+                "weight version has an active lease".to_string(),
+            )),
+            _ => Err(RefitBackendError::Internal(format!(
+                "unexpected Redis response: {result}"
+            ))),
+        }
+    }
+
+    async fn register_version_lease(
+        &self,
+        request: &RegisterVersionLeaseRequest,
+    ) -> RefitResult<VersionLease> {
+        let lease_id = lease_id(&request.version_id, &request.worker_id);
+        let mut redis = self.redis.clone();
+        let result: String = Script::new(REGISTER_LEASE_LUA)
+            .key(version_key(&request.version_id))
+            .key(worker_key(&request.worker_id))
+            .key(lease_key(&request.version_id, &lease_id))
+            .key(leases_key(&request.version_id))
+            .arg(&lease_id)
+            .arg(&request.version_id)
+            .arg(&request.worker_id)
+            .arg(u64::from(request.ttl_seconds).saturating_mul(1000))
+            .arg(i32::from(WeightVersionState::Ready))
+            .arg(i32::from(WeightVersionState::Releasing))
+            .arg(i32::from(
+                modelexpress_common::grpc::refit::WorkerRole::Generator,
+            ))
+            .invoke_async(&mut redis)
+            .await
+            .map_err(redis_error)?;
+        match result.as_str() {
+            value if value.starts_with("OK:") => {
+                self.get_lease(&request.version_id, &lease_id).await
+            }
+            "VERSION_NOT_FOUND" => Err(RefitBackendError::NotFound(
+                "weight version was not found".to_string(),
+            )),
+            "VERSION_NOT_LEASEABLE" => Err(RefitBackendError::FailedPrecondition(
+                "weight version does not accept this lease registration".to_string(),
+            )),
+            "WORKER_NOT_FOUND" => Err(RefitBackendError::FailedPrecondition(
+                "worker registration is missing or expired".to_string(),
+            )),
+            "WORKER_NOT_GENERATOR" => Err(RefitBackendError::FailedPrecondition(
+                "only a generator worker can hold a version lease".to_string(),
+            )),
+            "MODEL_MISMATCH" => Err(RefitBackendError::FailedPrecondition(
+                "worker and weight version model_name differ".to_string(),
+            )),
+            "LEASE_CONFLICT" => Err(RefitBackendError::AlreadyExists(
+                "version lease ID is already used by a different worker".to_string(),
+            )),
+            _ => Err(RefitBackendError::Internal(format!(
+                "unexpected Redis response: {result}"
+            ))),
+        }
+    }
+
+    async fn delete_version_lease(&self, request: &DeleteVersionLeaseRequest) -> RefitResult<bool> {
+        let mut redis = self.redis.clone();
+        let result: String = Script::new(DELETE_LEASE_LUA)
+            .key(lease_key(&request.version_id, &request.lease_id))
+            .key(leases_key(&request.version_id))
+            .arg(&request.lease_id)
+            .arg(&request.version_id)
+            .arg(&request.worker_id)
+            .invoke_async(&mut redis)
+            .await
+            .map_err(redis_error)?;
+        match result.as_str() {
+            "DELETED" => Ok(true),
+            "NOT_FOUND" => Ok(false),
+            "LEASE_CONFLICT" => Err(RefitBackendError::FailedPrecondition(
+                "version lease is owned by a different worker".to_string(),
+            )),
+            _ => Err(RefitBackendError::Internal(format!(
+                "unexpected Redis response: {result}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redis_errors_distinguish_transient_and_internal_failures() {
+        let transient: redis::RedisError = (redis::ErrorKind::TryAgain, "retry").into();
+        assert!(matches!(
+            redis_error(transient),
+            RefitBackendError::Unavailable(_)
+        ));
+
+        let internal: redis::RedisError =
+            (redis::ErrorKind::ResponseError, "invalid script").into();
+        assert!(matches!(
+            redis_error(internal),
+            RefitBackendError::Internal(_)
+        ));
+    }
+}

--- a/modelexpress_server/src/refit/backend/redis.rs
+++ b/modelexpress_server/src/refit/backend/redis.rs
@@ -37,6 +37,10 @@ fn shards_key(version_id: &str) -> String {
     format!("mx:refit:version:{version_id}:shards")
 }
 
+fn publication_key(worker_id: &str, source_slot_id: &str) -> String {
+    format!("{}:{worker_id}{source_slot_id}", worker_id.len())
+}
+
 fn coverage_key(version_id: &str) -> String {
     format!("mx:refit:version:{version_id}:coverage")
 }
@@ -125,7 +129,10 @@ fn version_from_hash(fields: HashMap<String, String>) -> RefitResult<WeightVersi
         sequence,
         idempotency_key: hash_field(&fields, "idempotency_key")?.to_string(),
         payload_format: parse_hash_field(&fields, "payload_format")?,
-        base_version_id: hash_field(&fields, "base_version_id")?.to_string(),
+        base_version_id: match hash_field(&fields, "base_version_id")? {
+            "" => None,
+            value => Some(value.to_string()),
+        },
         expected_source_slots: serde_json::from_str(hash_field(&fields, "expected_source_slots")?)
             .map_err(|error| {
                 RefitBackendError::Internal(format!("invalid expected_source_slots: {error}"))
@@ -198,7 +205,7 @@ impl RedisRefitBackend {
             )
             .arg(&request.idempotency_key)
             .arg(request.payload_format)
-            .arg(&request.base_version_id)
+            .arg(request.base_version_id.as_deref().unwrap_or_default())
             .arg(expected_source_slots)
             .arg(request.expected_source_slots.len())
             .arg(i32::from(WeightVersionState::Staging))
@@ -331,6 +338,7 @@ impl RefitBackend for RedisRefitBackend {
         shard: WeightVersionShard,
     ) -> RefitResult<(WeightVersionShard, WeightVersion)> {
         let mut version = self.get_weight_version(&shard.version_id).await?;
+        let publication_key = publication_key(&shard.worker_id, &shard.source_slot_id);
         let encoded = shard.encode_to_vec();
         let mut redis = self.redis.clone();
         let result: String = Script::new(CREATE_SHARD_LUA)
@@ -339,7 +347,7 @@ impl RefitBackend for RedisRefitBackend {
             .key(shards_key(&shard.version_id))
             .key(coverage_key(&shard.version_id))
             .key(expected_source_slots_key(&shard.version_id))
-            .arg(&shard.shard_id)
+            .arg(publication_key)
             .arg(encoded)
             .arg(&version.model_name)
             .arg(&shard.source_slot_id)
@@ -376,7 +384,7 @@ impl RefitBackend for RedisRefitBackend {
             }
             "SHARD_CONFLICT" => {
                 return Err(RefitBackendError::AlreadyExists(
-                    "shard_id was already published with different metadata".to_string(),
+                    "worker and source_slot_id already published different metadata".to_string(),
                 ));
             }
             value => {
@@ -418,7 +426,7 @@ impl RefitBackend for RedisRefitBackend {
             })
             .collect::<RefitResult<Vec<_>>>()?;
         shards.sort_by(|left, right| {
-            (&left.source_slot_id, &left.shard_id).cmp(&(&right.source_slot_id, &right.shard_id))
+            (&left.source_slot_id, &left.worker_id).cmp(&(&right.source_slot_id, &right.worker_id))
         });
         Ok(shards)
     }
@@ -427,9 +435,10 @@ impl RefitBackend for RedisRefitBackend {
         &self,
         request: &DeleteWeightVersionShardRequest,
     ) -> RefitResult<bool> {
+        let publication_key = publication_key(&request.worker_id, &request.source_slot_id);
         let mut redis = self.redis.clone();
         let encoded: Option<Vec<u8>> = redis
-            .hget(shards_key(&request.version_id), &request.shard_id)
+            .hget(shards_key(&request.version_id), &publication_key)
             .await
             .map_err(redis_error)?;
         let encoded = encoded.ok_or_else(|| {
@@ -449,7 +458,7 @@ impl RefitBackend for RedisRefitBackend {
             .key(worker_key(&request.worker_id))
             .key(shards_key(&request.version_id))
             .key(leases_key(&request.version_id))
-            .arg(&request.shard_id)
+            .arg(publication_key)
             .arg(encoded)
             .arg(i32::from(WeightVersionState::Releasing))
             .invoke_async(&mut redis)

--- a/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version.lua
@@ -1,0 +1,45 @@
+-- Atomically reserve an idempotency key and create one immutable WeightVersion.
+--
+-- KEYS[1]: version hash
+-- KEYS[2]: create-request idempotency key
+-- KEYS[3]: expected source slots set
+-- ARGV: version_id, model_name, sequence, idempotency_key, payload_format,
+--       base_version_id, expected_source_slots JSON, expected_source_slot_count,
+--       state,
+--       created_at_unix_ms
+--
+-- Returns:
+--   CREATED              this invocation created the version
+--   EXISTING:<id>        another invocation already owns the idempotency key
+--   COLLISION            the randomly selected version ID already exists
+--
+-- Redis executes the script atomically, so two MX server replicas cannot create
+-- different versions for the same idempotency key.
+
+local existing = redis.call('GET', KEYS[2])
+if existing then
+  return 'EXISTING:' .. existing
+end
+
+if redis.call('EXISTS', KEYS[1]) == 1 then
+  return 'COLLISION'
+end
+
+redis.call('HSET', KEYS[1],
+  'version_id', ARGV[1],
+  'model_name', ARGV[2],
+  'sequence', ARGV[3],
+  'idempotency_key', ARGV[4],
+  'payload_format', ARGV[5],
+  'base_version_id', ARGV[6],
+  'expected_source_slots', ARGV[7],
+  'expected_source_slot_count', ARGV[8],
+  'layout_signature', '',
+  'state', ARGV[9],
+  'created_at_unix_ms', ARGV[10])
+for index = 11, #ARGV do
+  redis.call('SADD', KEYS[3], ARGV[index])
+end
+redis.call('SET', KEYS[2], ARGV[1])
+
+return 'CREATED'

--- a/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version.lua
@@ -3,7 +3,7 @@
 -- KEYS[1]: version hash
 -- KEYS[2]: create-request idempotency key
 -- KEYS[3]: expected source slots set
--- ARGV: version_id, model_name, sequence, idempotency_key, payload_format,
+-- ARGV: uid, model_name, version_number, idempotency_key, payload_format,
 --       base_version_id, expected_source_slots JSON, expected_source_slot_count,
 --       state,
 --       created_at_unix_ms
@@ -26,9 +26,9 @@ if redis.call('EXISTS', KEYS[1]) == 1 then
 end
 
 redis.call('HSET', KEYS[1],
-  'version_id', ARGV[1],
+  'uid', ARGV[1],
   'model_name', ARGV[2],
-  'sequence', ARGV[3],
+  'version_number', ARGV[3],
   'idempotency_key', ARGV[4],
   'payload_format', ARGV[5],
   'base_version_id', ARGV[6],

--- a/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version_shard.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version_shard.lua
@@ -1,0 +1,53 @@
+-- Atomically publish one worker manifest and advance version readiness.
+--
+-- KEYS[1]: version hash
+-- KEYS[2]: publishing worker registration hash
+-- KEYS[3]: physical WeightVersionShard publications, keyed by shard_id
+-- KEYS[4]: covered version-scoped source slots set
+-- KEYS[5]: expected version-scoped source slots set
+-- ARGV: shard_id, encoded shard, model_name, source_slot_id, staging_state,
+--       ready_state
+--
+-- Returns OK:<state> for a new or byte-identical repeated publication. Other
+-- named results reject missing, incompatible, or conflicting inputs. The
+-- publication, source-slot coverage update, and final READY transition are one
+-- Redis operation, so observers cannot see partial readiness.
+
+if redis.call('EXISTS', KEYS[1]) == 0 then
+  return 'VERSION_NOT_FOUND'
+end
+if redis.call('EXISTS', KEYS[2]) == 0 then
+  return 'WORKER_NOT_FOUND'
+end
+
+if redis.call('HGET', KEYS[2], 'model_name') ~= ARGV[3] then
+  return 'MODEL_MISMATCH'
+end
+
+local state = redis.call('HGET', KEYS[1], 'state')
+if state ~= ARGV[5] and state ~= ARGV[6] then
+  return 'VERSION_NOT_WRITABLE'
+end
+if redis.call('SISMEMBER', KEYS[5], ARGV[4]) == 0 then
+  return 'SOURCE_SLOT_NOT_REQUIRED'
+end
+
+local existing = redis.call('HGET', KEYS[3], ARGV[1])
+if existing then
+  if existing == ARGV[2] then
+    return 'OK:' .. state
+  end
+  return 'SHARD_CONFLICT'
+end
+
+redis.call('HSET', KEYS[3], ARGV[1], ARGV[2])
+redis.call('SADD', KEYS[4], ARGV[4])
+
+local covered = redis.call('SCARD', KEYS[4])
+local expected = tonumber(redis.call('HGET', KEYS[1], 'expected_source_slot_count'))
+if covered == expected then
+  state = ARGV[6]
+  redis.call('HSET', KEYS[1], 'state', state)
+end
+
+return 'OK:' .. state

--- a/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version_shard.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/create_weight_version_shard.lua
@@ -2,10 +2,11 @@
 --
 -- KEYS[1]: version hash
 -- KEYS[2]: publishing worker registration hash
--- KEYS[3]: physical WeightVersionShard publications, keyed by shard_id
+-- KEYS[3]: physical WeightVersionShard publications, keyed by the private
+--          worker_id + source_slot_id identity
 -- KEYS[4]: covered version-scoped source slots set
 -- KEYS[5]: expected version-scoped source slots set
--- ARGV: shard_id, encoded shard, model_name, source_slot_id, staging_state,
+-- ARGV: publication key, encoded shard, model_name, source_slot_id, staging_state,
 --       ready_state
 --
 -- Returns OK:<state> for a new or byte-identical repeated publication. Other

--- a/modelexpress_server/src/refit/backend/redis/scripts/delete_version_lease.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/delete_version_lease.lua
@@ -1,0 +1,22 @@
+-- Atomically release one consumer lease.
+--
+-- KEYS[1]: lease hash
+-- KEYS[2]: active lease expiry sorted set for the version
+-- ARGV: lease_id, version_id, worker_id
+
+if redis.call('EXISTS', KEYS[1]) == 0 then
+  redis.call('ZREM', KEYS[2], ARGV[1])
+  return 'NOT_FOUND'
+end
+
+local same_lease =
+  redis.call('HGET', KEYS[1], 'lease_id') == ARGV[1]
+  and redis.call('HGET', KEYS[1], 'version_id') == ARGV[2]
+  and redis.call('HGET', KEYS[1], 'worker_id') == ARGV[3]
+if not same_lease then
+  return 'LEASE_CONFLICT'
+end
+
+redis.call('DEL', KEYS[1])
+redis.call('ZREM', KEYS[2], ARGV[1])
+return 'DELETED'

--- a/modelexpress_server/src/refit/backend/redis/scripts/delete_weight_version.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/delete_weight_version.lua
@@ -1,0 +1,20 @@
+-- Atomically mark a READY WeightVersion as logically deleted.
+--
+-- KEYS[1]: version hash
+-- ARGV[1]: RELEASING state value
+-- ARGV[2]: READY state value
+
+if redis.call('EXISTS', KEYS[1]) == 0 then
+  return 'VERSION_NOT_FOUND'
+end
+
+local state = redis.call('HGET', KEYS[1], 'state')
+if state == ARGV[1] then
+  return 'OK'
+end
+if state ~= ARGV[2] then
+  return 'VERSION_NOT_READY'
+end
+
+redis.call('HSET', KEYS[1], 'state', ARGV[1])
+return 'OK'

--- a/modelexpress_server/src/refit/backend/redis/scripts/delete_weight_version_shard.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/delete_weight_version_shard.lua
@@ -1,0 +1,37 @@
+-- Atomically delete one source shard after logical version release.
+--
+-- KEYS[1]: version hash
+-- KEYS[2]: source worker registration hash
+-- KEYS[3]: physical shards hash
+-- KEYS[4]: active lease expiry sorted set for the version
+-- ARGV: shard_id, encoded shard, releasing_state
+--
+-- Expired leases are removed using Redis time. Any remaining lease protects
+-- every shard of the version, independent of which source was selected.
+
+if redis.call('EXISTS', KEYS[1]) == 0 then
+  return 'VERSION_NOT_FOUND'
+end
+if redis.call('HGET', KEYS[1], 'state') ~= ARGV[3] then
+  return 'VERSION_NOT_RELEASING'
+end
+if redis.call('EXISTS', KEYS[2]) == 0 then
+  return 'WORKER_NOT_FOUND'
+end
+local current = redis.call('HGET', KEYS[3], ARGV[1])
+if not current then
+  return 'SHARD_NOT_FOUND'
+end
+if current ~= ARGV[2] then
+  return 'SHARD_CONFLICT'
+end
+
+local clock = redis.call('TIME')
+local now = clock[1] * 1000 + math.floor(clock[2] / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[4], '-inf', now)
+if redis.call('ZCARD', KEYS[4]) > 0 then
+  return 'VERSION_LEASED'
+end
+
+redis.call('HDEL', KEYS[3], ARGV[1])
+return 'DELETED'

--- a/modelexpress_server/src/refit/backend/redis/scripts/delete_weight_version_shard.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/delete_weight_version_shard.lua
@@ -4,7 +4,7 @@
 -- KEYS[2]: source worker registration hash
 -- KEYS[3]: physical shards hash
 -- KEYS[4]: active lease expiry sorted set for the version
--- ARGV: shard_id, encoded shard, releasing_state
+-- ARGV: publication key, encoded shard, releasing_state
 --
 -- Expired leases are removed using Redis time. Any remaining lease protects
 -- every shard of the version, independent of which source was selected.

--- a/modelexpress_server/src/refit/backend/redis/scripts/register_version_lease.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/register_version_lease.lua
@@ -1,0 +1,59 @@
+-- Atomically acquire or renew the one lease owned by a worker for a version.
+--
+-- KEYS[1]: version hash
+-- KEYS[2]: consumer worker registration hash
+-- KEYS[3]: deterministic lease hash
+-- KEYS[4]: active lease expiry sorted set for the version
+-- ARGV: lease_id, version_id, worker_id, ttl_milliseconds, ready_state,
+--       releasing_state, generator_role
+--
+-- A new lease is accepted only while the version is READY. The same owner may
+-- renew an existing lease while the version is READY or RELEASING, allowing an
+-- in-flight update to finish after logical release begins.
+--
+-- Returns OK:<expiry_ms> for a successful acquisition or renewal. Named
+-- results reject missing, incompatible, or no-longer-leaseable inputs.
+
+if redis.call('EXISTS', KEYS[1]) == 0 then
+  return 'VERSION_NOT_FOUND'
+end
+if redis.call('EXISTS', KEYS[2]) == 0 then
+  return 'WORKER_NOT_FOUND'
+end
+if redis.call('HGET', KEYS[2], 'role') ~= ARGV[7] then
+  return 'WORKER_NOT_GENERATOR'
+end
+if redis.call('HGET', KEYS[2], 'model_name') ~= redis.call('HGET', KEYS[1], 'model_name') then
+  return 'MODEL_MISMATCH'
+end
+
+local state = redis.call('HGET', KEYS[1], 'state')
+local existing = redis.call('EXISTS', KEYS[3]) == 1
+if existing then
+  local same_lease =
+    redis.call('HGET', KEYS[3], 'lease_id') == ARGV[1]
+    and redis.call('HGET', KEYS[3], 'version_id') == ARGV[2]
+    and redis.call('HGET', KEYS[3], 'worker_id') == ARGV[3]
+  if not same_lease then
+    return 'LEASE_CONFLICT'
+  end
+  if state ~= ARGV[5] and state ~= ARGV[6] then
+    return 'VERSION_NOT_LEASEABLE'
+  end
+elseif state ~= ARGV[5] then
+  return 'VERSION_NOT_LEASEABLE'
+end
+
+local clock = redis.call('TIME')
+local now = clock[1] * 1000 + math.floor(clock[2] / 1000)
+local expires_at = now + tonumber(ARGV[4])
+
+redis.call('HSET', KEYS[3],
+  'lease_id', ARGV[1],
+  'version_id', ARGV[2],
+  'worker_id', ARGV[3],
+  'expires_at_unix_ms', expires_at)
+redis.call('PEXPIRE', KEYS[3], ARGV[4])
+redis.call('ZADD', KEYS[4], expires_at, ARGV[1])
+
+return 'OK:' .. expires_at

--- a/modelexpress_server/src/refit/backend/redis/scripts/register_worker.lua
+++ b/modelexpress_server/src/refit/backend/redis/scripts/register_worker.lua
@@ -1,0 +1,32 @@
+-- Atomically register or refresh one TTL-bound worker process.
+--
+-- KEYS[1]: expiring worker registration hash
+-- ARGV: worker_id, role, model_name, endpoint, ttl_milliseconds
+--
+-- Returns:
+--   OK:<expiry_ms>       registration stored and TTL refreshed
+--   CONFLICT             the worker ID has different immutable metadata
+
+if redis.call('EXISTS', KEYS[1]) == 1 then
+  local same_registration =
+    redis.call('HGET', KEYS[1], 'role') == ARGV[2]
+    and redis.call('HGET', KEYS[1], 'model_name') == ARGV[3]
+    and redis.call('HGET', KEYS[1], 'endpoint') == ARGV[4]
+  if not same_registration then
+    return 'CONFLICT'
+  end
+end
+
+-- Redis time, rather than an MX server clock, makes expiry consistent across replicas.
+local clock = redis.call('TIME')
+local expires_at = clock[1] * 1000 + math.floor(clock[2] / 1000) + tonumber(ARGV[5])
+
+redis.call('HSET', KEYS[1],
+  'worker_id', ARGV[1],
+  'role', ARGV[2],
+  'model_name', ARGV[3],
+  'endpoint', ARGV[4],
+  'expires_at_unix_ms', expires_at)
+redis.call('PEXPIRE', KEYS[1], ARGV[5])
+
+return 'OK:' .. expires_at

--- a/modelexpress_server/src/refit/service.rs
+++ b/modelexpress_server/src/refit/service.rs
@@ -156,10 +156,10 @@ impl RefitService for RefitServiceImpl {
         &self,
         request: Request<GetWeightVersionRequest>,
     ) -> Result<Response<WeightVersion>, Status> {
-        let version_id = request.into_inner().version_id;
-        required(&version_id, "version_id")?;
+        let uid = request.into_inner().uid;
+        required(&uid, "uid")?;
         self.backend
-            .get_weight_version(&version_id)
+            .get_weight_version(&uid)
             .await
             .map(Response::new)
             .map_err(backend_status)
@@ -169,10 +169,10 @@ impl RefitService for RefitServiceImpl {
         &self,
         request: Request<DeleteWeightVersionRequest>,
     ) -> Result<Response<WeightVersion>, Status> {
-        let version_id = request.into_inner().version_id;
-        required(&version_id, "version_id")?;
+        let uid = request.into_inner().uid;
+        required(&uid, "uid")?;
         self.backend
-            .delete_weight_version(&version_id)
+            .delete_weight_version(&uid)
             .await
             .map(Response::new)
             .map_err(backend_status)

--- a/modelexpress_server/src/refit/service.rs
+++ b/modelexpress_server/src/refit/service.rs
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend-neutral gRPC service for RL refit control-plane metadata.
+
+#![allow(clippy::result_large_err)] // tonic service helpers return tonic::Status.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use modelexpress_common::grpc::refit::{
+    CreateWeightVersionRequest, CreateWeightVersionShardRequest, CreateWeightVersionShardResponse,
+    DeleteVersionLeaseRequest, DeleteVersionLeaseResponse, DeleteWeightVersionRequest,
+    DeleteWeightVersionShardRequest, DeleteWeightVersionShardResponse, GetWeightVersionRequest,
+    ListWeightVersionShardsRequest, ListWeightVersionShardsResponse, RegisterVersionLeaseRequest,
+    RegisterWorkerRequest, VersionLease, WeightPayloadFormat, WeightVersion, WeightVersionState,
+    WorkerRegistration, WorkerRole, refit_service_server::RefitService,
+};
+use tonic::{Request, Response, Status};
+
+use super::backend::{RefitBackend, RefitBackendError};
+
+fn required(value: &str, field: &str) -> Result<(), Status> {
+    if value.trim().is_empty() {
+        Err(Status::invalid_argument(format!("{field} is required")))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_ttl(ttl_seconds: u32) -> Result<(), Status> {
+    if ttl_seconds == 0 {
+        Err(Status::invalid_argument(
+            "ttl_seconds must be greater than zero",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn backend_status(error: RefitBackendError) -> Status {
+    match error {
+        RefitBackendError::InvalidArgument(message) => Status::invalid_argument(message),
+        RefitBackendError::NotFound(message) => Status::not_found(message),
+        RefitBackendError::FailedPrecondition(message) => Status::failed_precondition(message),
+        RefitBackendError::AlreadyExists(message) => Status::already_exists(message),
+        RefitBackendError::ResourceExhausted(message) => Status::resource_exhausted(message),
+        RefitBackendError::Internal(message) => Status::internal(message),
+        RefitBackendError::Unavailable(message) => {
+            Status::unavailable(format!("Refit metadata backend error: {message}"))
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RefitServiceImpl {
+    backend: Arc<dyn RefitBackend>,
+}
+
+impl RefitServiceImpl {
+    pub fn new(backend: Arc<dyn RefitBackend>) -> Self {
+        Self { backend }
+    }
+}
+
+#[tonic::async_trait]
+impl RefitService for RefitServiceImpl {
+    async fn register_worker(
+        &self,
+        request: Request<RegisterWorkerRequest>,
+    ) -> Result<Response<WorkerRegistration>, Status> {
+        let request = request.into_inner();
+        let worker = request
+            .worker
+            .ok_or_else(|| Status::invalid_argument("worker is required"))?;
+        required(&worker.worker_id, "worker.worker_id")?;
+        required(&worker.model_name, "worker.model_name")?;
+        required(&worker.endpoint, "worker.endpoint")?;
+        if WorkerRole::try_from(worker.role).unwrap_or(WorkerRole::Unspecified)
+            == WorkerRole::Unspecified
+        {
+            return Err(Status::invalid_argument("worker.role must be specified"));
+        }
+        validate_ttl(request.ttl_seconds)?;
+
+        self.backend
+            .register_worker(worker, request.ttl_seconds)
+            .await
+            .map(Response::new)
+            .map_err(backend_status)
+    }
+
+    async fn create_weight_version(
+        &self,
+        request: Request<CreateWeightVersionRequest>,
+    ) -> Result<Response<WeightVersion>, Status> {
+        let request = request.into_inner();
+        required(&request.model_name, "model_name")?;
+        required(&request.idempotency_key, "idempotency_key")?;
+        let payload_format = WeightPayloadFormat::try_from(request.payload_format)
+            .unwrap_or(WeightPayloadFormat::Unspecified);
+        match payload_format {
+            WeightPayloadFormat::FullTensor if !request.base_version_id.is_empty() => {
+                return Err(Status::invalid_argument(
+                    "base_version_id must be empty for FULL_TENSOR",
+                ));
+            }
+            WeightPayloadFormat::XorDelta if request.base_version_id.is_empty() => {
+                return Err(Status::invalid_argument(
+                    "base_version_id is required for XOR_DELTA",
+                ));
+            }
+            WeightPayloadFormat::Unspecified => {
+                return Err(Status::invalid_argument("payload_format must be specified"));
+            }
+            _ => {}
+        }
+        if request.expected_source_slots.is_empty() {
+            return Err(Status::invalid_argument(
+                "expected_source_slots must not be empty",
+            ));
+        }
+        let mut unique = HashSet::new();
+        for source_slot_id in &request.expected_source_slots {
+            required(source_slot_id, "expected_source_slots entry")?;
+            if !unique.insert(source_slot_id) {
+                return Err(Status::invalid_argument(
+                    "expected_source_slots must not contain duplicates",
+                ));
+            }
+        }
+        if payload_format == WeightPayloadFormat::XorDelta {
+            let base = self
+                .backend
+                .get_weight_version(&request.base_version_id)
+                .await
+                .map_err(backend_status)?;
+            if base.model_name != request.model_name
+                || base.state != i32::from(WeightVersionState::Ready)
+            {
+                return Err(Status::failed_precondition(
+                    "XOR_DELTA base version must be READY and have the same model_name",
+                ));
+            }
+        }
+        self.backend
+            .create_weight_version(&request)
+            .await
+            .map(Response::new)
+            .map_err(backend_status)
+    }
+
+    async fn get_weight_version(
+        &self,
+        request: Request<GetWeightVersionRequest>,
+    ) -> Result<Response<WeightVersion>, Status> {
+        let version_id = request.into_inner().version_id;
+        required(&version_id, "version_id")?;
+        self.backend
+            .get_weight_version(&version_id)
+            .await
+            .map(Response::new)
+            .map_err(backend_status)
+    }
+
+    async fn delete_weight_version(
+        &self,
+        request: Request<DeleteWeightVersionRequest>,
+    ) -> Result<Response<WeightVersion>, Status> {
+        let version_id = request.into_inner().version_id;
+        required(&version_id, "version_id")?;
+        self.backend
+            .delete_weight_version(&version_id)
+            .await
+            .map(Response::new)
+            .map_err(backend_status)
+    }
+
+    async fn create_weight_version_shard(
+        &self,
+        request: Request<CreateWeightVersionShardRequest>,
+    ) -> Result<Response<CreateWeightVersionShardResponse>, Status> {
+        let shard = request
+            .into_inner()
+            .shard
+            .ok_or_else(|| Status::invalid_argument("shard is required"))?;
+        required(&shard.version_id, "shard.version_id")?;
+        required(&shard.shard_id, "shard.shard_id")?;
+        required(&shard.source_slot_id, "shard.source_slot_id")?;
+        required(&shard.worker_id, "shard.worker_id")?;
+        required(&shard.manifest_digest, "shard.manifest_digest")?;
+        required(&shard.manifest_endpoint, "shard.manifest_endpoint")?;
+        required(&shard.transport, "shard.transport")?;
+
+        let (shard, version) = self
+            .backend
+            .create_weight_version_shard(shard)
+            .await
+            .map_err(backend_status)?;
+        Ok(Response::new(CreateWeightVersionShardResponse {
+            shard: Some(shard),
+            version: Some(version),
+        }))
+    }
+
+    async fn list_weight_version_shards(
+        &self,
+        request: Request<ListWeightVersionShardsRequest>,
+    ) -> Result<Response<ListWeightVersionShardsResponse>, Status> {
+        let version_id = request.into_inner().version_id;
+        required(&version_id, "version_id")?;
+        self.backend
+            .list_weight_version_shards(&version_id)
+            .await
+            .map(|shards| Response::new(ListWeightVersionShardsResponse { shards }))
+            .map_err(backend_status)
+    }
+
+    async fn delete_weight_version_shard(
+        &self,
+        request: Request<DeleteWeightVersionShardRequest>,
+    ) -> Result<Response<DeleteWeightVersionShardResponse>, Status> {
+        let request = request.into_inner();
+        required(&request.version_id, "version_id")?;
+        required(&request.shard_id, "shard_id")?;
+        required(&request.worker_id, "worker_id")?;
+        self.backend
+            .delete_weight_version_shard(&request)
+            .await
+            .map(|deleted| Response::new(DeleteWeightVersionShardResponse { deleted }))
+            .map_err(backend_status)
+    }
+
+    async fn register_version_lease(
+        &self,
+        request: Request<RegisterVersionLeaseRequest>,
+    ) -> Result<Response<VersionLease>, Status> {
+        let request = request.into_inner();
+        required(&request.version_id, "version_id")?;
+        required(&request.worker_id, "worker_id")?;
+        validate_ttl(request.ttl_seconds)?;
+        self.backend
+            .register_version_lease(&request)
+            .await
+            .map(Response::new)
+            .map_err(backend_status)
+    }
+
+    async fn delete_version_lease(
+        &self,
+        request: Request<DeleteVersionLeaseRequest>,
+    ) -> Result<Response<DeleteVersionLeaseResponse>, Status> {
+        let request = request.into_inner();
+        required(&request.version_id, "version_id")?;
+        required(&request.lease_id, "lease_id")?;
+        required(&request.worker_id, "worker_id")?;
+        self.backend
+            .delete_version_lease(&request)
+            .await
+            .map(|deleted| Response::new(DeleteVersionLeaseResponse { deleted }))
+            .map_err(backend_status)
+    }
+}

--- a/modelexpress_server/src/refit/service.rs
+++ b/modelexpress_server/src/refit/service.rs
@@ -100,12 +100,12 @@ impl RefitService for RefitServiceImpl {
         let payload_format = WeightPayloadFormat::try_from(request.payload_format)
             .unwrap_or(WeightPayloadFormat::Unspecified);
         match payload_format {
-            WeightPayloadFormat::FullTensor if !request.base_version_id.is_empty() => {
+            WeightPayloadFormat::FullTensor if request.base_version_id.is_some() => {
                 return Err(Status::invalid_argument(
-                    "base_version_id must be empty for FULL_TENSOR",
+                    "base_version_id must be omitted for FULL_TENSOR",
                 ));
             }
-            WeightPayloadFormat::XorDelta if request.base_version_id.is_empty() => {
+            WeightPayloadFormat::XorDelta if request.base_version_id.is_none() => {
                 return Err(Status::invalid_argument(
                     "base_version_id is required for XOR_DELTA",
                 ));
@@ -129,10 +129,12 @@ impl RefitService for RefitServiceImpl {
                 ));
             }
         }
-        if payload_format == WeightPayloadFormat::XorDelta {
+        if let Some(base_version_id) = request.base_version_id.as_deref()
+            && payload_format == WeightPayloadFormat::XorDelta
+        {
             let base = self
                 .backend
-                .get_weight_version(&request.base_version_id)
+                .get_weight_version(base_version_id)
                 .await
                 .map_err(backend_status)?;
             if base.model_name != request.model_name
@@ -185,7 +187,6 @@ impl RefitService for RefitServiceImpl {
             .shard
             .ok_or_else(|| Status::invalid_argument("shard is required"))?;
         required(&shard.version_id, "shard.version_id")?;
-        required(&shard.shard_id, "shard.shard_id")?;
         required(&shard.source_slot_id, "shard.source_slot_id")?;
         required(&shard.worker_id, "shard.worker_id")?;
         required(&shard.manifest_digest, "shard.manifest_digest")?;
@@ -222,7 +223,7 @@ impl RefitService for RefitServiceImpl {
     ) -> Result<Response<DeleteWeightVersionShardResponse>, Status> {
         let request = request.into_inner();
         required(&request.version_id, "version_id")?;
-        required(&request.shard_id, "shard_id")?;
+        required(&request.source_slot_id, "source_slot_id")?;
         required(&request.worker_id, "worker_id")?;
         self.backend
             .delete_weight_version_shard(&request)

--- a/modelexpress_server/src/server.rs
+++ b/modelexpress_server/src/server.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use modelexpress_common::grpc::{
     api::api_service_server::ApiServiceServer, health::health_service_server::HealthServiceServer,
     model::model_service_server::ModelServiceServer, p2p::p2p_service_server::P2pServiceServer,
+    refit::refit_service_server::RefitServiceServer,
     weight_sync::weight_sync_service_server::WeightSyncServiceServer,
 };
 use tonic::transport::Server;
@@ -22,6 +23,7 @@ use crate::backend_config::BackendConfig;
 use crate::cache::CacheEvictionService;
 use crate::config::{AuthMode, ServerConfig};
 use crate::p2p::{service::P2pServiceImpl, state::P2pStateManager};
+use crate::refit::{backend::create_backend as create_refit_backend, service::RefitServiceImpl};
 use crate::registry::state::RegistryManager;
 use crate::services::{ApiServiceImpl, HealthServiceImpl, ModelDownloadTracker, ModelServiceImpl};
 use crate::weight_sync::WeightSyncServiceImpl;
@@ -115,6 +117,31 @@ pub async fn run_server(
         .set_serving::<P2pServiceServer<P2pServiceImpl>>()
         .await;
 
+    let refit_backend = match tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        create_refit_backend(&backend),
+    )
+    .await
+    {
+        Ok(Ok(refit_backend)) => refit_backend,
+        Ok(Err(error)) => {
+            error!("Failed to connect Refit metadata backend: {error}");
+            return Err(error.to_string().into());
+        }
+        Err(_) => {
+            error!("Timed out connecting to Refit metadata backend");
+            return Err("Refit metadata backend connection timed out".into());
+        }
+    };
+    let refit_service = refit_backend.map(RefitServiceImpl::new);
+    if refit_service.is_some() {
+        health_reporter
+            .set_serving::<RefitServiceServer<RefitServiceImpl>>()
+            .await;
+    } else {
+        info!("Refit service is unavailable: this metadata backend is not implemented yet");
+    }
+
     // Initialize P2P state manager — fails fast if backend is misconfigured or unreachable
     let p2p_state = Arc::new(P2pStateManager::with_config(backend));
 
@@ -188,6 +215,11 @@ pub async fn run_server(
     let weight_sync = WeightSyncServiceServer::new(weight_sync_service)
         .max_decoding_message_size(MAX_MESSAGE_SIZE)
         .max_encoding_message_size(MAX_MESSAGE_SIZE);
+    let refit = refit_service.map(|service| {
+        RefitServiceServer::new(service)
+            .max_decoding_message_size(MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(MAX_MESSAGE_SIZE)
+    });
 
     info!("Starting gRPC server on: {addr}");
     let router = Server::builder()
@@ -198,12 +230,14 @@ pub async fn run_server(
             .add_service(layer.layer(api))
             .add_service(layer.layer(model))
             .add_service(layer.layer(p2p))
-            .add_service(layer.layer(weight_sync)),
+            .add_service(layer.layer(weight_sync))
+            .add_optional_service(refit.map(|service| layer.layer(service))),
         None => router
             .add_service(api)
             .add_service(model)
             .add_service(p2p)
-            .add_service(weight_sync),
+            .add_service(weight_sync)
+            .add_optional_service(refit),
     };
     let server_result = router.serve_with_shutdown(addr, shutdown_signal).await;
 

--- a/workspace-tests/Cargo.toml
+++ b/workspace-tests/Cargo.toml
@@ -22,6 +22,8 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tonic = { workspace = true }
+tonic-health = { workspace = true }
 kube = { workspace = true, features = ["ws"] }
 k8s-openapi = { workspace = true }
 anyhow = { workspace = true }

--- a/workspace-tests/tests/refit_service_redis.rs
+++ b/workspace-tests/tests/refit_service_redis.rs
@@ -102,7 +102,6 @@ fn worker(worker_id: &str, role: WorkerRole, ttl_seconds: u32) -> RegisterWorker
 fn shard(version_id: &str, source_slot_id: &str, worker_id: &str) -> WeightVersionShard {
     WeightVersionShard {
         version_id: version_id.to_string(),
-        shard_id: format!("{worker_id}-{source_slot_id}"),
         source_slot_id: source_slot_id.to_string(),
         worker_id: worker_id.to_string(),
         tensor_count: 10,
@@ -156,7 +155,7 @@ async fn version_becomes_ready_across_server_replicas() {
         sequence: Some(42),
         idempotency_key: unique_id("publish"),
         payload_format: WeightPayloadFormat::FullTensor.into(),
-        base_version_id: String::new(),
+        base_version_id: None,
         expected_source_slots: vec![
             "publisher:global-rank:0".to_string(),
             "publisher:global-rank:1".to_string(),
@@ -232,7 +231,7 @@ async fn version_becomes_ready_across_server_replicas() {
             shard: Some(conflicting_shard),
         })
         .await
-        .expect_err("the same shard_id cannot publish different metadata");
+        .expect_err("the same worker and source slot cannot publish different metadata");
     assert_eq!(conflict.code(), tonic::Code::AlreadyExists);
 
     let ready = client_b
@@ -289,7 +288,7 @@ async fn replacement_worker_can_publish_the_same_source_slot() {
             sequence: None,
             idempotency_key: unique_id("replacement-publish"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
-            base_version_id: String::new(),
+            base_version_id: None,
             expected_source_slots: vec!["publisher:global-rank:0".to_string()],
         })
         .await
@@ -369,7 +368,7 @@ async fn live_lease_protects_releasing_version_shards() {
             sequence: Some(43),
             idempotency_key: unique_id("lease-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
-            base_version_id: String::new(),
+            base_version_id: None,
             expected_source_slots: vec!["publisher:global-rank:0".to_string()],
         })
         .await
@@ -427,7 +426,7 @@ async fn live_lease_protects_releasing_version_shards() {
     let protected = client_a
         .delete_weight_version_shard(DeleteWeightVersionShardRequest {
             version_id: version.version_id.clone(),
-            shard_id: published_shard.shard_id.clone(),
+            source_slot_id: published_shard.source_slot_id.clone(),
             worker_id: trainer_id.clone(),
         })
         .await
@@ -445,7 +444,7 @@ async fn live_lease_protects_releasing_version_shards() {
     let deleted = client_a
         .delete_weight_version_shard(DeleteWeightVersionShardRequest {
             version_id: version.version_id.clone(),
-            shard_id: published_shard.shard_id,
+            source_slot_id: published_shard.source_slot_id,
             worker_id: trainer_id.clone(),
         })
         .await
@@ -468,7 +467,7 @@ async fn live_lease_protects_releasing_version_shards() {
             sequence: Some(44),
             idempotency_key: unique_id("expiring-lease-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
-            base_version_id: String::new(),
+            base_version_id: None,
             expected_source_slots: vec!["publisher:global-rank:0".to_string()],
         })
         .await
@@ -512,7 +511,7 @@ async fn live_lease_protects_releasing_version_shards() {
     client_a
         .delete_weight_version_shard(DeleteWeightVersionShardRequest {
             version_id: expiring_version.version_id,
-            shard_id: expiring_shard.shard_id,
+            source_slot_id: expiring_shard.source_slot_id,
             worker_id: trainer_id.clone(),
         })
         .await
@@ -548,7 +547,7 @@ async fn register_worker_refreshes_liveness_and_expires_without_renewal() {
             sequence: None,
             idempotency_key: unique_id("heartbeat-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
-            base_version_id: String::new(),
+            base_version_id: None,
             expected_source_slots: vec!["publisher:global-rank:0".to_string()],
         })
         .await
@@ -569,7 +568,7 @@ async fn register_worker_refreshes_liveness_and_expires_without_renewal() {
             sequence: None,
             idempotency_key: unique_id("expired-worker-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
-            base_version_id: String::new(),
+            base_version_id: None,
             expected_source_slots: vec!["publisher:global-rank:0".to_string()],
         })
         .await

--- a/workspace-tests/tests/refit_service_redis.rs
+++ b/workspace-tests/tests/refit_service_redis.rs
@@ -152,7 +152,7 @@ async fn version_becomes_ready_across_server_replicas() {
 
     let create_request = CreateWeightVersionRequest {
         model_name: "test/model".to_string(),
-        sequence: Some(42),
+        version_number: Some(42),
         idempotency_key: unique_id("publish"),
         payload_format: WeightPayloadFormat::FullTensor.into(),
         base_version_id: None,
@@ -168,13 +168,13 @@ async fn version_becomes_ready_across_server_replicas() {
     let repeated = version_b
         .expect("concurrent create through second server")
         .into_inner();
-    assert_eq!(version.version_id.len(), 8);
+    assert_eq!(version.uid.len(), 8);
     assert_eq!(version.state, i32::from(WeightVersionState::Staging));
     assert_eq!(repeated, version);
 
     let observed = client_b
         .get_weight_version(GetWeightVersionRequest {
-            version_id: version.version_id.clone(),
+            uid: version.uid.clone(),
         })
         .await
         .expect("second server reads version")
@@ -183,26 +183,18 @@ async fn version_becomes_ready_across_server_replicas() {
 
     let unexpected_source_slot = client_a
         .create_weight_version_shard(CreateWeightVersionShardRequest {
-            shard: Some(shard(
-                &version.version_id,
-                "publisher:global-rank:9",
-                &worker_a,
-            )),
+            shard: Some(shard(&version.uid, "publisher:global-rank:9", &worker_a)),
         })
         .await
         .expect_err("publication must cover a required source slot");
     assert_eq!(unexpected_source_slot.code(), tonic::Code::InvalidArgument);
 
-    let shard_a = shard(&version.version_id, "publisher:global-rank:0", &worker_a);
+    let shard_a = shard(&version.uid, "publisher:global-rank:0", &worker_a);
     let publish_a = client_a.create_weight_version_shard(CreateWeightVersionShardRequest {
         shard: Some(shard_a.clone()),
     });
     let publish_b = client_b.create_weight_version_shard(CreateWeightVersionShardRequest {
-        shard: Some(shard(
-            &version.version_id,
-            "publisher:global-rank:1",
-            &worker_b,
-        )),
+        shard: Some(shard(&version.uid, "publisher:global-rank:1", &worker_b)),
     });
     let (published_a, published_b) = tokio::join!(publish_a, publish_b);
     let states = [published_a, published_b].map(|result| {
@@ -236,7 +228,7 @@ async fn version_becomes_ready_across_server_replicas() {
 
     let ready = client_b
         .get_weight_version(GetWeightVersionRequest {
-            version_id: version.version_id.clone(),
+            uid: version.uid.clone(),
         })
         .await
         .expect("second server observes READY")
@@ -245,7 +237,7 @@ async fn version_becomes_ready_across_server_replicas() {
 
     let shards = client_a
         .list_weight_version_shards(ListWeightVersionShardsRequest {
-            version_id: version.version_id,
+            version_id: version.uid,
         })
         .await
         .expect("list shards")
@@ -285,7 +277,7 @@ async fn replacement_worker_can_publish_the_same_source_slot() {
     let version = client
         .create_weight_version(CreateWeightVersionRequest {
             model_name: "test/model".to_string(),
-            sequence: None,
+            version_number: None,
             idempotency_key: unique_id("replacement-publish"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
             base_version_id: None,
@@ -298,7 +290,7 @@ async fn replacement_worker_can_publish_the_same_source_slot() {
     client
         .create_weight_version_shard(CreateWeightVersionShardRequest {
             shard: Some(shard(
-                &version.version_id,
+                &version.uid,
                 "publisher:global-rank:0",
                 &original_worker_id,
             )),
@@ -308,7 +300,7 @@ async fn replacement_worker_can_publish_the_same_source_slot() {
     client
         .create_weight_version_shard(CreateWeightVersionShardRequest {
             shard: Some(shard(
-                &version.version_id,
+                &version.uid,
                 "publisher:global-rank:0",
                 &replacement_worker_id,
             )),
@@ -318,7 +310,7 @@ async fn replacement_worker_can_publish_the_same_source_slot() {
 
     let publications = client
         .list_weight_version_shards(ListWeightVersionShardsRequest {
-            version_id: version.version_id,
+            version_id: version.uid,
         })
         .await
         .expect("list publications")
@@ -365,7 +357,7 @@ async fn live_lease_protects_releasing_version_shards() {
     let version = client_a
         .create_weight_version(CreateWeightVersionRequest {
             model_name: "test/model".to_string(),
-            sequence: Some(43),
+            version_number: Some(43),
             idempotency_key: unique_id("lease-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
             base_version_id: None,
@@ -374,7 +366,7 @@ async fn live_lease_protects_releasing_version_shards() {
         .await
         .expect("create version")
         .into_inner();
-    let published_shard = shard(&version.version_id, "publisher:global-rank:0", &trainer_id);
+    let published_shard = shard(&version.uid, "publisher:global-rank:0", &trainer_id);
     client_a
         .create_weight_version_shard(CreateWeightVersionShardRequest {
             shard: Some(published_shard.clone()),
@@ -383,7 +375,7 @@ async fn live_lease_protects_releasing_version_shards() {
         .expect("publish complete version");
 
     let register_lease = RegisterVersionLeaseRequest {
-        version_id: version.version_id.clone(),
+        version_id: version.uid.clone(),
         worker_id: generator_id.clone(),
         ttl_seconds: 60,
     };
@@ -401,7 +393,7 @@ async fn live_lease_protects_releasing_version_shards() {
 
     let releasing = client_a
         .delete_weight_version(DeleteWeightVersionRequest {
-            version_id: version.version_id.clone(),
+            uid: version.uid.clone(),
         })
         .await
         .expect("logically release version")
@@ -410,7 +402,7 @@ async fn live_lease_protects_releasing_version_shards() {
 
     let late_lease = client_b
         .register_version_lease(RegisterVersionLeaseRequest {
-            version_id: version.version_id.clone(),
+            version_id: version.uid.clone(),
             worker_id: second_generator_id.clone(),
             ttl_seconds: 60,
         })
@@ -425,7 +417,7 @@ async fn live_lease_protects_releasing_version_shards() {
 
     let protected = client_a
         .delete_weight_version_shard(DeleteWeightVersionShardRequest {
-            version_id: version.version_id.clone(),
+            version_id: version.uid.clone(),
             source_slot_id: published_shard.source_slot_id.clone(),
             worker_id: trainer_id.clone(),
         })
@@ -435,7 +427,7 @@ async fn live_lease_protects_releasing_version_shards() {
 
     client_b
         .delete_version_lease(DeleteVersionLeaseRequest {
-            version_id: version.version_id.clone(),
+            version_id: version.uid.clone(),
             lease_id: lease.lease_id,
             worker_id: generator_id.clone(),
         })
@@ -443,7 +435,7 @@ async fn live_lease_protects_releasing_version_shards() {
         .expect("release consumer lease");
     let deleted = client_a
         .delete_weight_version_shard(DeleteWeightVersionShardRequest {
-            version_id: version.version_id.clone(),
+            version_id: version.uid.clone(),
             source_slot_id: published_shard.source_slot_id,
             worker_id: trainer_id.clone(),
         })
@@ -454,7 +446,7 @@ async fn live_lease_protects_releasing_version_shards() {
 
     let remaining = client_a
         .list_weight_version_shards(ListWeightVersionShardsRequest {
-            version_id: version.version_id,
+            version_id: version.uid,
         })
         .await
         .expect("list shards after eviction")
@@ -464,7 +456,7 @@ async fn live_lease_protects_releasing_version_shards() {
     let expiring_version = client_a
         .create_weight_version(CreateWeightVersionRequest {
             model_name: "test/model".to_string(),
-            sequence: Some(44),
+            version_number: Some(44),
             idempotency_key: unique_id("expiring-lease-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
             base_version_id: None,
@@ -474,7 +466,7 @@ async fn live_lease_protects_releasing_version_shards() {
         .expect("create version protected by an expiring lease")
         .into_inner();
     let expiring_shard = shard(
-        &expiring_version.version_id,
+        &expiring_version.uid,
         "publisher:global-rank:0",
         &trainer_id,
     );
@@ -485,7 +477,7 @@ async fn live_lease_protects_releasing_version_shards() {
         .await
         .expect("publish version protected by an expiring lease");
     let expiring_lease = RegisterVersionLeaseRequest {
-        version_id: expiring_version.version_id.clone(),
+        version_id: expiring_version.uid.clone(),
         worker_id: generator_id.clone(),
         ttl_seconds: 1,
     };
@@ -495,7 +487,7 @@ async fn live_lease_protects_releasing_version_shards() {
         .expect("register short consumer lease");
     client_a
         .delete_weight_version(DeleteWeightVersionRequest {
-            version_id: expiring_version.version_id.clone(),
+            uid: expiring_version.uid.clone(),
         })
         .await
         .expect("logically release version with short lease");
@@ -510,7 +502,7 @@ async fn live_lease_protects_releasing_version_shards() {
     );
     client_a
         .delete_weight_version_shard(DeleteWeightVersionShardRequest {
-            version_id: expiring_version.version_id,
+            version_id: expiring_version.uid,
             source_slot_id: expiring_shard.source_slot_id,
             worker_id: trainer_id.clone(),
         })
@@ -544,7 +536,7 @@ async fn register_worker_refreshes_liveness_and_expires_without_renewal() {
     let version = client
         .create_weight_version(CreateWeightVersionRequest {
             model_name: "test/model".to_string(),
-            sequence: None,
+            version_number: None,
             idempotency_key: unique_id("heartbeat-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
             base_version_id: None,
@@ -553,7 +545,7 @@ async fn register_worker_refreshes_liveness_and_expires_without_renewal() {
         .await
         .expect("create version")
         .into_inner();
-    let current_shard = shard(&version.version_id, "publisher:global-rank:0", &worker_id);
+    let current_shard = shard(&version.uid, "publisher:global-rank:0", &worker_id);
     client
         .create_weight_version_shard(CreateWeightVersionShardRequest {
             shard: Some(current_shard),
@@ -565,7 +557,7 @@ async fn register_worker_refreshes_liveness_and_expires_without_renewal() {
     let expired_version = client
         .create_weight_version(CreateWeightVersionRequest {
             model_name: "test/model".to_string(),
-            sequence: None,
+            version_number: None,
             idempotency_key: unique_id("expired-worker-version"),
             payload_format: WeightPayloadFormat::FullTensor.into(),
             base_version_id: None,
@@ -577,7 +569,7 @@ async fn register_worker_refreshes_liveness_and_expires_without_renewal() {
     let expired = client
         .create_weight_version_shard(CreateWeightVersionShardRequest {
             shard: Some(shard(
-                &expired_version.version_id,
+                &expired_version.uid,
                 "publisher:global-rank:0",
                 &worker_id,
             )),

--- a/workspace-tests/tests/refit_service_redis.rs
+++ b/workspace-tests/tests/refit_service_redis.rs
@@ -1,0 +1,591 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for the Redis-backed Refit gRPC service.
+//!
+//! Run with a Redis 7 server:
+//!
+//! ```sh
+//! REDIS_URL=redis://localhost:6379 cargo test -p model-express-workspace-tests \
+//!     --test refit_service_redis -- --include-ignored
+//! ```
+
+#![allow(clippy::expect_used)]
+
+use std::num::NonZeroU16;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use modelexpress_common::grpc::refit::{
+    CreateWeightVersionRequest, CreateWeightVersionShardRequest, DeleteVersionLeaseRequest,
+    DeleteWeightVersionRequest, DeleteWeightVersionShardRequest, GetWeightVersionRequest,
+    ListWeightVersionShardsRequest, RegisterVersionLeaseRequest, RegisterWorkerRequest,
+    WeightPayloadFormat, WeightVersionShard, WeightVersionState, WorkerRegistration, WorkerRole,
+    refit_service_client::RefitServiceClient,
+};
+use modelexpress_server::backend_config::BackendConfig;
+use modelexpress_server::config::ServerConfig;
+use modelexpress_server::run_server;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tonic_health::pb::{
+    HealthCheckRequest, health_check_response::ServingStatus, health_client::HealthClient,
+};
+
+type ServerResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("local addr").port()
+}
+
+fn unique_id(tag: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    format!("refit-test-{tag}-{nanos}")
+}
+
+fn start_server(port: u16, redis_url: &str) -> (oneshot::Sender<()>, JoinHandle<ServerResult>) {
+    let mut config = ServerConfig::default();
+    config.server.host = "127.0.0.1".to_string();
+    config.server.port = NonZeroU16::new(port).expect("port is non-zero");
+    config.cache.eviction.enabled = false;
+
+    let backend = BackendConfig::Redis {
+        url: redis_url.to_string(),
+    };
+    let (tx, rx) = oneshot::channel();
+    let handle = tokio::spawn(run_server(config, backend, async move {
+        let _ = rx.await;
+    }));
+    (tx, handle)
+}
+
+async fn connect(port: u16) -> RefitServiceClient<tonic::transport::Channel> {
+    let endpoint = format!("http://127.0.0.1:{port}");
+    for _ in 0..100 {
+        if let Ok(client) = RefitServiceClient::connect(endpoint.clone()).await {
+            return client;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server on port {port} never became reachable");
+}
+
+async fn stop(tx: oneshot::Sender<()>, handle: JoinHandle<ServerResult>) {
+    let _ = tx.send(());
+    tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("server did not stop")
+        .expect("server task panicked")
+        .expect("server failed");
+}
+
+fn trainer(worker_id: &str) -> RegisterWorkerRequest {
+    worker(worker_id, WorkerRole::Trainer, 60)
+}
+
+fn worker(worker_id: &str, role: WorkerRole, ttl_seconds: u32) -> RegisterWorkerRequest {
+    RegisterWorkerRequest {
+        worker: Some(WorkerRegistration {
+            worker_id: worker_id.to_string(),
+            role: role.into(),
+            model_name: "test/model".to_string(),
+            endpoint: format!("{worker_id}:9000"),
+            expires_at_unix_ms: 0,
+        }),
+        ttl_seconds,
+    }
+}
+
+fn shard(version_id: &str, source_slot_id: &str, worker_id: &str) -> WeightVersionShard {
+    WeightVersionShard {
+        version_id: version_id.to_string(),
+        shard_id: format!("{worker_id}-{source_slot_id}"),
+        source_slot_id: source_slot_id.to_string(),
+        worker_id: worker_id.to_string(),
+        tensor_count: 10,
+        total_bytes: 1024,
+        manifest_digest: format!("digest-{source_slot_id}"),
+        manifest_endpoint: format!("{worker_id}:9000"),
+        transport: "NIXL".to_string(),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live Redis at REDIS_URL"]
+async fn version_becomes_ready_across_server_replicas() {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let port_a = free_port();
+    let port_b = free_port();
+    let (stop_a, server_a) = start_server(port_a, &redis_url);
+    let (stop_b, server_b) = start_server(port_b, &redis_url);
+    let mut client_a = connect(port_a).await;
+    let mut client_b = connect(port_b).await;
+    let health_channel =
+        tonic::transport::Endpoint::from_shared(format!("http://127.0.0.1:{port_a}"))
+            .expect("valid health endpoint")
+            .connect()
+            .await
+            .expect("connect health client");
+    let mut health = HealthClient::new(health_channel);
+    let health_status = health
+        .check(HealthCheckRequest {
+            service: "model_express.refit.RefitService".to_string(),
+        })
+        .await
+        .expect("check Refit service health")
+        .into_inner();
+    assert_eq!(health_status.status, i32::from(ServingStatus::Serving));
+
+    let worker_a = unique_id("worker-a");
+    let worker_b = unique_id("worker-b");
+    client_a
+        .register_worker(trainer(&worker_a))
+        .await
+        .expect("register trainer A");
+    client_b
+        .register_worker(trainer(&worker_b))
+        .await
+        .expect("register trainer B");
+
+    let create_request = CreateWeightVersionRequest {
+        model_name: "test/model".to_string(),
+        sequence: Some(42),
+        idempotency_key: unique_id("publish"),
+        payload_format: WeightPayloadFormat::FullTensor.into(),
+        base_version_id: String::new(),
+        expected_source_slots: vec![
+            "publisher:global-rank:0".to_string(),
+            "publisher:global-rank:1".to_string(),
+        ],
+    };
+    let create_a = client_a.create_weight_version(create_request.clone());
+    let create_b = client_b.create_weight_version(create_request);
+    let (version_a, version_b) = tokio::join!(create_a, create_b);
+    let version = version_a.expect("create version").into_inner();
+    let repeated = version_b
+        .expect("concurrent create through second server")
+        .into_inner();
+    assert_eq!(version.version_id.len(), 8);
+    assert_eq!(version.state, i32::from(WeightVersionState::Staging));
+    assert_eq!(repeated, version);
+
+    let observed = client_b
+        .get_weight_version(GetWeightVersionRequest {
+            version_id: version.version_id.clone(),
+        })
+        .await
+        .expect("second server reads version")
+        .into_inner();
+    assert_eq!(observed, version);
+
+    let unexpected_source_slot = client_a
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(shard(
+                &version.version_id,
+                "publisher:global-rank:9",
+                &worker_a,
+            )),
+        })
+        .await
+        .expect_err("publication must cover a required source slot");
+    assert_eq!(unexpected_source_slot.code(), tonic::Code::InvalidArgument);
+
+    let shard_a = shard(&version.version_id, "publisher:global-rank:0", &worker_a);
+    let publish_a = client_a.create_weight_version_shard(CreateWeightVersionShardRequest {
+        shard: Some(shard_a.clone()),
+    });
+    let publish_b = client_b.create_weight_version_shard(CreateWeightVersionShardRequest {
+        shard: Some(shard(
+            &version.version_id,
+            "publisher:global-rank:1",
+            &worker_b,
+        )),
+    });
+    let (published_a, published_b) = tokio::join!(publish_a, publish_b);
+    let states = [published_a, published_b].map(|result| {
+        result
+            .expect("concurrent shard publication")
+            .into_inner()
+            .version
+            .expect("version in response")
+            .state
+    });
+    assert!(
+        states.contains(&i32::from(WeightVersionState::Ready)),
+        "the publication completing logical coverage must observe READY"
+    );
+
+    client_a
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(shard_a.clone()),
+        })
+        .await
+        .expect("byte-identical repeated shard publication is idempotent");
+    let mut conflicting_shard = shard_a;
+    conflicting_shard.total_bytes = 2048;
+    let conflict = client_a
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(conflicting_shard),
+        })
+        .await
+        .expect_err("the same shard_id cannot publish different metadata");
+    assert_eq!(conflict.code(), tonic::Code::AlreadyExists);
+
+    let ready = client_b
+        .get_weight_version(GetWeightVersionRequest {
+            version_id: version.version_id.clone(),
+        })
+        .await
+        .expect("second server observes READY")
+        .into_inner();
+    assert_eq!(ready.state, i32::from(WeightVersionState::Ready));
+
+    let shards = client_a
+        .list_weight_version_shards(ListWeightVersionShardsRequest {
+            version_id: version.version_id,
+        })
+        .await
+        .expect("list shards")
+        .into_inner()
+        .shards;
+    assert_eq!(
+        shards
+            .iter()
+            .map(|shard| shard.source_slot_id.as_str())
+            .collect::<Vec<_>>(),
+        ["publisher:global-rank:0", "publisher:global-rank:1"]
+    );
+
+    stop(stop_a, server_a).await;
+    stop(stop_b, server_b).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a live Redis at REDIS_URL"]
+async fn replacement_worker_can_publish_the_same_source_slot() {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let port = free_port();
+    let (shutdown, server) = start_server(port, &redis_url);
+    let mut client = connect(port).await;
+
+    let original_worker_id = unique_id("original-worker");
+    let replacement_worker_id = unique_id("replacement-worker");
+    client
+        .register_worker(trainer(&original_worker_id))
+        .await
+        .expect("register original worker");
+    client
+        .register_worker(trainer(&replacement_worker_id))
+        .await
+        .expect("register replacement worker");
+    let version = client
+        .create_weight_version(CreateWeightVersionRequest {
+            model_name: "test/model".to_string(),
+            sequence: None,
+            idempotency_key: unique_id("replacement-publish"),
+            payload_format: WeightPayloadFormat::FullTensor.into(),
+            base_version_id: String::new(),
+            expected_source_slots: vec!["publisher:global-rank:0".to_string()],
+        })
+        .await
+        .expect("create version")
+        .into_inner();
+
+    client
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(shard(
+                &version.version_id,
+                "publisher:global-rank:0",
+                &original_worker_id,
+            )),
+        })
+        .await
+        .expect("original worker publishes its manifest");
+    client
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(shard(
+                &version.version_id,
+                "publisher:global-rank:0",
+                &replacement_worker_id,
+            )),
+        })
+        .await
+        .expect("replacement may publish the same source slot");
+
+    let publications = client
+        .list_weight_version_shards(ListWeightVersionShardsRequest {
+            version_id: version.version_id,
+        })
+        .await
+        .expect("list publications")
+        .into_inner()
+        .shards;
+    assert_eq!(publications.len(), 2);
+    assert!(
+        publications
+            .iter()
+            .all(|publication| publication.source_slot_id == "publisher:global-rank:0")
+    );
+
+    stop(shutdown, server).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a live Redis at REDIS_URL"]
+async fn live_lease_protects_releasing_version_shards() {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let port_a = free_port();
+    let port_b = free_port();
+    let (stop_a, server_a) = start_server(port_a, &redis_url);
+    let (stop_b, server_b) = start_server(port_b, &redis_url);
+    let mut client_a = connect(port_a).await;
+    let mut client_b = connect(port_b).await;
+
+    let trainer_id = unique_id("lease-trainer");
+    let generator_id = unique_id("lease-generator");
+    let second_generator_id = unique_id("late-generator");
+    client_a
+        .register_worker(trainer(&trainer_id))
+        .await
+        .expect("register trainer");
+    client_a
+        .register_worker(worker(&generator_id, WorkerRole::Generator, 60))
+        .await
+        .expect("register generator");
+    client_b
+        .register_worker(worker(&second_generator_id, WorkerRole::Generator, 60))
+        .await
+        .expect("register second generator");
+
+    let version = client_a
+        .create_weight_version(CreateWeightVersionRequest {
+            model_name: "test/model".to_string(),
+            sequence: Some(43),
+            idempotency_key: unique_id("lease-version"),
+            payload_format: WeightPayloadFormat::FullTensor.into(),
+            base_version_id: String::new(),
+            expected_source_slots: vec!["publisher:global-rank:0".to_string()],
+        })
+        .await
+        .expect("create version")
+        .into_inner();
+    let published_shard = shard(&version.version_id, "publisher:global-rank:0", &trainer_id);
+    client_a
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(published_shard.clone()),
+        })
+        .await
+        .expect("publish complete version");
+
+    let register_lease = RegisterVersionLeaseRequest {
+        version_id: version.version_id.clone(),
+        worker_id: generator_id.clone(),
+        ttl_seconds: 60,
+    };
+    let lease = client_b
+        .register_version_lease(register_lease.clone())
+        .await
+        .expect("register lease through second server")
+        .into_inner();
+    let repeated = client_a
+        .register_version_lease(register_lease.clone())
+        .await
+        .expect("repeated registration renews the lease")
+        .into_inner();
+    assert_eq!(repeated.lease_id, lease.lease_id);
+
+    let releasing = client_a
+        .delete_weight_version(DeleteWeightVersionRequest {
+            version_id: version.version_id.clone(),
+        })
+        .await
+        .expect("logically release version")
+        .into_inner();
+    assert_eq!(releasing.state, i32::from(WeightVersionState::Releasing));
+
+    let late_lease = client_b
+        .register_version_lease(RegisterVersionLeaseRequest {
+            version_id: version.version_id.clone(),
+            worker_id: second_generator_id.clone(),
+            ttl_seconds: 60,
+        })
+        .await
+        .expect_err("a releasing version rejects new consumers");
+    assert_eq!(late_lease.code(), tonic::Code::FailedPrecondition);
+
+    client_b
+        .register_version_lease(register_lease)
+        .await
+        .expect("an existing consumer may renew while finishing");
+
+    let protected = client_a
+        .delete_weight_version_shard(DeleteWeightVersionShardRequest {
+            version_id: version.version_id.clone(),
+            shard_id: published_shard.shard_id.clone(),
+            worker_id: trainer_id.clone(),
+        })
+        .await
+        .expect_err("a live lease protects every source shard");
+    assert_eq!(protected.code(), tonic::Code::FailedPrecondition);
+
+    client_b
+        .delete_version_lease(DeleteVersionLeaseRequest {
+            version_id: version.version_id.clone(),
+            lease_id: lease.lease_id,
+            worker_id: generator_id.clone(),
+        })
+        .await
+        .expect("release consumer lease");
+    let deleted = client_a
+        .delete_weight_version_shard(DeleteWeightVersionShardRequest {
+            version_id: version.version_id.clone(),
+            shard_id: published_shard.shard_id,
+            worker_id: trainer_id.clone(),
+        })
+        .await
+        .expect("source may evict after the final lease is gone")
+        .into_inner();
+    assert!(deleted.deleted);
+
+    let remaining = client_a
+        .list_weight_version_shards(ListWeightVersionShardsRequest {
+            version_id: version.version_id,
+        })
+        .await
+        .expect("list shards after eviction")
+        .into_inner();
+    assert!(remaining.shards.is_empty());
+
+    let expiring_version = client_a
+        .create_weight_version(CreateWeightVersionRequest {
+            model_name: "test/model".to_string(),
+            sequence: Some(44),
+            idempotency_key: unique_id("expiring-lease-version"),
+            payload_format: WeightPayloadFormat::FullTensor.into(),
+            base_version_id: String::new(),
+            expected_source_slots: vec!["publisher:global-rank:0".to_string()],
+        })
+        .await
+        .expect("create version protected by an expiring lease")
+        .into_inner();
+    let expiring_shard = shard(
+        &expiring_version.version_id,
+        "publisher:global-rank:0",
+        &trainer_id,
+    );
+    client_a
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(expiring_shard.clone()),
+        })
+        .await
+        .expect("publish version protected by an expiring lease");
+    let expiring_lease = RegisterVersionLeaseRequest {
+        version_id: expiring_version.version_id.clone(),
+        worker_id: generator_id.clone(),
+        ttl_seconds: 1,
+    };
+    client_b
+        .register_version_lease(expiring_lease.clone())
+        .await
+        .expect("register short consumer lease");
+    client_a
+        .delete_weight_version(DeleteWeightVersionRequest {
+            version_id: expiring_version.version_id.clone(),
+        })
+        .await
+        .expect("logically release version with short lease");
+    tokio::time::sleep(Duration::from_millis(1_250)).await;
+    let expired_re_registration = client_b
+        .register_version_lease(expiring_lease)
+        .await
+        .expect_err("an expired lease cannot be re-registered after logical release");
+    assert_eq!(
+        expired_re_registration.code(),
+        tonic::Code::FailedPrecondition
+    );
+    client_a
+        .delete_weight_version_shard(DeleteWeightVersionShardRequest {
+            version_id: expiring_version.version_id,
+            shard_id: expiring_shard.shard_id,
+            worker_id: trainer_id.clone(),
+        })
+        .await
+        .expect("expired lease no longer protects source shards");
+
+    stop(stop_a, server_a).await;
+    stop(stop_b, server_b).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a live Redis at REDIS_URL"]
+async fn register_worker_refreshes_liveness_and_expires_without_renewal() {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let port = free_port();
+    let (shutdown, server) = start_server(port, &redis_url);
+    let mut client = connect(port).await;
+
+    let worker_id = unique_id("heartbeat-worker");
+    client
+        .register_worker(worker(&worker_id, WorkerRole::Trainer, 1))
+        .await
+        .expect("initial registration");
+    client
+        .register_worker(worker(&worker_id, WorkerRole::Trainer, 10))
+        .await
+        .expect("same registration refreshes its TTL");
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let version = client
+        .create_weight_version(CreateWeightVersionRequest {
+            model_name: "test/model".to_string(),
+            sequence: None,
+            idempotency_key: unique_id("heartbeat-version"),
+            payload_format: WeightPayloadFormat::FullTensor.into(),
+            base_version_id: String::new(),
+            expected_source_slots: vec!["publisher:global-rank:0".to_string()],
+        })
+        .await
+        .expect("create version")
+        .into_inner();
+    let current_shard = shard(&version.version_id, "publisher:global-rank:0", &worker_id);
+    client
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(current_shard),
+        })
+        .await
+        .expect("refreshed registration remains live past its original TTL");
+
+    tokio::time::sleep(Duration::from_secs(6)).await;
+    let expired_version = client
+        .create_weight_version(CreateWeightVersionRequest {
+            model_name: "test/model".to_string(),
+            sequence: None,
+            idempotency_key: unique_id("expired-worker-version"),
+            payload_format: WeightPayloadFormat::FullTensor.into(),
+            base_version_id: String::new(),
+            expected_source_slots: vec!["publisher:global-rank:0".to_string()],
+        })
+        .await
+        .expect("create version after worker expiry")
+        .into_inner();
+    let expired = client
+        .create_weight_version_shard(CreateWeightVersionShardRequest {
+            shard: Some(shard(
+                &expired_version.version_id,
+                "publisher:global-rank:0",
+                &worker_id,
+            )),
+        })
+        .await
+        .expect_err("expired worker registration cannot publish a manifest");
+    assert_eq!(expired.code(), tonic::Code::FailedPrecondition);
+
+    stop(shutdown, server).await;
+}


### PR DESCRIPTION
## Summary

- add a clean RL-specific `RefitService` without changing the existing `WeightSyncService`
- define external orchestrator APIs for creating, reading, and releasing immutable weight versions
- define internal worker APIs for registration, manifest publication, discovery, version leases, and safe source-manifest eviction
- add the `STAGING -> READY -> RELEASING` lifecycle
- use a fresh TTL-bound `worker_id` for each process lifetime; `RegisterWorker` is also the heartbeat API
- represent each worker's manifest publication as `WeightVersionShard`; retain multiple publications for a source slot so a replacement or peer generator can become an additional source
- use `RegisterVersionLease` and `DeleteVersionLease` as the complete lease API
- organize storage behind a backend-neutral `RefitBackend` contract, following the existing inference backend layout
- implement Redis first with one documented atomic Lua transition per domain operation; Kubernetes CRD support remains a separate backend implementation

Weight bytes and full tensor manifests remain on trainer and generator workers. Redis stores only control-plane metadata.

## API visibility

External APIs called by the RL framework orchestrator:

- `CreateWeightVersion`
- `GetWeightVersion`
- `DeleteWeightVersion`

Internal APIs called by ModelExpress worker clients:

- `RegisterWorker`
- `CreateWeightVersionShard`
- `ListWeightVersionShards`
- `DeleteWeightVersionShard`
- `RegisterVersionLease`
- `DeleteVersionLease`

## Lifecycle guarantees

- a version becomes `READY` atomically after all expected version-scoped source slots are published
- `WeightVersionShard` is a physical worker manifest, while `source_slot_id` identifies the required logical contribution; multiple worker publications may cover the same slot
- deleting a `READY` version moves it to `RELEASING`
- `RELEASING` rejects new leases and shard publications
- `RegisterVersionLease` acquires a lease only while a version is `READY`
- registering the same live lease owner renews its expiry while the version is `READY` or `RELEASING`, so an in-flight generator update can finish
- an expired lease cannot be registered again after logical release begins
- any active lease protects every shard of the version
- explicit lease release or TTL expiration allows source workers to evict their shards

## Validation

- `cargo fmt --all`
- `cargo check -p modelexpress-server -p model-express-workspace-tests`
- `cargo test -p model-express-workspace-tests --test refit_service_redis --no-run`
- `git diff --check`
- Redis 7 public gRPC E2E coverage exercises concurrent idempotent creation, source-slot readiness, replacement-source publication, lease/release/eviction, and TTL expiry. Local execution is blocked by the local Docker daemon returning HTTP 500; CI runs it against Redis 7.