### PR TITLE
fix: stop rewriting the full worker record on every heartbeat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,14 @@ jobs:
           --test registry_backend_redis \
           -- --include-ignored --test-threads=1
 
+    - name: Run P2P Redis status ordering test
+      env:
+        MX_TEST_REDIS_URL: redis://localhost:6379
+      run: |
+        cargo test -p modelexpress-server --lib \
+          p2p::backend::redis::tests::older_status_update_does_not_replace_newer_status \
+          -- --ignored --exact --test-threads=1
+
     - name: Run Refit service Redis integration tests
       env:
         REDIS_URL: redis://localhost:6379

--- a/modelexpress_server/src/p2p/backend/redis.rs
+++ b/modelexpress_server/src/p2p/backend/redis.rs
@@ -53,6 +53,53 @@ end
 return remaining
 "#;
 
+const UPDATE_STATUS_IF_FRESH_LUA: &str = r#"
+if redis.call('HEXISTS', KEYS[1], ARGV[1]) == 0 then
+    return -1
+end
+
+local incoming_updated_at = tonumber(ARGV[5])
+local current_json = redis.call('HGET', KEYS[1], ARGV[2])
+if current_json then
+    local ok, current = pcall(cjson.decode, current_json)
+    if ok and type(current) == 'table' then
+        local current_updated_at = tonumber(current['updated_at'])
+        if current_updated_at and current_updated_at > incoming_updated_at then
+            return 0
+        end
+    end
+end
+
+local update_source_summary = false
+local source_json = redis.call('HGET', KEYS[2], ARGV[3])
+if not source_json then
+    update_source_summary = true
+else
+    local representative_rank = tonumber(source_json)
+    if representative_rank then
+        update_source_summary = representative_rank == tonumber(ARGV[1])
+    else
+        local ok, source = pcall(cjson.decode, source_json)
+        if ok and type(source) == 'table' then
+            representative_rank = tonumber(source['worker_rank'])
+            local source_updated_at = tonumber(source['updated_at'])
+            if representative_rank == tonumber(ARGV[1]) then
+                if source_updated_at and source_updated_at > incoming_updated_at then
+                    return 0
+                end
+                update_source_summary = true
+            end
+        end
+    end
+end
+
+redis.call('HSET', KEYS[1], ARGV[2], ARGV[4])
+if update_source_summary then
+    redis.call('HSET', KEYS[2], ARGV[3], ARGV[4])
+end
+return 1
+"#;
+
 /// All fields of a SourceIdentity stored once per source in the index hash.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct SourceAttributesJson {
@@ -156,25 +203,36 @@ fn source_identity_from_attributes(attr_json: Option<&str>) -> (String, Option<S
     (model_name, identity)
 }
 
-fn representative_worker_rank(summary: Option<&str>, fallback: u32) -> u32 {
-    summary
-        .and_then(|value| {
-            value.parse().ok().or_else(|| {
-                serde_json::from_str::<WorkerSummaryJson>(value)
-                    .ok()
-                    .map(|summary| summary.worker_rank)
-            })
-        })
-        .unwrap_or(fallback)
-}
-
-fn representative_summary_rank_to_update(summary: Option<&str>, updated_rank: u32) -> Option<u32> {
-    let representative_rank = representative_worker_rank(summary, updated_rank);
-    (summary.is_none() || representative_rank == updated_rank).then_some(representative_rank)
-}
-
 fn status_field(worker_rank: u32) -> String {
     format!("{}{}", keys::STATUS_FIELD_PREFIX, worker_rank)
+}
+
+async fn update_status_if_fresh(
+    conn: &mut ConnectionManager,
+    worker_key: &str,
+    source_key: &str,
+    worker_id: &str,
+    worker_rank: u32,
+    summary: &str,
+    updated_at: i64,
+) -> MetadataResult<bool> {
+    let result: i32 = redis::Script::new(UPDATE_STATUS_IF_FRESH_LUA)
+        .key(worker_key)
+        .key(source_key)
+        .arg(worker_rank)
+        .arg(status_field(worker_rank))
+        .arg(worker_id)
+        .arg(summary)
+        .arg(updated_at)
+        .invoke_async(conn)
+        .await?;
+
+    match result {
+        -1 => Err(format!("worker rank {worker_rank} not found in '{worker_key}'").into()),
+        0 => Ok(false),
+        1 => Ok(true),
+        value => Err(format!("unexpected status update result: {value}").into()),
+    }
 }
 
 /// Live (status, updated_at) of a rank: `status:{rank}` if at least as fresh, else the record.
@@ -972,29 +1030,31 @@ impl MetadataBackend for RedisBackend {
             worker_rank,
             status: status as i32,
             updated_at,
-            accelerator: accelerator.clone(),
+            accelerator,
         })?;
         let source_key = format!("{}{}", keys::SOURCE_PREFIX, source_id);
-        let existing_summary: Option<String> = conn.hget(&source_key, worker_id).await?;
-        let mut pipe = redis::pipe();
-        pipe.hset(&key, status_field(worker_rank), &status_summary);
-        if let Some(representative_rank) =
-            representative_summary_rank_to_update(existing_summary.as_deref(), worker_rank)
-        {
-            let summary = serde_json::to_string(&WorkerSummaryJson {
-                worker_rank: representative_rank,
-                status: status as i32,
-                updated_at,
-                accelerator,
-            })?;
-            pipe.hset(&source_key, worker_id, summary);
-        }
-        pipe.exec_async(&mut conn).await?;
+        let updated = update_status_if_fresh(
+            &mut conn,
+            &key,
+            &source_key,
+            worker_id,
+            worker_rank,
+            &status_summary,
+            updated_at,
+        )
+        .await?;
 
-        debug!(
-            "Updated status for source '{}' worker '{}' rank {} -> {}",
-            source_id, worker_id, worker_rank, status as i32
-        );
+        if updated {
+            debug!(
+                "Updated status for source '{}' worker '{}' rank {} -> {}",
+                source_id, worker_id, worker_rank, status as i32
+            );
+        } else {
+            debug!(
+                "Ignored older status for source '{}' worker '{}' rank {} at {}",
+                source_id, worker_id, worker_rank, updated_at
+            );
+        }
         Ok(())
     }
 }
@@ -1132,27 +1192,6 @@ mod tests {
             serde_json::from_str(r#"{"worker_rank":0,"status":2,"updated_at":1700000000000}"#)
                 .expect("parse legacy summary");
         assert!(parsed.accelerator.is_empty());
-    }
-
-    #[test]
-    fn test_representative_worker_rank_preserves_summary_rank() {
-        let summary = r#"{"worker_rank":7,"status":2,"updated_at":1700000000000}"#;
-        assert_eq!(representative_worker_rank(Some(summary), 3), 7);
-        assert_eq!(
-            representative_summary_rank_to_update(Some(summary), 3),
-            None
-        );
-        assert_eq!(
-            representative_summary_rank_to_update(Some(summary), 7),
-            Some(7)
-        );
-    }
-
-    #[test]
-    fn test_representative_worker_rank_supports_legacy_rank() {
-        assert_eq!(representative_worker_rank(Some("5"), 3), 5);
-        assert_eq!(representative_summary_rank_to_update(Some("5"), 3), None);
-        assert_eq!(representative_worker_rank(Some("corrupt"), 3), 3);
     }
 
     #[test]
@@ -1316,5 +1355,111 @@ mod tests {
             identity.expect("valid legacy attributes").model_name,
             "legacy-model"
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at MX_TEST_REDIS_URL"]
+    async fn older_status_update_does_not_replace_newer_status() {
+        let redis_url = std::env::var("MX_TEST_REDIS_URL")
+            .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+        let backend = RedisBackend::new(&redis_url);
+        backend.connect().await.expect("connect");
+
+        let mut identity = test_identity();
+        identity.model_name = format!("status-order-test/{}", uuid::Uuid::new_v4());
+        let source_id = crate::p2p::source_identity::compute_mx_source_id(&identity);
+        let worker_id = uuid::Uuid::new_v4().to_string();
+
+        backend
+            .publish_metadata(
+                &identity,
+                &worker_id,
+                WorkerMetadata {
+                    worker_rank: 0,
+                    status: SourceStatus::Initializing as i32,
+                    updated_at: 50,
+                    accelerator: "cuda".to_string(),
+                    ..Default::default()
+                },
+                "",
+                "",
+                "",
+            )
+            .await
+            .expect("publish");
+        backend
+            .update_status(&source_id, &worker_id, 0, SourceStatus::Ready, 200)
+            .await
+            .expect("newer update");
+        backend
+            .update_status(&source_id, &worker_id, 0, SourceStatus::Stale, 100)
+            .await
+            .expect("older update");
+
+        let metadata = backend
+            .get_metadata(&source_id, &worker_id)
+            .await
+            .expect("get metadata")
+            .expect("metadata exists");
+        assert_eq!(metadata.workers[0].status, SourceStatus::Ready as i32);
+        assert_eq!(metadata.workers[0].updated_at, 200);
+
+        let workers = backend
+            .list_workers(Some(source_id.clone()), None)
+            .await
+            .expect("list workers");
+        assert_eq!(workers[0].status, SourceStatus::Ready as i32);
+        assert_eq!(workers[0].updated_at, 200);
+        let summaries = backend
+            .list_workers_filtered(Some(source_id.clone()), None, None, None, None, None, None)
+            .await
+            .expect("list worker summaries");
+        assert_eq!(summaries[0].status, SourceStatus::Ready as i32);
+        assert_eq!(summaries[0].updated_at, 200);
+
+        let worker_key = format!("{}{}:{}", keys::SOURCE_PREFIX, source_id, worker_id);
+        let mut conn = backend.get_conn().await.expect("connection");
+        let _: usize = conn
+            .hdel(&worker_key, status_field(0))
+            .await
+            .expect("remove status field");
+        backend
+            .update_status(&source_id, &worker_id, 0, SourceStatus::Stale, 100)
+            .await
+            .expect("older legacy update");
+        let metadata = backend
+            .get_metadata(&source_id, &worker_id)
+            .await
+            .expect("get metadata after older legacy update")
+            .expect("metadata exists after older legacy update");
+        assert_eq!(
+            metadata.workers[0].status,
+            SourceStatus::Initializing as i32
+        );
+        assert_eq!(metadata.workers[0].updated_at, 50);
+
+        backend
+            .update_status(&source_id, &worker_id, 0, SourceStatus::Ready, 300)
+            .await
+            .expect("legacy record update");
+        let metadata = backend
+            .get_metadata(&source_id, &worker_id)
+            .await
+            .expect("get legacy metadata")
+            .expect("legacy metadata exists");
+        assert_eq!(metadata.workers[0].updated_at, 300);
+
+        assert!(
+            backend
+                .update_status(&source_id, &worker_id, 99, SourceStatus::Ready, 400)
+                .await
+                .is_err(),
+            "a heartbeat must not create a missing rank"
+        );
+
+        backend
+            .remove_worker(&source_id, &worker_id)
+            .await
+            .expect("cleanup");
     }
 }

--- a/modelexpress_server/src/p2p/backend/redis.rs
+++ b/modelexpress_server/src/p2p/backend/redis.rs
@@ -9,7 +9,10 @@
 //!                                            per source); each other field is an worker_id
 //!                                            with an empty-string value (presence marker).
 //!   `mx:source:{source_id}:{worker_id}` — Redis Hash; field = worker_rank (string),
-//!                                            value = JSON-serialized WorkerRecordJson.
+//!                                            value = JSON-serialized WorkerRecordJson;
+//!                                            field `status:{worker_rank}` = JSON-serialized
+//!                                            WorkerSummaryJson holding the rank's mutable
+//!                                            state, so heartbeats don't rewrite the record.
 //!
 //! Global listing uses SCAN with pattern `mx:source:????????????????` (16-char source IDs)
 //! to enumerate source index keys without a separate secondary index.
@@ -35,6 +38,8 @@ mod keys {
     pub const SOURCE_SCAN_PATTERN: &str = "mx:source:????????????????";
     /// Reserved hash field in the source index key that stores SourceAttributesJson.
     pub const ATTRIBUTES_FIELD: &str = "__attributes__";
+    /// Prefix of the per-rank mutable-state field (`status:{rank}`) rewritten by heartbeats.
+    pub const STATUS_FIELD_PREFIX: &str = "status:";
 }
 
 const REMOVE_WORKER_LUA: &str = r#"
@@ -168,13 +173,38 @@ fn representative_summary_rank_to_update(summary: Option<&str>, updated_rank: u3
     (summary.is_none() || representative_rank == updated_rank).then_some(representative_rank)
 }
 
-fn worker_records_match_status<'a>(
-    records: impl IntoIterator<Item = &'a str>,
+fn status_field(worker_rank: u32) -> String {
+    format!("{}{}", keys::STATUS_FIELD_PREFIX, worker_rank)
+}
+
+/// Live (status, updated_at) of a rank: `status:{rank}` if at least as fresh, else the record.
+fn overlay_status(
+    fields: &std::collections::HashMap<String, String>,
+    worker_rank: u32,
+    record_status: i32,
+    record_updated_at: i64,
+) -> (i32, i64) {
+    fields
+        .get(&status_field(worker_rank))
+        .and_then(|value| serde_json::from_str::<WorkerSummaryJson>(value).ok())
+        .filter(|summary| summary.updated_at >= record_updated_at)
+        .map(|summary| (summary.status, summary.updated_at))
+        .unwrap_or((record_status, record_updated_at))
+}
+
+fn worker_records_match_status(
+    fields: &std::collections::HashMap<String, String>,
     required_status: SourceStatus,
 ) -> bool {
-    records.into_iter().any(|value| {
-        serde_json::from_str::<WorkerRecordJson>(value)
-            .is_ok_and(|record| record.status == required_status as i32)
+    fields.iter().any(|(field, value)| {
+        if field.starts_with(keys::STATUS_FIELD_PREFIX) {
+            return false;
+        }
+        serde_json::from_str::<WorkerRecordJson>(value).is_ok_and(|record| {
+            let (status, _) =
+                overlay_status(fields, record.worker_rank, record.status, record.updated_at);
+            status == required_status as i32
+        })
     })
 }
 
@@ -522,6 +552,11 @@ impl MetadataBackend for RedisBackend {
 
         let mut pipe = redis::pipe();
         pipe.hset(&worker_key, worker_record.worker_rank.to_string(), &value);
+        pipe.hset(
+            &worker_key,
+            status_field(worker_record.worker_rank),
+            &summary,
+        );
         pipe.hset(&source_key, keys::ATTRIBUTES_FIELD, &attr_json);
         pipe.hset(&source_key, worker_id, summary);
         pipe.exec_async(&mut conn).await?;
@@ -561,9 +596,21 @@ impl MetadataBackend for RedisBackend {
         let (model_name, identity) = source_identity_from_attributes(attr_json.as_deref());
 
         let mut workers: Vec<WorkerRecord> = Vec::with_capacity(fields.len());
-        for value in fields.values() {
+        for (field, value) in &fields {
+            if field.starts_with(keys::STATUS_FIELD_PREFIX) {
+                continue;
+            }
             let json: WorkerRecordJson = serde_json::from_str(value)?;
-            workers.push(WorkerRecord::from(json));
+            let mut worker = WorkerRecord::from(json);
+            let (status, updated_at) = overlay_status(
+                &fields,
+                worker.worker_rank,
+                worker.status,
+                worker.updated_at,
+            );
+            worker.status = status;
+            worker.updated_at = updated_at;
+            workers.push(worker);
         }
         workers.sort_by_key(|w| w.worker_rank);
 
@@ -634,10 +681,7 @@ impl MetadataBackend for RedisBackend {
                 }
 
                 if let Some(required_status) = status_filter
-                    && !worker_records_match_status(
-                        fields.values().map(String::as_str),
-                        required_status,
-                    )
+                    && !worker_records_match_status(&fields, required_status)
                 {
                     continue;
                 }
@@ -645,7 +689,11 @@ impl MetadataBackend for RedisBackend {
                 let (status, updated_at, accelerator) = fields
                     .get(&worker_rank.to_string())
                     .and_then(|v| serde_json::from_str::<WorkerRecordJson>(v).ok())
-                    .map(|j| (j.status, j.updated_at, j.accelerator))
+                    .map(|j| {
+                        let (status, updated_at) =
+                            overlay_status(&fields, worker_rank, j.status, j.updated_at);
+                        (status, updated_at, j.accelerator)
+                    })
                     .unwrap_or((0, 0, String::new()));
 
                 result.push(super::SourceInstanceInfo {
@@ -793,15 +841,19 @@ impl MetadataBackend for RedisBackend {
                 if fields.is_empty() {
                     continue;
                 }
-                if status_filter.is_some_and(|required| {
-                    !worker_records_match_status(fields.values().map(String::as_str), required)
-                }) {
+                if status_filter
+                    .is_some_and(|required| !worker_records_match_status(&fields, required))
+                {
                     continue;
                 }
                 let (status, updated_at, accelerator) = fields
                     .get(&worker_rank.to_string())
                     .and_then(|value| serde_json::from_str::<WorkerRecordJson>(value).ok())
-                    .map(|record| (record.status, record.updated_at, record.accelerator))
+                    .map(|record| {
+                        let (status, updated_at) =
+                            overlay_status(&fields, worker_rank, record.status, record.updated_at);
+                        (status, updated_at, record.accelerator)
+                    })
                     .unwrap_or((0, 0, String::new()));
                 if min_updated_at.is_some_and(|minimum| updated_at < minimum) {
                     continue;
@@ -896,25 +948,36 @@ impl MetadataBackend for RedisBackend {
     ) -> MetadataResult<()> {
         let mut conn = self.get_conn().await?;
         let key = format!("{}{}:{}", keys::SOURCE_PREFIX, source_id, worker_id);
-        let field = worker_rank.to_string();
 
-        let value: Option<String> = conn.hget(&key, &field).await?;
-        let json_str = value.ok_or_else(|| {
-            format!(
-                "update_status: rank {} not found in source '{}' worker '{}'",
-                worker_rank, source_id, worker_id
-            )
+        // Heartbeats rewrite only the small `status:{rank}` field, never the record.
+        let status_json: Option<String> = conn.hget(&key, status_field(worker_rank)).await?;
+        let accelerator = if let Some(summary) = status_json
+            .as_deref()
+            .and_then(|value| serde_json::from_str::<WorkerSummaryJson>(value).ok())
+        {
+            summary.accelerator
+        } else {
+            // Record predating the status field: seed the accelerator from it once.
+            let value: Option<String> = conn.hget(&key, worker_rank.to_string()).await?;
+            let json_str = value.ok_or_else(|| {
+                format!(
+                    "update_status: rank {} not found in source '{}' worker '{}'",
+                    worker_rank, source_id, worker_id
+                )
+            })?;
+            serde_json::from_str::<WorkerRecordJson>(&json_str)?.accelerator
+        };
+
+        let status_summary = serde_json::to_string(&WorkerSummaryJson {
+            worker_rank,
+            status: status as i32,
+            updated_at,
+            accelerator: accelerator.clone(),
         })?;
-
-        let mut record: WorkerRecordJson = serde_json::from_str(&json_str)?;
-        record.status = status as i32;
-        record.updated_at = updated_at;
-
-        let updated = serde_json::to_string(&record)?;
         let source_key = format!("{}{}", keys::SOURCE_PREFIX, source_id);
         let existing_summary: Option<String> = conn.hget(&source_key, worker_id).await?;
         let mut pipe = redis::pipe();
-        pipe.hset(&key, &field, &updated);
+        pipe.hset(&key, status_field(worker_rank), &status_summary);
         if let Some(representative_rank) =
             representative_summary_rank_to_update(existing_summary.as_deref(), worker_rank)
         {
@@ -922,7 +985,7 @@ impl MetadataBackend for RedisBackend {
                 worker_rank: representative_rank,
                 status: status as i32,
                 updated_at,
-                accelerator: record.accelerator,
+                accelerator,
             })?;
             pipe.hset(&source_key, worker_id, summary);
         }
@@ -1096,14 +1159,48 @@ mod tests {
     fn test_status_filter_matches_any_rank_record() {
         let initializing = r#"{"worker_rank":0,"nixl_metadata":[],"tensors":[],"status":1}"#;
         let ready = r#"{"worker_rank":1,"nixl_metadata":[],"tensors":[],"status":2}"#;
-        assert!(worker_records_match_status(
-            [initializing, ready],
-            SourceStatus::Ready
-        ));
+        let both: std::collections::HashMap<String, String> = [
+            ("0".to_string(), initializing.to_string()),
+            ("1".to_string(), ready.to_string()),
+        ]
+        .into();
+        let only_initializing: std::collections::HashMap<String, String> =
+            [("0".to_string(), initializing.to_string())].into();
+        assert!(worker_records_match_status(&both, SourceStatus::Ready));
         assert!(!worker_records_match_status(
-            [initializing],
+            &only_initializing,
             SourceStatus::Ready
         ));
+    }
+
+    #[test]
+    fn test_status_overlay_prefers_fresher_status_field() {
+        let record =
+            r#"{"worker_rank":0,"nixl_metadata":[],"tensors":[],"status":1,"updated_at":100}"#;
+        let fresh_status = r#"{"worker_rank":0,"status":2,"updated_at":200}"#;
+        let stale_status = r#"{"worker_rank":0,"status":3,"updated_at":50}"#;
+
+        let with_fresh: std::collections::HashMap<String, String> = [
+            ("0".to_string(), record.to_string()),
+            ("status:0".to_string(), fresh_status.to_string()),
+        ]
+        .into();
+        assert_eq!(overlay_status(&with_fresh, 0, 1, 100), (2, 200));
+        assert!(worker_records_match_status(
+            &with_fresh,
+            SourceStatus::Ready
+        ));
+
+        let with_stale: std::collections::HashMap<String, String> = [
+            ("0".to_string(), record.to_string()),
+            ("status:0".to_string(), stale_status.to_string()),
+        ]
+        .into();
+        assert_eq!(overlay_status(&with_stale, 0, 1, 100), (1, 100));
+
+        let without_status: std::collections::HashMap<String, String> =
+            [("0".to_string(), record.to_string())].into();
+        assert_eq!(overlay_status(&without_status, 0, 1, 100), (1, 100));
     }
 
     // ── SourceAttributesJson ────────────────────────────────────────────────

--- a/modelexpress_server/src/p2p/backend/redis.rs
+++ b/modelexpress_server/src/p2p/backend/redis.rs
@@ -84,10 +84,7 @@ else
             representative_rank = tonumber(source['worker_rank'])
             local source_updated_at = tonumber(source['updated_at'])
             if representative_rank == tonumber(ARGV[1]) then
-                if source_updated_at and source_updated_at > incoming_updated_at then
-                    return 0
-                end
-                update_source_summary = true
+                update_source_summary = not (source_updated_at and source_updated_at > incoming_updated_at)
             end
         end
     end
@@ -1426,17 +1423,20 @@ mod tests {
         backend
             .update_status(&source_id, &worker_id, 0, SourceStatus::Stale, 100)
             .await
-            .expect("older legacy update");
+            .expect("rank-fresh legacy update");
         let metadata = backend
             .get_metadata(&source_id, &worker_id)
             .await
-            .expect("get metadata after older legacy update")
-            .expect("metadata exists after older legacy update");
-        assert_eq!(
-            metadata.workers[0].status,
-            SourceStatus::Initializing as i32
-        );
-        assert_eq!(metadata.workers[0].updated_at, 50);
+            .expect("get metadata after legacy rank update")
+            .expect("metadata exists after legacy rank update");
+        assert_eq!(metadata.workers[0].status, SourceStatus::Stale as i32);
+        assert_eq!(metadata.workers[0].updated_at, 100);
+        let summaries = backend
+            .list_workers_filtered(Some(source_id.clone()), None, None, None, None, None, None)
+            .await
+            .expect("list summaries after legacy rank update");
+        assert_eq!(summaries[0].status, SourceStatus::Ready as i32);
+        assert_eq!(summaries[0].updated_at, 200);
 
         backend
             .update_status(&source_id, &worker_id, 0, SourceStatus::Ready, 300)


### PR DESCRIPTION
Each heartbeat currently rewrites the whole ~1 MB worker record just to bump status/updated_at. This stores the mutable part in a small `status:{rank}` field instead. Full context and measurements in #608.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker status updates so heartbeat information is refreshed reliably and stale updates do not overwrite newer data.
  * Ensured current worker status is consistently reflected in metadata and worker listings.
  * Preserved compatibility with existing worker records during status updates.
  * Maintained worker performance settings and representative-worker behavior while refreshing status.

* **Tests**
  * Expanded coverage for status refreshes, metadata overlays, legacy compatibility, missing workers, and update ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->