### PR TITLE
feat(refit): add canonical S3 revision receiver

### DIFF
--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     MX_REFIT_STAGE_RECORD: bool
     MX_RESHARD_MAX_GBPS: float
     MX_REFIT_S3_UPLOAD_WORKERS: int
+    MX_REFIT_S3_DOWNLOAD_WORKERS: int
     MX_REFIT_S3_MAX_POOL_CONNECTIONS: int
     # Kubernetes service backend
     MX_K8S_SERVICE_PATTERN: str
@@ -271,6 +272,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # real per-rank limit for their fabric.
     "MX_RESHARD_MAX_GBPS": lambda: _env_float("MX_RESHARD_MAX_GBPS", 0.0),
     "MX_REFIT_S3_UPLOAD_WORKERS": lambda: _env_int("MX_REFIT_S3_UPLOAD_WORKERS", 4),
+    "MX_REFIT_S3_DOWNLOAD_WORKERS": lambda: _env_int(
+        "MX_REFIT_S3_DOWNLOAD_WORKERS", _env_int("MX_REFIT_S3_UPLOAD_WORKERS", 4)
+    ),
     "MX_REFIT_S3_MAX_POOL_CONNECTIONS": lambda: _env_int(
         "MX_REFIT_S3_MAX_POOL_CONNECTIONS", 10
     ),

--- a/modelexpress_client/python/modelexpress/refit/receiver.py
+++ b/modelexpress_client/python/modelexpress/refit/receiver.py
@@ -1,0 +1,657 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical S3 receiver and persistent checkpoint installer."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import mmap
+import socket
+import shutil
+import struct
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import quote
+
+import numpy as np
+import torch
+import zstandard
+
+from .. import envs
+from .api import ReceiverRevisionState, ReceiverStatus, WeightUpdateResult
+from .catalog import GrpcRevisionCatalog
+from .delta import bucket_parts
+from .manifest import RevisionState, S3Object
+from .s3 import S3Client
+from .source.canonical import snapshot_digest
+from .source.canonical import format_digest as canonical_format_digest
+
+
+@dataclass(frozen=True)
+class ReceiverConfig:
+    model_id: str
+    catalog_endpoint: str
+    initial_version: str
+    preparation_cache_dir: str | Path
+    ready_timeout_seconds: float = 600.0
+    s3_endpoint_url: str | None = None
+
+
+class ReceiverInstallError(RuntimeError):
+    def __init__(self, detail: str, mutation_started: bool) -> None:
+        super().__init__(detail)
+        self.mutation_started = mutation_started
+
+
+@dataclass(frozen=True)
+class PreparedRevision:
+    target_version: str
+    target_digest: str
+    path: Path
+    metrics: dict[str, float]
+
+
+class ModelExpressWeightReceiver:
+    def __init__(
+        self,
+        config: ReceiverConfig,
+        receiver_id: str,
+        model_runner,
+    ) -> None:
+        self.config = config
+        self.receiver_id = receiver_id
+        self.model_id = config.model_id
+        self.model_runner = model_runner
+        checkpoint, _, _ = model_runner.loader._prepare_weights(
+            model_runner.model_config.model_path,
+            model_runner.model_config.revision,
+            False,
+        )
+        self.launch_checkpoint = Path(checkpoint)
+        self.installed_version = config.initial_version
+        self.installed_digest: str
+        self.catalog = None
+        self.s3 = None
+        self.checkpoint: _LocalCheckpoint
+        self.prepared: PreparedRevision | None = None
+        self.state = None
+        self.detail = ""
+        self._metrics: dict[str, float] = {}
+
+    def initialize(self) -> None:
+        self.catalog = GrpcRevisionCatalog(self.config.catalog_endpoint)
+        self.s3 = S3Client(endpoint_url=self.config.s3_endpoint_url)
+        deadline = time.monotonic() + self.config.ready_timeout_seconds
+        while True:
+            try:
+                launch = self.catalog.get_revision(
+                    self.model_id, self.installed_version
+                )
+                break
+            except Exception:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(1)
+        if launch.state not in {RevisionState.READY, RevisionState.COMMITTED}:
+            raise ValueError("installed launch revision is not ready")
+        self.checkpoint = _LocalCheckpoint(
+            self.config, self.catalog, self.s3, self.launch_checkpoint
+        )
+        self.installed_digest = self.checkpoint.initialize(launch)
+        self.state = ReceiverRevisionState.VERIFIED
+
+    @property
+    def prepared_identity(self):
+        return self.prepared
+
+    def install_prepared_checkpoint(self, prepared: PreparedRevision) -> None:
+        try:
+            from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+            from sglang.srt.model_loader.loader import (
+                DefaultModelLoader,
+                get_model_loader,
+            )
+
+            loader = get_model_loader(
+                LoadConfig(
+                    load_format=LoadFormat.SAFETENSORS,
+                    download_dir=self.model_runner.server_args.download_dir,
+                    model_loader_extra_config=(
+                        self.model_runner.server_args.model_loader_extra_config
+                    ),
+                ),
+                self.model_runner.model_config,
+            )
+            if not isinstance(loader, DefaultModelLoader):
+                raise TypeError("ModelExpress requires DefaultModelLoader")
+            source = SimpleNamespace(
+                model_or_path=str(prepared.path),
+                revision=None,
+                prefix="",
+                fall_back_to_pt=False,
+                model_config=self.model_runner.model_config,
+            )
+            weights = loader._get_weights_iterator(source)
+        except Exception as error:
+            raise ReceiverInstallError(str(error), False) from error
+
+        try:
+            from sglang.srt.model_loader.utils import set_default_torch_dtype
+
+            with set_default_torch_dtype(self.model_runner.model_config.dtype):
+                loader.load_weights_and_postprocess(
+                    self.model_runner.model,
+                    weights,
+                    torch.device(self.model_runner.device),
+                )
+            device = torch.get_device_module(self.model_runner.device)
+            if hasattr(device, "synchronize"):
+                device.synchronize()
+        except Exception as error:
+            raise ReceiverInstallError(str(error), True) from error
+
+    def start_weight_update(self, version: str) -> None:
+        if self.state is ReceiverRevisionState.POISONED:
+            raise RuntimeError("poisoned receiver cannot install another update")
+        self._metrics = {}
+        self.prepared = None
+        started = time.perf_counter()
+        try:
+            self.prepared = self.checkpoint.prepare(
+                version, self.installed_version, self.installed_digest
+            )
+            self._metrics.update(self.prepared.metrics)
+        finally:
+            self._metrics["perf/mx_receive_prepare_time"] = (
+                time.perf_counter() - started
+            )
+        self.detail = ""
+
+    def update_weights(self, layers=None) -> WeightUpdateResult:
+        if layers is not None:
+            raise ValueError("ModelExpress supports complete-model updates only")
+        if self.prepared is None:
+            raise RuntimeError("no prepared ModelExpress update")
+        if self.state is ReceiverRevisionState.POISONED:
+            raise RuntimeError("poisoned receiver cannot install another update")
+        target = self.prepared
+        started = time.perf_counter()
+        try:
+            with self.checkpoint.installation(target):
+                self.install_prepared_checkpoint(target)
+        except ReceiverInstallError as error:
+            self._metrics = {
+                "perf/mx_receive_install_time": time.perf_counter() - started
+            }
+            self.state = (
+                ReceiverRevisionState.POISONED
+                if error.mutation_started
+                else ReceiverRevisionState.FAILED
+            )
+            self.detail = str(error)
+            return WeightUpdateResult(
+                success=False,
+                receiver_id=self.receiver_id,
+                installed_version=self.installed_version,
+                state=self.state,
+                target_digest=self.installed_digest,
+                detail=self.detail,
+            )
+        self.installed_version = target.target_version
+        self.installed_digest = target.target_digest
+        self.prepared = None
+        self.state = ReceiverRevisionState.VERIFIED
+        self._metrics = {"perf/mx_receive_install_time": time.perf_counter() - started}
+        return WeightUpdateResult(
+            success=True,
+            receiver_id=self.receiver_id,
+            installed_version=self.installed_version,
+            state=self.state,
+            target_digest=self.installed_digest,
+            detail=self.detail,
+        )
+
+    def pop_metrics(self) -> dict[str, float]:
+        metrics, self._metrics = self._metrics, {}
+        return metrics
+
+    def mark_poisoned(self, detail: str):
+        self.state = ReceiverRevisionState.POISONED
+        self.detail = detail
+        return WeightUpdateResult(
+            success=False,
+            receiver_id=self.receiver_id,
+            installed_version=self.installed_version,
+            state=self.state,
+            target_digest=self.installed_digest,
+            detail=self.detail,
+        )
+
+    def status(self) -> ReceiverStatus:
+        return ReceiverStatus(
+            receiver_id=self.receiver_id,
+            model_id=self.model_id,
+            installed_version=self.installed_version,
+            target_digest=self.installed_digest,
+            state=self.state,
+            detail=self.detail,
+        )
+
+
+def _seed_checkpoint(source: Path, target: Path) -> None:
+    shutil.rmtree(target, ignore_errors=True)
+    target.mkdir(parents=True)
+    if source.is_file():
+        shutil.copy2(source, target / "model.safetensors")
+        return
+    for entry in source.iterdir():
+        if entry.is_file():
+            shutil.copy2(entry, target / entry.name)
+
+
+_SAFETENSORS_DTYPES = {
+    "BOOL": "bool",
+    "U8": "uint8",
+    "I8": "int8",
+    "I16": "int16",
+    "I32": "int32",
+    "I64": "int64",
+    "F16": "float16",
+    "BF16": "bfloat16",
+    "F32": "float32",
+    "F64": "float64",
+}
+
+
+def _tensor_locations(checkpoint: Path):
+    locations = {}
+    metadata = {}
+    tied = set()
+    config = checkpoint / "config.json"
+    if config.is_file() and json.loads(config.read_text()).get(
+        "tie_word_embeddings", False
+    ):
+        tied.add("lm_head.weight")
+    for path in checkpoint.glob("*.safetensors"):
+        with path.open("rb") as handle:
+            (header_size,) = struct.unpack("<Q", handle.read(8))
+            header = json.loads(handle.read(header_size))
+        for name, item in header.items():
+            if name == "__metadata__":
+                continue
+            name = name.removeprefix("module.")
+            if name in tied:
+                continue
+            begin, end = item["data_offsets"]
+            locations[name] = (path, 8 + header_size + begin, end - begin)
+            metadata[name] = {
+                "name": name,
+                "shape": item["shape"],
+                "dtype": _SAFETENSORS_DTYPES[item["dtype"]],
+                "byte_size": end - begin,
+            }
+    return locations, metadata
+
+
+def _checkpoint_identity(locations, metadata):
+    values = {name: dict(item) for name, item in metadata.items()}
+    maps = {}
+    try:
+        for path in {item[0] for item in locations.values()}:
+            handle = path.open("rb")
+            maps[path] = (
+                handle,
+                mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ),
+            )
+        for name, (path, offset, size) in locations.items():
+            view = memoryview(maps[path][1])[offset : offset + size]
+            try:
+                values[name]["target_digest"] = (
+                    f"sha256:{hashlib.sha256(view).hexdigest()}"
+                )
+            finally:
+                view.release()
+    finally:
+        for handle, mapped in maps.values():
+            mapped.close()
+            handle.close()
+    return canonical_format_digest(values), snapshot_digest(values)
+
+
+def _checkpoint_files_state(locations):
+    return {
+        path.name: [path.stat().st_size, path.stat().st_mtime_ns]
+        for path in sorted({item[0] for item in locations.values()})
+    }
+
+
+def _apply_bucket(data, locations, maps, index, descriptor, coverage) -> None:
+    header, compressed = bucket_parts(data)
+    if (
+        header["model_id"] != index["model_id"]
+        or header["base_version"] != index["base_version"]
+        or header["target_version"] != index["target_version"]
+        or header["base_digest"] != index["base_digest"]
+        or header["format_digest"] != index["format_digest"]
+        or header["ordinal"] != descriptor["ordinal"]
+        or header["decoded_size"] != descriptor["decoded_size"]
+        or header["compression"] != "zstd"
+        or header["delta"] != "xor"
+        or [item["name"] for item in header["entries"]] != descriptor["tensors"]
+    ):
+        raise ValueError("canonical bucket does not match its delta-index descriptor")
+    reader = zstandard.ZstdDecompressor().stream_reader(compressed)
+    decoded_position = 0
+    for entry in header["entries"]:
+        name = entry["name"]
+        if entry["offset"] != decoded_position:
+            raise ValueError(f"{name} has a non-contiguous canonical delta offset")
+        target_identity = coverage[name]
+        if (
+            target_identity.get("state") != "dirty"
+            or target_identity.get("bucket_ordinal") != descriptor["ordinal"]
+            or any(
+                entry[field] != target_identity[field]
+                for field in ("shape", "dtype", "byte_size", "target_digest")
+            )
+        ):
+            raise ValueError(f"canonical bucket identity differs for {name}")
+        path, file_offset, size = locations[name]
+        if size != entry["byte_size"]:
+            raise ValueError(f"{name} byte size differs from the local checkpoint")
+        mapped = maps[path][1]
+        target = np.frombuffer(mapped, dtype=np.uint8, count=size, offset=file_offset)
+        try:
+            hasher = hashlib.sha256()
+            position = 0
+            while position < size:
+                block = reader.read(min(2 << 20, size - position))
+                if not block:
+                    break
+                delta = np.frombuffer(block, dtype=np.uint8)
+                region = target[position : position + delta.size]
+                try:
+                    np.bitwise_xor(region, delta, out=region)
+                    hasher.update(region)
+                finally:
+                    del region
+                position += delta.size
+            if position != size:
+                raise ValueError(
+                    f"{name} delta byte size differs from canonical metadata"
+                )
+            digest = f"sha256:{hasher.hexdigest()}"
+            if digest != entry["target_digest"]:
+                raise ValueError(f"canonical target checksum differs for {name}")
+            decoded_position += size
+        finally:
+            del target
+    if decoded_position != header["decoded_size"]:
+        raise ValueError("canonical bucket decoded size differs from its entries")
+    reader.close()
+
+
+def _write_state(path: Path, state: dict) -> None:
+    temporary = path.with_name(f"{path.name}.tmp")
+    temporary.write_text(json.dumps(state))
+    temporary.replace(path)
+
+
+class _LocalCheckpoint:
+    def __init__(self, config, catalog, s3, launch_checkpoint):
+        self.model_id = config.model_id
+        self.initial_version = config.initial_version
+        self.catalog = catalog
+        self.s3 = s3
+        self.launch_checkpoint = Path(launch_checkpoint)
+        self.cache = Path(config.preparation_cache_dir) / quote(self.model_id, safe="")
+        self.local_checkpoint = self.cache / "checkpoint"
+        self.state_path = self.cache / "state.json"
+        self.lock_path = self.cache / ".lock"
+        self.locations = None
+        self.metadata = None
+        self.format_digest = None
+
+    def initialize(self, launch) -> str:
+        installed_digest = launch.manifest.target_digest
+        self.format_digest = launch.manifest.format_digest
+        self.cache.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            state = (
+                json.loads(self.state_path.read_text())
+                if self.state_path.exists()
+                else None
+            )
+            seeded = (
+                state is None
+                or state.get("poisoned")
+                or state.get("version") != self.initial_version
+                or state.get("digest") != installed_digest
+                or not any(self.local_checkpoint.glob("*.safetensors"))
+            )
+            if not seeded:
+                self.locations, self.metadata = _tensor_locations(self.local_checkpoint)
+                seeded = state.get("files") != _checkpoint_files_state(self.locations)
+            if seeded:
+                _seed_checkpoint(self.launch_checkpoint, self.local_checkpoint)
+                self.locations, self.metadata = _tensor_locations(self.local_checkpoint)
+            if canonical_format_digest(self.metadata) != self.format_digest:
+                raise ValueError("local checkpoint format differs from revision 0")
+            if seeded:
+                actual_format, actual_digest = _checkpoint_identity(
+                    self.locations, self.metadata
+                )
+                if (
+                    actual_format != self.format_digest
+                    or actual_digest != installed_digest
+                ):
+                    raise ValueError("local checkpoint differs from revision 0")
+                _write_state(
+                    self.state_path,
+                    {
+                        "version": self.initial_version,
+                        "digest": installed_digest,
+                        "format_digest": self.format_digest,
+                        "files": _checkpoint_files_state(self.locations),
+                    },
+                )
+            elif state["format_digest"] != self.format_digest:
+                raise ValueError("existing local checkpoint state is not reusable")
+        return installed_digest
+
+    def prepare(
+        self, version: str, base_version: str, base_digest: str
+    ) -> PreparedRevision:
+        record = self.catalog.get_revision(self.model_id, version)
+        if record.state not in {RevisionState.READY, RevisionState.COMMITTED}:
+            raise ValueError("revision is not ready")
+        manifest = record.manifest
+        if (
+            manifest.base_version != base_version
+            or manifest.base_digest != base_digest
+            or manifest.format_digest != self.format_digest
+        ):
+            raise ValueError("revision does not match the installed exact base")
+
+        with self.lock_path.open("a+") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            state = json.loads(self.state_path.read_text())
+            if state.get("poisoned"):
+                raise ValueError("local checkpoint is poisoned")
+            if state.get("files") != _checkpoint_files_state(self.locations):
+                raise ValueError("local checkpoint files changed outside ModelExpress")
+            if (
+                state["version"] == version
+                and state["digest"] == manifest.target_digest
+            ):
+                return PreparedRevision(
+                    version,
+                    manifest.target_digest,
+                    self.local_checkpoint,
+                    {
+                        "perf/mx_receive_delta_index_download": 0.0,
+                        "perf/mx_receive_pool": 0.0,
+                    },
+                )
+            if state["version"] != base_version or state["digest"] != base_digest:
+                raise ValueError("local checkpoint does not match the exact base")
+            if manifest.payload is None:
+                raise ValueError("revision has no canonical payload")
+            index_started = time.perf_counter()
+            index_payload = self.s3.get(manifest.payload)
+            index_download_time = time.perf_counter() - index_started
+            index = json.loads(index_payload)
+            if (
+                index["model_id"] != self.model_id
+                or index["base_version"] != base_version
+                or index["target_version"] != version
+                or index["base_digest"] != base_digest
+                or index["target_digest"] != manifest.target_digest
+                or index["format_digest"] != self.format_digest
+            ):
+                raise ValueError("delta index does not match the requested revision")
+            coverage = {item["name"]: item for item in index["tensors"]}
+            if len(coverage) != len(index["tensors"]) or set(coverage) != set(
+                self.locations
+            ):
+                raise ValueError(
+                    "delta-index tensor coverage differs from the local checkpoint"
+                )
+            for name, item in self.metadata.items():
+                target = coverage[name]
+                if any(
+                    target[field] != item[field]
+                    for field in ("shape", "dtype", "byte_size")
+                ):
+                    raise ValueError(f"delta-index metadata differs for {name}")
+            identity = {
+                name: {
+                    field: item[field]
+                    for field in (
+                        "name",
+                        "shape",
+                        "dtype",
+                        "byte_size",
+                        "target_digest",
+                    )
+                }
+                for name, item in coverage.items()
+            }
+            if (
+                canonical_format_digest(identity) != self.format_digest
+                or snapshot_digest(identity) != manifest.target_digest
+            ):
+                raise ValueError(
+                    "delta-index target identity differs from the revision"
+                )
+            bucket_ordinals = [item["ordinal"] for item in index["buckets"]]
+            bucket_names = [
+                name for item in index["buckets"] for name in item["tensors"]
+            ]
+            dirty_names = [
+                name for name, item in coverage.items() if item["state"] == "dirty"
+            ]
+            if (
+                len(bucket_ordinals) != len(set(bucket_ordinals))
+                or len(bucket_names) != len(set(bucket_names))
+                or set(bucket_names) != set(dirty_names)
+            ):
+                raise ValueError(
+                    "delta-index buckets do not cover the dirty tensor set"
+                )
+            _write_state(self.state_path, {**state, "poisoned": True})
+            maps = {}
+            for path in {item[0] for item in self.locations.values()}:
+                file_handle = path.open("r+b")
+                maps[path] = (file_handle, mmap.mmap(file_handle.fileno(), 0))
+
+            def apply(bucket):
+                location = bucket["object"]
+                payload = self.s3.get(
+                    S3Object(
+                        bucket=location["bucket"],
+                        key=location["key"],
+                        checksum=location["checksum"],
+                        object_version=location.get("object_version"),
+                    )
+                )
+                _apply_bucket(payload, self.locations, maps, index, bucket, coverage)
+
+            bucket_pool_time = 0.0
+            try:
+                buckets = index["buckets"]
+                if buckets:
+                    pool_started = time.perf_counter()
+                    with ThreadPoolExecutor(
+                        max_workers=min(
+                            max(1, envs.MX_REFIT_S3_DOWNLOAD_WORKERS), len(buckets)
+                        )
+                    ) as pool:
+                        list(pool.map(apply, buckets))
+                    bucket_pool_time = time.perf_counter() - pool_started
+            finally:
+                for file_handle, mapped in maps.values():
+                    mapped.close()
+                    file_handle.close()
+            _write_state(
+                self.state_path,
+                {
+                    "version": version,
+                    "digest": manifest.target_digest,
+                    "format_digest": self.format_digest,
+                    "files": _checkpoint_files_state(self.locations),
+                },
+            )
+            return PreparedRevision(
+                version,
+                manifest.target_digest,
+                self.local_checkpoint,
+                {
+                    "perf/mx_receive_delta_index_download": index_download_time,
+                    "perf/mx_receive_pool": bucket_pool_time,
+                },
+            )
+
+    @contextmanager
+    def installation(self, prepared: PreparedRevision):
+        with self.lock_path.open("a+") as handle:
+            fcntl.flock(handle, fcntl.LOCK_SH)
+            state = json.loads(self.state_path.read_text())
+            if (
+                state.get("poisoned")
+                or state["version"] != prepared.target_version
+                or state["digest"] != prepared.target_digest
+                or state.get("files") != _checkpoint_files_state(self.locations)
+            ):
+                raise ReceiverInstallError(
+                    "prepared checkpoint changed before installation",
+                    False,
+                )
+            yield
+
+
+def build_weight_receiver(model_runner):
+    args = model_runner.server_args
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    receiver = ModelExpressWeightReceiver(
+        ReceiverConfig(
+            model_id=args.modelexpress_model_id,
+            catalog_endpoint=args.modelexpress_catalog_endpoint,
+            initial_version=args.modelexpress_initial_version,
+            preparation_cache_dir=args.modelexpress_preparation_cache_dir,
+            ready_timeout_seconds=args.modelexpress_ready_timeout_seconds,
+            s3_endpoint_url=args.modelexpress_delta_s3_endpoint,
+        ),
+        f"{socket.gethostname()}:{rank}",
+        model_runner,
+    )
+    receiver.initialize()
+    return receiver

--- a/modelexpress_client/python/tests/test_envs.py
+++ b/modelexpress_client/python/tests/test_envs.py
@@ -26,6 +26,7 @@ def test_defaults_when_unset(monkeypatch):
         "MX_HEARTBEAT_INTERVAL_SECS",
         "MX_RESHARD_FUSED_WIRE",
         "MX_REFIT_S3_UPLOAD_WORKERS",
+        "MX_REFIT_S3_DOWNLOAD_WORKERS",
         "MX_REFIT_S3_MAX_POOL_CONNECTIONS",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -46,6 +47,7 @@ def test_defaults_when_unset(monkeypatch):
     assert envs.MX_HEARTBEAT_INTERVAL_SECS == 30
     assert envs.MX_RESHARD_FUSED_WIRE is True
     assert envs.MX_REFIT_S3_UPLOAD_WORKERS == 4
+    assert envs.MX_REFIT_S3_DOWNLOAD_WORKERS == 4
     assert envs.MX_REFIT_S3_MAX_POOL_CONNECTIONS == 10
 
 
@@ -54,12 +56,21 @@ def test_int_and_float_parsing(monkeypatch):
     monkeypatch.setenv("MX_GDS_TIMEOUT", "1.5")
     monkeypatch.setenv("MX_SOURCE_QUERY_TIMEOUT", "42")
     monkeypatch.setenv("MX_REFIT_S3_UPLOAD_WORKERS", "16")
+    monkeypatch.setenv("MX_REFIT_S3_DOWNLOAD_WORKERS", "12")
     monkeypatch.setenv("MX_REFIT_S3_MAX_POOL_CONNECTIONS", "16")
     assert envs.MX_METADATA_PORT == 1234
     assert envs.MX_GDS_TIMEOUT == pytest.approx(1.5)
     assert envs.MX_SOURCE_QUERY_TIMEOUT == 42
     assert envs.MX_REFIT_S3_UPLOAD_WORKERS == 16
+    assert envs.MX_REFIT_S3_DOWNLOAD_WORKERS == 12
     assert envs.MX_REFIT_S3_MAX_POOL_CONNECTIONS == 16
+
+
+def test_download_workers_inherit_upload_workers(monkeypatch):
+    monkeypatch.setenv("MX_REFIT_S3_UPLOAD_WORKERS", "16")
+    monkeypatch.delenv("MX_REFIT_S3_DOWNLOAD_WORKERS", raising=False)
+
+    assert envs.MX_REFIT_S3_DOWNLOAD_WORKERS == 16
 
 
 def test_invalid_int_falls_back_to_default(monkeypatch):

--- a/modelexpress_client/python/tests/test_refit_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_receiver.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from modelexpress.refit.api import ReceiverRevisionState
+from modelexpress.refit.receiver import (
+    ModelExpressWeightReceiver,
+    PreparedRevision,
+    ReceiverConfig,
+    ReceiverInstallError,
+)
+
+
+class Receiver(ModelExpressWeightReceiver):
+    def __init__(self, tmp_path: Path):
+        self.targets = {}
+        loader = SimpleNamespace(
+            _prepare_weights=lambda *_args: (tmp_path / "launch", None, None)
+        )
+        super().__init__(
+            ReceiverConfig(
+                model_id="model",
+                catalog_endpoint="mx:8001",
+                initial_version="0",
+                preparation_cache_dir=tmp_path / "cache",
+            ),
+            "receiver",
+            SimpleNamespace(
+                loader=loader,
+                model_config=SimpleNamespace(
+                    model_path=str(tmp_path / "launch"),
+                    revision=None,
+                ),
+            ),
+        )
+        self.installed_digest = "sha256:base"
+        self.state = ReceiverRevisionState.VERIFIED
+        self.installed = []
+        self.install_error = None
+        receiver = self
+
+        class Checkpoint:
+            def prepare(self, version, _installed_version, _installed_digest):
+                target = receiver.targets[version]
+                if isinstance(target, Exception):
+                    raise target
+                return target
+
+            def installation(self, _prepared):
+                return nullcontext()
+
+        self.checkpoint = Checkpoint()
+
+    def install_prepared_checkpoint(self, prepared):
+        if self.install_error is not None:
+            raise self.install_error
+        self.installed.append(prepared)
+
+
+def prepared(tmp_path: Path, version="1", digest="sha256:target", metrics=None):
+    path = tmp_path / version
+    path.mkdir(exist_ok=True)
+    return PreparedRevision(version, digest, path, metrics or {})
+
+
+def receiver(tmp_path):
+    value = Receiver(tmp_path)
+    target = prepared(tmp_path)
+    value.targets["1"] = target
+    return value, target
+
+
+def test_prepare_and_install_advance_exact_identity(tmp_path):
+    value, target = receiver(tmp_path)
+
+    value.start_weight_update("1")
+    result = value.update_weights()
+
+    assert value.installed == [target]
+    assert result.success
+    assert result.installed_version == "1"
+    assert result.target_digest == "sha256:target"
+    assert value.status().installed_version == "1"
+
+
+def test_receiver_metrics_are_drained_per_phase(tmp_path):
+    value, _target = receiver(tmp_path)
+
+    value.start_weight_update("1")
+    prepare_metrics = value.pop_metrics()
+
+    assert prepare_metrics["perf/mx_receive_prepare_time"] >= 0
+    assert value.pop_metrics() == {}
+
+    value.update_weights()
+    install_metrics = value.pop_metrics()
+
+    assert install_metrics["perf/mx_receive_install_time"] >= 0
+    assert value.pop_metrics() == {}
+
+
+def test_failed_prepare_replaces_stale_metrics(tmp_path):
+    value, _target = receiver(tmp_path)
+    value.targets["1"] = prepared(
+        tmp_path,
+        metrics={"perf/stale": 1.0},
+    )
+    value.targets["2"] = RuntimeError("download failed")
+    value.start_weight_update("1")
+
+    with pytest.raises(RuntimeError, match="download failed"):
+        value.start_weight_update("2")
+
+    metrics = value.pop_metrics()
+    assert metrics["perf/mx_receive_prepare_time"] >= 0
+    assert "perf/stale" not in metrics
+    assert value.prepared_identity is None
+    assert value.pop_metrics() == {}
+
+
+def test_prepare_does_not_mutate_live_weights(tmp_path):
+    value, _target = receiver(tmp_path)
+
+    value.start_weight_update("1")
+
+    assert value.installed == []
+    assert value.status().installed_version == "0"
+
+
+def test_prewrite_install_failure_is_failed(tmp_path):
+    value, _target = receiver(tmp_path)
+    value.install_error = ReceiverInstallError("setup failed", False)
+    value.start_weight_update("1")
+
+    result = value.update_weights()
+
+    assert not result.success
+    assert result.state.name == "FAILED"
+    assert value.status().installed_version == "0"
+
+
+def test_postwrite_install_failure_is_poisoned(tmp_path):
+    value, _target = receiver(tmp_path)
+    value.install_error = ReceiverInstallError("load failed", True)
+    value.start_weight_update("1")
+
+    result = value.update_weights()
+
+    assert not result.success
+    assert result.state.name == "POISONED"
+    with pytest.raises(RuntimeError, match="poisoned"):
+        value.start_weight_update("2")
+
+
+def test_complete_model_only(tmp_path):
+    value, _target = receiver(tmp_path)
+    value.start_weight_update("1")
+
+    with pytest.raises(ValueError, match="complete-model"):
+        value.update_weights(layers=("model.layer",))

--- a/modelexpress_client/python/tests/test_refit_receiver_checkpoint.py
+++ b/modelexpress_client/python/tests/test_refit_receiver_checkpoint.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import fcntl
+import hashlib
+import json
+import threading
+from types import SimpleNamespace
+
+import google_crc32c
+import numpy as np
+import pytest
+import torch
+from safetensors.torch import load_file, save_file
+
+from modelexpress.refit import receiver as receiver_module
+from modelexpress.refit.manifest import (
+    RevisionManifest,
+    RevisionRecord,
+    RevisionState,
+    S3Object,
+)
+from modelexpress.refit.delta import encode_bucket
+from modelexpress.refit.receiver import ModelExpressWeightReceiver, ReceiverConfig
+from modelexpress.refit.source.canonical import load_hf_snapshot, snapshot_digest
+
+
+def test_receiver_uses_direct_worker_policy_and_result_construction():
+    assert not hasattr(receiver_module, "_download_worker_count")
+    assert not hasattr(ModelExpressWeightReceiver, "_result")
+
+
+def test_receiver_has_no_callback_or_forwarding_helpers():
+    import inspect
+
+    parameters = inspect.signature(ModelExpressWeightReceiver).parameters
+    builder_parameters = inspect.signature(
+        receiver_module.build_weight_receiver
+    ).parameters
+
+    assert "model_runner" in parameters
+    assert "launch_checkpoint" not in parameters
+    assert "catalog" not in parameters
+    assert "s3_client" not in parameters
+    assert "prepare_target" not in parameters
+    assert "install_target" not in parameters
+    assert "catalog" not in builder_parameters
+    assert "s3_client" not in builder_parameters
+    assert "checkpoint" not in builder_parameters
+    assert not hasattr(ModelExpressWeightReceiver, "_prepare_revision")
+    assert not hasattr(ModelExpressWeightReceiver, "_installation")
+    assert not hasattr(receiver_module, "_location")
+    assert not hasattr(receiver_module, "load_prepared_checkpoint")
+
+
+class Catalog:
+    def __init__(self, records, misses=0):
+        self.records = records
+        self.misses = misses
+
+    def get_revision(self, _model_id, version):
+        if self.misses:
+            self.misses -= 1
+            raise KeyError(version)
+        return self.records[version]
+
+
+class S3:
+    def __init__(self, objects):
+        self.objects = objects
+        self.calls = []
+
+    def get(self, location):
+        self.calls.append(location.key)
+        data = self.objects[location.key]
+        assert location.checksum == f"crc32c:{google_crc32c.value(data):08x}"
+        return data
+
+
+class Receiver(ModelExpressWeightReceiver):
+    install_started: threading.Event | None = None
+    install_release: threading.Event | None = None
+
+    def install_prepared_checkpoint(self, _prepared):
+        if self.install_started is not None:
+            self.install_started.set()
+            release = self.install_release
+            assert release is not None
+            assert release.wait(5)
+
+
+def location(key, data, include_size=False):
+    value = {
+        "bucket": "bucket",
+        "key": key,
+        "checksum": f"crc32c:{google_crc32c.value(data):08x}",
+    }
+    if include_size:
+        value["size"] = len(data)
+    return value
+
+
+def test_receiver_downloads_and_patches_one_persistent_exact_checkpoint(
+    tmp_path, monkeypatch
+):
+    checkpoint = tmp_path / "hf"
+    checkpoint.mkdir()
+    save_file(
+        {"model.weight": torch.tensor([1.0, 2.0])}, checkpoint / "model.safetensors"
+    )
+    snapshot, metadata, format_digest, base_digest = load_hf_snapshot(checkpoint)
+    target = torch.tensor([3.0, 4.0])
+    name = "model.weight"
+    old = snapshot[name].tobytes()
+    new = target.contiguous().view(torch.uint8).numpy().tobytes()
+    delta = np.frombuffer(
+        bytes(left ^ right for left, right in zip(old, new, strict=True)),
+        dtype=np.uint8,
+    )
+    metadata[name]["target_digest"] = f"sha256:{hashlib.sha256(new).hexdigest()}"
+    ordinal = 0
+    bucket, decoded_size = encode_bucket(
+        model_id="model",
+        base_version="0",
+        target_version="1",
+        base_digest=base_digest,
+        format_digest=format_digest,
+        ordinal=ordinal,
+        tensors=[(name, delta)],
+        metadata=metadata,
+    )
+    target_digest = snapshot_digest(metadata)
+    coverage = [{**metadata[name], "state": "dirty", "bucket_ordinal": ordinal}]
+    bucket_location = location("bucket-0.mxdb", bucket, include_size=True)
+    index = json.dumps(
+        {
+            "model_id": "model",
+            "base_version": "0",
+            "target_version": "1",
+            "base_digest": base_digest,
+            "target_digest": target_digest,
+            "format_digest": format_digest,
+            "buckets": [
+                {
+                    "ordinal": ordinal,
+                    "decoded_size": decoded_size,
+                    "tensors": [name],
+                    "object": bucket_location,
+                }
+            ],
+            "tensors": coverage,
+        }
+    ).encode()
+    launch = RevisionRecord(
+        RevisionManifest(
+            model_id="model",
+            target_version="0",
+            target_digest=base_digest,
+            format_digest=format_digest,
+        ),
+        RevisionState.READY,
+    )
+    target_record = RevisionRecord(
+        RevisionManifest(
+            model_id="model",
+            target_version="1",
+            base_version="0",
+            base_digest=base_digest,
+            target_digest=target_digest,
+            format_digest=format_digest,
+            payload=S3Object(**location("delta-index.json", index)),
+        ),
+        RevisionState.READY,
+    )
+    config = ReceiverConfig(
+        model_id="model",
+        catalog_endpoint="mx:8001",
+        initial_version="0",
+        preparation_cache_dir=tmp_path / "cache",
+        ready_timeout_seconds=1,
+    )
+    catalog = Catalog({"0": launch, "1": target_record}, misses=1)
+    s3 = S3({"delta-index.json": index, "bucket-0.mxdb": bucket})
+    monkeypatch.setattr(
+        receiver_module,
+        "GrpcRevisionCatalog",
+        lambda _endpoint: catalog,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        receiver_module,
+        "S3Client",
+        lambda **_kwargs: s3,
+        raising=False,
+    )
+
+    def build():
+        runner = SimpleNamespace(
+            loader=SimpleNamespace(
+                _prepare_weights=lambda *_args: (checkpoint, None, None)
+            ),
+            model_config=SimpleNamespace(model_path=str(checkpoint), revision=None),
+        )
+        value = Receiver(config, "host:0", runner)
+        value.initialize()
+        return value
+
+    receiver = build()
+    assert receiver.catalog is catalog
+    assert receiver.s3 is s3
+    follower = build()
+    local_checkpoint = tmp_path / "cache" / "model" / "checkpoint"
+    local_file = local_checkpoint / "model.safetensors"
+    inode = local_file.stat().st_ino
+
+    receiver.start_weight_update("1")
+
+    metrics = receiver.pop_metrics()
+    assert metrics["perf/mx_receive_prepare_time"] >= 0
+    assert metrics["perf/mx_receive_delta_index_download"] >= 0
+    assert metrics["perf/mx_receive_pool"] >= 0
+    assert "perf/mx_receive_wire_bytes" not in metrics
+
+    assert receiver.status().installed_version == "0"
+    assert receiver.prepared.target_digest == target_digest
+    assert receiver.prepared.path == local_checkpoint
+    assert local_file.stat().st_ino == inode
+    assert torch.equal(load_file(local_file)["model.weight"], target)
+    assert not (tmp_path / "cache" / "model" / "1").exists()
+    assert torch.equal(
+        load_file(checkpoint / "model.safetensors")["model.weight"],
+        torch.tensor([1.0, 2.0]),
+    )
+    assert s3.calls == ["delta-index.json", "bucket-0.mxdb"]
+
+    follower.start_weight_update("1")
+    assert s3.calls == ["delta-index.json", "bucket-0.mxdb"]
+    follower_metrics = follower.pop_metrics()
+    assert follower_metrics["perf/mx_receive_prepare_time"] >= 0
+    assert "perf/mx_receive_wire_bytes" not in follower_metrics
+
+    install_started = threading.Event()
+    install_release = threading.Event()
+    follower.install_started = install_started
+    follower.install_release = install_release
+    install_result = []
+    install_thread = threading.Thread(
+        target=lambda: install_result.append(follower.update_weights())
+    )
+    install_thread.start()
+    assert install_started.wait(5)
+    checkpoint_state = follower.checkpoint
+    assert checkpoint_state is not None
+    try:
+        with checkpoint_state.lock_path.open("a+") as handle:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        install_release.set()
+        install_thread.join(5)
+    assert not install_thread.is_alive()
+    assert install_result[0].success
+
+    restarted = build()
+    assert restarted.status().installed_version == "0"
+    assert torch.equal(load_file(local_file)["model.weight"], torch.tensor([1.0, 2.0]))
+
+    result = receiver.update_weights()
+    assert not result.success
+    assert "changed before installation" in result.detail
+
+    with local_file.open("r+b") as handle:
+        handle.seek(-1, 2)
+        value = handle.read(1)[0]
+        handle.seek(-1, 2)
+        handle.write(bytes([value ^ 1]))
+    recovered = build()
+    assert recovered.status().installed_version == "0"
+    assert torch.equal(load_file(local_file)["model.weight"], torch.tensor([1.0, 2.0]))

--- a/modelexpress_client/python/tests/test_sglang_refit.py
+++ b/modelexpress_client/python/tests/test_sglang_refit.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from modelexpress.refit import receiver as refit
+
+
+def runner(tmp_path):
+    loader = SimpleNamespace(
+        _prepare_weights=Mock(return_value=(tmp_path / "hf", None, None))
+    )
+    return SimpleNamespace(
+        model=object(),
+        device="cpu",
+        loader=loader,
+        model_config=SimpleNamespace(
+            model_path=str(tmp_path / "hf"),
+            revision=None,
+            dtype=torch.float32,
+        ),
+        server_args=SimpleNamespace(
+            model_path="original-model",
+            load_format="auto",
+            modelexpress_model_id="model",
+            modelexpress_catalog_endpoint="mx:8001",
+            modelexpress_delta_s3_endpoint="http://minio:9000",
+            modelexpress_preparation_cache_dir=str(tmp_path / "cache"),
+            modelexpress_initial_version="0",
+            modelexpress_ready_timeout_seconds=123,
+            download_dir=None,
+            model_loader_extra_config=None,
+        ),
+    )
+
+
+def receiver(tmp_path):
+    model_runner = runner(tmp_path)
+    return (
+        refit.ModelExpressWeightReceiver(
+            refit.ReceiverConfig(
+                model_id="model",
+                catalog_endpoint="mx:8001",
+                initial_version="0",
+                preparation_cache_dir=tmp_path / "cache",
+            ),
+            "host:0",
+            model_runner,
+        ),
+        model_runner,
+    )
+
+
+def install_sglang_modules(monkeypatch, loader=None, setup_error=None):
+    class DefaultModelLoader:
+        pass
+
+    if loader is None:
+        loader = DefaultModelLoader()
+        loader._get_weights_iterator = Mock(
+            return_value=iter([("weight", torch.ones(1))])
+        )
+        loader.load_weights_and_postprocess = Mock()
+    else:
+        DefaultModelLoader = type(loader)
+
+    modules = {
+        name: ModuleType(name)
+        for name in (
+            "sglang",
+            "sglang.srt",
+            "sglang.srt.configs",
+            "sglang.srt.configs.load_config",
+            "sglang.srt.model_loader",
+            "sglang.srt.model_loader.loader",
+            "sglang.srt.model_loader.utils",
+        )
+    }
+    load_config = modules["sglang.srt.configs.load_config"]
+    load_config.LoadConfig = lambda **values: SimpleNamespace(**values)
+    load_config.LoadFormat = SimpleNamespace(SAFETENSORS="safetensors")
+    loader_module = modules["sglang.srt.model_loader.loader"]
+    loader_module.DefaultModelLoader = DefaultModelLoader
+    if setup_error is None:
+        loader_module.get_model_loader = lambda *_args: loader
+    else:
+        loader_module.get_model_loader = Mock(side_effect=setup_error)
+    modules["sglang.srt.model_loader.utils"].set_default_torch_dtype = lambda _dtype: (
+        nullcontext()
+    )
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    return loader
+
+
+def test_factory_initializes_receiver(tmp_path, monkeypatch):
+    captured = {}
+
+    class Receiver:
+        def __init__(self, config, receiver_id, model_runner):
+            captured.update(
+                config=config,
+                receiver_id=receiver_id,
+                model_runner=model_runner,
+            )
+
+        def initialize(self):
+            captured["initialized"] = True
+
+    monkeypatch.setattr(refit, "ModelExpressWeightReceiver", Receiver)
+    monkeypatch.setattr(refit.socket, "gethostname", lambda: "host")
+    model_runner = runner(tmp_path)
+
+    result = refit.build_weight_receiver(model_runner)
+
+    assert isinstance(result, Receiver)
+    assert captured["config"].model_id == "model"
+    assert captured["config"].catalog_endpoint == "mx:8001"
+    assert captured["config"].s3_endpoint_url == "http://minio:9000"
+    assert captured["config"].initial_version == "0"
+    assert captured["config"].preparation_cache_dir == str(tmp_path / "cache")
+    assert captured["config"].ready_timeout_seconds == 123
+    assert captured["receiver_id"] == "host:0"
+    assert captured["model_runner"] is model_runner
+    assert captured["initialized"] is True
+
+
+def test_receiver_constructor_prepares_launch_checkpoint(tmp_path):
+    value, model_runner = receiver(tmp_path)
+
+    assert value.launch_checkpoint == tmp_path / "hf"
+    model_runner.loader._prepare_weights.assert_called_once_with(
+        model_runner.model_config.model_path,
+        model_runner.model_config.revision,
+        False,
+    )
+
+
+def test_receiver_install_uses_prepared_path_without_reconfiguring_runner(
+    tmp_path, monkeypatch
+):
+    value, model_runner = receiver(tmp_path)
+    loader = install_sglang_modules(monkeypatch)
+    prepared = refit.PreparedRevision("1", "sha256:target", tmp_path / "prepared", {})
+
+    value.install_prepared_checkpoint(prepared)
+
+    source = loader._get_weights_iterator.call_args.args[0]
+    assert Path(source.model_or_path) == prepared.path
+    loader.load_weights_and_postprocess.assert_called_once()
+    assert model_runner.model_config.model_path == str(tmp_path / "hf")
+    assert model_runner.server_args.model_path == "original-model"
+    assert model_runner.server_args.load_format == "auto"
+
+
+def test_receiver_install_classifies_setup_failure_before_write(tmp_path, monkeypatch):
+    value, _model_runner = receiver(tmp_path)
+    install_sglang_modules(monkeypatch, setup_error=RuntimeError("loader setup failed"))
+
+    with pytest.raises(refit.ReceiverInstallError) as error:
+        value.install_prepared_checkpoint(
+            refit.PreparedRevision("1", "sha256:target", tmp_path, {})
+        )
+
+    assert error.value.mutation_started is False
+
+
+def test_receiver_install_classifies_load_failure_after_possible_write(
+    tmp_path, monkeypatch
+):
+    value, _model_runner = receiver(tmp_path)
+
+    class Loader:
+        def _get_weights_iterator(self, _source):
+            return iter([("weight", torch.ones(1))])
+
+        def load_weights_and_postprocess(self, *_args):
+            raise RuntimeError("load failed")
+
+    install_sglang_modules(monkeypatch, Loader())
+
+    with pytest.raises(refit.ReceiverInstallError) as error:
+        value.install_prepared_checkpoint(
+            refit.PreparedRevision("1", "sha256:target", tmp_path, {})
+        )
+
+    assert error.value.mutation_started is True


### PR DESCRIPTION
## Summary

Add the receiver-side reconstruction and SGLang installation path for canonical S3 revisions. The receiver seeds one private mutable checkpoint from the launch Hugging Face snapshot, applies exact-base XOR deltas in place, verifies the complete target identity, and installs the prepared checkpoint through SGLang’s native model loader.

**This is a parallel effort along the current refit API work. A separate follow-up PRs will merge this into the standard refit API.**

## Changes

- Add receiver configuration and lifecycle state.
- Resolve revision metadata from the immutable catalog.
- Seed a private mutable checkpoint from the launch snapshot.
- Parse safetensors headers to locate tensor byte ranges.
- Download and validate the canonical delta index.
- Download S3 buckets concurrently.
- Apply XOR deltas directly to mmap-backed tensor regions.
- Verify per-tensor checksums and the complete target digest.
- Persist exact installed version, digest, format, and file identity.
- Install prepared weights through SGLang’s `DefaultModelLoader`.
- Distinguish failures before model mutation from failures after mutation begins.
- Mark receivers poisoned when an installation may have partially modified model state.
- Expose preparation, installation, status, and timing results to the framework integration.

## Receive Flow

1. Resolve metadata-only revision 0 from the catalog.
2. Seed one private mutable checkpoint from the launch Hugging Face snapshot.
3. Verify its canonical format and target digest.
4. Resolve the requested target revision.
5. Require its base version and digest to equal the installed identity.
6. Download and validate the delta index.
7. Apply changed buckets directly to mmap-backed safetensors.
8. Verify tensor coverage and the complete reconstructed target identity.
9. Install the prepared checkpoint through SGLang’s native loader.
10. Report the exact installed version, digest, and receiver state.

## Correctness

- The receiver accepts only an exact `base_version + base_digest` match.
- Canonical tensor coverage must equal the local checkpoint tensor set.
- Clean and dirty tensor metadata must preserve shape, dtype, and byte size.
- Bucket ordinals and tensor assignments must be unique and complete.
- Every reconstructed dirty tensor is checksum-verified.
- The final snapshot digest must equal the catalog target digest.
- Unexpected changes to local checkpoint files invalidate reuse.
- The checkpoint is marked poisoned before in-place mutation and cleared only after successful reconstruction.
- Loader setup failures remain recoverable; failures after possible model writes poison the receiver.

## SGLang Integration

The receiver uses SGLang’s native `DefaultModelLoader` to install the prepared safetensors checkpoint. It does not alter the runner’s configured model path or load format, and it classifies failures according to whether model mutation may have begun.

## Validation

- Receiver, checkpoint reconstruction, and SGLang integration tests: 15 passed
- Full focused refit stack: 55 passed
- `pre-commit run --from-ref origin/main --to-ref hwoo/mx-delta-phase3-prs`
- `cargo fmt`
- `cargo clippy`
- `cargo check`
- Multi-node Miles validation exercised canonical publication, S3 reconstruction, exact-version installation, and resumed generation using the complete stack.