### PR TITLE
chore: bump version from 0.5.0 to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "model-express-workspace-tests"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-common"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "modelexpress-server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Model Express: High-performance model serving and management"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -38,9 +38,9 @@ hf-hub = { version = "0.4.3", default-features = false, features = [
     "rustls-tls",
 ] }
 jiff = { version = "0.2.15", features = ["serde"] }
-modelexpress-common = { path = "modelexpress_common", version = "0.5.0" }
-modelexpress-client = { path = "modelexpress_client", version = "0.5.0" }
-modelexpress-server = { path = "modelexpress_server", version = "0.5.0" }
+modelexpress-common = { path = "modelexpress_common", version = "0.5.1" }
+modelexpress-client = { path = "modelexpress_client", version = "0.5.1" }
+modelexpress-server = { path = "modelexpress_server", version = "0.5.1" }
 once_cell = "1.21.3"
 prost = "0.13"
 rustls = { version = "0.23.37", default-features = false, features = ["ring", "std"] }

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -30,7 +30,7 @@ Every source is identified by a `SourceIdentity` proto containing all fields tha
 
 | Field | Example | Purpose |
 |-------|---------|---------|
-| `mx_version` | `"0.5.0"` | Format compatibility across upgrades |
+| `mx_version` | `"0.5.1"` | Format compatibility across upgrades |
 | `mx_source_type` | `WEIGHTS`, `LORA`, `CUDA_GRAPH`, `TORCH_COMPILE_CACHE`, `TRITON_CACHE`, `DEEP_GEMM_CACHE`, `TILELANG_CACHE`, `CUTE_DSL_CACHE`, `FLASHINFER_CACHE` | Type of source metadata being served |
 | `model_name` | `"deepseek-ai/DeepSeek-V3"` | Model identifier |
 | `backend_framework` | `VLLM`, `SGLANG`, `TRT_LLM` | Inference framework |
@@ -263,7 +263,7 @@ No Redis TTL is applied to keys. P2P stale detection and cleanup are handled by 
 ```
 # Source index -- identity stored once, workers as presence markers
 mx:source:a1b2c3d4e5f67890
-  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.5.0",...}
+  __attributes__  ->  {"model_name":"deepseek-ai/DeepSeek-V3","mx_version":"0.5.1",...}
   f3a2b1c4        ->  "0"    # worker_id f3a2b1c4, global rank 0
   e7d6c5b8        ->  "1"    # worker_id e7d6c5b8, global rank 1
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: modelexpress
 description: A Helm chart for ModelExpress - a AI model cache management service
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.5.1
+appVersion: "0.5.1"
 keywords:
   - model-serving
   - ai

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modelexpress"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python client for ModelExpress P2P GPU transfer service"
 readme = "README.md"
 license = "Apache-2.0"

--- a/modelexpress_client/python/tests/test_artifact_transfer.py
+++ b/modelexpress_client/python/tests/test_artifact_transfer.py
@@ -835,7 +835,7 @@ def test_publish_artifact_source_registers_mx_discovery_metadata(tmp_path):
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.5.1",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
@@ -894,7 +894,7 @@ def test_discover_artifact_source_does_not_rank_match_by_default(tmp_path):
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.5.1",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
     )
@@ -1084,7 +1084,7 @@ def test_publish_artifact_source_stops_server_when_refresh_fails(
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.5.1",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
     )
@@ -1125,7 +1125,7 @@ def test_torch_compile_cache_transfer_discovers_source_through_mx_server(tmp_pat
     )
     bundle = transfer.prepare_source()
     identity = p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.5.1",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_TORCH_COMPILE_CACHE,
         model_name="test/model",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/tests/test_k8s_service_client.py
+++ b/modelexpress_client/python/tests/test_k8s_service_client.py
@@ -23,7 +23,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.5.1",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/tests/test_source_id.py
+++ b/modelexpress_client/python/tests/test_source_id.py
@@ -17,7 +17,7 @@ from modelexpress.metadata.source_id import compute_mx_source_id
 
 def _base_identity() -> p2p_pb2.SourceIdentity:
     return p2p_pb2.SourceIdentity(
-        mx_version="0.5.0",
+        mx_version="0.5.1",
         mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
         model_name="deepseek-ai/DeepSeek-V3",
         backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
@@ -60,7 +60,7 @@ def test_different_revision_gives_different_id():
 
 
 def test_empty_artifact_fields_preserve_existing_id():
-    assert compute_mx_source_id(_base_identity()) == "5a5f555570065064"
+    assert compute_mx_source_id(_base_identity()) == "6b8678cb07d7e9f9"
 
 
 def test_artifact_compatibility_fields_affect_id():
@@ -144,13 +144,13 @@ def test_extra_parameters_sorted():
 # ---------------------------------------------------------------------------
 
 def test_pinned_hash_base_identity():
-    assert compute_mx_source_id(_base_identity()) == "5a5f555570065064"
+    assert compute_mx_source_id(_base_identity()) == "6b8678cb07d7e9f9"
 
 
 def test_pinned_hash_with_revision():
     pinned = _base_identity()
     pinned.revision = "abc123def4567890"
-    assert compute_mx_source_id(pinned) == "d0c184b2a9a34c82"
+    assert compute_mx_source_id(pinned) == "07e75d26825f86cf"
 
 
 def test_case_colliding_extra_parameters_are_deterministic():
@@ -166,4 +166,4 @@ def test_case_colliding_extra_parameters_are_deterministic():
     b.extra_parameters["foo"] = "b"
     b.extra_parameters["Foo"] = "a"
     assert compute_mx_source_id(a) == compute_mx_source_id(b)
-    assert compute_mx_source_id(a) == "bf71fb9340cd940a"
+    assert compute_mx_source_id(a) == "6c036282142a7517"

--- a/modelexpress_client/python/tests/test_vllm_artifacts.py
+++ b/modelexpress_client/python/tests/test_vllm_artifacts.py
@@ -79,7 +79,7 @@ def test_torch_compile_artifact_identity_uses_model_cache_criteria(monkeypatch):
     ctx = SimpleNamespace(
         device_id=2,
         identity=p2p_pb2.SourceIdentity(
-            mx_version="0.5.0",
+            mx_version="0.5.1",
             mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
             model_name="test/model",
             backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
@@ -132,7 +132,7 @@ def test_triton_artifact_identity_uses_runtime_cache_criteria(monkeypatch):
     ctx = SimpleNamespace(
         device_id=0,
         identity=p2p_pb2.SourceIdentity(
-            mx_version="0.5.0",
+            mx_version="0.5.1",
             mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
             model_name="test/model",
             tensor_parallel_size=8,
@@ -166,7 +166,7 @@ def test_deep_gemm_artifact_identity_uses_deep_gemm_cache_criteria(monkeypatch):
     ctx = SimpleNamespace(
         device_id=0,
         identity=p2p_pb2.SourceIdentity(
-            mx_version="0.5.0",
+            mx_version="0.5.1",
             mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
             model_name="test/model",
             backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,

--- a/modelexpress_client/python/uv.lock
+++ b/modelexpress_client/python/uv.lock
@@ -389,7 +389,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -908,13 +908,12 @@ wheels = [
 
 [[package]]
 name = "modelexpress"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-crc32c" },
     { name = "grpcio" },
     { name = "huggingface-hub" },
-    { name = "nixl", extra = ["cu12"], marker = "sys_platform == 'linux'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "protobuf" },
@@ -931,6 +930,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
+metrics = [
+    { name = "prometheus-client" },
+]
 otel = [
     { name = "opentelemetry-api" },
 ]
@@ -945,11 +947,11 @@ requires-dist = [
     { name = "grpcio", specifier = ">=1.66.2" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60.0,<=1.66.2" },
     { name = "huggingface-hub", specifier = ">=0.20.0" },
-    { name = "nixl", extras = ["cu12"], marker = "sys_platform == 'linux'" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.41.1" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.41.1" },
+    { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20.0" },
     { name = "protobuf", specifier = ">=5.27.0,<6.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -957,7 +959,7 @@ requires-dist = [
     { name = "runai-model-streamer", extras = ["s3", "gcs", "azure"], marker = "sys_platform == 'linux'" },
     { name = "torch", specifier = ">=2.6.0" },
 ]
-provides-extras = ["dev", "otel", "vmm"]
+provides-extras = ["dev", "otel", "metrics", "vmm"]
 
 [[package]]
 name = "mpmath"
@@ -1018,44 +1020,6 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
-]
-
-[[package]]
-name = "nixl"
-version = "0.10.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nixl-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/a4/10e80e623790d3fb070e966b36bced009419d483c92ae0df6645230f606f/nixl-0.10.1-py3-none-any.whl", hash = "sha256:616465673dae5180d296525a03237af4cd5f2c00c3228d185bc06dbe621509b7", size = 6680, upload-time = "2026-03-03T19:55:44.848Z" },
-]
-
-[package.optional-dependencies]
-cu12 = [
-    { name = "nixl-cu12" },
-]
-
-[[package]]
-name = "nixl-cu12"
-version = "0.10.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "torch" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/33/db0e850acbca1c9f4b6a793d483d9844dedd756f8dc8ab1f91dcf3294d21/nixl_cu12-0.10.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:277cde28bc45f706df689ed399327d0cce5432382606a5fc1d19fc470fcc57b4", size = 50217293, upload-time = "2026-03-03T19:55:12.262Z" },
-    { url = "https://files.pythonhosted.org/packages/50/35/3f46dd00810df6aef402a7ee0aabf3257f86978d2df44b09248d810fe985/nixl_cu12-0.10.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0bb1b3532f95c2f376e21008e91e8ec5791304a29af19e75d29fd1bcc754c9bc", size = 51522014, upload-time = "2026-03-03T19:54:59.365Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1c/4fb9401047fe9af215596c71247b12b3b83b112bbb1d0a827b839e5dfeab/nixl_cu12-0.10.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ba46837abee8e06c8d86bd9b2cd7dab8c3d1e8407e04d52e6db3a9b137478c4b", size = 50219873, upload-time = "2026-03-03T19:55:12.43Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/1c/f5e974ea562fe27194d1591a4187be55f07642df7d7fc6a0f0db334530a3/nixl_cu12-0.10.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:48d3d9cc882edaa0a323d0ddfed39e0864b873ef1fa56e774c5a793629bcf083", size = 51524522, upload-time = "2026-03-03T19:55:02.013Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/21/c1f34212a3e612b5c0da389c1aa3557588d9cfc2adf864914b32e270847b/nixl_cu12-0.10.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b4712c6e0f18f57fee34cd970faac01480f0caf12da33d4a40ef4e9096a4caf7", size = 50227261, upload-time = "2026-03-03T19:55:17.177Z" },
-    { url = "https://files.pythonhosted.org/packages/71/32/3fe6bb57de847ab59fb9e36c5a64249fb5674959773faca0aeefb791fd8e/nixl_cu12-0.10.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:26e59f9841985cf5b547202865036f84ae6dc23184789446fe5833e7499e21a9", size = 51534091, upload-time = "2026-03-03T19:55:02.199Z" },
-    { url = "https://files.pythonhosted.org/packages/48/7b/054b7521fd4880e991d6e631f80d59cb772f7bf43c8775aea0b2292c2747/nixl_cu12-0.10.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:685a0b8c5cdaa9cdbd826ea54cf46b4b3e46b016ee73a919cd2cf489402c56fd", size = 50227352, upload-time = "2026-03-03T19:55:13.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/68/488d5d655c3a0cac1b9af95c57fe8fc961321ee7eb511ce206a52ea7af43/nixl_cu12-0.10.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3dde565c9d6e1d5af139a4dca240e902d5dbb32ea622acb31cdca3fb25cb859f", size = 51534426, upload-time = "2026-03-03T19:55:07.345Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/dc/aab37d1a3761ac45a4b34c0eeced4fd3b0b0be4953f869cb50ba8c617b2e/nixl_cu12-0.10.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:15376c1527c68d77fff5c6bb7cf7466a16dae0ab3bb32de152a602ba9edaaa9d", size = 50229113, upload-time = "2026-03-03T19:55:37.758Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/99/ae66edc2ed2052042bacd66fa9dae28cc41c01e524fa8d677fb2f974ca64/nixl_cu12-0.10.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:7641bc2bd3aeeefcf2ea3a3fd9f940f54a62d985ce2426dde6b3860d0edce13e", size = 51534633, upload-time = "2026-03-03T19:55:14.228Z" },
 ]
 
 [[package]]
@@ -1397,6 +1361,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
 ]
 
 [[package]]

--- a/modelexpress_server/src/p2p/backend/redis.rs
+++ b/modelexpress_server/src/p2p/backend/redis.rs
@@ -1110,7 +1110,7 @@ mod tests {
 
     fn test_identity() -> modelexpress_common::grpc::p2p::SourceIdentity {
         modelexpress_common::grpc::p2p::SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.5.1".to_string(),
             mx_source_type: 0,
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1,
@@ -1136,7 +1136,7 @@ mod tests {
         let attr = SourceAttributesJson::from(&id);
 
         assert_eq!(attr.model_name, "deepseek-ai/DeepSeek-V3");
-        assert_eq!(attr.mx_version, "0.5.0");
+        assert_eq!(attr.mx_version, "0.5.1");
         assert_eq!(attr.tensor_parallel_size, 8);
         assert_eq!(attr.pipeline_parallel_size, 2);
         assert_eq!(attr.expert_parallel_size, 4);

--- a/modelexpress_server/src/p2p/service.rs
+++ b/modelexpress_server/src/p2p/service.rs
@@ -372,7 +372,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.5.1".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,

--- a/modelexpress_server/src/p2p/source_identity.rs
+++ b/modelexpress_server/src/p2p/source_identity.rs
@@ -100,7 +100,7 @@ mod tests {
 
     fn base_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.5.1".to_string(),
             mx_source_type: 0, // Weights (default)
             model_name: "deepseek-ai/DeepSeek-V3".to_string(),
             backend_framework: 1, // vllm
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_empty_artifact_fields_preserve_existing_id() {
-        assert_eq!(compute_mx_source_id(&base_identity()), "5a5f555570065064");
+        assert_eq!(compute_mx_source_id(&base_identity()), "6b8678cb07d7e9f9");
     }
 
     #[test]
@@ -260,14 +260,14 @@ mod tests {
     // the mismatch is caught in CI.
     #[test]
     fn test_python_cross_check_base_identity() {
-        assert_eq!(compute_mx_source_id(&base_identity()), "5a5f555570065064");
+        assert_eq!(compute_mx_source_id(&base_identity()), "6b8678cb07d7e9f9");
     }
 
     #[test]
     fn test_python_cross_check_with_revision() {
         let mut pinned = base_identity();
         pinned.revision = "abc123def4567890".to_string();
-        assert_eq!(compute_mx_source_id(&pinned), "d0c184b2a9a34c82");
+        assert_eq!(compute_mx_source_id(&pinned), "07e75d26825f86cf");
     }
 
     #[test]
@@ -283,7 +283,7 @@ mod tests {
             .insert("Foo".to_string(), "a".to_string());
         id.extra_parameters
             .insert("foo".to_string(), "b".to_string());
-        assert_eq!(compute_mx_source_id(&id), "bf71fb9340cd940a");
+        assert_eq!(compute_mx_source_id(&id), "6c036282142a7517");
     }
 
     #[test]

--- a/modelexpress_server/src/p2p/state.rs
+++ b/modelexpress_server/src/p2p/state.rs
@@ -217,7 +217,7 @@ mod tests {
 
     fn test_identity() -> SourceIdentity {
         SourceIdentity {
-            mx_version: "0.5.0".to_string(),
+            mx_version: "0.5.1".to_string(),
             mx_source_type: MxSourceType::Weights as i32,
             model_name: "my-model".to_string(),
             backend_framework: 1,

--- a/workspace-tests/tests/artifact_transfer_contract.rs
+++ b/workspace-tests/tests/artifact_transfer_contract.rs
@@ -17,7 +17,7 @@ use std::fs;
 
 fn base_identity() -> SourceIdentity {
     SourceIdentity {
-        mx_version: "0.5.0".to_string(),
+        mx_version: "0.5.1".to_string(),
         mx_source_type: MxSourceType::Weights as i32,
         model_name: "Qwen/Qwen2.5-0.5B-Instruct".to_string(),
         backend_framework: BackendFramework::Vllm as i32,


### PR DESCRIPTION
Bump the workspace, Python package, and Helm chart to 0.5.1 per the "Bumping the ModelExpress Version" procedure in CLAUDE.md, and recompute the pinned mx_source_id hashes on both the Python and Rust sides.

Regenerating uv.lock also resyncs it to the already-committed pyproject.toml: it drops nixl/nixl-cu12 and adds prometheus-client, which the lock had drifted from on release/0.5.0.

Public release-image tag references are deliberately untouched; those move only after the 0.5.1 container is published on NGC.