### PR TITLE
fix(reshard): validate published elsize against its dtype

### DIFF
--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -176,9 +176,21 @@ def decode_shard_entries(entries: list) -> list:
 
 
 def _torch_dtype(label: str):
+    """Resolve a shard-table dtype label to a ``torch.dtype``.
+
+    Publishers emit either ``"torch.bfloat16"`` or ``"bfloat16"``, so the prefix
+    is optional. The label must name a dtype rather than merely some torch
+    attribute. A fixed allowlist of names is deliberately avoided: the publish
+    format is an external contract, and a hardcoded list would reject dtypes a
+    newer torch supports.
+    """
     import torch
 
-    return getattr(torch, label.split(".")[-1])
+    name = label.split(".")[-1]
+    dtype = getattr(torch, name, None)
+    if not isinstance(dtype, torch.dtype):
+        raise ValueError(f"unsupported dtype label {label!r} in shard table")
+    return dtype
 
 
 def build_sources(tensors: list) -> tuple:
@@ -193,6 +205,12 @@ def build_sources(tensors: list) -> tuple:
     session_to_device = {}
     for t in tensors:
         dtype = _torch_dtype(t.dtype)
+        if t.elsize != dtype.itemsize:
+            raise ValueError(
+                f"tensor {t.name!r} published elsize {t.elsize} disagrees with dtype "
+                f"{t.dtype} (itemsize {dtype.itemsize}); elsize drives raw address "
+                f"arithmetic, so a mismatch would read the wrong bytes"
+            )
         shards = []
         for s in t.shards:
             session = s.agent_name
@@ -250,10 +268,14 @@ def merge_shard_tables(tables: list) -> list:
                     t.name, t.dtype, t.elsize, t.full_shape, []
                 )
                 candidates[t.name] = {}
-            elif cur.full_shape != t.full_shape or cur.dtype != t.dtype:
+            elif (
+                cur.full_shape != t.full_shape
+                or cur.dtype != t.dtype
+                or cur.elsize != t.elsize
+            ):
                 raise ValueError(
-                    f"tensor {t.name!r} published with inconsistent shape/dtype across ranks: "
-                    f"{cur.full_shape}/{cur.dtype} vs {t.full_shape}/{t.dtype}"
+                    f"tensor {t.name!r} published with inconsistent shape/dtype/elsize across ranks: "
+                    f"{cur.full_shape}/{cur.dtype}/{cur.elsize} vs {t.full_shape}/{t.dtype}/{t.elsize}"
                 )
             per_geometry = candidates[t.name]
             for shard in t.shards:

--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -175,19 +175,30 @@ def decode_shard_entries(entries: list) -> list:
     return tensors
 
 
-def _torch_dtype(label: str):
-    """Resolve a shard-table dtype label to a ``torch.dtype``.
+def _dtype_key(label) -> str:
+    """Canonical comparison key for a shard-table dtype label.
 
     Publishers emit either ``"torch.bfloat16"`` or ``"bfloat16"``, so the prefix
-    is optional. The label must name a dtype rather than merely some torch
-    attribute. A fixed allowlist of names is deliberately avoided: the publish
-    format is an external contract, and a hardcoded list would reject dtypes a
-    newer torch supports.
+    is optional and the two spellings of one dtype must not read as a
+    disagreement. The label comes straight from decoded JSON, so its type is a
+    publisher's claim rather than a guarantee; a non-string is rejected as
+    invalid metadata instead of failing later on an attribute it does not have.
+    """
+    if not isinstance(label, str):
+        raise ValueError(f"unsupported dtype label {label!r} in shard table")
+    return label.split(".")[-1]
+
+
+def _torch_dtype(label):
+    """Resolve a shard-table dtype label to a ``torch.dtype``.
+
+    The label must name a dtype rather than merely some torch attribute. A fixed
+    allowlist of names is deliberately avoided: the publish format is an external
+    contract, and a hardcoded list would reject dtypes a newer torch supports.
     """
     import torch
 
-    name = label.split(".")[-1]
-    dtype = getattr(torch, name, None)
+    dtype = getattr(torch, _dtype_key(label), None)
     if not isinstance(dtype, torch.dtype):
         raise ValueError(f"unsupported dtype label {label!r} in shard table")
     return dtype
@@ -255,6 +266,11 @@ def merge_shard_tables(tables: list) -> list:
     collide under one name, and then retaining the first installs bytes that
     belong to the other. Publishers must therefore use globally unique names for
     parallelism-local tensors.
+
+    Dtype agreement is decided on the canonicalized label, since the publish
+    contract accepts both the prefixed and unprefixed spellings: ranks that
+    spell one dtype differently agree, and reporting them as inconsistent would
+    name a cross-rank disagreement that does not exist.
     """
     merged: dict = {}
     # name -> geometry -> first shard, insertion-ordered so the retained geometry
@@ -270,7 +286,7 @@ def merge_shard_tables(tables: list) -> list:
                 candidates[t.name] = {}
             elif (
                 cur.full_shape != t.full_shape
-                or cur.dtype != t.dtype
+                or _dtype_key(cur.dtype) != _dtype_key(t.dtype)
                 or cur.elsize != t.elsize
             ):
                 raise ValueError(

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -499,3 +499,27 @@ def test_ranks_publishing_a_consistent_tensor_merge_their_shards():
 def test_a_dtype_label_that_names_nothing_in_torch_is_rejected():
     with pytest.raises(ValueError, match="unsupported dtype label"):
         build_sources([_tensor(dtype="torch.not_a_real_dtype", elsize=2)])
+
+
+def test_ranks_spelling_one_dtype_differently_are_not_a_disagreement():
+    # The publish contract accepts both spellings, so ranks that disagree only
+    # on the prefix agree on the dtype; rejecting them would name a cross-rank
+    # inconsistency that does not exist.
+    merged = merge_shard_tables(
+        [[_tensor(dtype="torch.bfloat16")], [_tensor(dtype="bfloat16")]]
+    )
+    assert len(merged) == 1
+    assert len(merged[0].shards) == 2
+
+
+def test_ranks_publishing_the_same_tensor_with_different_dtype_are_rejected():
+    with pytest.raises(ValueError, match="inconsistent shape/dtype/elsize"):
+        merge_shard_tables(
+            [[_tensor(dtype="torch.bfloat16")], [_tensor(dtype="float16")]]
+        )
+
+
+def test_a_non_string_dtype_label_is_rejected_as_invalid_metadata():
+    # dtype rides through decode untouched, so its type is a publisher's claim.
+    with pytest.raises(ValueError, match="unsupported dtype label"):
+        build_sources([_tensor(dtype=123, elsize=2)])

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -442,7 +442,22 @@ def test_one_unreadable_rank_does_not_abort_the_sweep():
     # The readable ranks are still returned when the quorum only needs them.
     discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
     assert [p.agent_name for p in discovered] == ["rank-0", "rank-2"]
-def _tensor(dtype="torch.bfloat16", elsize=2, name="weight"):
+
+
+def _tensor(
+    dtype="torch.bfloat16",
+    elsize=2,
+    name="weight",
+    shard_offset=(0, 0),
+    shape=(4, 4),
+):
+    """One published tensor with a single shard.
+
+    ``shard_offset``/``shape`` are parameterized because the merge retains one
+    representative per distinct geometry: two ranks publishing the SAME box are
+    replicas and collapse to one shard, so a test about cross-rank fan-in has to
+    hand the two ranks different boxes.
+    """
     return PublishedTensor(
         name=name,
         dtype=dtype,
@@ -453,8 +468,8 @@ def _tensor(dtype="torch.bfloat16", elsize=2, name="weight"):
                 agent_name="trainer-agent",
                 device_id=0,
                 addr=4096,
-                shard_offset=(0, 0),
-                shape=(4, 4),
+                shard_offset=shard_offset,
+                shape=shape,
             )
         ],
     )
@@ -491,7 +506,12 @@ def test_ranks_publishing_the_same_tensor_with_different_elsize_are_rejected():
 
 
 def test_ranks_publishing_a_consistent_tensor_merge_their_shards():
-    merged = merge_shard_tables([[_tensor()], [_tensor()]])
+    merged = merge_shard_tables(
+        [
+            [_tensor(shard_offset=(0, 0), shape=(2, 4))],
+            [_tensor(shard_offset=(2, 0), shape=(2, 4))],
+        ]
+    )
     assert len(merged) == 1
     assert len(merged[0].shards) == 2
 
@@ -506,7 +526,10 @@ def test_ranks_spelling_one_dtype_differently_are_not_a_disagreement():
     # on the prefix agree on the dtype; rejecting them would name a cross-rank
     # inconsistency that does not exist.
     merged = merge_shard_tables(
-        [[_tensor(dtype="torch.bfloat16")], [_tensor(dtype="bfloat16")]]
+        [
+            [_tensor(dtype="torch.bfloat16", shard_offset=(0, 0), shape=(2, 4))],
+            [_tensor(dtype="bfloat16", shard_offset=(2, 0), shape=(2, 4))],
+        ]
     )
     assert len(merged) == 1
     assert len(merged[0].shards) == 2

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -13,6 +13,8 @@ from modelexpress.refit.reshard.rendezvous import (
     PublishedShard,
     PublishedTensor,
     _mx_version,
+    build_sources,
+    merge_shard_tables,
     wrap_rendezvous_blob,
 )
 
@@ -440,3 +442,60 @@ def test_one_unreadable_rank_does_not_abort_the_sweep():
     # The readable ranks are still returned when the quorum only needs them.
     discovered = _rendezvous(client).discover_trainers(expected_trainers=2, timeout=0)
     assert [p.agent_name for p in discovered] == ["rank-0", "rank-2"]
+def _tensor(dtype="torch.bfloat16", elsize=2, name="weight"):
+    return PublishedTensor(
+        name=name,
+        dtype=dtype,
+        elsize=elsize,
+        full_shape=(4, 4),
+        shards=[
+            PublishedShard(
+                agent_name="trainer-agent",
+                device_id=0,
+                addr=4096,
+                shard_offset=(0, 0),
+                shape=(4, 4),
+            )
+        ],
+    )
+
+
+def test_a_published_elsize_that_disagrees_with_its_dtype_is_rejected():
+    # elsize drives raw address arithmetic in the slice plan, so a wrong value
+    # reads the wrong bytes rather than failing.
+    with pytest.raises(ValueError, match="disagrees with dtype"):
+        build_sources([_tensor(dtype="torch.bfloat16", elsize=4)])
+
+
+def test_a_published_elsize_matching_its_dtype_is_accepted():
+    sources, _, _ = build_sources([_tensor(dtype="torch.bfloat16", elsize=2)])
+    assert sources["weight"].elsize == 2
+
+
+def test_a_stripped_dtype_label_resolves_the_same_as_a_prefixed_one():
+    stripped, _, _ = build_sources([_tensor(dtype="bfloat16", elsize=2)])
+    prefixed, _, _ = build_sources([_tensor(dtype="torch.bfloat16", elsize=2)])
+    assert stripped["weight"].dtype == prefixed["weight"].dtype
+
+
+def test_a_dtype_label_naming_a_non_dtype_torch_attribute_is_rejected():
+    # getattr(torch, "load") resolves to a function; without an allowlist it
+    # would be accepted as a dtype.
+    with pytest.raises(ValueError, match="unsupported dtype label"):
+        build_sources([_tensor(dtype="torch.load", elsize=2)])
+
+
+def test_ranks_publishing_the_same_tensor_with_different_elsize_are_rejected():
+    with pytest.raises(ValueError, match="inconsistent shape/dtype/elsize"):
+        merge_shard_tables([[_tensor(elsize=2)], [_tensor(elsize=4)]])
+
+
+def test_ranks_publishing_a_consistent_tensor_merge_their_shards():
+    merged = merge_shard_tables([[_tensor()], [_tensor()]])
+    assert len(merged) == 1
+    assert len(merged[0].shards) == 2
+
+
+def test_a_dtype_label_that_names_nothing_in_torch_is_rejected():
+    with pytest.raises(ValueError, match="unsupported dtype label"):
+        build_sources([_tensor(dtype="torch.not_a_real_dtype", elsize=2)])


### PR DESCRIPTION
The reshard shard table carries `dtype` and `elsize` as independent fields and nothing reconciled them. `elsize` is what the slice plan does address arithmetic with, `src_addr = addr + offset * elsize` and `nbytes = n * elsize`, so a publisher emitting a byte width that disagrees with its dtype silently produced reads at the wrong offset and the wrong length. `plan_pull` already compares source and destination dtypes; the byte width behind it was checked against nothing.

`build_sources` now rejects a tensor whose `elsize` disagrees with its resolved dtype's `itemsize`, and `merge_shard_tables` includes `elsize` in the cross-rank agreement check, which its docstring already described it as doing. Both checks sit on the consumer side, since encode and decode stay dependency-free and a publish-side check would cover only the in-tree publishers. `_torch_dtype` also now requires its label to resolve to an actual `torch.dtype`; it was a bare `getattr`, so `torch.load` resolved to a function and was carried forward as a dtype.

Nothing in the repo can trigger this today, since both in-tree publishers derive `elsize` from `tensor.element_size()`. It seems worth guarding anyway because the publish path is the documented trainer integration contract, and `elsize` is a required field on it with no invariant tying it to `dtype`. The six added tests were confirmed failing against the unpatched module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of tensor data types and element sizes during shard planning and merging.
  * Detects and reports inconsistent shard shapes, data types, or element sizes across ranks.
  * Rejects unsupported data type labels with clearer validation errors.

* **Tests**
  * Added coverage for data type validation, element-size mismatches, inconsistent shard metadata, and successful shard merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->