### PR TITLE
ci: own the GitLab mirror credentials instead of the shared workflow

### DIFF
--- a/.github/workflows/mirror_repo.sh
+++ b/.github/workflows/mirror_repo.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Description: This script triggers a GitLab mirror update and waits for completion
+# Usage: ./update_gitlab_mirror.sh <gitlab_access_token> <gitlab_mirror_url>
+
+GITLAB_ACCESS_TOKEN=$1
+GITLAB_MIRROR_URL=$2
+
+SYNC_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+curl --fail-with-body --request POST --header "PRIVATE-TOKEN: ${GITLAB_ACCESS_TOKEN}" "${GITLAB_MIRROR_URL}"
+
+echo "Mirror update request submitted at ${SYNC_TIME}"
+
+# Poll for completion
+# GitLab limits the frequency of mirror updates to once every 5 mins.
+# If you trigger an update more frequently, it may not start immediately.
+# Make sure sync is finished after sync request was submitted
+MAX_RETRIES=15
+RETRY_INTERVAL=30
+# Convert timestamps to epoch for comparison, timezone agnostic
+SYNC_TIME_SECONDS=$(date -d "$SYNC_TIME" +%s)
+for i in $(seq 1 $MAX_RETRIES); do
+    MIRROR_INFO=$(curl --silent --header "PRIVATE-TOKEN: ${GITLAB_ACCESS_TOKEN}" "${GITLAB_MIRROR_URL}")
+    MIRROR_STATUS=$(echo "$MIRROR_INFO" | jq -r '.update_status')
+    LAST_UPDATE=$(echo "$MIRROR_INFO" | jq -r '.last_update_at')
+    LAST_UPDATE_SECONDS=$(date -d "$LAST_UPDATE" +%s)
+    if [ "$MIRROR_STATUS" = "finished" ] && [ $LAST_UPDATE_SECONDS -gt $SYNC_TIME_SECONDS ]; then
+        echo "Mirror sync successful. Last update: $LAST_UPDATE"
+        exit 0
+    fi
+    echo "Waiting for mirror sync to complete. Attempt $i of $MAX_RETRIES"
+    echo "Last update: $LAST_UPDATE"
+    sleep $RETRY_INTERVAL
+done
+echo "Mirror sync failed or timed out"
+exit 1

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -19,15 +19,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  trigger:
-    # Fork PRs do not receive repository secrets, so the GitLab mirror workflow
-    # would fail with empty TOKEN/MIRROR_URL/PIPELINE_* values.
+  mirror_repo:
+    name: Mirror Repository to GitLab
+    # Fork PRs do not receive repository secrets, so the mirror/trigger jobs
+    # would fail with empty PROJECT_ACCESS_TOKEN/MIRROR_URL/PIPELINE_* values.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: ai-dynamo/.github/.github/workflows/mirror_and_trigger_ci.yml@main
-    with:
-      ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-    secrets:
-      TOKEN: ${{ secrets.TOKEN }}
-      MIRROR_URL: ${{ secrets.MIRROR_URL }}
-      PIPELINE_TOKEN: ${{ secrets.PIPELINE_TOKEN }}
-      PIPELINE_URL: ${{ secrets.PIPELINE_URL }}
+    environment: GITLAB
+    runs-on: gitlab
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Sync Mirror Repository
+        env:
+          PROJECT_ACCESS_TOKEN: ${{ secrets.PROJECT_ACCESS_TOKEN }}
+          MIRROR_URL: ${{ secrets.MIRROR_URL }}
+        run: ./.github/workflows/mirror_repo.sh "$PROJECT_ACCESS_TOKEN" "$MIRROR_URL"
+
+  trigger_ci:
+    name: Trigger CI Pipeline
+    needs: mirror_repo
+    environment: GITLAB
+    runs-on: gitlab
+    steps:
+      - name: Trigger GitLab pipeline
+        env:
+          REF: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          PIPELINE_TOKEN: ${{ secrets.PIPELINE_TOKEN }}
+          PIPELINE_URL: ${{ secrets.PIPELINE_URL }}
+        run: |
+          echo "Triggering GitLab pipeline for ref: $REF"
+
+          curl --fail-with-body \
+            --request POST \
+            --form token="$PIPELINE_TOKEN" \
+            --form ref="$REF" \
+            "$PIPELINE_URL"


### PR DESCRIPTION
modelexpress was the last repo calling the centralized ai-dynamo/.github mirror_and_trigger_ci.yml workflow, and the only consumer of the org-level `TOKEN` secret it needs. That token expired on 2026-08-13 and every trigger_ci run has failed since with a GitLab 401:

    curl: (22) The requested URL returned error: 401
    {"error":"invalid_token","error_description":"Token is expired."}

A job that calls a reusable workflow cannot declare `environment:`, so `secrets.TOKEN` could only ever resolve from a repo- or org-level secret and never from the repo's GITLAB environment. dynamo already moved off this path to inline jobs reading PROJECT_ACCESS_TOKEN from the GITLAB environment; mirror the same structure here so the credential is owned and rotatable by this repo.

Inline mirror_repo/trigger_ci jobs pinned to `environment: GITLAB`, and vendor mirror_repo.sh (byte-identical to dynamo's and to the centralized copy, plus the SPDX header this repo's copyright check requires). Secrets and the ref are passed through `env:` rather than interpolated into the shell, so a branch name cannot inject into the curl command.

Fork-PR guard and concurrency behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved repository mirroring and CI pipeline triggering.
  * Added status monitoring with clear success, timeout, and failure handling.
  * Preserved safeguards that exclude fork pull requests from mirror and pipeline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->