### PR TITLE
fix(server): accept Gcs in the ModelCacheEntry provider enum

### DIFF
--- a/ci/k8s/server/crd-modelmetadata.yaml
+++ b/ci/k8s/server/crd-modelmetadata.yaml
@@ -216,6 +216,7 @@ spec:
                   enum:
                     - HuggingFace
                     - Ngc
+                    - Gcs
             status:
               type: object
               properties:

--- a/examples/crds.yaml
+++ b/examples/crds.yaml
@@ -217,6 +217,7 @@ spec:
                   enum:
                     - HuggingFace
                     - Ngc
+                    - Gcs
             status:
               type: object
               properties:
@@ -230,9 +231,11 @@ spec:
                     - Error
                 createdAt:
                   type: string
+                  format: date-time
                   description: RFC3339 timestamp of first write
                 lastUsedAt:
                   type: string
+                  format: date-time
                   description: RFC3339 timestamp of most recent status write or touch
                 message:
                   type: string


### PR DESCRIPTION
The registry Kubernetes backend writes "Gcs" into spec.provider for a GCS-cached model, but the ModelCacheEntry CRD constrained that field to HuggingFace and Ngc, so a GCS-cached model on the Kubernetes metadata backend produced a resource the API server rejects. Both copies of the CRD carried the narrow enum, so the example users apply and the copy CI tests were equally affected.

The code is built for all three providers in both directions: provider_from_str already parses "Gcs" on the read path, ALL_PROVIDERS carries it for candidate name enumeration, and the CR spec struct in registry/k8s_types.rs documents the field as one of the three. This is the schema lagging the code rather than a provider that was deliberately excluded.

Also reconciles a drift between the two copies while they are both open: examples/crds.yaml was missing format: date-time on status.createdAt and status.lastUsedAt, which the CI copy has.

Widening an enum is backward compatible for existing resources, but the CRD needs re-applying before a server that can write Gcs starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud Storage (GCS) as a supported model cache provider.
  * Updated the model cache resource definition with explicit date-time formatting for status timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->