### PR TITLE
refactor(client): remove the retry configuration nothing consumed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,6 @@ MX_METADATA_BACKEND=redis REDIS_URL=redis://localhost:6379 cargo run -p modelexp
 | `MODEL_EXPRESS_ENDPOINT` | `http://localhost:8001` | Server endpoint |
 | `MODEL_EXPRESS_TIMEOUT` | `30` | Request timeout in seconds |
 | `MODEL_EXPRESS_CACHE_DIRECTORY` | (see below) | Cache path override |
-| `MODEL_EXPRESS_MAX_RETRIES` | (none) | Max retry attempts |
 | `MODEL_EXPRESS_NO_SHARED_STORAGE` | `false` | Disable shared storage mode |
 
 Cache directory resolution order: `MODEL_EXPRESS_CACHE_DIRECTORY` -> `HF_HUB_CACHE` -> `~/.cache/huggingface/hub`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -192,7 +192,6 @@ The CLI client also uses layered configuration: CLI args > env vars > config fil
 | `MODEL_EXPRESS_ENDPOINT` | `http://localhost:8001` | Server endpoint |
 | `MODEL_EXPRESS_TIMEOUT` | `30` | Request timeout (seconds) |
 | `MODEL_EXPRESS_CACHE_DIRECTORY` | (auto) | Cache path override |
-| `MODEL_EXPRESS_MAX_RETRIES` | (none) | Max retry attempts |
 | `MODEL_EXPRESS_NO_SHARED_STORAGE` | `false` | Use gRPC streaming instead of shared storage |
 | `MODEL_EXPRESS_TRANSFER_CHUNK_SIZE` | `32768` | Transfer chunk size (bytes) |
 

--- a/modelexpress_common/src/client_config.rs
+++ b/modelexpress_common/src/client_config.rs
@@ -64,14 +64,6 @@ pub struct ClientArgs {
     #[arg(long, short = 'q')]
     pub quiet: bool,
 
-    /// Maximum number of retries
-    #[arg(long, env = crate::envs::MODEL_EXPRESS_MAX_RETRIES)]
-    pub max_retries: Option<u32>,
-
-    /// Retry delay in seconds
-    #[arg(long, env = crate::envs::MODEL_EXPRESS_RETRY_DELAY)]
-    pub retry_delay: Option<u64>,
-
     /// Disable shared storage mode (will transfer files from server to client)
     #[arg(long, env = crate::envs::MODEL_EXPRESS_NO_SHARED_STORAGE)]
     pub no_shared_storage: bool,
@@ -138,14 +130,6 @@ impl ClientConfig {
 
         if let Some(timeout) = args.timeout {
             config.connection.timeout_secs = Some(timeout);
-        }
-
-        if let Some(max_retries) = args.max_retries {
-            config.connection.max_retries = Some(max_retries);
-        }
-
-        if let Some(retry_delay) = args.retry_delay {
-            config.connection.retry_delay_secs = Some(retry_delay);
         }
 
         // Cache settings
@@ -407,8 +391,6 @@ mod tests {
             log_level: None,
             log_format: None,
             quiet: true,
-            max_retries: Some(5),
-            retry_delay: Some(10),
             no_shared_storage: true,
             transfer_chunk_size: Some(2097152),
         };
@@ -418,8 +400,6 @@ mod tests {
         assert_eq!(config.connection.endpoint, "http://cli-override:7777");
         assert_eq!(config.connection.timeout_secs, Some(120));
         assert!(config.logging.quiet);
-        assert_eq!(config.connection.max_retries, Some(5));
-        assert_eq!(config.connection.retry_delay_secs, Some(10));
         assert!(!config.cache.shared_storage);
         assert_eq!(config.cache.transfer_chunk_size, 2097152);
     }

--- a/modelexpress_common/src/config.rs
+++ b/modelexpress_common/src/config.rs
@@ -329,12 +329,6 @@ pub struct ConnectionConfig {
 
     /// Timeout in seconds for requests
     pub timeout_secs: Option<u64>,
-
-    /// Maximum retries for failed requests
-    pub max_retries: Option<u32>,
-
-    /// Retry delay in seconds
-    pub retry_delay_secs: Option<u64>,
 }
 
 pub fn normalize_grpc_endpoint(endpoint: impl Into<String>) -> String {
@@ -352,8 +346,6 @@ impl Default for ConnectionConfig {
         Self {
             endpoint: format!("http://localhost:{}", crate::constants::DEFAULT_GRPC_PORT),
             timeout_secs: Some(crate::constants::DEFAULT_TIMEOUT_SECS),
-            max_retries: Some(3),
-            retry_delay_secs: Some(1),
         }
     }
 }
@@ -363,19 +355,11 @@ impl ConnectionConfig {
         Self {
             endpoint: normalize_grpc_endpoint(endpoint),
             timeout_secs: Some(crate::constants::DEFAULT_TIMEOUT_SECS),
-            max_retries: Some(3),
-            retry_delay_secs: Some(1),
         }
     }
 
     pub fn with_timeout(mut self, timeout_secs: u64) -> Self {
         self.timeout_secs = Some(timeout_secs);
-        self
-    }
-
-    pub fn with_retries(mut self, max_retries: u32, delay_secs: u64) -> Self {
-        self.max_retries = Some(max_retries);
-        self.retry_delay_secs = Some(delay_secs);
         self
     }
 }
@@ -448,14 +432,10 @@ mod tests {
 
     #[test]
     fn test_connection_config_builder() {
-        let config = ConnectionConfig::new("http://test.com:8080")
-            .with_timeout(60)
-            .with_retries(5, 2);
+        let config = ConnectionConfig::new("http://test.com:8080").with_timeout(60);
 
         assert_eq!(config.endpoint, "http://test.com:8080");
         assert_eq!(config.timeout_secs, Some(60));
-        assert_eq!(config.max_retries, Some(5));
-        assert_eq!(config.retry_delay_secs, Some(2));
     }
 
     #[test]
@@ -481,8 +461,6 @@ mod tests {
         let valid_config = r#"
             endpoint: "http://localhost:9999"
             timeout_secs: 60
-            max_retries: 5
-            retry_delay_secs: 2
         "#;
 
         fs::write(&config_file, valid_config).expect("Failed to write config file");
@@ -493,8 +471,6 @@ mod tests {
         let config = result.expect("Expected successful config parsing");
         assert_eq!(config.endpoint, "http://localhost:9999");
         assert_eq!(config.timeout_secs, Some(60));
-        assert_eq!(config.max_retries, Some(5));
-        assert_eq!(config.retry_delay_secs, Some(2));
     }
 
     #[test]

--- a/modelexpress_common/src/envs.rs
+++ b/modelexpress_common/src/envs.rs
@@ -45,10 +45,6 @@ pub const MODEL_EXPRESS_CACHE_DIRECTORY: &str = "MODEL_EXPRESS_CACHE_DIRECTORY";
 pub const MODEL_EXPRESS_LOG_LEVEL: &str = "MODEL_EXPRESS_LOG_LEVEL";
 /// Log output format (client and server).
 pub const MODEL_EXPRESS_LOG_FORMAT: &str = "MODEL_EXPRESS_LOG_FORMAT";
-/// Maximum connection/request retries (`ClientArgs::max_retries`).
-pub const MODEL_EXPRESS_MAX_RETRIES: &str = "MODEL_EXPRESS_MAX_RETRIES";
-/// Delay between retries in seconds (`ClientArgs::retry_delay`).
-pub const MODEL_EXPRESS_RETRY_DELAY: &str = "MODEL_EXPRESS_RETRY_DELAY";
 /// Disable shared-storage mode (`ClientArgs::no_shared_storage`).
 pub const MODEL_EXPRESS_NO_SHARED_STORAGE: &str = "MODEL_EXPRESS_NO_SHARED_STORAGE";
 /// File-transfer chunk size in bytes (`ClientArgs::transfer_chunk_size`).
@@ -302,8 +298,6 @@ mod tests {
         );
         assert_eq!(MODEL_EXPRESS_LOG_LEVEL, "MODEL_EXPRESS_LOG_LEVEL");
         assert_eq!(MODEL_EXPRESS_LOG_FORMAT, "MODEL_EXPRESS_LOG_FORMAT");
-        assert_eq!(MODEL_EXPRESS_MAX_RETRIES, "MODEL_EXPRESS_MAX_RETRIES");
-        assert_eq!(MODEL_EXPRESS_RETRY_DELAY, "MODEL_EXPRESS_RETRY_DELAY");
         assert_eq!(
             MODEL_EXPRESS_NO_SHARED_STORAGE,
             "MODEL_EXPRESS_NO_SHARED_STORAGE"


### PR DESCRIPTION
max_retries and retry_delay_secs were wired through clap, env, serde and defaults, and documented, but no code read them. There is no retry loop in the client crate, no tower or tonic retry layer, and the with_retries builder had exactly one caller: its own unit test. A user setting MODEL_EXPRESS_MAX_RETRIES=5 got no retries and no warning.

The surface is removed instead of implemented, because the retry semantics for the calls that matter are already defined elsewhere and a client loop would contradict them. EnsureModelDownloaded is already retried server side: a second call on a model in ERROR drives an ERROR to DOWNLOADING compare-and-swap, deduplicated across replicas, and the client contract is to bail on ERROR and be re-invoked, so a client loop would race that CAS and double-drive downloads. StreamModelFiles cannot be retried, only restarted destructively: the request carries no offset, there is no checksum and no partial-file concept, and the receive path unlinks existing files before recreating them, so a retry would delete completed files and restart the transfer from zero. Resumable transfer would be a feature in its own right, and the protocol already reserves ListModelFiles for it. SendRequest carries a caller-supplied action and a fresh request id per call, so it is not certifiably safe to repeat.

On compatibility: no struct in the workspace uses serde deny_unknown_fields, so an existing YAML setting these keys keeps parsing and the keys are ignored. The CLI flags are a hard removal, so --max-retries and --retry-delay now fail argument parsing, and the two env vars become no-ops. The timeout_secs field in the same struct is genuinely consumed and is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed documentation for deprecated retry-related configuration options.

* **Refactor**
  * Removed support for configuring client retry counts and delays through command-line options, environment variables, and connection settings.
  * Updated default and sample configurations to reflect the simplified settings.

* **Tests**
  * Removed outdated retry configuration checks and test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->