### PR TITLE
test: verify CodeRabbit architecture path instructions

### DIFF
--- a/modelexpress_client/python/modelexpress/metadata/_coderabbit_architecture_test.py
+++ b/modelexpress_client/python/modelexpress/metadata/_coderabbit_architecture_test.py
@@ -1,0 +1,8 @@
+"""Intentional architecture violation used to test CodeRabbit instructions."""
+
+import vllm
+
+
+def engine_runtime() -> object:
+    """Return an engine-owned runtime from the engine-agnostic metadata layer."""
+    return vllm


### PR DESCRIPTION
Temporary validation PR for #628.

This intentionally introduces an engine-specific vLLM import under the engine-agnostic `metadata/` package. CodeRabbit should flag the package architecture boundary defined by the feature branch's `.coderabbit.yaml`.

This PR will be closed and the scratch branch removed after the result is recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an architecture validation test for metadata-layer access to the engine runtime.
  * Added coverage confirming the engine runtime can be retrieved successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->