### PR TITLE
fix(helm): remove default NGC pull secret

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -11,57 +11,21 @@ This Helm chart deploys ModelExpress, a model serving and management platform, t
 
 - Kubernetes 1.19+
 - Helm 3.0+
-- Access to NVIDIA Container Registry (nvcr.io) for pulling the ModelExpress image
 
 ## Installation
 
-### 1. Create NVIDIA Container Registry Secret
-
-Before installing the chart, you must create a Kubernetes secret to access the private NVIDIA Container Registry (nvcr.io). The default image requires authentication.
-
-```bash
-# Create the secret in your target namespace
-kubectl create secret docker-registry nvcr-secret \
-  --docker-server=nvcr.io \
-  --docker-username='$oauthtoken' \
-  --docker-password='YOUR_NVCR_API_KEY' \
-  --docker-email='your-email@nvidia.com' \
-  --namespace=your-namespace
-
-# Or create it in the default namespace if you plan to use that
-kubectl create secret docker-registry nvcr-secret \
-  --docker-server=nvcr.io \
-  --docker-username='$oauthtoken' \
-  --docker-password='YOUR_NVCR_API_KEY' \
-  --docker-email='your-email@nvidia.com'
-```
-
-**Important Notes:**
-- Replace `YOUR_NVCR_API_KEY` with your actual NVIDIA Container Registry API key
-- The username must be `$oauthtoken` (literal string, not a variable)
-- The email should be your NVIDIA email address
-- The secret name `nvcr-secret` is referenced in the default values
-
-### 2. Update Values to Use the Secret
-
-The default `values.yaml` already includes the image pull secret configuration:
-
-```yaml
-# values.yaml (default)
-imagePullSecrets:
-  - name: nvcr-secret
-```
-
-If you're using a custom values file, ensure it includes this configuration or the deployment will fail with image pull errors.
-
-### 3. Add the Helm repository (if using a repository)
+### 1. Add the Helm repository (if using a repository)
 
 ```bash
 helm repo add modelexpress https://your-repo-url
 helm repo update
 ```
 
-### 4. Install the chart
+### 2. Install the chart
+
+To view the available tags for the official ModelExpress image, see the
+[ModelExpress Server tags](https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/containers/modelexpress-server/-/tags)
+in the NVIDIA NGC catalog.
 
 ```bash
 # Install with default values
@@ -254,51 +218,6 @@ kubectl get svc -l app.kubernetes.io/name=modelexpress
 ```bash
 kubectl port-forward svc/my-modelexpress 8001:8001
 ```
-
-### Image Pull Issues
-
-If you encounter `ErrImagePull` or `ImagePullBackOff` errors:
-
-1. **Check if the nvcr.io secret exists:**
-   ```bash
-   kubectl get secrets -n your-namespace | grep nvcr
-   ```
-
-2. **Verify the secret is properly configured:**
-   ```bash
-   kubectl describe secret nvcr-secret -n your-namespace
-   ```
-
-3. **Check if the secret is referenced in your values:**
-   ```yaml
-   imagePullSecrets:
-     - name: nvcr-secret
-   ```
-
-4. **Verify your API key is correct:**
-   ```bash
-   # Test Docker login locally
-   docker login nvcr.io -u '$oauthtoken' -p 'YOUR_NVCR_API_KEY'
-   ```
-
-5. **Check pod events for detailed error messages:**
-   ```bash
-   kubectl describe pod -l app.kubernetes.io/name=modelexpress -n your-namespace
-   ```
-
-## Using the Official Image
-
-The Helm chart uses the official NVIDIA ModelExpress image from the NVIDIA Container Registry (nvcr.io):
-
-```bash
-# Login to nvcr.io (requires NVIDIA credentials)
-docker login nvcr.io -u '$oauthtoken' -p 'YOUR_NVCR_API_KEY'
-
-# Pull the image
-docker pull nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
-```
-
-**Note:** The default image requires authentication. See the [Installation](#installation) section for creating the required Kubernetes secret.
 
 ## Contributing
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,8 +12,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "0.3.0"
 
-imagePullSecrets:
-  - name: nvcr-secret
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Summary

- Remove the default `nvcr-secret` because the ModelExpress server image is public. I was able to pull the image successfully without logging in to NVIDIA's container registry.

  <img width="1090" height="332" alt="Successful anonymous ModelExpress image pull" src="https://github.com/user-attachments/assets/3dca7eaf-47d2-4e70-b6af-fc4a1f0a54e8" />

- Stop rendering `imagePullSecrets` unless users explicitly configure them.
- Remove the mandatory NGC authentication instructions from the Helm README.
- Remove the obsolete image-pull troubleshooting section.
- Link to the public NGC tags catalog from the chart installation instructions.

## Validation

- Successfully pulled `nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.5.0` without logging in to NVIDIA's container registry.
- Confirmed that the default Helm render does not include `imagePullSecrets`.
- Confirmed that an explicitly configured pull secret still renders correctly.
- Ran `helm lint helm`.
- Ran `git diff --check`.
