### PR TITLE
fix(helm): default image tag to appVersion

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the ModelExpress chart 
 | `replicaCount`                               | Number of ModelExpress replicas                | `1`     |
 | `image.repository`                           | ModelExpress image repository                  | `nvcr.io/nvidia/ai-dynamo/modelexpress-server` |
 | `image.pullPolicy`                           | Image pull policy                              | `IfNotPresent` |
-| `image.tag`                                  | ModelExpress image tag                         | `0.3.0` |
+| `image.tag`                                  | ModelExpress image tag                         | Chart `appVersion` |
 | `imagePullSecrets`                           | Image pull secrets for nvcr.io access          | `[]`     |
 | `nameOverride`                               | Override the chart name                        | `""`     |
 | `fullnameOverride`                           | Override the full app name                     | `""`     |

--- a/helm/test-values.yaml
+++ b/helm/test-values.yaml
@@ -7,7 +7,8 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
 
 serviceAccount:
   create: true

--- a/helm/values-development.yaml
+++ b/helm/values-development.yaml
@@ -7,7 +7,8 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
 
 serviceAccount:
   create: true

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -7,7 +7,8 @@ replicaCount: 3
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: Always
-  tag: "0.3.0"
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
 
 serviceAccount:
   create: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,7 +10,8 @@ replicaCount: 1
 image:
   repository: nvcr.io/nvidia/ai-dynamo/modelexpress-server
   pullPolicy: IfNotPresent
-  tag: "0.3.0"
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
 
 imagePullSecrets:
   - name: nvcr-secret


### PR DESCRIPTION
## Summary

- leave the default image tag empty in the default, development, production, and test values
- use the chart's existing `.Chart.AppVersion` fallback for default image selection
- document the effective image tag default

## Root cause

The chart template already falls back to `.Chart.AppVersion`, but all four values files pinned `image.tag` to `0.3.0`. That non-empty value bypassed the fallback, so a chart version bump could leave the deployed server image on 0.3.0.

With this change, release version bumps only need to update `Chart.yaml`. Users can still override `image.tag` explicitly.

Fixes NVBugs 6622121.

## Validation

- rendered each of `values.yaml`, `values-development.yaml`, `values-production.yaml`, and `test-values.yaml`; all select main's chart `appVersion` (`modelexpress-server:0.5.0`)
- rendered with `--set image.tag=custom-test-tag`; the explicit override remains effective
- ran `helm lint` with each values profile; all passed
- ran `git diff --check`
