### PR TITLE
fix(reshard): map global QKV intervals when KV heads are below TP

### DIFF
--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/aliases.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/aliases.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -172,6 +173,187 @@ def _build_qkv_aliases(
 ) -> list[PublishedTensor]:
     if len(item.hf_names) != 3 or item.tensor.ndim != 2:
         raise ValueError(f"{item.name}: QKV aliasing requires 2D q/k/v weights")
+    has_global_q = "num_heads" in item.extras
+    has_global_kv = "num_kv_heads" in item.extras
+    if has_global_q != has_global_kv:
+        raise ValueError(
+            f"{item.name}: global QKV metadata requires both num_heads and num_kv_heads"
+        )
+    if has_global_q:
+        return _build_global_qkv_aliases(item, agent_name)
+    return _build_legacy_qkv_aliases(item, agent_name)
+
+
+def _qkv_source_interval(item: MegatronTensorSpec) -> tuple[int, int]:
+    """Return this rank's raw row interval in the global fused QKV tensor."""
+    local_rows = int(item.tensor.shape[0])
+    global_rows = int(item.global_shape[0])
+    if item.placement_kind != "SHARD":
+        if local_rows != global_rows:
+            raise ValueError(f"{item.name}: replicated QKV shape mismatch")
+        return 0, global_rows
+    if item.shard_axis != 0 or item.local_shard_range is None:
+        raise ValueError(f"{item.name}: QKV shards must carry a row range")
+    lo, hi = (int(value) for value in item.local_shard_range)
+    if not 0 <= lo < hi <= global_rows or hi - lo != local_rows:
+        raise ValueError(f"{item.name}: inconsistent QKV source row interval")
+    return lo, hi
+
+
+_Q, _K, _V = 0, 1, 2
+
+
+@dataclass(frozen=True)
+class _QkvBand:
+    """One run of fused rows that belongs to a single projection.
+
+    ``destination_start`` is where the run lands in that projection's own
+    tensor, which is not where it sits in the fused tensor.
+    """
+
+    projection: int
+    start: int
+    rows: int
+    destination_start: int
+
+
+@dataclass(frozen=True)
+class _QkvLayout:
+    """Global row layout of a fused QKV tensor, derived from head counts.
+
+    Megatron lays the tensor out as one block per KV group: that group's query
+    rows, then its single K head, then its single V head. Blocks repeat for
+    every KV group, so Q, K and V rows interleave rather than forming three
+    contiguous regions.
+    """
+
+    head_dim: int
+    q_heads: int
+    kv_heads: int
+
+    @property
+    def q_rows_per_group(self) -> int:
+        return (self.q_heads // self.kv_heads) * self.head_dim
+
+    @property
+    def group_rows(self) -> int:
+        return self.q_rows_per_group + 2 * self.head_dim
+
+    @property
+    def total_rows(self) -> int:
+        return self.kv_heads * self.group_rows
+
+    @property
+    def destination_rows(self) -> tuple[int, int, int]:
+        """Row count of the whole q, k and v tensors this layout unpacks into."""
+        kv_rows = self.kv_heads * self.head_dim
+        return self.q_heads * self.head_dim, kv_rows, kv_rows
+
+    def bands(self) -> Iterator[_QkvBand]:
+        """Yield every projection run, in global row order."""
+        for group in range(self.kv_heads):
+            group_start = group * self.group_rows
+            k_start = group_start + self.q_rows_per_group
+            yield _QkvBand(
+                _Q, group_start, self.q_rows_per_group, group * self.q_rows_per_group
+            )
+            yield _QkvBand(_K, k_start, self.head_dim, group * self.head_dim)
+            yield _QkvBand(
+                _V, k_start + self.head_dim, self.head_dim, group * self.head_dim
+            )
+
+
+def _read_qkv_layout(item: MegatronTensorSpec) -> _QkvLayout:
+    """Validate the published global head metadata and derive the row layout."""
+    if item.extras.get("qkv_interleave") != "by_head":
+        raise ValueError(
+            f"{item.name}: global QKV aliasing requires qkv_interleave='by_head'"
+        )
+    if "head_dim" not in item.extras:
+        raise ValueError(
+            f"{item.name}: global QKV aliasing requires extras['head_dim']"
+        )
+    layout = _QkvLayout(
+        head_dim=int(item.extras["head_dim"]),
+        q_heads=int(item.extras["num_heads"]),
+        kv_heads=int(item.extras["num_kv_heads"]),
+    )
+    if (
+        layout.head_dim < 1
+        or layout.q_heads < 1
+        or layout.kv_heads < 1
+        or layout.q_heads % layout.kv_heads
+    ):
+        raise ValueError(f"{item.name}: invalid global Q/KV head geometry")
+    return layout
+
+
+def _build_global_qkv_aliases(
+    item: MegatronTensorSpec, agent_name: str
+) -> list[PublishedTensor]:
+    """Map one raw TP row interval through Megatron's global QKV interleave.
+
+    This rank owns a single contiguous interval of fused rows. Intersecting it
+    with each band says which projection those rows belong to and where they
+    land, so a rank that happens to own no K or V rows simply matches no K or V
+    band.
+    """
+    layout = _read_qkv_layout(item)
+    hidden = int(item.tensor.shape[1])
+    if len(item.global_shape) != 2 or int(item.global_shape[1]) != hidden:
+        raise ValueError(f"{item.name}: QKV hidden dimension mismatch")
+    if int(item.global_shape[0]) != layout.total_rows:
+        raise ValueError(f"{item.name}: global QKV rows disagree with head metadata")
+
+    source_lo, source_hi = _qkv_source_interval(item)
+    shards: tuple[list[PublishedShard], ...] = ([], [], [])
+    mapped_rows = 0
+    for band in layout.bands():
+        overlap_lo = max(source_lo, band.start)
+        overlap_hi = min(source_hi, band.start + band.rows)
+        if overlap_lo >= overlap_hi:
+            continue
+        tensor = item.tensor.narrow(0, overlap_lo - source_lo, overlap_hi - overlap_lo)
+        shards[band.projection].append(
+            PublishedShard(
+                agent_name=agent_name,
+                device_id=int(tensor.device.index or 0),
+                addr=int(tensor.data_ptr()),
+                shard_offset=(band.destination_start + overlap_lo - band.start, 0),
+                shape=tuple(int(dim) for dim in tensor.shape),
+                digest=published_digest(tensor),
+            )
+        )
+        mapped_rows += overlap_hi - overlap_lo
+
+    if mapped_rows != int(item.tensor.shape[0]):
+        raise ValueError(
+            f"{item.name}: QKV interval mapping covered {mapped_rows} of "
+            f"{int(item.tensor.shape[0])} source rows"
+        )
+
+    # When KV heads are fewer than TP ranks, most publishers legitimately own no
+    # K or V rows. Other ranks contribute those destination intervals when the
+    # per-rank tables are merged.
+    return [
+        PublishedTensor(
+            name=name,
+            dtype=str(item.tensor.dtype),
+            elsize=int(item.tensor.element_size()),
+            full_shape=(rows, hidden),
+            shards=projection_shards,
+        )
+        for name, rows, projection_shards in zip(
+            item.hf_names, layout.destination_rows, shards, strict=True
+        )
+        if projection_shards
+    ]
+
+
+def _build_legacy_qkv_aliases(
+    item: MegatronTensorSpec, agent_name: str
+) -> list[PublishedTensor]:
+    """Compatibility path for descriptors whose head counts divide across TP."""
     required = ("head_dim", "num_heads_local", "num_kv_heads_local")
     missing = [key for key in required if key not in item.extras]
     if missing:

--- a/modelexpress_client/python/tests/test_reshard_megatron_gqa.py
+++ b/modelexpress_client/python/tests/test_reshard_megatron_gqa.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from modelexpress.refit.reshard.rendezvous import build_sources, merge_shard_tables
+from modelexpress.refit.reshard.transfer_plan import plan_transfer
+from modelexpress.refit.reshard.types import CaptureResult, RecordedCopy
+from modelexpress_rl.train.engines.megatron import (
+    MegatronTensorSpec,
+    build_hf_aliases,
+)
+
+HF_NAMES = ("q_proj.weight", "k_proj.weight", "v_proj.weight")
+
+
+def _global_fused(q_heads: int, kv_heads: int, head_dim: int, hidden: int):
+    rows = (q_heads + 2 * kv_heads) * head_dim
+    return torch.arange(rows * hidden, dtype=torch.float32).reshape(rows, hidden)
+
+
+def _global_extras(q_heads: int, kv_heads: int, head_dim: int):
+    return {
+        "qkv_interleave": "by_head",
+        "num_heads": str(q_heads),
+        "num_kv_heads": str(kv_heads),
+        "head_dim": str(head_dim),
+    }
+
+
+def _publish_all_ranks(
+    q_heads: int, kv_heads: int, tp_size: int, head_dim: int, hidden: int = 3
+):
+    fused = _global_fused(q_heads, kv_heads, head_dim, hidden)
+    assert fused.shape[0] % tp_size == 0
+    local_rows = fused.shape[0] // tp_size
+    published = []
+    locals_by_agent = {}
+    for rank in range(tp_size):
+        lo = rank * local_rows
+        hi = lo + local_rows
+        local = fused[lo:hi].clone()
+        agent = f"tp{rank}"
+        locals_by_agent[agent] = local
+        published.extend(
+            build_hf_aliases(
+                [
+                    MegatronTensorSpec(
+                        name="linear_qkv.weight",
+                        tensor=local,
+                        role="qkv_column",
+                        hf_names=HF_NAMES,
+                        global_shape=tuple(fused.shape),
+                        placement_kind="SHARD" if tp_size > 1 else "REPLICATE",
+                        shard_axis=0 if tp_size > 1 else None,
+                        local_shard_range=(lo, hi) if tp_size > 1 else None,
+                        extras=_global_extras(q_heads, kv_heads, head_dim),
+                    )
+                ],
+                agent_name=agent,
+            )
+        )
+    return fused, locals_by_agent, published
+
+
+def _expected_hf(fused: torch.Tensor, q_heads: int, kv_heads: int, head_dim: int):
+    q_per_group = q_heads // kv_heads
+    q_rows = q_per_group * head_dim
+    group_rows = q_rows + 2 * head_dim
+    q, k, v = [], [], []
+    for group in range(kv_heads):
+        group_lo = group * group_rows
+        q.append(fused[group_lo : group_lo + q_rows])
+        k.append(fused[group_lo + q_rows : group_lo + q_rows + head_dim])
+        v.append(fused[group_lo + q_rows + head_dim : group_lo + group_rows])
+    return tuple(torch.cat(parts) for parts in (q, k, v))
+
+
+def _reconstruct(published, locals_by_agent):
+    by_name = {name: [] for name in HF_NAMES}
+    full_shapes = {}
+    for tensor in published:
+        by_name[tensor.name].extend(tensor.shards)
+        full_shapes[tensor.name] = tensor.full_shape
+
+    actual = []
+    for name in HF_NAMES:
+        assert name in full_shapes
+        sample = next(iter(locals_by_agent.values()))
+        destination = torch.empty(
+            full_shapes[name], dtype=sample.dtype, device=sample.device
+        )
+        coverage = torch.zeros(full_shapes[name][0], dtype=torch.int32)
+        for shard in by_name[name]:
+            local = locals_by_agent[shard.agent_name]
+            row_bytes = local.shape[1] * local.element_size()
+            byte_offset = shard.addr - local.data_ptr()
+            assert byte_offset % row_bytes == 0
+            source_lo = byte_offset // row_bytes
+            rows = shard.shape[0]
+            destination_lo = shard.shard_offset[0]
+            destination[destination_lo : destination_lo + rows].copy_(
+                local[source_lo : source_lo + rows]
+            )
+            coverage[destination_lo : destination_lo + rows] += 1
+        assert torch.all(coverage == 1), (name, coverage)
+        actual.append(destination)
+
+    for agent, local in locals_by_agent.items():
+        source_coverage = torch.zeros(local.shape[0], dtype=torch.int32)
+        for shards in by_name.values():
+            for shard in shards:
+                if shard.agent_name != agent:
+                    continue
+                row_bytes = local.shape[1] * local.element_size()
+                source_lo = (shard.addr - local.data_ptr()) // row_bytes
+                source_coverage[source_lo : source_lo + shard.shape[0]] += 1
+        assert torch.all(source_coverage == 1), (agent, source_coverage)
+    return tuple(actual)
+
+
+def _tables_by_agent(published):
+    tables = {}
+    for tensor in published:
+        assert tensor.shards
+        agent = tensor.shards[0].agent_name
+        assert all(shard.agent_name == agent for shard in tensor.shards)
+        tables.setdefault(agent, []).append(tensor)
+    return [tables[name] for name in sorted(tables)]
+
+
+def _full_copy(name: str, shape: tuple[int, int]) -> RecordedCopy:
+    return RecordedCopy(
+        src_name=name,
+        op_chain=(),
+        param_name=name,
+        dest_offset=0,
+        dest_shape=shape,
+        dest_stride=(shape[1], 1),
+        dest_dtype=torch.float32,
+    )
+
+
+@pytest.mark.parametrize(
+    ("q_heads", "kv_heads", "tp_size", "head_dim"),
+    [
+        (32, 4, 2, 4),
+        (32, 4, 1, 4),
+        (64, 2, 8, 128),
+        (24, 6, 4, 2),
+    ],
+)
+def test_global_interval_aliases_cover_qkv_without_gaps_or_overlaps(
+    q_heads: int, kv_heads: int, tp_size: int, head_dim: int
+):
+    fused, locals_by_agent, published = _publish_all_ranks(
+        q_heads, kv_heads, tp_size, head_dim
+    )
+
+    actual = _reconstruct(published, locals_by_agent)
+    expected = _expected_hf(fused, q_heads, kv_heads, head_dim)
+
+    assert all(
+        torch.equal(got, want) for got, want in zip(actual, expected, strict=True)
+    )
+
+
+def test_kv_below_tp_only_advertises_kv_on_ranks_that_own_it():
+    _, _, published = _publish_all_ranks(64, 2, 8, 128)
+    names_by_agent = {f"tp{rank}": set() for rank in range(8)}
+    for tensor in published:
+        for shard in tensor.shards:
+            names_by_agent[shard.agent_name].add(tensor.name)
+
+    assert names_by_agent["tp0"] == {"q_proj.weight"}
+    assert names_by_agent["tp3"] == set(HF_NAMES)
+    assert names_by_agent["tp4"] == {"q_proj.weight"}
+    assert names_by_agent["tp7"] == set(HF_NAMES)
+
+
+def test_two_layers_may_use_different_qkv_geometry():
+    fixtures = [(64, 2, 8, 128), (32, 8, 8, 64)]
+    for q_heads, kv_heads, tp_size, head_dim in fixtures:
+        fused, locals_by_agent, published = _publish_all_ranks(
+            q_heads, kv_heads, tp_size, head_dim
+        )
+        actual = _reconstruct(published, locals_by_agent)
+        expected = _expected_hf(fused, q_heads, kv_heads, head_dim)
+        assert all(
+            torch.equal(got, want) for got, want in zip(actual, expected, strict=True)
+        )
+
+
+def test_divisible_global_descriptors_match_legacy_aliases_byte_for_byte():
+    q_heads, kv_heads, tp_size, head_dim, hidden = 32, 4, 2, 4, 3
+    fused = _global_fused(q_heads, kv_heads, head_dim, hidden)
+    local_rows = fused.shape[0] // tp_size
+    for rank in range(tp_size):
+        lo = rank * local_rows
+        hi = lo + local_rows
+        local = fused[lo:hi].clone()
+        common = {
+            "name": "linear_qkv.weight",
+            "tensor": local,
+            "role": "qkv_column",
+            "hf_names": HF_NAMES,
+            "global_shape": tuple(fused.shape),
+            "placement_kind": "SHARD",
+            "shard_axis": 0,
+            "local_shard_range": (lo, hi),
+        }
+        legacy = build_hf_aliases(
+            [
+                MegatronTensorSpec(
+                    **common,
+                    extras={
+                        "num_heads_local": str(q_heads // tp_size),
+                        "num_kv_heads_local": str(kv_heads // tp_size),
+                        "head_dim": str(head_dim),
+                    },
+                )
+            ],
+            agent_name=f"tp{rank}",
+        )
+        global_aliases = build_hf_aliases(
+            [
+                MegatronTensorSpec(
+                    **common,
+                    extras=_global_extras(q_heads, kv_heads, head_dim),
+                )
+            ],
+            agent_name=f"tp{rank}",
+        )
+        assert global_aliases == legacy
+
+
+def test_sparse_kv_tables_merge_into_a_complete_bounded_plan():
+    _, _, published = _publish_all_ranks(64, 2, 8, 128)
+    merged = merge_shard_tables(_tables_by_agent(published))
+    sources, _, _ = build_sources(merged)
+    capture = CaptureResult(
+        copies=[
+            _full_copy(name, tuple(sources[name].global_shape)) for name in HF_NAMES
+        ]
+    )
+
+    plan = plan_transfer(capture, sources, max_segments_per_copy=1)
+
+    assert plan.fallback == []
+    assert {pull.src_name for pull in plan.full_pulls} == set(HF_NAMES)
+    assert plan.bytes_planned() == sum(
+        tensor.numel() * tensor.element_size()
+        for tensor in _expected_hf(_global_fused(64, 2, 128, 3), 64, 2, 128)
+    )
+
+
+def test_missing_kv_publishers_fail_closed_instead_of_silently_falling_back():
+    _, _, published = _publish_all_ranks(64, 2, 8, 128)
+    q_only = [tensor for tensor in published if tensor.name == HF_NAMES[0]]
+    sources, _, _ = build_sources(merge_shard_tables(_tables_by_agent(q_only)))
+    capture = CaptureResult(
+        copies=[
+            _full_copy(HF_NAMES[0], (64 * 128, 3)),
+            _full_copy(HF_NAMES[1], (2 * 128, 3)),
+            _full_copy(HF_NAMES[2], (2 * 128, 3)),
+        ]
+    )
+
+    plan = plan_transfer(capture, sources)
+
+    assert set(plan.fallback) == {HF_NAMES[1], HF_NAMES[2]}
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA tensors")
+def test_cuda_64q_2kv_tp8_noop_and_moving_weight_refits_match_logits():
+    device = torch.device("cuda", 0)
+    q_heads, kv_heads, tp_size, head_dim, hidden = 64, 2, 8, 128, 64
+    rows = (q_heads + 2 * kv_heads) * head_dim
+    generator = torch.Generator(device=device).manual_seed(20260818)
+    base = torch.randn(
+        (rows, hidden),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    activation = torch.randn(
+        (4, hidden),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+
+    def refit(fused):
+        local_rows = fused.shape[0] // tp_size
+        published = []
+        locals_by_agent = {}
+        for rank in range(tp_size):
+            lo = rank * local_rows
+            hi = lo + local_rows
+            agent = f"tp{rank}"
+            local = fused[lo:hi].clone()
+            locals_by_agent[agent] = local
+            published.extend(
+                build_hf_aliases(
+                    [
+                        MegatronTensorSpec(
+                            name="linear_qkv.weight",
+                            tensor=local,
+                            role="qkv_column",
+                            hf_names=HF_NAMES,
+                            global_shape=tuple(fused.shape),
+                            placement_kind="SHARD",
+                            shard_axis=0,
+                            local_shard_range=(lo, hi),
+                            extras=_global_extras(q_heads, kv_heads, head_dim),
+                        )
+                    ],
+                    agent_name=agent,
+                )
+            )
+        actual = _reconstruct(published, locals_by_agent)
+        expected = _expected_hf(fused, q_heads, kv_heads, head_dim)
+        assert all(
+            torch.equal(got, want)
+            for got, want in zip(actual, expected, strict=True)
+        )
+        actual_logits = tuple(activation @ weight.T for weight in actual)
+        expected_logits = tuple(activation @ weight.T for weight in expected)
+        assert all(
+            torch.equal(got, want)
+            for got, want in zip(actual_logits, expected_logits, strict=True)
+        )
+        return actual
+
+    no_op = refit(base)
+    moving = refit(base + torch.tensor(0.125, dtype=base.dtype, device=device))
+
+    assert any(
+        not torch.equal(before, after)
+        for before, after in zip(no_op, moving, strict=True)
+    )
+
+
+@pytest.mark.parametrize(
+    ("extras", "global_rows", "match"),
+    [
+        (
+            {"num_heads": "64", "head_dim": "128", "qkv_interleave": "by_head"},
+            8704,
+            "requires both",
+        ),
+        (
+            {
+                "num_heads": "64",
+                "num_kv_heads": "2",
+                "qkv_interleave": "by_head",
+            },
+            8704,
+            "head_dim",
+        ),
+        (_global_extras(64, 2, 128), 8192, "rows disagree"),
+        (
+            {**_global_extras(64, 2, 128), "qkv_interleave": "unsupported"},
+            8704,
+            "qkv_interleave",
+        ),
+        (_global_extras(63, 2, 128), 8576, "invalid global"),
+    ],
+)
+def test_unrecoverable_global_geometry_fails_closed(extras, global_rows, match):
+    assert global_rows % 8 == 0
+    local = torch.zeros(global_rows // 8, 3)
+    with pytest.raises(ValueError, match=match):
+        build_hf_aliases(
+            [
+                MegatronTensorSpec(
+                    name="linear_qkv.weight",
+                    tensor=local,
+                    role="qkv_column",
+                    hf_names=HF_NAMES,
+                    global_shape=(global_rows, 3),
+                    placement_kind="SHARD",
+                    shard_axis=0,
+                    local_shard_range=(0, local.shape[0]),
+                    extras=extras,
+                )
+            ],
+            agent_name="tp0",
+        )


### PR DESCRIPTION
## The bug

Publishing a Megatron fused QKV tensor computed a local KV head count as `num_kv_heads // tp_size`. Nemotron Ultra has 64 query heads but only **2** KV heads, so at TP8 that is `2 // 8 = 0` — either a `ZeroDivisionError` or `invalid local Q/KV head geometry`, depending on the path.

The arithmetic wasn't the problem. The premise was.

## Why the premise was wrong

Megatron does not hand every TP rank a whole KV head. It slices the globally interleaved fused QKV tensor **by raw rows**. When KV heads are fewer than TP ranks, most ranks legitimately own query rows and no K or V rows at all. There is no local KV head count to compute, so no amount of fixing the division helps.

Megatron's row order is one block per KV group — that group's query rows, then its single K head, then its single V head — repeated per group. Q, K and V therefore interleave rather than forming three contiguous regions:

```mermaid
flowchart LR
    subgraph G0["KV group 0"]
      Q0["Q rows"] --> K0["K head"] --> V0["V head"]
    end
    subgraph G1["KV group 1"]
      Q1["Q rows"] --> K1["K head"] --> V1["V head"]
    end
    G0 --> G1
```

## The fix

Map each rank's **real row interval** through that layout instead of inventing a local head count.

```mermaid
flowchart LR
    E[Global per-layer Q/KV metadata] --> L[_QkvLayout]
    L --> B["bands(): projection runs<br/>in global row order"]
    S[This rank's raw fused-row interval] --> X[Interval intersection]
    B --> X
    X --> Q[q_proj shards]
    X --> K[k_proj shards]
    X --> V[v_proj shards]
```

A rank that owns no K/V rows simply matches no K/V band and publishes Q only. The sparse per-rank offers merge into complete tensors downstream.

## Review guide

Two files, and they are the whole change:

| File | Lines | What to look at |
| --- | --- | --- |
| `modelexpress_rl/train/engines/megatron/aliases.py` | +182 | the mapping itself |
| `tests/test_reshard_megatron_gqa.py` | +390 | reconstruction and planner coverage |

In `aliases.py`, the code is deliberately arranged so the layout is a named thing rather than index arithmetic inside a loop:

- **`_QkvLayout`** — holds the head counts, derives the group geometry.
- **`bands()`** — states Megatron's row order exactly **once**, as a sequence of runs. If our understanding of Megatron's layout is ever wrong, or upstream changes it, this is the single place to correct.
- **`_read_qkv_layout`** — validates the published metadata; half-specified metadata fails closed rather than guessing.
- **`_build_global_qkv_aliases`** — a plain interval intersection against those runs.

Worth scrutinising: the per-group overlap math, that every source row is mapped **exactly once** (there's an explicit coverage assertion), that empty K/V tensors are omitted rather than published as zero-row tensors, and that divisible layouts still take the legacy path unchanged.

## Compatibility

Descriptors carrying only the old divisible local-head fields keep working through the legacy path, so this is not a breaking change for existing topologies. The new path activates only when global head metadata is present.

Requires the companion NeMo-RL change that publishes global, per-layer QKV geometry: NVIDIA-NeMo/RL#3632. Neither half is useful alone — NeMo-RL publishes the geometry, ModelExpress maps the intervals.

## Evidence, and what is still missing

Qualified on CPU and representative CUDA tensors:

- Q=64, KV=2, head_dim=128 at logical TP8 reconstructs byte-exact Q/K/V with no gaps or overlaps
- ranks without K/V rows publish Q only, and sparse tables merge into complete sources with zero fallback
- divisible layouts remain byte-for-byte identical to the legacy local-head path
- 24Q/6KV/TP4 and heterogeneous per-layer geometry are covered
- missing or invalid global geometry fails closed
- BF16 CUDA same-weight and changed-weight refits agree on parameters and projection outputs

**Not yet covered:** real Megatron TP8 to vLLM TP8 end-to-end for Q=64/KV=2, and full Nemotron Ultra qualification. I'd rather state that plainly than imply this is fully qualified.

## Known limitation

This reverse-engineers Megatron's fused-QKV row order rather than obtaining it from a supported interface, so it is sensitive to upstream Megatron changes. `bands()` exists to keep that assumption in one auditable place. Asking Megatron to expose the layout properly is the right long-term fix and is worth a follow-up.

## Test plan

- `PYTHONPATH=. python3 -m pytest tests/test_reshard_megatron_gqa.py -q` — 15 passed
- Full reshard suite on this branch — no regressions
- Real Megatron TP8 to vLLM TP8 Q=64/KV=2 E2E
- Full Nemotron Ultra qualification

## Context

Split out of #635 at review request, to grow this surface gradually rather than land it all at once. Independent of the other split PRs — it touches only `aliases.py` and its test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Megatron models using grouped-query attention (GQA), including interleaved head layouts and uneven query/key-value distribution across devices.
  * Added reliable reconstruction of Q, K, and V weights across supported parallel configurations.

* **Bug Fixes**
  * Prevented incomplete or inconsistent model metadata from producing incorrect weight mappings.
  * Improved handling of sparse key/value assignments and missing tensors with safe failure behavior.
  * Verified refits preserve model outputs across supported GPU configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->