### PR TITLE
feat(metrics): per-RPC and storage-backend metrics on the server

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,12 @@ ModelExpress/
 │       ├── backend_config.rs           # Shared BackendConfig (Redis / K8s) + env parsing
 │       ├── cache.rs                    # CacheEvictionService, LRU policy
 │       ├── services.rs                 # Health, API, Model gRPC services + ModelDownloadTracker
+│       ├── metrics.rs                   # Prometheus registry, mx_build_info, encoding
+│       ├── metrics/
+│       │   ├── exposition.rs            # HTTP/1.1 /metrics listener (separate port)
+│       │   ├── buckets.rs               # Shared histogram bucket boundaries
+│       │   ├── grpc.rs                  # Per-RPC tower layer; in-handler outcomes
+│       │   └── backend.rs               # Backend op counters and latency
 │       ├── p2p/
 │       │   ├── state.rs                # P2pStateManager wrapper
 │       │   ├── service.rs              # P2P gRPC service implementation
@@ -94,13 +100,15 @@ ModelExpress/
 │       │   ├── backend.rs              # MetadataBackend trait + types
 │       │   └── backend/
 │       │       ├── redis.rs            # P2P Redis backend
-│       │       └── kubernetes.rs       # P2P Kubernetes CRD backend
+│       │       ├── kubernetes.rs       # P2P Kubernetes CRD backend
+│       │       └── instrumented.rs     # Metrics decorator over MetadataBackend
 │       ├── refit.rs                     # Refit module exports
 │       ├── refit/
 │       │   ├── service.rs               # Backend-neutral Refit gRPC service
 │       │   ├── backend.rs               # RefitBackend contract and factory
 │       │   └── backend/
-│       │       └── redis.rs             # Redis backend and atomic Lua scripts
+│       │       ├── redis.rs             # Redis backend and atomic Lua scripts
+│       │       └── instrumented.rs      # Metrics decorator over RefitBackend
 │       ├── registry/
 │       │   ├── state.rs                # RegistryManager wrapper
 │       │   ├── backend.rs              # RegistryBackend trait + ModelRecord
@@ -108,7 +116,8 @@ ModelExpress/
 │       │   ├── k8s_types.rs            # ModelCacheEntry CRD type
 │       │   └── backend/
 │       │       ├── redis.rs            # Redis registry backend
-│       │       └── kubernetes.rs       # K8s ModelCacheEntry registry backend
+│       │       ├── kubernetes.rs       # K8s ModelCacheEntry registry backend
+│       │       └── instrumented.rs     # Metrics decorator over RegistryBackend
 │       └── bin/
 │           └── config_gen.rs           # Config file generator/migrator
 │

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -10,9 +10,9 @@ default, and the Python client, opt-in. This page covers how to scrape both,
 what the pipeline guarantees, and the two operational choices it leaves to the
 deployment.
 
-This documents what ships today: the exposition path and `mx_build_info`, the
-family that later ones join against. Request/backend coverage, the load and
-transfer timing tiers, and the dashboard surface come later and are not here yet.
+This documents what ships today: the exposition path, `mx_build_info`, and
+per-RPC and storage-backend coverage on the server. The load and transfer timing
+tiers and the dashboard surface come later and are not here yet.
 
 ---
 
@@ -167,6 +167,67 @@ of the deployment export it, distinguished by `component`.
 | Family | Type | Labels |
 | --- | --- | --- |
 | `mx_build_info` | Gauge (= 1) | `component="server"`, `version`, `backend`, `scheme` |
+| `mx_grpc_requests_total` | Counter | `method`, `outcome` |
+| `mx_grpc_request_seconds` | Histogram | `method`, `outcome` |
+| `mx_grpc_requests_in_flight` | Gauge | `method` |
+| `mx_backend_ops_total` | Counter | `store`, `op`, `result` |
+| `mx_backend_op_seconds` | Histogram | `store`, `op`, `result` |
+| `mx_backend_ops_in_flight` | Gauge | `store`, `op` |
+
+`method` is a closed set of the 21 routed RPCs plus `other`; an unrecognised path
+cannot mint a series.
+
+`outcome` includes `cancelled`, recorded from a drop guard when the caller goes
+away before the handler finishes -- a client disconnect, an `RST_STREAM`, or a
+deadline. Without it the gap would not be uniform: the requests most likely to be
+cancelled are the slow ones, so the latency histogram would be conditioned on
+completion and its tail would look healthy precisely because the slowest samples
+were missing. A cancellation increments the counter only and writes no latency
+sample, since a partial duration would enter the distribution as a fast one.
+
+The two `_in_flight` gauges are the direct reading of the same situation: a store
+that wedges while its peers serve normally shows up immediately as operations
+accumulating, instead of having to be inferred from an absence of samples. They
+are plain gauges rather than the `_started_total`/`_finished_total` counter pairs
+the client side uses, because that pattern exists to survive a SIGKILLed rank
+under multiprocess mode -- the server is one process with an in-process registry,
+so there is nothing to wedge.
+
+**The two streaming RPCs are deliberately absent.** `EnsureModelDownloaded` and
+`StreamModelFiles` return their response head as soon as the stream is set up and
+report failure as a stream item or trailer, so recording at the head would show
+`outcome="ok"` and a sub-millisecond duration for a download that ran for forty
+minutes and failed. `Health/Watch` is excluded for the same reason. Timing these
+means instrumenting the response body, which is a later change; until then they
+are absent rather than wrong. `store` names the subsystem (`p2p`, `registry`, `refit`),
+not the storage engine -- only one engine is live per pod, so the engine is
+carried by `mx_build_info{backend=...}` and joined from there.
+
+#### `outcome` is not the gRPC status code
+
+Several handlers report failure *in band*: they return `Ok` carrying
+`success: false`, or an empty list. `ListSources` is the clearest case -- a
+backend outage and "no peers have published yet" are the same
+`Ok(ListSourcesResponse { instances: [] })` on the wire.
+
+A metric derived from the status code would therefore read 100% success straight
+through a total backend outage. Instead each handler publishes its own verdict,
+which the metrics layer prefers over anything it could infer:
+
+```promql
+# Backend outages, which a status-code-derived metric would report as success.
+sum by (method) (rate(mx_grpc_requests_total{outcome="backend_error"}[5m]))
+```
+
+`backend_error` is wider than the metadata store: every `Unavailable` maps to it,
+including the auth layer's when the Kubernetes TokenReview API is down. That case
+appears on every method at once and can read like a total store outage, so
+confirm against `mx_backend_ops_total{result="error"}` -- a real store outage
+lights that family up too.
+
+Handlers that fail honestly with `Err(Status)` need no such tag -- the status
+carries itself -- so only the handlers that would otherwise misreport are
+touched.
 
 ### Client
 

--- a/modelexpress_server/src/metrics.rs
+++ b/modelexpress_server/src/metrics.rs
@@ -28,7 +28,10 @@
 //!   Redis `SCAN` or a similar keyspace walk belongs in a refresh task that
 //!   writes a plain gauge; the scrape only encodes what is already in memory.
 
+pub mod backend;
+pub mod buckets;
 pub mod exposition;
+pub mod grpc;
 
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::encoding::text::encode;

--- a/modelexpress_server/src/metrics/backend.rs
+++ b/modelexpress_server/src/metrics/backend.rs
@@ -1,0 +1,355 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the storage backends behind the server.
+//!
+//! Three unrelated traits sit between the server and its storage --
+//! `MetadataBackend` (P2P source metadata), `RegistryBackend` (model registry)
+//! and `RefitBackend` (weight versions) -- each with its own error type and no
+//! common supertrait. They are instrumented by decorators that implement the
+//! same trait and delegate, so the concrete Redis, Kubernetes and in-memory
+//! implementations are untouched and a new backend is instrumented by
+//! construction rather than by remembering to add timing code.
+//!
+//! `store` names the **subsystem**, not the storage engine. Only one engine is
+//! live per pod, so `store="redis"` would be a constant; the engine is already
+//! carried by `mx_build_info{backend=...}` and joins on from there. Naming the
+//! subsystem also keeps `op="connect"` unambiguous, which it would not be if two
+//! subsystems both reported it against the same engine.
+
+use std::future::Future;
+use std::time::Instant;
+
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
+
+use super::buckets;
+
+/// Which storage subsystem performed the operation.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum Store {
+    /// P2P source metadata (`MetadataBackend`).
+    P2p,
+    /// Model registry (`RegistryBackend`).
+    Registry,
+    /// Weight-version store for RL refit (`RefitBackend`).
+    Refit,
+}
+
+impl Store {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::P2p => "p2p",
+            Self::Registry => "registry",
+            Self::Refit => "refit",
+        }
+    }
+}
+
+// Hand-written for the same reason as `RpcOutcome`: the derive would encode the
+// variant identifier, giving `P2p` rather than `p2p`.
+impl EncodeLabelValue for Store {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_str(), encoder)
+    }
+}
+
+/// Whether the operation succeeded.
+///
+/// Two values only. The error *kind* is deliberately not a label: the three
+/// backends have three unrelated error types, two of them boxed
+/// `dyn Error`, so any faithful mapping would be an unbounded string.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum OpResult {
+    /// The operation returned `Ok`.
+    Ok,
+    /// The operation returned `Err`.
+    Error,
+    /// The caller was dropped before the operation finished. Recorded from a
+    /// drop guard, so a store that hangs is visible rather than absent.
+    Cancelled,
+}
+
+impl OpResult {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Error => "error",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl EncodeLabelValue for OpResult {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_str(), encoder)
+    }
+}
+
+/// Label set for the backend families.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct BackendLabels {
+    /// Storage subsystem.
+    pub store: Store,
+    /// Trait method name. Bounded because every call site passes a literal.
+    pub op: &'static str,
+    /// Success or failure.
+    pub result: OpResult,
+}
+
+/// Label set for in-flight tracking. No `result`: an operation still running
+/// does not have one yet.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct BackendOpLabels {
+    /// Storage subsystem.
+    pub store: Store,
+    /// Trait method name.
+    pub op: &'static str,
+}
+
+fn fast_histogram() -> Histogram {
+    Histogram::new(buckets::FAST)
+}
+
+type LatencyFamily = Family<BackendLabels, Histogram, fn() -> Histogram>;
+
+/// Handles for the backend families. Cloning shares the underlying storage.
+#[derive(Clone)]
+pub struct BackendMetrics {
+    ops: Family<BackendLabels, Counter>,
+    latency: LatencyFamily,
+    in_flight: Family<BackendOpLabels, Gauge>,
+}
+
+impl BackendMetrics {
+    /// Register the families on `registry` and return handles to them.
+    ///
+    /// Registered without the `_total` suffix; the encoder appends it.
+    pub fn register(registry: &mut Registry) -> Self {
+        let ops = Family::<BackendLabels, Counter>::default();
+        let latency: LatencyFamily =
+            Family::new_with_constructor(fast_histogram as fn() -> Histogram);
+        let in_flight = Family::<BackendOpLabels, Gauge>::default();
+
+        let backend = registry.sub_registry_with_prefix("backend");
+        backend.register(
+            "ops",
+            "Storage backend operations by subsystem, method and result",
+            ops.clone(),
+        );
+        backend.register(
+            "op_seconds",
+            "Storage backend operation latency by subsystem, method and result",
+            latency.clone(),
+        );
+
+        // See the note in `metrics::grpc`: a plain Gauge is safe here because the
+        // server is one process with an in-process registry, so there is no
+        // SIGKILLed rank whose gauge could wedge.
+        backend.register(
+            "ops_in_flight",
+            "Storage backend operations currently running, by subsystem and method",
+            in_flight.clone(),
+        );
+
+        Self {
+            ops,
+            latency,
+            in_flight,
+        }
+    }
+
+    /// Mark one operation as started.
+    fn in_flight_inc(&self, store: Store, op: &'static str) {
+        self.in_flight
+            .get_or_create(&BackendOpLabels { store, op })
+            .inc();
+    }
+
+    /// Mark one operation as finished, however it finished.
+    fn in_flight_dec(&self, store: Store, op: &'static str) {
+        self.in_flight
+            .get_or_create(&BackendOpLabels { store, op })
+            .dec();
+    }
+
+    /// Count an operation whose future was dropped before it completed.
+    ///
+    /// The counter only, never the histogram: a partial duration would enter the
+    /// distribution as a fast sample for an operation that was in fact still
+    /// running, which biases the tail in exactly the wrong direction.
+    fn record_cancelled(&self, store: Store, op: &'static str) {
+        self.ops
+            .get_or_create(&BackendLabels {
+                store,
+                op,
+                result: OpResult::Cancelled,
+            })
+            .inc();
+    }
+
+    /// Await `future`, then record its latency and result.
+    ///
+    /// The recording happens strictly after the await. That ordering is
+    /// load-bearing: `Family::get_or_create` returns a `!Send` guard, so holding
+    /// one across an await would make the caller's future non-`Send` and break
+    /// the `#[async_trait]` bound with an error pointing at lock internals.
+    pub async fn time<T, E, F>(&self, store: Store, op: &'static str, future: F) -> Result<T, E>
+    where
+        F: Future<Output = Result<T, E>>,
+    {
+        // A hung store is precisely what this histogram exists to reveal, and a
+        // hang is precisely the case that produces no sample: whoever is waiting
+        // gives up, this future is dropped, and the recording below never runs.
+        // The guard turns that into a counter increment, and holds the in-flight
+        // gauge so a wedged store is visible while it is still wedged rather than
+        // only afterwards.
+        let mut guard = InFlightGuard::enter(self.clone(), store, op);
+        let started = Instant::now();
+        let outcome = future.await;
+        guard.pending = false;
+        let labels = BackendLabels {
+            store,
+            op,
+            result: if outcome.is_ok() {
+                OpResult::Ok
+            } else {
+                OpResult::Error
+            },
+        };
+        // `as_secs_f64` is float division; `Instant - Instant` would trip
+        // `arithmetic_side_effects`.
+        let elapsed = started.elapsed().as_secs_f64();
+        self.ops.get_or_create(&labels).inc();
+        self.latency.get_or_create(&labels).observe(elapsed);
+        outcome
+    }
+}
+
+/// Tracks one in-flight operation, and records a cancellation if the future is
+/// dropped before it completed. See the equivalent in [`crate::metrics::grpc`].
+struct InFlightGuard {
+    metrics: BackendMetrics,
+    store: Store,
+    op: &'static str,
+    /// Cleared once the operation resolves. Still set at drop means cancelled.
+    pending: bool,
+}
+
+impl InFlightGuard {
+    fn enter(metrics: BackendMetrics, store: Store, op: &'static str) -> Self {
+        metrics.in_flight_inc(store, op);
+        Self {
+            metrics,
+            store,
+            op,
+            pending: true,
+        }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        // Runs on every exit path, so the gauge cannot drift.
+        self.metrics.in_flight_dec(self.store, self.op);
+        if self.pending {
+            self.metrics.record_cancelled(self.store, self.op);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+
+    #[tokio::test]
+    async fn both_results_encode_under_the_documented_names() {
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+
+        let ok: Result<(), ()> = metrics
+            .time(Store::P2p, "list_workers", async { Ok(()) })
+            .await;
+        assert!(ok.is_ok());
+
+        let failed: Result<(), ()> = metrics
+            .time(Store::Registry, "connect", async { Err(()) })
+            .await;
+        assert!(failed.is_err());
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+
+        assert!(
+            encoded
+                .contains(r#"mx_backend_ops_total{store="p2p",op="list_workers",result="ok"} 1"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(
+                r#"mx_backend_ops_total{store="registry",op="connect",result="error"} 1"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains("mx_backend_op_seconds_bucket"),
+            "{encoded}"
+        );
+        assert!(!encoded.contains("_total_total"), "{encoded}");
+    }
+
+    /// A dropped operation is counted, and contributes no latency sample.
+    #[tokio::test]
+    async fn a_dropped_operation_is_recorded_as_cancelled() {
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+
+        // Polled, then dropped mid-flight -- the guard is created inside the
+        // async body, so it exists only once the future has been polled at least
+        // once. That is the real shape of a cancellation: a caller gives up on a
+        // store that stopped answering, exactly as the startup timeouts in
+        // `run_server` do.
+        let timed_out = tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            metrics.time(
+                Store::P2p,
+                "get_metadata",
+                std::future::pending::<Result<(), ()>>(),
+            ),
+        )
+        .await;
+        assert!(timed_out.is_err(), "the inner future should never resolve");
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_backend_ops_total{store="p2p",op="get_metadata",result="cancelled"} 1"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            !encoded.contains(r#"mx_backend_op_seconds_count{store="p2p",op="get_metadata"#),
+            "a cancellation wrote a latency sample: {encoded}"
+        );
+        // The guard decrements on every exit path, so a cancelled operation must
+        // not leave the gauge stuck above zero -- that is the failure mode a
+        // gauge has and a counter pair does not.
+        assert!(
+            encoded.contains(r#"mx_backend_ops_in_flight{store="p2p",op="get_metadata"} 0"#),
+            "in-flight gauge did not return to zero: {encoded}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_inner_value_is_passed_through_untouched() {
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+
+        let value: Result<u32, ()> = metrics.time(Store::Refit, "get", async { Ok(7) }).await;
+        assert_eq!(value, Ok(7));
+    }
+}

--- a/modelexpress_server/src/metrics/buckets.rs
+++ b/modelexpress_server/src/metrics/buckets.rs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared histogram bucket boundaries.
+//!
+//! Latency families draw their boundaries from a shared constant rather than
+//! writing literals, so two families measuring the same class of work stay
+//! comparable and one recording rule covers both. Boundaries are written out as
+//! literals rather than generated: a generator emits values like
+//! `0.00193069772888325`, which makes the `le` label churn between releases and
+//! breaks every dashboard pinned to a boundary.
+//!
+//! [`Histogram::new`](prometheus_client::metrics::histogram::Histogram::new)
+//! appends the `+Inf` bucket itself, so these arrays must not carry one.
+//!
+//! Only [`FAST`] has a consumer today. The transfer- and load-scale bands the
+//! metrics design also defines land with the families that need them, rather
+//! than sitting here unused.
+
+/// 1 ms to 10 s: gRPC handlers and metadata-backend operations.
+///
+/// The upper bound is deliberately well past any healthy value for this class of
+/// work. Anything slower is already an outage, and the `+Inf` bucket is enough to
+/// see it.
+pub const FAST: [f64; 13] = [
+    0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];

--- a/modelexpress_server/src/metrics/grpc.rs
+++ b/modelexpress_server/src/metrics/grpc.rs
@@ -1,0 +1,706 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-RPC metrics for every gRPC service the server exposes.
+//!
+//! # Why the outcome is not the gRPC status code
+//!
+//! Several handlers report failure *in band*: they catch a backend error, log
+//! it, and return `Ok` with an empty or defaulted response body. `ListSources`
+//! is the clearest case — a Redis outage and "no peers have published yet" are
+//! the same `Ok(ListSourcesResponse { instances: [] })` on the wire. A metric
+//! derived from the status code would therefore read 100% success straight
+//! through a total backend outage, which is precisely the incident it exists to
+//! surface.
+//!
+//! So the outcome is resolved in three steps, in order:
+//!
+//! 1. An [`RpcOutcome`] the handler itself inserted into the response
+//!    extensions. This is the authoritative value and the only one that can see
+//!    an in-band failure.
+//! 2. Otherwise a [`tonic::Status`] in the response extensions. Every
+//!    `Err(Status)` path puts itself there — `Status::into_http` does
+//!    `response.extensions_mut().insert(self)` — so handlers that fail honestly
+//!    need no edit at all, and neither do auth rejections or tonic's own
+//!    `unimplemented` fallback for an unrouted path.
+//! 3. Otherwise success. A successful unary response carries `grpc-status` in
+//!    the HTTP/2 trailers, not the head, so its absence here is the success
+//!    signal.
+//!
+//! Step 2 is why instrumenting 21 routed paths costs a handful of one-line tags
+//! rather than 21 rewrites: only handlers that lie about their outcome need
+//! touching.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
+use tower::{Layer, Service};
+
+use super::buckets;
+
+/// Outcome of one RPC.
+///
+/// A closed enum, deliberately: `method` is already a 22-value label, so an
+/// open-ended outcome would multiply an unbounded domain into it. Anything that
+/// does not map onto a named variant becomes [`RpcOutcome::Error`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum RpcOutcome {
+    /// The handler completed and reported no failure.
+    Ok,
+    /// The caller's request was malformed.
+    InvalidArgument,
+    /// The requested model, source, or version does not exist. Distinct from
+    /// [`RpcOutcome::BackendError`] because it is a normal, expected answer.
+    NotFound,
+    /// A backend the handler depends on failed. This is the variant a
+    /// status-code-derived metric cannot see, and the reason this module exists.
+    ///
+    /// Wider than the metadata store: every `Code::Unavailable` maps here, which
+    /// includes the auth layer's `Status::unavailable` when the Kubernetes
+    /// TokenReview API is down. Because this layer sits outside `AuthLayer`, that
+    /// case appears on every method at once and can read like a total
+    /// metadata-store outage. `mx_backend_ops_total` disambiguates: a real store
+    /// outage lights that family up too.
+    BackendError,
+    /// Rejected by the ServiceAccount auth layer.
+    Unauthenticated,
+    /// The caller went away before the handler finished: client disconnect,
+    /// `RST_STREAM`, or a deadline. Recorded from a drop guard, never from a
+    /// response, because in this case there is no response.
+    Cancelled,
+    /// Any other failure.
+    Error,
+}
+
+impl RpcOutcome {
+    /// Wire form. `snake_case`, matching every other label value in the schema.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::InvalidArgument => "invalid_argument",
+            Self::NotFound => "not_found",
+            Self::BackendError => "backend_error",
+            Self::Unauthenticated => "unauthenticated",
+            Self::Cancelled => "cancelled",
+            Self::Error => "error",
+        }
+    }
+
+    /// Map a gRPC status code onto the closed domain.
+    fn from_code(code: tonic::Code) -> Self {
+        match code {
+            tonic::Code::Ok => Self::Ok,
+            tonic::Code::InvalidArgument => Self::InvalidArgument,
+            tonic::Code::NotFound => Self::NotFound,
+            tonic::Code::Unauthenticated | tonic::Code::PermissionDenied => Self::Unauthenticated,
+            tonic::Code::Unavailable => Self::BackendError,
+            _ => Self::Error,
+        }
+    }
+}
+
+// Hand-written rather than derived: the derive encodes `stringify!(Variant)`,
+// which would emit `BackendError`. Renaming the variants to match the wire form
+// would trip `non_camel_case_types` under `-D warnings`, so the mapping lives in
+// `as_str` instead.
+impl EncodeLabelValue for RpcOutcome {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_str(), encoder)
+    }
+}
+
+/// Label set for the per-RPC families.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct RpcLabels {
+    /// `Service/Method`, drawn from a closed set by [`method_label`].
+    pub method: &'static str,
+    /// Resolved outcome; see the module docs for the resolution order.
+    pub outcome: RpcOutcome,
+}
+
+/// Label set for in-flight tracking. No `outcome`: a request that is still
+/// running does not have one yet.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct MethodLabel {
+    /// `Service/Method`, from [`method_label`].
+    pub method: &'static str,
+}
+
+fn fast_histogram() -> Histogram {
+    Histogram::new(buckets::FAST)
+}
+
+type LatencyFamily = Family<RpcLabels, Histogram, fn() -> Histogram>;
+
+/// Handles for the per-RPC families.
+///
+/// Cloning is cheap and shares the underlying storage: every family in
+/// `prometheus_client` is `Arc`-backed, so the clone held by the tower layer and
+/// the clone held by the registry are the same counters.
+#[derive(Clone)]
+pub struct GrpcMetrics {
+    requests: Family<RpcLabels, Counter>,
+    latency: LatencyFamily,
+    in_flight: Family<MethodLabel, Gauge>,
+}
+
+impl GrpcMetrics {
+    /// Register the families on `registry` and return handles to them.
+    ///
+    /// Counters are registered **without** the `_total` suffix. The OpenMetrics
+    /// encoder appends it, so registering `requests_total` would export
+    /// `mx_grpc_requests_total_total`. The unit tests assert the encoded names
+    /// rather than the registered ones for exactly this reason.
+    pub fn register(registry: &mut Registry) -> Self {
+        let requests = Family::<RpcLabels, Counter>::default();
+        let latency: LatencyFamily =
+            Family::new_with_constructor(fast_histogram as fn() -> Histogram);
+        let in_flight = Family::<MethodLabel, Gauge>::default();
+
+        let grpc = registry.sub_registry_with_prefix("grpc");
+        grpc.register(
+            "requests",
+            "gRPC requests by method and resolved outcome",
+            requests.clone(),
+        );
+        grpc.register(
+            "request_seconds",
+            "gRPC handler latency by method and resolved outcome",
+            latency.clone(),
+        );
+
+        // A plain Gauge, deliberately, unlike the counter pairs the client side
+        // uses. That pattern exists because `prometheus_client` multiprocess mode
+        // cannot reclaim a gauge owned by a rank that was SIGKILLed, so an
+        // in-flight gauge wedges forever. The server is a single process with an
+        // in-process registry: if it dies the registry dies with it, so there is
+        // nothing to wedge and the direct reading is worth more than a
+        // subtraction.
+        grpc.register(
+            "requests_in_flight",
+            "gRPC requests currently being handled, by method",
+            in_flight.clone(),
+        );
+
+        Self {
+            requests,
+            latency,
+            in_flight,
+        }
+    }
+
+    /// Record one completed RPC.
+    ///
+    /// Each `get_or_create` is a complete statement. The guard it returns is
+    /// `!Send`, so holding one across an `.await` would make the enclosing future
+    /// non-`Send` and break the tonic handler bound, with an error that points at
+    /// lock internals rather than at this line.
+    fn record(&self, labels: &RpcLabels, elapsed_seconds: f64) {
+        self.requests.get_or_create(labels).inc();
+        self.latency.get_or_create(labels).observe(elapsed_seconds);
+    }
+
+    /// Mark one request as started.
+    fn in_flight_inc(&self, method: &'static str) {
+        self.in_flight.get_or_create(&MethodLabel { method }).inc();
+    }
+
+    /// Mark one request as finished, however it finished.
+    fn in_flight_dec(&self, method: &'static str) {
+        self.in_flight.get_or_create(&MethodLabel { method }).dec();
+    }
+
+    /// Count a request whose future was dropped before it produced a response.
+    ///
+    /// The counter only. Writing the elapsed time into the histogram would
+    /// manufacture a short-latency sample for a request that was still running,
+    /// skewing the distribution worse than the gap it closes.
+    fn record_cancelled(&self, method: &'static str) {
+        self.requests
+            .get_or_create(&RpcLabels {
+                method,
+                outcome: RpcOutcome::Cancelled,
+            })
+            .inc();
+    }
+}
+
+/// Map a request path onto the closed `method` domain.
+///
+/// The layer wraps the whole router, so it sees every path that reaches the
+/// listener, including ones no service claims. Taking the label straight from
+/// the URI would let any caller mint a new series per request, so unknown paths
+/// collapse to `other`.
+#[must_use]
+pub fn method_label(path: &str) -> &'static str {
+    match path {
+        "/model_express.api.ApiService/SendRequest" => "ApiService/SendRequest",
+        "/model_express.health.HealthService/GetHealth" => "HealthService/GetHealth",
+
+        "/model_express.model.ModelService/EnsureModelDownloaded" => {
+            "ModelService/EnsureModelDownloaded"
+        }
+        "/model_express.model.ModelService/StreamModelFiles" => "ModelService/StreamModelFiles",
+        "/model_express.model.ModelService/ListModelFiles" => "ModelService/ListModelFiles",
+        "/model_express.model.ModelService/DeleteModel" => "ModelService/DeleteModel",
+
+        "/model_express.p2p.P2pService/PublishMetadata" => "P2pService/PublishMetadata",
+        "/model_express.p2p.P2pService/ListSources" => "P2pService/ListSources",
+        "/model_express.p2p.P2pService/GetMetadata" => "P2pService/GetMetadata",
+        "/model_express.p2p.P2pService/UpdateStatus" => "P2pService/UpdateStatus",
+
+        "/model_express.refit.RefitService/CreateWeightVersion" => {
+            "RefitService/CreateWeightVersion"
+        }
+        "/model_express.refit.RefitService/GetWeightVersion" => "RefitService/GetWeightVersion",
+        "/model_express.refit.RefitService/DeleteWeightVersion" => {
+            "RefitService/DeleteWeightVersion"
+        }
+        "/model_express.refit.RefitService/RegisterWorker" => "RefitService/RegisterWorker",
+        "/model_express.refit.RefitService/CreateWeightVersionShard" => {
+            "RefitService/CreateWeightVersionShard"
+        }
+        "/model_express.refit.RefitService/ListWeightVersionShards" => {
+            "RefitService/ListWeightVersionShards"
+        }
+        "/model_express.refit.RefitService/DeleteWeightVersionShard" => {
+            "RefitService/DeleteWeightVersionShard"
+        }
+        "/model_express.refit.RefitService/RegisterVersionLease" => {
+            "RefitService/RegisterVersionLease"
+        }
+        "/model_express.refit.RefitService/DeleteVersionLease" => "RefitService/DeleteVersionLease",
+
+        // The standard health service, served for kubelet probes. Counted
+        // deliberately: it is the cheapest evidence that the gRPC listener is
+        // answering at all, including during the drain window.
+        "/grpc.health.v1.Health/Check" => "Health/Check",
+        "/grpc.health.v1.Health/Watch" => "Health/Watch",
+
+        _ => "other",
+    }
+}
+
+/// Methods whose response head is produced before the work happens.
+///
+/// `EnsureModelDownloaded` and `StreamModelFiles` return
+/// `Ok(Response::new(ReceiverStream::new(rx)))` once a task is spawned, and report
+/// failure as a stream item or a trailer -- `EnsureModelDownloaded` sends
+/// `ModelStatus::ERROR` as an item. `Health/Watch` is long-lived by design. For
+/// all three, this layer's future resolves at stream setup, so it would record
+/// `outcome="ok"` and a sub-millisecond duration for work that can run for forty
+/// minutes and fail.
+///
+/// They are therefore not recorded at all. A confidently wrong number is worse
+/// than an absent one, and this module exists to remove exactly that class of
+/// lie. Covering them means timing the response body and reading the trailer,
+/// which is a separate change.
+fn resolves_at_head(method: &str) -> bool {
+    matches!(
+        method,
+        "ModelService/EnsureModelDownloaded" | "ModelService/StreamModelFiles" | "Health/Watch"
+    )
+}
+
+/// Resolve the outcome of a response. See the module docs for the ordering.
+///
+/// Everything readable here comes from the response *head*. A failure raised
+/// while hyper drains the body lands in the HTTP/2 trailers instead, after this
+/// has already run: `map_response` is not async, so the future this layer awaits
+/// resolves once the body is wrapped, not once it is encoded. The reachable case
+/// is a unary response exceeding `max_encoding_message_size`, which
+/// `finish_encoding` rejects during the drain -- the client sees an error and the
+/// server records a success. Streaming methods are excluded separately by
+/// [`resolves_at_head`].
+fn resolve_outcome<B>(response: &http::Response<B>) -> RpcOutcome {
+    if let Some(outcome) = response.extensions().get::<RpcOutcome>() {
+        return *outcome;
+    }
+    if let Some(status) = response.extensions().get::<tonic::Status>() {
+        return RpcOutcome::from_code(status.code());
+    }
+    RpcOutcome::Ok
+}
+
+/// Tracks one in-flight request, and records a cancellation if the future is
+/// dropped before it produced a response.
+///
+/// Both signals hang off the same `Drop` because they answer the same question
+/// from opposite ends. hyper drops the handler future on client disconnect,
+/// `RST_STREAM`, or a deadline, and the recording after the await then never
+/// runs -- and that gap is not uniform, because the requests most likely to be
+/// cancelled are the slow ones. Left alone, the latency histogram ends up
+/// conditioned on completion, with a tail that looks healthy precisely because
+/// the slowest samples are the ones missing.
+///
+/// The gauge is the direct reading of the same situation: a backend that wedges
+/// while its peers serve normally shows up immediately as requests accumulating,
+/// rather than having to be inferred from an absence.
+struct InFlightGuard {
+    metrics: GrpcMetrics,
+    method: &'static str,
+    /// Cleared once the call resolves. Still set at drop means cancelled.
+    pending: bool,
+}
+
+impl InFlightGuard {
+    fn enter(metrics: GrpcMetrics, method: &'static str) -> Self {
+        metrics.in_flight_inc(method);
+        Self {
+            metrics,
+            method,
+            pending: true,
+        }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        // Runs on every exit path, so the gauge cannot drift.
+        self.metrics.in_flight_dec(self.method);
+        if self.pending {
+            self.metrics.record_cancelled(self.method);
+        }
+    }
+}
+
+/// Tower layer recording [`GrpcMetrics`] for every request that reaches the router.
+///
+/// Applied once, to the whole router, rather than per service: it then also
+/// covers the health services and any service added later without a second edit.
+/// It sits outside the auth layer, so rejected calls are counted as
+/// `outcome="unauthenticated"` rather than vanishing.
+#[derive(Clone)]
+pub struct GrpcMetricsLayer {
+    metrics: GrpcMetrics,
+}
+
+impl GrpcMetricsLayer {
+    #[must_use]
+    pub fn new(metrics: GrpcMetrics) -> Self {
+        Self { metrics }
+    }
+}
+
+impl<S> Layer<S> for GrpcMetricsLayer {
+    type Service = GrpcMetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcMetricsService {
+            inner,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+/// The service produced by [`GrpcMetricsLayer`].
+#[derive(Clone)]
+pub struct GrpcMetricsService<S> {
+    inner: S,
+    metrics: GrpcMetrics,
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for GrpcMetricsService<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<ReqBody>) -> Self::Future {
+        let method = method_label(request.uri().path());
+        // See `resolves_at_head`: for streaming methods this future resolves before
+        // the work does, so anything recorded here would describe stream setup
+        // while claiming to describe the call.
+        let record = !resolves_at_head(method);
+        let metrics = self.metrics.clone();
+
+        // Readiness was established on `self.inner` by `poll_ready` and does not
+        // transfer to a clone. Swap so the future drives the ready service and
+        // the fresh clone is the one polled ready next time.
+        let ready = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, ready);
+
+        Box::pin(async move {
+            // Streaming methods are excluded from this too: their future resolves
+            // at the head, so the gauge would decrement immediately and read zero
+            // for a stream that is still running.
+            let mut guard = record.then(|| InFlightGuard::enter(metrics.clone(), method));
+            let started = Instant::now();
+            let result = inner.call(request).await;
+            if let Some(guard) = guard.as_mut() {
+                guard.pending = false;
+            }
+
+            if record && let Ok(response) = &result {
+                let labels = RpcLabels {
+                    method,
+                    outcome: resolve_outcome(response),
+                };
+                // `Duration::as_secs_f64` is float division, which
+                // `arithmetic_side_effects` permits; `Instant - Instant` is not.
+                metrics.record(&labels, started.elapsed().as_secs_f64());
+            }
+            result
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+
+    /// The encoder appends `_total` to counters, so the registered name and the
+    /// exported name differ. Assert the exported one.
+    #[test]
+    fn families_encode_under_the_documented_names() {
+        let mut registry = new_registry();
+        let metrics = GrpcMetrics::register(&mut registry);
+
+        metrics.record(
+            &RpcLabels {
+                method: "P2pService/ListSources",
+                outcome: RpcOutcome::BackendError,
+            },
+            0.5,
+        );
+        metrics.record_cancelled("P2pService/GetMetadata");
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+
+        assert!(
+            encoded.contains(
+                r#"mx_grpc_requests_total{method="P2pService/ListSources",outcome="backend_error"} 1"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(
+                r#"mx_grpc_requests_total{method="P2pService/GetMetadata",outcome="cancelled"} 1"#
+            ),
+            "{encoded}"
+        );
+        // A cancellation contributes no latency sample: only the one real
+        // observation reaches the histogram.
+        assert!(
+            encoded.contains(r#"mx_grpc_request_seconds_count{method="P2pService/ListSources"#),
+            "{encoded}"
+        );
+        assert!(
+            !encoded.contains(r#"mx_grpc_request_seconds_count{method="P2pService/GetMetadata"#),
+            "a cancellation wrote a latency sample: {encoded}"
+        );
+        assert!(
+            encoded.contains("# TYPE mx_grpc_request_seconds histogram"),
+            "{encoded}"
+        );
+        // Not `_total_total`.
+        assert!(!encoded.contains("_total_total"), "{encoded}");
+    }
+
+    /// The guard decrements on every exit path, so the gauge must come back to
+    /// zero whether the request completed or was dropped.
+    #[test]
+    fn the_in_flight_gauge_returns_to_zero() {
+        let mut registry = new_registry();
+        let metrics = GrpcMetrics::register(&mut registry);
+
+        let guard = InFlightGuard::enter(metrics.clone(), "P2pService/ListSources");
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_grpc_requests_in_flight{method="P2pService/ListSources"} 1"#),
+            "{encoded}"
+        );
+
+        drop(guard);
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_grpc_requests_in_flight{method="P2pService/ListSources"} 0"#),
+            "{encoded}"
+        );
+        // Dropped while still pending, so it also counts as a cancellation.
+        assert!(
+            encoded.contains(
+                r#"mx_grpc_requests_total{method="P2pService/ListSources",outcome="cancelled"} 1"#
+            ),
+            "{encoded}"
+        );
+    }
+
+    #[test]
+    fn outcome_labels_are_snake_case() {
+        // The derive would have emitted `BackendError` here.
+        assert_eq!(RpcOutcome::BackendError.as_str(), "backend_error");
+        assert_eq!(RpcOutcome::InvalidArgument.as_str(), "invalid_argument");
+        assert_eq!(RpcOutcome::Ok.as_str(), "ok");
+    }
+
+    /// The cardinality guard: an unknown path must not mint a series.
+    #[test]
+    fn unknown_paths_collapse_to_other() {
+        assert_eq!(
+            method_label("/model_express.p2p.P2pService/ListSources"),
+            "P2pService/ListSources"
+        );
+        assert_eq!(method_label("/grpc.health.v1.Health/Check"), "Health/Check");
+        assert_eq!(method_label("/model_express.p2p.P2pService/Bogus"), "other");
+        assert_eq!(method_label("/nonsense"), "other");
+        assert_eq!(method_label(""), "other");
+    }
+
+    /// A handler-set outcome outranks anything derivable from the status.
+    ///
+    /// This covers the resolution order only. It cannot cover the propagation
+    /// step -- `tonic::Response::into_http`, which copies handler extensions onto
+    /// the `http::Response`, is `pub(crate)`, so no test outside tonic can drive
+    /// it directly. That half is covered end to end by the `in_process_server`
+    /// integration test, which drives a real client against a real server.
+    #[test]
+    fn handler_set_outcome_wins_over_the_status_code() {
+        let mut response = http::Response::new(());
+        response.extensions_mut().insert(RpcOutcome::BackendError);
+        // A conflicting status is present and must lose.
+        response.extensions_mut().insert(tonic::Status::ok(""));
+        assert_eq!(resolve_outcome(&response), RpcOutcome::BackendError);
+    }
+
+    #[test]
+    fn status_is_used_when_the_handler_did_not_tag() {
+        let response = tonic::Status::not_found("nope").into_http::<()>();
+        assert_eq!(resolve_outcome(&response), RpcOutcome::NotFound);
+
+        let response = tonic::Status::unavailable("redis down").into_http::<()>();
+        assert_eq!(resolve_outcome(&response), RpcOutcome::BackendError);
+    }
+
+    /// Services this server actually routes. `WorkerService` is served by the
+    /// Python client and `RefitWorkerService` has no ModelExpress-owned server,
+    /// so neither reaches this layer.
+    const SERVED_SERVICES: [&str; 5] = [
+        "ApiService",
+        "HealthService",
+        "ModelService",
+        "P2pService",
+        "RefitService",
+    ];
+
+    /// Extract `/package.Service/Method` for every RPC a proto declares.
+    fn routed_paths(proto: &str) -> Vec<(String, String, bool)> {
+        let mut package = String::new();
+        let mut service = String::new();
+        let mut paths = Vec::new();
+        for line in proto.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("package ") {
+                package = rest.trim_end_matches(';').trim().to_string();
+            } else if let Some(rest) = line.strip_prefix("service ") {
+                service = rest
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or_default()
+                    .to_string();
+            } else if let Some(rest) = line.strip_prefix("rpc ")
+                && let Some(name) = rest.split('(').next()
+            {
+                paths.push((
+                    service.clone(),
+                    format!("/{package}.{service}/{}", name.trim()),
+                    rest.contains("returns (stream "),
+                ));
+            }
+        }
+        paths
+    }
+
+    /// Every routed RPC must have a `method_label` arm.
+    ///
+    /// Without this, adding an RPC to a proto silently lands it in `other` --
+    /// and because `resolves_at_head("other")` is false, a *streaming* RPC added
+    /// that way would be treated as unary and recorded with a bogus `ok` and a
+    /// stream-setup duration. This fails the build instead.
+    #[test]
+    fn every_routed_proto_rpc_has_a_method_label_arm() {
+        const PROTOS: [&str; 5] = [
+            include_str!("../../../modelexpress_common/proto/api.proto"),
+            include_str!("../../../modelexpress_common/proto/health.proto"),
+            include_str!("../../../modelexpress_common/proto/model.proto"),
+            include_str!("../../../modelexpress_common/proto/p2p.proto"),
+            include_str!("../../../modelexpress_common/proto/refit.proto"),
+        ];
+
+        let mut checked = 0;
+        for proto in PROTOS {
+            for (service, path, is_streaming) in routed_paths(proto) {
+                if !SERVED_SERVICES.contains(&service.as_str()) {
+                    continue;
+                }
+                let method = method_label(&path);
+                assert_ne!(
+                    method, "other",
+                    "{path} has no method_label arm, so it would be recorded as `other`"
+                );
+                // Derived from the proto rather than from a hand-kept list, so
+                // adding a streaming RPC and its arm -- but forgetting
+                // `resolves_at_head` -- fails here instead of silently recording
+                // `ok` with a stream-setup duration.
+                assert_eq!(
+                    resolves_at_head(method),
+                    is_streaming,
+                    "{path} is {} in the proto but {} excluded by resolves_at_head",
+                    if is_streaming { "streaming" } else { "unary" },
+                    if resolves_at_head(method) {
+                        "is"
+                    } else {
+                        "is not"
+                    }
+                );
+                checked += 1;
+            }
+        }
+        // Guards the parser itself: a change that stopped matching `rpc` lines
+        // would otherwise make this test pass by checking nothing.
+        assert_eq!(
+            checked, 19,
+            "expected 19 routed server RPCs, parsed {checked}"
+        );
+    }
+
+    /// `Health/Watch` is long-lived but is not declared in our protos, so
+    /// `every_routed_proto_rpc_has_a_method_label_arm` cannot derive it. The two
+    /// model.proto streams are pinned there against the proto itself; they are
+    /// repeated here only to keep this test readable on its own.
+    #[test]
+    fn streaming_methods_are_not_recorded() {
+        assert!(resolves_at_head("ModelService/EnsureModelDownloaded"));
+        assert!(resolves_at_head("ModelService/StreamModelFiles"));
+        assert!(resolves_at_head("Health/Watch"));
+
+        // Everything unary is recorded.
+        assert!(!resolves_at_head("P2pService/ListSources"));
+        assert!(!resolves_at_head("ModelService/ListModelFiles"));
+        assert!(!resolves_at_head("Health/Check"));
+        assert!(!resolves_at_head("other"));
+    }
+
+    #[test]
+    fn an_untagged_success_is_ok() {
+        let response = http::Response::new(());
+        assert_eq!(resolve_outcome(&response), RpcOutcome::Ok);
+    }
+}

--- a/modelexpress_server/src/p2p/backend.rs
+++ b/modelexpress_server/src/p2p/backend.rs
@@ -18,6 +18,7 @@ use modelexpress_common::grpc::p2p::{
 use std::collections::HashMap;
 use std::sync::Arc;
 
+pub mod instrumented;
 pub mod kubernetes;
 #[cfg(feature = "memory-backend")]
 pub mod memory;

--- a/modelexpress_server/src/p2p/backend/instrumented.rs
+++ b/modelexpress_server/src/p2p/backend/instrumented.rs
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics decorator for [`MetadataBackend`].
+//!
+//! Wraps any backend and records [`crate::metrics::backend`] families around
+//! every call, leaving the Redis, Kubernetes and in-memory implementations
+//! untouched. A backend added later is instrumented because it is wrapped at
+//! construction, not because someone remembered to add timing code to it.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::metrics::backend::{BackendMetrics, Store};
+use crate::p2p::backend::{
+    MetadataBackend, MetadataResult, ModelMetadataRecord, SourceInstanceInfo,
+};
+use modelexpress_common::grpc::p2p::{SourceIdentity, SourceStatus, WorkerMetadata};
+
+/// A [`MetadataBackend`] that records timing and outcome for each operation.
+pub struct InstrumentedMetadataBackend {
+    inner: Arc<dyn MetadataBackend>,
+    metrics: BackendMetrics,
+}
+
+impl InstrumentedMetadataBackend {
+    /// Wrap `inner`, returning it as a trait object so call sites are unchanged.
+    #[must_use]
+    pub fn wrap(
+        inner: Arc<dyn MetadataBackend>,
+        metrics: BackendMetrics,
+    ) -> Arc<dyn MetadataBackend> {
+        Arc::new(Self { inner, metrics })
+    }
+}
+
+#[async_trait]
+impl MetadataBackend for InstrumentedMetadataBackend {
+    async fn connect(&self) -> MetadataResult<()> {
+        self.metrics
+            .time(Store::P2p, "connect", self.inner.connect())
+            .await
+    }
+
+    async fn publish_metadata(
+        &self,
+        identity: &SourceIdentity,
+        worker_id: &str,
+        worker: WorkerMetadata,
+        pod_name: &str,
+        pod_uid: &str,
+        pod_namespace: &str,
+    ) -> MetadataResult<()> {
+        self.metrics
+            .time(
+                Store::P2p,
+                "publish_metadata",
+                self.inner.publish_metadata(
+                    identity,
+                    worker_id,
+                    worker,
+                    pod_name,
+                    pod_uid,
+                    pod_namespace,
+                ),
+            )
+            .await
+    }
+
+    async fn get_metadata(
+        &self,
+        source_id: &str,
+        worker_id: &str,
+    ) -> MetadataResult<Option<ModelMetadataRecord>> {
+        self.metrics
+            .time(
+                Store::P2p,
+                "get_metadata",
+                self.inner.get_metadata(source_id, worker_id),
+            )
+            .await
+    }
+
+    async fn list_workers(
+        &self,
+        source_id: Option<String>,
+        status_filter: Option<SourceStatus>,
+    ) -> MetadataResult<Vec<SourceInstanceInfo>> {
+        self.metrics
+            .time(
+                Store::P2p,
+                "list_workers",
+                self.inner.list_workers(source_id, status_filter),
+            )
+            .await
+    }
+
+    /// Forwarded explicitly, and it must stay that way.
+    ///
+    /// This is the one trait method with a default body, and only the Redis
+    /// backend overrides it. If this decorator inherited the default, the default
+    /// would run *here* and call `self.list_workers` -- the decorator's -- which
+    /// delegates to the inner backend. Redis's pipelined implementation would
+    /// never run, reintroducing the per-source and per-worker round trips it
+    /// exists to avoid, and every call would be counted twice: once as
+    /// `list_workers_filtered` and once as `list_workers`. Nothing would fail to
+    /// compile and no existing test would go red.
+    async fn list_workers_filtered(
+        &self,
+        source_id: Option<String>,
+        status_filter: Option<SourceStatus>,
+        model_name_filter: Option<String>,
+        worker_rank_filter: Option<u32>,
+        min_training_step: Option<u64>,
+        min_updated_at: Option<i64>,
+        limit: Option<usize>,
+    ) -> MetadataResult<Vec<SourceInstanceInfo>> {
+        self.metrics
+            .time(
+                Store::P2p,
+                "list_workers_filtered",
+                self.inner.list_workers_filtered(
+                    source_id,
+                    status_filter,
+                    model_name_filter,
+                    worker_rank_filter,
+                    min_training_step,
+                    min_updated_at,
+                    limit,
+                ),
+            )
+            .await
+    }
+
+    async fn remove_metadata(&self, source_id: &str) -> MetadataResult<()> {
+        self.metrics
+            .time(
+                Store::P2p,
+                "remove_metadata",
+                self.inner.remove_metadata(source_id),
+            )
+            .await
+    }
+
+    async fn remove_worker(&self, source_id: &str, worker_id: &str) -> MetadataResult<()> {
+        self.metrics
+            .time(
+                Store::P2p,
+                "remove_worker",
+                self.inner.remove_worker(source_id, worker_id),
+            )
+            .await
+    }
+
+    async fn list_sources(&self) -> MetadataResult<Vec<(String, String)>> {
+        self.metrics
+            .time(Store::P2p, "list_sources", self.inner.list_sources())
+            .await
+    }
+
+    async fn update_status(
+        &self,
+        source_id: &str,
+        worker_id: &str,
+        worker_rank: u32,
+        status: SourceStatus,
+        updated_at: i64,
+    ) -> MetadataResult<()> {
+        self.metrics
+            .time(
+                Store::P2p,
+                "update_status",
+                self.inner
+                    .update_status(source_id, worker_id, worker_rank, status, updated_at),
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+    use crate::p2p::backend::MockMetadataBackend;
+
+    /// The forwarding trap: `list_workers_filtered` must reach the inner
+    /// backend's implementation, not fall through the default body onto
+    /// `list_workers`.
+    #[tokio::test]
+    async fn list_workers_filtered_does_not_fall_through_to_list_workers() {
+        let mut mock = MockMetadataBackend::new();
+        mock.expect_list_workers_filtered()
+            .times(1)
+            .returning(|_, _, _, _, _, _, _| Ok(Vec::new()));
+        // If the decorator inherited the default body, this would be called.
+        mock.expect_list_workers().times(0);
+
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend = InstrumentedMetadataBackend::wrap(Arc::new(mock), metrics);
+
+        let result = backend
+            .list_workers_filtered(None, None, None, None, None, None, None)
+            .await;
+        assert!(result.is_ok());
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_backend_ops_total{store="p2p",op="list_workers_filtered",result="ok"} 1"#
+            ),
+            "{encoded}"
+        );
+        // Counted once, under one name.
+        assert!(
+            !encoded.contains(r#"op="list_workers","#),
+            "list_workers was also recorded: {encoded}"
+        );
+    }
+
+    /// Nine near-identical forwarding bodies invite a copy-pasted op literal, so
+    /// pin that each method reports under its own name and none under another's.
+    #[tokio::test]
+    async fn every_method_reports_under_its_own_op_name() {
+        let mut mock = MockMetadataBackend::new();
+        mock.expect_connect().times(1).returning(|| Ok(()));
+        mock.expect_publish_metadata()
+            .times(1)
+            .returning(|_, _, _, _, _, _| Ok(()));
+        mock.expect_get_metadata()
+            .times(1)
+            .returning(|_, _| Ok(None));
+        mock.expect_list_workers()
+            .times(1)
+            .returning(|_, _| Ok(Vec::new()));
+        mock.expect_list_workers_filtered()
+            .times(1)
+            .returning(|_, _, _, _, _, _, _| Ok(Vec::new()));
+        mock.expect_remove_metadata().times(1).returning(|_| Ok(()));
+        mock.expect_remove_worker()
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock.expect_list_sources()
+            .times(1)
+            .returning(|| Ok(Vec::new()));
+        mock.expect_update_status()
+            .times(1)
+            .returning(|_, _, _, _, _| Ok(()));
+
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend = InstrumentedMetadataBackend::wrap(Arc::new(mock), metrics);
+
+        let _ = backend.connect().await;
+        let _ = backend
+            .publish_metadata(
+                &SourceIdentity::default(),
+                "worker-0",
+                WorkerMetadata::default(),
+                "pod",
+                "uid",
+                "namespace",
+            )
+            .await;
+        let _ = backend.get_metadata("source-0", "worker-0").await;
+        let _ = backend.list_workers(None, None).await;
+        let _ = backend
+            .list_workers_filtered(None, None, None, None, None, None, None)
+            .await;
+        let _ = backend.remove_metadata("source-0").await;
+        let _ = backend.remove_worker("source-0", "worker-0").await;
+        let _ = backend.list_sources().await;
+        let _ = backend
+            .update_status("source-0", "worker-0", 0, SourceStatus::Ready, 0)
+            .await;
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        for op in [
+            "connect",
+            "publish_metadata",
+            "get_metadata",
+            "list_workers",
+            "list_workers_filtered",
+            "remove_metadata",
+            "remove_worker",
+            "list_sources",
+            "update_status",
+        ] {
+            let expected =
+                format!(r#"mx_backend_ops_total{{store="p2p",op="{op}",result="ok"}} 1"#);
+            assert!(encoded.contains(&expected), "missing {op}: {encoded}");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_backend_failure_is_recorded_as_an_error() {
+        let mut mock = MockMetadataBackend::new();
+        mock.expect_connect()
+            .times(1)
+            .returning(|| Err("redis is down".into()));
+
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend = InstrumentedMetadataBackend::wrap(Arc::new(mock), metrics);
+
+        assert!(backend.connect().await.is_err());
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_backend_ops_total{store="p2p",op="connect",result="error"} 1"#),
+            "{encoded}"
+        );
+    }
+}

--- a/modelexpress_server/src/p2p/service.rs
+++ b/modelexpress_server/src/p2p/service.rs
@@ -6,6 +6,7 @@
 //! Metadata is keyed by mx_source_id, a 16-char hex hash of SourceIdentity.
 //! Clients send the full SourceIdentity; the server computes and returns the hash.
 
+use crate::metrics::grpc::RpcOutcome;
 use crate::p2p::backend::SourceInstanceInfo;
 use crate::p2p::source_identity::{compute_mx_source_id, validate_identity};
 use crate::p2p::state::P2pStateManager;
@@ -17,6 +18,25 @@ use modelexpress_common::grpc::p2p::{
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
+
+/// Return `body` with the handler's own verdict attached.
+///
+/// Every handler in this file reports failure **in band**: `Ok` carrying
+/// `success: false`, or an empty `instances` list, rather than `Err(Status)`.
+/// That is deliberate and stays as it is -- clients depend on it -- but it means
+/// the status code reads `Ok` straight through a backend outage, so nothing
+/// outside the handler can tell an outage from an empty-but-healthy answer.
+///
+/// This publishes the real outcome into the response extensions, where
+/// [`crate::metrics::grpc`] reads it. The tag is metrics-only: it does not touch
+/// the response body or the status code, and losing it degrades the metric to
+/// `outcome="ok"` rather than breaking the call.
+#[allow(clippy::result_large_err)] // Returns the handlers' own tonic::Status result type.
+fn tagged<T>(body: T, outcome: RpcOutcome) -> Result<Response<T>, Status> {
+    let mut response = Response::new(body);
+    response.extensions_mut().insert(outcome);
+    Ok(response)
+}
 
 /// P2P Service implementation
 pub struct P2pServiceImpl {
@@ -69,42 +89,54 @@ impl P2pService for P2pServiceImpl {
         let identity = match req.identity {
             Some(id) => id,
             None => {
-                return Ok(Response::new(PublishMetadataResponse {
-                    success: false,
-                    message: "identity is required".to_string(),
-                    mx_source_id: String::new(),
-                    worker_id: String::new(),
-                }));
+                return tagged(
+                    PublishMetadataResponse {
+                        success: false,
+                        message: "identity is required".to_string(),
+                        mx_source_id: String::new(),
+                        worker_id: String::new(),
+                    },
+                    RpcOutcome::InvalidArgument,
+                );
             }
         };
 
         if let Err(e) = validate_identity(&identity) {
-            return Ok(Response::new(PublishMetadataResponse {
-                success: false,
-                message: e,
-                mx_source_id: String::new(),
-                worker_id: String::new(),
-            }));
+            return tagged(
+                PublishMetadataResponse {
+                    success: false,
+                    message: e,
+                    mx_source_id: String::new(),
+                    worker_id: String::new(),
+                },
+                RpcOutcome::InvalidArgument,
+            );
         }
 
         if req.worker_id.is_empty() {
-            return Ok(Response::new(PublishMetadataResponse {
-                success: false,
-                message: "worker_id is required".to_string(),
-                mx_source_id: String::new(),
-                worker_id: String::new(),
-            }));
+            return tagged(
+                PublishMetadataResponse {
+                    success: false,
+                    message: "worker_id is required".to_string(),
+                    mx_source_id: String::new(),
+                    worker_id: String::new(),
+                },
+                RpcOutcome::InvalidArgument,
+            );
         }
 
         let worker = match req.worker {
             Some(w) => w,
             None => {
-                return Ok(Response::new(PublishMetadataResponse {
-                    success: false,
-                    message: "worker is required".to_string(),
-                    mx_source_id: String::new(),
-                    worker_id: String::new(),
-                }));
+                return tagged(
+                    PublishMetadataResponse {
+                        success: false,
+                        message: "worker is required".to_string(),
+                        mx_source_id: String::new(),
+                        worker_id: String::new(),
+                    },
+                    RpcOutcome::InvalidArgument,
+                );
             }
         };
 
@@ -131,24 +163,30 @@ impl P2pService for P2pServiceImpl {
                     "PublishMetadata: model='{}' source_id={} worker_id={} worker_rank={} tensors={}",
                     model_name, source_id, worker_id, worker_rank, tensor_count
                 );
-                Ok(Response::new(PublishMetadataResponse {
-                    success: true,
-                    message: format!(
-                        "Published metadata for '{}' (source_id={}, worker_id={}, worker_rank={}, {} tensors)",
-                        model_name, source_id, worker_id, worker_rank, tensor_count
-                    ),
-                    mx_source_id: source_id,
-                    worker_id,
-                }))
+                tagged(
+                    PublishMetadataResponse {
+                        success: true,
+                        message: format!(
+                            "Published metadata for '{}' (source_id={}, worker_id={}, worker_rank={}, {} tensors)",
+                            model_name, source_id, worker_id, worker_rank, tensor_count
+                        ),
+                        mx_source_id: source_id,
+                        worker_id,
+                    },
+                    RpcOutcome::Ok,
+                )
             }
             Err(e) => {
                 error!("Failed to publish metadata: {}", e);
-                Ok(Response::new(PublishMetadataResponse {
-                    success: false,
-                    message: format!("Failed to publish metadata: {e}"),
-                    mx_source_id: String::new(),
-                    worker_id: String::new(),
-                }))
+                tagged(
+                    PublishMetadataResponse {
+                        success: false,
+                        message: format!("Failed to publish metadata: {e}"),
+                        mx_source_id: String::new(),
+                        worker_id: String::new(),
+                    },
+                    RpcOutcome::BackendError,
+                )
             }
         }
     }
@@ -189,9 +227,12 @@ impl P2pService for P2pServiceImpl {
             Ok(v) => v,
             Err(e) => {
                 error!("Failed to list workers: {}", e);
-                return Ok(Response::new(ListSourcesResponse {
-                    instances: Vec::new(),
-                }));
+                return tagged(
+                    ListSourcesResponse {
+                        instances: Vec::new(),
+                    },
+                    RpcOutcome::BackendError,
+                );
             }
         };
 
@@ -223,7 +264,7 @@ impl P2pService for P2pServiceImpl {
 
         debug!("ListSources: returning {} instances", refs.len());
 
-        Ok(Response::new(ListSourcesResponse { instances: refs }))
+        tagged(ListSourcesResponse { instances: refs }, RpcOutcome::Ok)
     }
 
     async fn get_metadata(
@@ -233,13 +274,16 @@ impl P2pService for P2pServiceImpl {
         let req = request.into_inner();
 
         if req.mx_source_id.is_empty() || req.worker_id.is_empty() {
-            return Ok(Response::new(GetMetadataResponse {
-                found: false,
-                worker: None,
-                mx_source_id: String::new(),
-                worker_id: String::new(),
-                identity: None,
-            }));
+            return tagged(
+                GetMetadataResponse {
+                    found: false,
+                    worker: None,
+                    mx_source_id: String::new(),
+                    worker_id: String::new(),
+                    identity: None,
+                },
+                RpcOutcome::InvalidArgument,
+            );
         }
 
         match self
@@ -260,36 +304,53 @@ impl P2pService for P2pServiceImpl {
                     worker.as_ref().map_or(0, worker_tensor_count),
                     identity.is_some(),
                 );
-                Ok(Response::new(GetMetadataResponse {
-                    found,
-                    worker,
-                    mx_source_id: req.mx_source_id,
-                    worker_id: req.worker_id,
-                    identity,
-                }))
+                // A record with no workers is the same answer as no record at
+                // all, so it carries the same outcome. Reporting it as Ok would
+                // make an absent worker look like a successful lookup.
+                let outcome = if found {
+                    RpcOutcome::Ok
+                } else {
+                    RpcOutcome::NotFound
+                };
+                tagged(
+                    GetMetadataResponse {
+                        found,
+                        worker,
+                        mx_source_id: req.mx_source_id,
+                        worker_id: req.worker_id,
+                        identity,
+                    },
+                    outcome,
+                )
             }
             Ok(None) => {
                 info!(
                     "No metadata found for source_id={} worker_id={}",
                     req.mx_source_id, req.worker_id
                 );
-                Ok(Response::new(GetMetadataResponse {
-                    found: false,
-                    worker: None,
-                    mx_source_id: req.mx_source_id,
-                    worker_id: req.worker_id,
-                    identity: None,
-                }))
+                tagged(
+                    GetMetadataResponse {
+                        found: false,
+                        worker: None,
+                        mx_source_id: req.mx_source_id,
+                        worker_id: req.worker_id,
+                        identity: None,
+                    },
+                    RpcOutcome::NotFound,
+                )
             }
             Err(e) => {
                 error!("Failed to get metadata: {}", e);
-                Ok(Response::new(GetMetadataResponse {
-                    found: false,
-                    worker: None,
-                    mx_source_id: String::new(),
-                    worker_id: String::new(),
-                    identity: None,
-                }))
+                tagged(
+                    GetMetadataResponse {
+                        found: false,
+                        worker: None,
+                        mx_source_id: String::new(),
+                        worker_id: String::new(),
+                        identity: None,
+                    },
+                    RpcOutcome::BackendError,
+                )
             }
         }
     }
@@ -301,26 +362,35 @@ impl P2pService for P2pServiceImpl {
         let req = request.into_inner();
 
         if req.mx_source_id.is_empty() {
-            return Ok(Response::new(UpdateStatusResponse {
-                success: false,
-                message: "mx_source_id is required".to_string(),
-            }));
+            return tagged(
+                UpdateStatusResponse {
+                    success: false,
+                    message: "mx_source_id is required".to_string(),
+                },
+                RpcOutcome::InvalidArgument,
+            );
         }
 
         if req.worker_id.is_empty() {
-            return Ok(Response::new(UpdateStatusResponse {
-                success: false,
-                message: "worker_id is required".to_string(),
-            }));
+            return tagged(
+                UpdateStatusResponse {
+                    success: false,
+                    message: "worker_id is required".to_string(),
+                },
+                RpcOutcome::InvalidArgument,
+            );
         }
 
         let status = match SourceStatus::try_from(req.status) {
             Ok(s) => s,
             Err(_) => {
-                return Ok(Response::new(UpdateStatusResponse {
-                    success: false,
-                    message: format!("invalid status value: {}", req.status),
-                }));
+                return tagged(
+                    UpdateStatusResponse {
+                        success: false,
+                        message: format!("invalid status value: {}", req.status),
+                    },
+                    RpcOutcome::InvalidArgument,
+                );
             }
         };
 
@@ -329,19 +399,25 @@ impl P2pService for P2pServiceImpl {
             .update_worker_status(&req.mx_source_id, &req.worker_id, req.worker_rank, status)
             .await
         {
-            Ok(()) => Ok(Response::new(UpdateStatusResponse {
-                success: true,
-                message: format!(
-                    "Updated status for source '{}' worker_id '{}' rank {}",
-                    req.mx_source_id, req.worker_id, req.worker_rank
-                ),
-            })),
+            Ok(()) => tagged(
+                UpdateStatusResponse {
+                    success: true,
+                    message: format!(
+                        "Updated status for source '{}' worker_id '{}' rank {}",
+                        req.mx_source_id, req.worker_id, req.worker_rank
+                    ),
+                },
+                RpcOutcome::Ok,
+            ),
             Err(e) => {
                 error!("Failed to update status: {}", e);
-                Ok(Response::new(UpdateStatusResponse {
-                    success: false,
-                    message: format!("Failed to update status: {e}"),
-                }))
+                tagged(
+                    UpdateStatusResponse {
+                        success: false,
+                        message: format!("Failed to update status: {e}"),
+                    },
+                    RpcOutcome::BackendError,
+                )
             }
         }
     }
@@ -953,15 +1029,24 @@ mod tests {
             .returning(|_, _, _, _, _, _, _| Err("backend down".into()));
 
         let svc = make_service(mock);
-        let resp = svc
+        let response = svc
             .list_sources(Request::new(ListSourcesRequest {
                 identity: Some(test_identity()),
                 status_filter: None,
                 ..Default::default()
             }))
             .await
-            .expect("rpc")
-            .into_inner();
+            .expect("rpc");
+
+        // The reason the tag exists: on the wire this is indistinguishable from
+        // a healthy "no peers have published yet" -- same Ok, same empty list.
+        // Only the handler knows it was an outage, so only the handler can say so.
+        assert_eq!(
+            response.extensions().get::<RpcOutcome>(),
+            Some(&RpcOutcome::BackendError)
+        );
+
+        let resp = response.into_inner();
         assert!(resp.instances.is_empty());
     }
 
@@ -1043,14 +1128,22 @@ mod tests {
             });
 
         let svc = make_service(mock);
-        let resp = svc
+        let response = svc
             .get_metadata(Request::new(GetMetadataRequest {
                 mx_source_id: "abc123def456abcd".to_string(),
                 worker_id: "worker-uuid-1".to_string(),
             }))
             .await
-            .expect("rpc")
-            .into_inner();
+            .expect("rpc");
+
+        // A record that exists but carries no workers is the same answer as no
+        // record at all, and must not be reported as a successful lookup.
+        assert_eq!(
+            response.extensions().get::<RpcOutcome>(),
+            Some(&RpcOutcome::NotFound)
+        );
+
+        let resp = response.into_inner();
         assert!(!resp.found);
         assert!(resp.worker.is_none());
     }

--- a/modelexpress_server/src/p2p/state.rs
+++ b/modelexpress_server/src/p2p/state.rs
@@ -7,6 +7,8 @@
 //! All state — model metadata and source status — is persisted to the backend,
 //! making the server stateless and horizontally scalable.
 
+use crate::metrics::backend::{BackendMetrics, Store};
+use crate::p2p::backend::instrumented::InstrumentedMetadataBackend;
 use crate::p2p::backend::{BackendConfig, MetadataBackend, MetadataResult, create_backend};
 use modelexpress_common::grpc::p2p::{SourceIdentity, WorkerMetadata};
 use std::sync::Arc;
@@ -26,6 +28,7 @@ pub use crate::p2p::backend::{
 pub struct P2pStateManager {
     backend: Arc<RwLock<Option<Arc<dyn MetadataBackend>>>>,
     config: Option<BackendConfig>,
+    metrics: Option<BackendMetrics>,
 }
 
 impl P2pStateManager {
@@ -34,7 +37,43 @@ impl P2pStateManager {
         Self {
             backend: Arc::new(RwLock::new(None)),
             config: Some(config),
+            metrics: None,
         }
+    }
+
+    /// Record backend operations against `metrics`.
+    ///
+    /// Opt-in rather than a `with_config` parameter so the call sites that do not
+    /// care -- tests, and anything constructing a manager outside `run_server` --
+    /// are unchanged. Without it the backend is used bare.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: BackendMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    /// Build the backend for `config`, wrapping it in the metrics decorator when
+    /// one is configured.
+    ///
+    /// Both connection paths route through here. Wrapping inside `create_backend`
+    /// instead would also instrument the direct-construction integration tests.
+    async fn build_backend(
+        &self,
+        config: BackendConfig,
+    ) -> MetadataResult<Arc<dyn MetadataBackend>> {
+        let Some(metrics) = self.metrics.clone() else {
+            return create_backend(config).await;
+        };
+        // The connect is timed around the factory rather than through the
+        // decorator's own `connect` forward. `create_backend` connects the
+        // concrete backend before returning it, so by the time there is anything
+        // to wrap the connection has already happened -- and this is not a
+        // startup-only path: `get_backend` reconnects lazily, so a flapping
+        // backend shows up here as repeated `connect` failures.
+        let backend = metrics
+            .time(Store::P2p, "connect", create_backend(config))
+            .await?;
+        Ok(InstrumentedMetadataBackend::wrap(backend, metrics))
     }
 
     /// Inject a pre-built backend directly (test only).
@@ -43,6 +82,7 @@ impl P2pStateManager {
         Self {
             backend: Arc::new(RwLock::new(Some(backend))),
             config: None,
+            metrics: None,
         }
     }
 
@@ -53,7 +93,7 @@ impl P2pStateManager {
         )?;
 
         let backend_name = config.to_string();
-        let backend = create_backend(config).await?;
+        let backend = self.build_backend(config).await?;
         let mut guard = self.backend.write().await;
         *guard = Some(backend);
 
@@ -79,7 +119,7 @@ impl P2pStateManager {
             "MX_METADATA_BACKEND is not set or invalid. Set it to 'redis' or 'kubernetes'.",
         )?;
 
-        let backend = create_backend(config.clone()).await?;
+        let backend = self.build_backend(config.clone()).await?;
         info!("P2pStateManager connected with {:?}", config);
         *guard = Some(backend.clone());
         Ok(backend)
@@ -555,6 +595,7 @@ mod tests {
         let manager = P2pStateManager {
             backend: Arc::new(RwLock::new(None)),
             config: None,
+            metrics: None,
         };
         assert!(manager.connect().await.is_err());
     }

--- a/modelexpress_server/src/refit/backend.rs
+++ b/modelexpress_server/src/refit/backend.rs
@@ -14,6 +14,7 @@ use modelexpress_common::grpc::refit::{
 
 use crate::backend_config::BackendConfig;
 
+pub mod instrumented;
 pub mod redis;
 
 pub type RefitResult<T> = Result<T, RefitBackendError>;

--- a/modelexpress_server/src/refit/backend/instrumented.rs
+++ b/modelexpress_server/src/refit/backend/instrumented.rs
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics decorator for [`RefitBackend`].
+//!
+//! Wraps any backend and records [`crate::metrics::backend`] families around
+//! every call, leaving the Redis implementation untouched. A backend added later
+//! is instrumented because it is wrapped at construction, not because someone
+//! remembered to add timing code to it.
+//!
+//! Every trait method is forwarded explicitly. The trait has no default bodies
+//! today; if one is added later it must be overridden here as well, because an
+//! inherited default would run on the decorator, call back into the decorator's
+//! other methods, bypass any specialised override in the concrete backend and
+//! count the call twice under two op names -- all without failing to compile.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::metrics::backend::{BackendMetrics, Store};
+use crate::refit::backend::{RefitBackend, RefitResult};
+use modelexpress_common::grpc::refit::{
+    CreateWeightVersionRequest, DeleteVersionLeaseRequest, DeleteWeightVersionShardRequest,
+    RegisterVersionLeaseRequest, VersionLease, WeightVersion, WeightVersionShard,
+    WorkerRegistration,
+};
+
+/// A [`RefitBackend`] that records timing and outcome for each operation.
+pub struct InstrumentedRefitBackend {
+    inner: Arc<dyn RefitBackend>,
+    metrics: BackendMetrics,
+}
+
+impl InstrumentedRefitBackend {
+    /// Wrap `inner`, returning it as a trait object so call sites are unchanged.
+    #[must_use]
+    pub fn wrap(inner: Arc<dyn RefitBackend>, metrics: BackendMetrics) -> Arc<dyn RefitBackend> {
+        Arc::new(Self { inner, metrics })
+    }
+}
+
+#[async_trait]
+impl RefitBackend for InstrumentedRefitBackend {
+    async fn register_worker(
+        &self,
+        worker: WorkerRegistration,
+        ttl_seconds: u32,
+    ) -> RefitResult<WorkerRegistration> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "register_worker",
+                self.inner.register_worker(worker, ttl_seconds),
+            )
+            .await
+    }
+
+    async fn create_weight_version(
+        &self,
+        request: &CreateWeightVersionRequest,
+    ) -> RefitResult<WeightVersion> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "create_weight_version",
+                self.inner.create_weight_version(request),
+            )
+            .await
+    }
+
+    async fn get_weight_version(&self, uid: &str) -> RefitResult<WeightVersion> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "get_weight_version",
+                self.inner.get_weight_version(uid),
+            )
+            .await
+    }
+
+    async fn delete_weight_version(&self, uid: &str) -> RefitResult<WeightVersion> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "delete_weight_version",
+                self.inner.delete_weight_version(uid),
+            )
+            .await
+    }
+
+    async fn create_weight_version_shard(
+        &self,
+        shard: WeightVersionShard,
+    ) -> RefitResult<(WeightVersionShard, WeightVersion)> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "create_weight_version_shard",
+                self.inner.create_weight_version_shard(shard),
+            )
+            .await
+    }
+
+    async fn list_weight_version_shards(
+        &self,
+        version_id: &str,
+    ) -> RefitResult<Vec<WeightVersionShard>> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "list_weight_version_shards",
+                self.inner.list_weight_version_shards(version_id),
+            )
+            .await
+    }
+
+    async fn delete_weight_version_shard(
+        &self,
+        request: &DeleteWeightVersionShardRequest,
+    ) -> RefitResult<bool> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "delete_weight_version_shard",
+                self.inner.delete_weight_version_shard(request),
+            )
+            .await
+    }
+
+    async fn register_version_lease(
+        &self,
+        request: &RegisterVersionLeaseRequest,
+    ) -> RefitResult<VersionLease> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "register_version_lease",
+                self.inner.register_version_lease(request),
+            )
+            .await
+    }
+
+    async fn delete_version_lease(&self, request: &DeleteVersionLeaseRequest) -> RefitResult<bool> {
+        self.metrics
+            .time(
+                Store::Refit,
+                "delete_version_lease",
+                self.inner.delete_version_lease(request),
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+    use crate::refit::backend::RefitBackendError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// `RefitBackend` carries no `mockall` mock, and adding `automock` to it
+    /// would change shared code, so the tests drive a stub that returns a fixed
+    /// outcome and counts how many calls reached it.
+    #[derive(Default)]
+    struct StubRefitBackend {
+        fail: bool,
+        calls: AtomicUsize,
+    }
+
+    impl StubRefitBackend {
+        fn failing() -> Self {
+            Self {
+                fail: true,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn outcome<T: Default>(&self) -> RefitResult<T> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            if self.fail {
+                Err(RefitBackendError::Unavailable("redis is down".to_owned()))
+            } else {
+                Ok(T::default())
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RefitBackend for StubRefitBackend {
+        async fn register_worker(
+            &self,
+            _worker: WorkerRegistration,
+            _ttl_seconds: u32,
+        ) -> RefitResult<WorkerRegistration> {
+            self.outcome()
+        }
+
+        async fn create_weight_version(
+            &self,
+            _request: &CreateWeightVersionRequest,
+        ) -> RefitResult<WeightVersion> {
+            self.outcome()
+        }
+
+        async fn get_weight_version(&self, _uid: &str) -> RefitResult<WeightVersion> {
+            self.outcome()
+        }
+
+        async fn delete_weight_version(&self, _uid: &str) -> RefitResult<WeightVersion> {
+            self.outcome()
+        }
+
+        async fn create_weight_version_shard(
+            &self,
+            _shard: WeightVersionShard,
+        ) -> RefitResult<(WeightVersionShard, WeightVersion)> {
+            self.outcome()
+        }
+
+        async fn list_weight_version_shards(
+            &self,
+            _version_id: &str,
+        ) -> RefitResult<Vec<WeightVersionShard>> {
+            self.outcome()
+        }
+
+        async fn delete_weight_version_shard(
+            &self,
+            _request: &DeleteWeightVersionShardRequest,
+        ) -> RefitResult<bool> {
+            self.outcome()
+        }
+
+        async fn register_version_lease(
+            &self,
+            _request: &RegisterVersionLeaseRequest,
+        ) -> RefitResult<VersionLease> {
+            self.outcome()
+        }
+
+        async fn delete_version_lease(
+            &self,
+            _request: &DeleteVersionLeaseRequest,
+        ) -> RefitResult<bool> {
+            self.outcome()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_successful_op_is_recorded_against_its_method_name() {
+        let stub = Arc::new(StubRefitBackend::default());
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend =
+            InstrumentedRefitBackend::wrap(Arc::clone(&stub) as Arc<dyn RefitBackend>, metrics);
+
+        assert!(backend.get_weight_version("v1").await.is_ok());
+        assert_eq!(stub.calls.load(Ordering::Relaxed), 1);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_backend_ops_total{store="refit",op="get_weight_version",result="ok"} 1"#
+            ),
+            "{encoded}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_backend_failure_is_recorded_as_an_error() {
+        let stub = Arc::new(StubRefitBackend::failing());
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend =
+            InstrumentedRefitBackend::wrap(Arc::clone(&stub) as Arc<dyn RefitBackend>, metrics);
+
+        assert!(
+            backend
+                .register_version_lease(&RegisterVersionLeaseRequest::default())
+                .await
+                .is_err()
+        );
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_backend_ops_total{store="refit",op="register_version_lease",result="error"} 1"#
+            ),
+            "{encoded}"
+        );
+    }
+
+    /// Nine near-identical forwarding bodies invite a copy-pasted op literal, so
+    /// pin that each method reports under its own name and none under another's.
+    #[tokio::test]
+    async fn every_method_reports_under_its_own_op_name() {
+        let stub = Arc::new(StubRefitBackend::default());
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend =
+            InstrumentedRefitBackend::wrap(Arc::clone(&stub) as Arc<dyn RefitBackend>, metrics);
+
+        let _ = backend
+            .register_worker(WorkerRegistration::default(), 30)
+            .await;
+        let _ = backend
+            .create_weight_version(&CreateWeightVersionRequest::default())
+            .await;
+        let _ = backend.get_weight_version("v1").await;
+        let _ = backend.delete_weight_version("v1").await;
+        let _ = backend
+            .create_weight_version_shard(WeightVersionShard::default())
+            .await;
+        let _ = backend.list_weight_version_shards("v1").await;
+        let _ = backend
+            .delete_weight_version_shard(&DeleteWeightVersionShardRequest::default())
+            .await;
+        let _ = backend
+            .register_version_lease(&RegisterVersionLeaseRequest::default())
+            .await;
+        let _ = backend
+            .delete_version_lease(&DeleteVersionLeaseRequest::default())
+            .await;
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        for op in [
+            "register_worker",
+            "create_weight_version",
+            "get_weight_version",
+            "delete_weight_version",
+            "create_weight_version_shard",
+            "list_weight_version_shards",
+            "delete_weight_version_shard",
+            "register_version_lease",
+            "delete_version_lease",
+        ] {
+            let expected =
+                format!(r#"mx_backend_ops_total{{store="refit",op="{op}",result="ok"}} 1"#);
+            assert!(encoded.contains(&expected), "missing {op}: {encoded}");
+        }
+        assert_eq!(stub.calls.load(Ordering::Relaxed), 9);
+    }
+}

--- a/modelexpress_server/src/registry/backend.rs
+++ b/modelexpress_server/src/registry/backend.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use modelexpress_common::models::{ModelProvider, ModelStatus};
 use std::sync::Arc;
 
+pub mod instrumented;
 pub mod kubernetes;
 #[cfg(feature = "memory-backend")]
 pub mod memory;

--- a/modelexpress_server/src/registry/backend/instrumented.rs
+++ b/modelexpress_server/src/registry/backend/instrumented.rs
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics decorator for [`RegistryBackend`].
+//!
+//! Wraps any backend and records [`crate::metrics::backend`] families around
+//! every call, leaving the Redis, Kubernetes and in-memory implementations
+//! untouched. A backend added later is instrumented because it is wrapped at
+//! construction, not because someone remembered to add timing code to it.
+//!
+//! Every method is forwarded explicitly. The trait has no default bodies today;
+//! if one is added it must still be overridden here, because a default body
+//! would run on the decorator, call back through the decorator's other methods,
+//! and so bypass any specialised override in the concrete backend while
+//! counting the call twice under two op names. That failure compiles and turns
+//! no test red.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::metrics::backend::{BackendMetrics, Store};
+use crate::registry::backend::{ClaimOutcome, ModelRecord, RegistryBackend, RegistryResult};
+use modelexpress_common::models::{ModelProvider, ModelStatus};
+
+/// A [`RegistryBackend`] that records timing and outcome for each operation.
+pub struct InstrumentedRegistryBackend {
+    inner: Arc<dyn RegistryBackend>,
+    metrics: BackendMetrics,
+}
+
+impl InstrumentedRegistryBackend {
+    /// Wrap `inner`, returning it as a trait object so call sites are unchanged.
+    #[must_use]
+    pub fn wrap(
+        inner: Arc<dyn RegistryBackend>,
+        metrics: BackendMetrics,
+    ) -> Arc<dyn RegistryBackend> {
+        Arc::new(Self { inner, metrics })
+    }
+}
+
+#[async_trait]
+impl RegistryBackend for InstrumentedRegistryBackend {
+    async fn connect(&self) -> RegistryResult<()> {
+        self.metrics
+            .time(Store::Registry, "connect", self.inner.connect())
+            .await
+    }
+
+    async fn get_status(&self, model_name: &str) -> RegistryResult<Option<ModelStatus>> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "get_status",
+                self.inner.get_status(model_name),
+            )
+            .await
+    }
+
+    async fn get_model_record(&self, model_name: &str) -> RegistryResult<Option<ModelRecord>> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "get_model_record",
+                self.inner.get_model_record(model_name),
+            )
+            .await
+    }
+
+    async fn set_status(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        status: ModelStatus,
+        message: Option<String>,
+    ) -> RegistryResult<()> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "set_status",
+                self.inner.set_status(model_name, provider, status, message),
+            )
+            .await
+    }
+
+    async fn touch_model(&self, model_name: &str) -> RegistryResult<()> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "touch_model",
+                self.inner.touch_model(model_name),
+            )
+            .await
+    }
+
+    async fn delete_model(&self, model_name: &str) -> RegistryResult<()> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "delete_model",
+                self.inner.delete_model(model_name),
+            )
+            .await
+    }
+
+    async fn get_models_by_last_used(
+        &self,
+        limit: Option<u32>,
+    ) -> RegistryResult<Vec<ModelRecord>> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "get_models_by_last_used",
+                self.inner.get_models_by_last_used(limit),
+            )
+            .await
+    }
+
+    async fn get_status_counts(&self) -> RegistryResult<(u32, u32, u32)> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "get_status_counts",
+                self.inner.get_status_counts(),
+            )
+            .await
+    }
+
+    async fn try_claim_for_download(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        claim_id: &str,
+        lease_duration: std::time::Duration,
+    ) -> RegistryResult<ClaimOutcome> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "try_claim_for_download",
+                self.inner
+                    .try_claim_for_download(model_name, provider, claim_id, lease_duration),
+            )
+            .await
+    }
+
+    async fn try_reset_error_for_retry(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        claim_id: &str,
+        lease_duration: std::time::Duration,
+    ) -> RegistryResult<bool> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "try_reset_error_for_retry",
+                self.inner.try_reset_error_for_retry(
+                    model_name,
+                    provider,
+                    claim_id,
+                    lease_duration,
+                ),
+            )
+            .await
+    }
+
+    async fn refresh_download_claim(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        claim_id: &str,
+        lease_duration: std::time::Duration,
+    ) -> RegistryResult<bool> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "refresh_download_claim",
+                self.inner
+                    .refresh_download_claim(model_name, provider, claim_id, lease_duration),
+            )
+            .await
+    }
+
+    async fn finish_download_claim(
+        &self,
+        model_name: &str,
+        provider: ModelProvider,
+        claim_id: &str,
+        status: ModelStatus,
+        message: Option<String>,
+    ) -> RegistryResult<bool> {
+        self.metrics
+            .time(
+                Store::Registry,
+                "finish_download_claim",
+                self.inner
+                    .finish_download_claim(model_name, provider, claim_id, status, message),
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+    use crate::registry::backend::MockRegistryBackend;
+
+    #[tokio::test]
+    async fn a_successful_op_is_recorded_as_ok() {
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_get_status()
+            .times(1)
+            .returning(|_| Ok(Some(ModelStatus::DOWNLOADED)));
+
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend = InstrumentedRegistryBackend::wrap(Arc::new(mock), metrics);
+
+        let status = backend.get_status("google-t5/t5-small").await;
+        assert_eq!(status.ok().flatten(), Some(ModelStatus::DOWNLOADED));
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_backend_ops_total{store="registry",op="get_status",result="ok"} 1"#
+            ),
+            "{encoded}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_backend_failure_is_recorded_as_an_error() {
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_connect()
+            .times(1)
+            .returning(|| Err("redis is down".into()));
+
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend = InstrumentedRegistryBackend::wrap(Arc::new(mock), metrics);
+
+        assert!(backend.connect().await.is_err());
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_backend_ops_total{store="registry",op="connect",result="error"} 1"#
+            ),
+            "{encoded}"
+        );
+    }
+
+    /// Twelve near-identical forwarding bodies invite a copy-pasted op literal, so
+    /// pin that each method reports under its own name and none under another's.
+    #[tokio::test]
+    async fn every_method_reports_under_its_own_op_name() {
+        let lease = std::time::Duration::from_secs(30);
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_connect().times(1).returning(|| Ok(()));
+        mock.expect_get_status().times(1).returning(|_| Ok(None));
+        mock.expect_get_model_record()
+            .times(1)
+            .returning(|_| Ok(None));
+        mock.expect_set_status()
+            .times(1)
+            .returning(|_, _, _, _| Ok(()));
+        mock.expect_touch_model().times(1).returning(|_| Ok(()));
+        mock.expect_delete_model().times(1).returning(|_| Ok(()));
+        mock.expect_get_models_by_last_used()
+            .times(1)
+            .returning(|_| Ok(Vec::new()));
+        mock.expect_get_status_counts()
+            .times(1)
+            .returning(|| Ok((0, 0, 0)));
+        mock.expect_try_claim_for_download()
+            .times(1)
+            .returning(|_, _, _, _| Ok(ClaimOutcome::Claimed));
+        mock.expect_try_reset_error_for_retry()
+            .times(1)
+            .returning(|_, _, _, _| Ok(false));
+        mock.expect_refresh_download_claim()
+            .times(1)
+            .returning(|_, _, _, _| Ok(true));
+        mock.expect_finish_download_claim()
+            .times(1)
+            .returning(|_, _, _, _, _| Ok(true));
+
+        let mut registry = new_registry();
+        let metrics = BackendMetrics::register(&mut registry);
+        let backend = InstrumentedRegistryBackend::wrap(Arc::new(mock), metrics);
+
+        let model = "google-t5/t5-small";
+        let _ = backend.connect().await;
+        let _ = backend.get_status(model).await;
+        let _ = backend.get_model_record(model).await;
+        let _ = backend
+            .set_status(
+                model,
+                ModelProvider::HuggingFace,
+                ModelStatus::DOWNLOADED,
+                None,
+            )
+            .await;
+        let _ = backend.touch_model(model).await;
+        let _ = backend.delete_model(model).await;
+        let _ = backend.get_models_by_last_used(Some(10)).await;
+        let _ = backend.get_status_counts().await;
+        let _ = backend
+            .try_claim_for_download(model, ModelProvider::HuggingFace, "claim-1", lease)
+            .await;
+        let _ = backend
+            .try_reset_error_for_retry(model, ModelProvider::HuggingFace, "claim-1", lease)
+            .await;
+        let _ = backend
+            .refresh_download_claim(model, ModelProvider::HuggingFace, "claim-1", lease)
+            .await;
+        let _ = backend
+            .finish_download_claim(
+                model,
+                ModelProvider::HuggingFace,
+                "claim-1",
+                ModelStatus::DOWNLOADED,
+                None,
+            )
+            .await;
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        for op in [
+            "connect",
+            "get_status",
+            "get_model_record",
+            "set_status",
+            "touch_model",
+            "delete_model",
+            "get_models_by_last_used",
+            "get_status_counts",
+            "try_claim_for_download",
+            "try_reset_error_for_retry",
+            "refresh_download_claim",
+            "finish_download_claim",
+        ] {
+            let expected =
+                format!(r#"mx_backend_ops_total{{store="registry",op="{op}",result="ok"}} 1"#);
+            assert!(encoded.contains(&expected), "missing {op}: {encoded}");
+        }
+    }
+}

--- a/modelexpress_server/src/registry/state.rs
+++ b/modelexpress_server/src/registry/state.rs
@@ -4,6 +4,8 @@
 //! Lazy-connect wrapper around `RegistryBackend`, parallel to [`crate::p2p::state`].
 
 use crate::backend_config::BackendConfig;
+use crate::metrics::backend::{BackendMetrics, Store};
+use crate::registry::backend::instrumented::InstrumentedRegistryBackend;
 use crate::registry::backend::{
     ClaimOutcome, ModelRecord, RegistryBackend, RegistryResult, create_registry_backend,
 };
@@ -16,6 +18,7 @@ use tracing::info;
 pub struct RegistryManager {
     backend: Arc<RwLock<Option<Arc<dyn RegistryBackend>>>>,
     config: Option<BackendConfig>,
+    metrics: Option<BackendMetrics>,
 }
 
 impl RegistryManager {
@@ -23,7 +26,34 @@ impl RegistryManager {
         Self {
             backend: Arc::new(RwLock::new(None)),
             config: Some(config),
+            metrics: None,
         }
+    }
+
+    /// Record backend operations against `metrics`. See
+    /// [`crate::p2p::state::P2pStateManager::with_metrics`] for why this is
+    /// opt-in rather than a `with_config` parameter.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: BackendMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    /// Build the backend for `config`, wrapping it when metrics are configured.
+    async fn build_backend(
+        &self,
+        config: BackendConfig,
+    ) -> RegistryResult<Arc<dyn RegistryBackend>> {
+        let Some(metrics) = self.metrics.clone() else {
+            return create_registry_backend(config).await;
+        };
+        // Timed around the factory for the same reason as
+        // [`crate::p2p::state::P2pStateManager::build_backend`]: the concrete
+        // backend is already connected by the time it can be wrapped.
+        let backend = metrics
+            .time(Store::Registry, "connect", create_registry_backend(config))
+            .await?;
+        Ok(InstrumentedRegistryBackend::wrap(backend, metrics))
     }
 
     /// Inject a pre-built backend directly (tests only).
@@ -32,6 +62,7 @@ impl RegistryManager {
         Self {
             backend: Arc::new(RwLock::new(Some(backend))),
             config: None,
+            metrics: None,
         }
     }
 
@@ -58,7 +89,7 @@ impl RegistryManager {
             return Ok(config.to_string());
         }
         let backend_name = config.to_string();
-        let backend = create_registry_backend(config).await?;
+        let backend = self.build_backend(config).await?;
         *guard = Some(backend);
         info!("RegistryManager connected (backend: {})", backend_name);
         Ok(backend_name)
@@ -81,7 +112,7 @@ impl RegistryManager {
         // Use Display (redacts connection URLs for Redis) — Debug would print the full
         // `BackendConfig` including the unredacted URL.
         let backend_name = config.to_string();
-        let backend = create_registry_backend(config).await?;
+        let backend = self.build_backend(config).await?;
         info!("RegistryManager lazily connected ({})", backend_name);
         *guard = Some(backend.clone());
         Ok(backend)
@@ -196,6 +227,7 @@ mod tests {
         let mgr = RegistryManager {
             backend: Arc::new(RwLock::new(None)),
             config: None,
+            metrics: None,
         };
         assert!(mgr.connect().await.is_err());
     }

--- a/modelexpress_server/src/server.rs
+++ b/modelexpress_server/src/server.rs
@@ -23,7 +23,10 @@ use crate::cache::CacheEvictionService;
 use crate::config::{AuthMode, ServerConfig};
 use crate::metrics;
 use crate::p2p::{service::P2pServiceImpl, state::P2pStateManager};
-use crate::refit::{backend::create_backend as create_refit_backend, service::RefitServiceImpl};
+use crate::refit::{
+    backend::create_backend as create_refit_backend,
+    backend::instrumented::InstrumentedRefitBackend, service::RefitServiceImpl,
+};
 use crate::registry::state::RegistryManager;
 use crate::services::{ApiServiceImpl, HealthServiceImpl, ModelDownloadTracker, ModelServiceImpl};
 
@@ -62,18 +65,21 @@ struct MetricsListener {
 
 impl MetricsListener {
     /// Start the listener. Returns `None` when metrics are disabled.
-    fn spawn(metrics_addr: Option<std::net::SocketAddr>, backend: &BackendConfig) -> Option<Self> {
+    ///
+    /// The registry is built and fully populated by the caller. It has to be:
+    /// `Registry::register` takes `&mut self` and there is no interior
+    /// mutability, so once the registry is behind the `Arc` this task shares, no
+    /// further family can be added. Building it here would make the listener the
+    /// only thing that could ever own a metric.
+    fn spawn(
+        metrics_addr: Option<std::net::SocketAddr>,
+        registry: Arc<prometheus_client::registry::Registry>,
+    ) -> Option<Self> {
         let metrics_addr = metrics_addr?;
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-        let mut registry = metrics::new_registry();
-        metrics::register_build_info(&mut registry, backend);
-        let handle = tokio::spawn(metrics::serve(
-            metrics_addr,
-            Arc::new(registry),
-            async move {
-                let _ = shutdown_rx.await;
-            },
-        ));
+        let handle = tokio::spawn(metrics::serve(metrics_addr, registry, async move {
+            let _ = shutdown_rx.await;
+        }));
         Some(Self {
             handle: Some(handle),
             shutdown_tx: Some(shutdown_tx),
@@ -162,14 +168,26 @@ pub async fn run_server(
     //
     // Held in a guard so every return path stops it: the steps below can fail,
     // and a detached listener would keep the port for the next call.
-    let metrics_listener = MetricsListener::spawn(metrics_addr, &backend);
+    //
+    // The families are registered unconditionally, even when the listener is
+    // disabled. The alternative -- an `Option` at every instrumentation site --
+    // buys four `Arc` allocations and a second, untested code path.
+    let mut metrics_registry = metrics::new_registry();
+    metrics::register_build_info(&mut metrics_registry, &backend);
+    let grpc_metrics = metrics::grpc::GrpcMetrics::register(&mut metrics_registry);
+    let backend_metrics = metrics::backend::BackendMetrics::register(&mut metrics_registry);
+    let metrics_registry = Arc::new(metrics_registry);
+
+    let metrics_listener = MetricsListener::spawn(metrics_addr, Arc::clone(&metrics_registry));
     if metrics_listener.is_none() {
         info!("Metrics endpoint is disabled");
     }
 
     // Initialize the model registry manager (Redis or Kubernetes CRDs). Shares the
     // injected backend with the P2P state manager below.
-    let registry = Arc::new(RegistryManager::with_config(backend.clone()));
+    let registry = Arc::new(
+        RegistryManager::with_config(backend.clone()).with_metrics(backend_metrics.clone()),
+    );
     match tokio::time::timeout(std::time::Duration::from_secs(10), registry.connect()).await {
         Ok(Ok(backend_name)) => info!("Model registry connected (backend: {backend_name})"),
         Ok(Err(e)) => {
@@ -228,9 +246,20 @@ pub async fn run_server(
         .set_serving::<P2pServiceServer<P2pServiceImpl>>()
         .await;
 
+    // Timed inside the timeout, matching the P2P and registry managers: the
+    // factory connects the concrete backend before it can be wrapped, so the
+    // decorator's own `connect` forward is never reached.
+    //
+    // A connect that exceeds the timeout is recorded too: `BackendMetrics::time`
+    // installs its guard before the await, so the dropped future lands as
+    // `result="cancelled"` rather than as silence.
     let refit_backend = match tokio::time::timeout(
         std::time::Duration::from_secs(10),
-        create_refit_backend(&backend),
+        backend_metrics.time(
+            metrics::backend::Store::Refit,
+            "connect",
+            create_refit_backend(&backend),
+        ),
     )
     .await
     {
@@ -244,7 +273,9 @@ pub async fn run_server(
             return Err("Refit metadata backend connection timed out".into());
         }
     };
-    let refit_service = refit_backend.map(RefitServiceImpl::new);
+    let refit_service = refit_backend
+        .map(|inner| InstrumentedRefitBackend::wrap(inner, backend_metrics.clone()))
+        .map(RefitServiceImpl::new);
     if refit_service.is_some() {
         health_reporter
             .set_serving::<RefitServiceServer<RefitServiceImpl>>()
@@ -254,7 +285,8 @@ pub async fn run_server(
     }
 
     // Initialize P2P state manager — fails fast if backend is misconfigured or unreachable
-    let p2p_state = Arc::new(P2pStateManager::with_config(backend));
+    let p2p_state =
+        Arc::new(P2pStateManager::with_config(backend).with_metrics(backend_metrics.clone()));
 
     match tokio::time::timeout(std::time::Duration::from_secs(10), p2p_state.connect()).await {
         Ok(Ok(backend_name)) => info!("P2P state manager connected (backend: {backend_name})"),
@@ -329,7 +361,12 @@ pub async fn run_server(
     });
 
     info!("Starting gRPC server on: {addr}");
+    // One layer for the whole router rather than one per service: it covers the
+    // two health services as well, and a service added later is instrumented
+    // without a second edit. It sits outside `AuthLayer`, so a rejected call is
+    // counted as `outcome="unauthenticated"` instead of vanishing.
     let router = Server::builder()
+        .layer(metrics::grpc::GrpcMetricsLayer::new(grpc_metrics))
         .add_service(health_service_v1)
         .add_service(HealthServiceServer::new(health_service));
     let router = match &auth_layer {

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::metrics::grpc::RpcOutcome;
 use crate::registry::backend::ClaimOutcome;
 use crate::registry::entry_key::EntryKey;
 use crate::registry::state::RegistryManager;
@@ -183,6 +184,17 @@ impl HealthService for HealthServiceImpl {
 #[derive(Debug, Default)]
 pub struct ApiServiceImpl;
 
+/// Return `body` with the handler's own verdict attached.
+///
+/// See [`crate::metrics::grpc`]. Mirrors the helper in `p2p/service.rs`; kept
+/// local to each module so a handler's outcome is stated next to the handler.
+#[allow(clippy::result_large_err)] // Returns the handlers' own tonic::Status result type.
+fn tagged<T>(body: T, outcome: RpcOutcome) -> Result<Response<T>, Status> {
+    let mut response = Response::new(body);
+    response.extensions_mut().insert(outcome);
+    Ok(response)
+}
+
 #[tonic::async_trait]
 impl ApiService for ApiServiceImpl {
     async fn send_request(
@@ -199,18 +211,27 @@ impl ApiService for ApiServiceImpl {
             let data_bytes = serde_json::to_vec(&response_data)
                 .map_err(|e| Status::internal(format!("Serialization error: {e}")))?;
 
-            Ok(Response::new(ApiResponse {
-                success: true,
-                data: Some(data_bytes),
-                error: None,
-            }))
+            tagged(
+                ApiResponse {
+                    success: true,
+                    data: Some(data_bytes),
+                    error: None,
+                },
+                RpcOutcome::Ok,
+            )
         } else {
             error!("Unknown action: {}", api_request.action);
-            Ok(Response::new(ApiResponse {
-                success: false,
-                data: None,
-                error: Some(format!("Unknown action: {}", api_request.action)),
-            }))
+            // In band, like the P2P handlers: `Ok` on the wire with
+            // `success: false` in the body, so the outcome has to be stated
+            // rather than inferred from the status code.
+            tagged(
+                ApiResponse {
+                    success: false,
+                    data: None,
+                    error: Some(format!("Unknown action: {}", api_request.action)),
+                },
+                RpcOutcome::InvalidArgument,
+            )
         }
     }
 }
@@ -660,16 +681,41 @@ impl ModelService for ModelServiceImpl {
         // for metadata-only downloads). `model clear` means "forget this model", so drop
         // all of them rather than only the unpinned full-weight entry.
         let tracker = self.tracker.clone();
-        let removed = tracker.delete_model_entries(&model_name).await;
+        let outcome = tracker.delete_model_entries(&model_name).await;
+        let removed = outcome.removed;
         info!("Deleted {removed} registry record(s) for model '{model_name}'");
 
-        Ok(Response::new(DeleteModelResponse {
-            success: true,
-            message: Some(format!(
-                "Model '{model_name}' removed from registry ({removed} record(s))"
-            )),
-        }))
+        // The response stays `success: true` -- the fallback delete was still
+        // attempted and callers depend on that shape. But a registry outage and a
+        // model with no entries both return zero records here, so without the tag
+        // the RPC would be recorded as a plain success during an outage. That is
+        // the exact failure this layer exists to prevent.
+        tagged(
+            DeleteModelResponse {
+                success: true,
+                message: Some(format!(
+                    "Model '{model_name}' removed from registry ({removed} record(s))"
+                )),
+            },
+            if outcome.degraded {
+                RpcOutcome::BackendError
+            } else {
+                RpcOutcome::Ok
+            },
+        )
     }
+}
+
+/// What clearing a model's registry entries actually achieved.
+///
+/// `removed` alone cannot distinguish "this model had no entries" from "the
+/// registry was unreachable and only the fallback key was tried" -- both are
+/// zero.
+pub struct DeleteEntriesOutcome {
+    /// How many records were removed.
+    pub removed: usize,
+    /// The registry listing failed, so `removed` is a floor rather than a count.
+    pub degraded: bool,
 }
 
 /// Type alias for the complex waiting channels type
@@ -826,8 +872,13 @@ impl ModelDownloadTracker {
     }
 
     /// Deletes every registry entry belonging to `model_name`, whatever revision or
-    /// weight mode each entry covers. Returns how many records were removed.
-    pub async fn delete_model_entries(&self, model_name: &str) -> usize {
+    /// weight mode each entry covers.
+    ///
+    /// The registry-listing failure is swallowed on purpose: the fallback still
+    /// clears the common case, which is better than refusing outright. It is
+    /// reported in the return value so the caller can say so, because otherwise a
+    /// backend outage and a model with no entries are the same `0`.
+    pub async fn delete_model_entries(&self, model_name: &str) -> DeleteEntriesOutcome {
         let records = match self.registry.get_models_by_last_used(None).await {
             Ok(records) => records,
             Err(e) => {
@@ -835,7 +886,10 @@ impl ModelDownloadTracker {
                 // Fall back to the unpinned full-weight key so the common case still
                 // clears rather than failing outright.
                 self.delete_status(model_name).await;
-                return 0;
+                return DeleteEntriesOutcome {
+                    removed: 0,
+                    degraded: true,
+                };
             }
         };
 
@@ -846,7 +900,10 @@ impl ModelDownloadTracker {
                 removed = removed.saturating_add(1);
             }
         }
-        removed
+        DeleteEntriesOutcome {
+            removed,
+            degraded: false,
+        }
     }
 
     /// Spawn a background task that actually downloads the model, updating the tracker on
@@ -1129,6 +1186,26 @@ mod tests {
         assert_eq!(health_response.status, "ok");
         // uptime is u64, always >= 0, so just verify it exists
         let _uptime = health_response.uptime;
+    }
+
+    /// The unknown-action path is an in-band failure and must not read as `ok`.
+    #[tokio::test]
+    async fn unknown_action_is_tagged_invalid_argument() {
+        let service = ApiServiceImpl;
+        let response = service
+            .send_request(Request::new(ApiRequest {
+                id: "test-id".to_string(),
+                action: "not-a-real-action".to_string(),
+                payload: None,
+            }))
+            .await
+            .expect("the RPC itself succeeds");
+
+        assert_eq!(
+            response.extensions().get::<RpcOutcome>(),
+            Some(&RpcOutcome::InvalidArgument)
+        );
+        assert!(!response.into_inner().success);
     }
 
     #[tokio::test]

--- a/modelexpress_server/tests/in_process_server.rs
+++ b/modelexpress_server/tests/in_process_server.rs
@@ -275,3 +275,78 @@ async fn an_early_failure_releases_the_metrics_port() {
          the listener was detached rather than stopped"
     );
 }
+
+/// The Phase 2 exit criterion, end to end: a handler that fails **in band** is
+/// reported as a failure by the metrics layer.
+///
+/// `PublishMetadata` with no identity returns `Ok` with `success: false`. The
+/// gRPC status is therefore `Ok`, so a status-code-derived metric would record
+/// this as a success -- and would likewise record a total Redis outage as a
+/// success, since `ListSources` reports that failure the same way.
+///
+/// This is also the only test that can exercise the *propagation* half of the
+/// mechanism. The handler inserts an `RpcOutcome` into its response extensions
+/// and the tower layer reads it back off the encoded `http::Response`; the step
+/// between them is `tonic::Response::into_http`, which is `pub(crate)`, so no
+/// unit test outside tonic can drive it.
+#[tokio::test]
+async fn an_in_band_failure_is_not_recorded_as_a_success() {
+    use modelexpress_common::grpc::p2p::PublishMetadataRequest;
+    use modelexpress_common::grpc::p2p::p2p_service_client::P2pServiceClient;
+
+    let [port, metrics_port] = free_ports::<2>();
+    let (shutdown, handle) = start_server_with_metrics(port, metrics_port);
+
+    // Wait for the gRPC side before driving it.
+    let mut client = connect_client(port).await;
+    client
+        .health_check()
+        .await
+        .expect("health_check round-trip should succeed");
+
+    let mut p2p = P2pServiceClient::connect(format!("http://127.0.0.1:{port}"))
+        .await
+        .expect("connect to the p2p service");
+
+    let response = p2p
+        .publish_metadata(PublishMetadataRequest {
+            identity: None,
+            ..Default::default()
+        })
+        .await
+        .expect("the RPC itself succeeds -- that is the point");
+    assert!(
+        !response.into_inner().success,
+        "expected an in-band failure, not a transport failure"
+    );
+
+    let body = scrape(metrics_port).await;
+
+    // The outcome came from the handler, not from the status code.
+    assert!(
+        body.contains(
+            r#"mx_grpc_requests_total{method="P2pService/PublishMetadata",outcome="invalid_argument"} 1"#
+        ),
+        "expected the handler's own outcome in the scrape, got: {body}"
+    );
+    // The same call must not also be counted as a success.
+    assert!(
+        !body.contains(
+            r#"mx_grpc_requests_total{method="P2pService/PublishMetadata",outcome="ok"}"#
+        ),
+        "the in-band failure was also counted as a success: {body}"
+    );
+    // Latency is observed under the same label set.
+    assert!(
+        body.contains(r#"mx_grpc_request_seconds_count{method="P2pService/PublishMetadata""#),
+        "expected a latency observation, got: {body}"
+    );
+    // The health probe that got us here is counted too, proving one layer covers
+    // services it was never explicitly attached to.
+    assert!(
+        body.contains(r#"method="HealthService/GetHealth""#),
+        "expected the health service to be covered by the same layer, got: {body}"
+    );
+
+    stop_and_join(shutdown, handle).await;
+}


### PR DESCRIPTION
## Summary

Adds per-RPC and storage-backend metrics to the server. This is step 3 of the six in #645,
and the first step that adds real families rather than plumbing.

The point of it is one thing: **make a backend outage visible.** Today it is not.

| Step | Scope | Exit criterion |
| --- | --- | --- |
| 1–2. Pipeline (#645) | exposition path, `mx_build_info`, client multiprocess mode | `up == 1`; merged series at TP=8 |
| **3. Request and backend coverage** — *this PR* | one tower layer over 21 routed methods, decorators over 3 backend traits | a backend error surfaces as `outcome="backend_error"`, not as silence |
| 4. Export what is already computed | refit stage timings, cache statistics, registry status counts, NIXL health | refit stage sums match the existing JSON log record |
| 5. Load and transfer timing tiers | `mx_load_seconds` down to `mx_transfer_phase_seconds` | Σ L4 ≤ L3 ≤ L2 ≤ L1 ≤ L0 on a live run |
| 6. Deployment surface | gauges, PodMonitor, dashboards, recording rules | a dashboard answers "why was this load slow" |

## Problem

Four `P2pService` handlers report failure **in band**: they catch the error, log it, and
return `Ok` carrying `success: false` or an empty list. That is deliberate and clients
depend on it — but it means the gRPC status code says `Ok` throughout.

`ListSources` is the clearest case. These two are byte-identical on the wire:

- Redis is down.
- No peers have published yet.

Both are `Ok(ListSourcesResponse { instances: [] })`. So the obvious implementation — a
status-code-derived interceptor — would report **100% success through a total backend
outage**, while the client independently misfiles the same outage as `metadata_miss`. The
metric would be worse than no metric: confidently wrong during the incident it exists to
explain.

Nothing else on the server is covered either. There are no RPC counts, no handler latency,
and no visibility into Redis or the kube API, so "is the server slow, or is the store slow"
is unanswerable.

## Fix

**One tower layer**, applied once at `Server::builder()`, covering all 21 routed methods.
It resolves the outcome in three steps:

1. an `RpcOutcome` the handler tagged onto its own response;
2. otherwise a `tonic::Status` in the response extensions;
3. otherwise success.

Step 2 is why this is cheap. `Status::into_http` already does
`response.extensions_mut().insert(self)`, so **every** `Err(Status)` path self-reports —
including auth rejections and tonic's `unimplemented` fallback. All nine `RefitService`
handlers, which fail honestly, needed no edit. Only handlers that would otherwise misreport
were touched.

**Three decorators** for the backend traits, implementing the same trait and delegating.
The Redis, Kubernetes and in-memory implementations are untouched, and a backend added later
is instrumented by construction rather than by remembering to add timing code.

To be explicit about scope, since the problem above is told through P2P: this half is
**server-wide, not P2P-only**. `mx_backend_ops_total` covers all three storage subsystems --
P2P source metadata, the model registry, and the refit weight-version store -- distinguished
by the `store` label. P2P leads the narrative only because that is where the in-band-failure
problem is sharpest.

**The registry is hoisted out of `MetricsListener::spawn`**, which built it and froze it
into an `Arc` in one expression. `Registry::register` takes `&mut self` with no interior
mutability, so nothing could register a family after that point.

| Family | Type | Labels |
| --- | --- | --- |
| `mx_grpc_requests_total` | Counter | `method`, `outcome` |
| `mx_grpc_request_seconds` | Histogram | `method`, `outcome` |
| `mx_grpc_requests_in_flight` | Gauge | `method` |
| `mx_backend_ops_total` | Counter | `store`, `op`, `result` |
| `mx_backend_op_seconds` | Histogram | `store`, `op`, `result` |
| `mx_backend_ops_in_flight` | Gauge | `store`, `op` |

`method` is a closed set of the 21 known routes plus `other`, so an unrecognised path cannot
mint a series.

**The two streaming RPCs are deliberately not recorded.** `EnsureModelDownloaded` and
`StreamModelFiles` return their response head as soon as the stream is set up, and report
failure as a stream item -- `EnsureModelDownloaded` sends `ModelStatus::ERROR` as an item.
The layer's future resolves at the head, so recording there would report `outcome="ok"` and a
sub-millisecond duration for a download that ran for forty minutes and failed. That is the
same confidently-wrong number this PR exists to remove, so they are absent rather than wrong.
`Health/Watch` is excluded for the same reason. Covering them means instrumenting the
response body and reading the trailer, which is its own change. `store` is the subsystem (`p2p`, `registry`, `refit`), not the storage engine
— only one engine is live per pod, so the engine stays on `mx_build_info{backend=...}` and
joins from there.

## Two deltas from the plan in #645

Worth calling out, because #645's roadmap table said otherwise:

- **The 5 Python `WorkerService` RPCs are not here.** They are a client-side family
  (`mx_worker_grpc_requests_total`) and belong with the client work, so this PR is
  Rust-server-only.
- **The backend half is three decorators, not one wrapper.** `MetadataBackend` (9 methods),
  `RegistryBackend` (12) and `RefitBackend` (9) share no supertrait and have three different
  error types, so no blanket impl is possible. That is 30 explicit forwards and the bulk of
  the diff. A macro would shrink it to roughly a third and be harder to review than the code
  it replaced.

## Testing

- **Exit criterion, end to end** — `an_in_band_failure_is_not_recorded_as_a_success` drives a
  real client against a real server, and asserts the scrape shows `outcome="invalid_argument"`
  for a call whose gRPC status was `Ok`. This is also the only test that can cover the
  propagation step: `tonic::Response::into_http` is `pub(crate)`, so no unit test outside
  tonic can drive it.
- **The forwarding trap** — `list_workers_filtered` is the one trait method with a default
  body, and only Redis overrides it. A decorator that inherited the default would silently
  bypass the pipelined implementation and double-count every call. Asserted with a mock that
  requires `list_workers` to be called exactly zero times.
- **Encoded names** — counters are registered *without* `_total` because the encoder appends
  it; the tests assert the exported names, and that nothing ends in `_total_total`.
- **Cardinality** — unknown paths collapse to `other`.
- **Cancellation** — a request dropped mid-flight records `outcome="cancelled"` and writes no
  latency sample, so the histogram is not silently conditioned on completion; the in-flight
  gauges are asserted to return to zero on every exit path.
- Both load-bearing assertions were mutation-tested: flipping the `list_sources` tag to `Ok`,
  and disabling the tag insertion entirely, each fail the relevant test.

- **Route coverage** — a test parses the protos and fails the build if any routed RPC lacks a
  `method_label` arm. Note what this does *not* cover: a new **streaming** RPC that does get a
  `method_label` arm but is not added to `resolves_at_head` would still be recorded at the
  head. The limitation is stated on `resolves_at_head` itself; closing it needs
  streaming-ness derived from the protos rather than from a hand-maintained list.

280 server unit tests (`--features integration-tests`), 5 integration tests, `cargo clippy
--workspace --all-targets --all-features -- -D warnings` clean.

## Verified against a real backend

The unit tests prove the mechanism; only a real outage proves the exit criterion. Run against
a Redis on an internal dev cluster, with the server driven by the generated Python stubs.

**The exit criterion holds.** With Redis healthy, 200 `ListSources` calls recorded
`outcome="ok"`. Redis was then force-deleted and the calls repeated. On the wire those calls
still returned `Ok` with an empty `instances` list -- indistinguishable from a healthy empty
cluster -- and the metric said otherwise:

```
mx_grpc_requests_total{method="P2pService/ListSources",outcome="backend_error"} 2
mx_backend_ops_total{store="p2p",op="list_workers_filtered",result="error"} 2
```

The gRPC layer and the backend decorator reached that verdict independently, by different
routes, and agree. A status-code-derived metric would have recorded both calls as successes.

**The forwarding trap is real and is avoided.** During the healthy phase the counters read
`op="list_workers_filtered"` 200 and `op="list_workers"` 4 -- the latter only from the
reaper, which genuinely calls it. Had the decorator inherited the default body, the 200 would
have appeared under both names and Redis's pipelined implementation would never have run.

**Overhead is below this harness's noise floor.** Four interleaved rounds of 3000 RPCs
against the pre-change binary and this one, on the in-memory backend so nothing but the layer
differs, on a path that returns before touching any backend:

| | p50 | p95 | mean |
| --- | --- | --- | --- |
| `main` (29e2f7cd) | 0.095-0.096 ms | 0.150-0.158 ms | 0.101-0.104 ms |
| this PR | 0.095-0.101 ms | 0.149-0.179 ms | 0.102-0.113 ms |

p50 is identical. Run-to-run variance within each arm exceeds the difference between them,
and the newer binary was faster on mean in two of the four rounds, so the honest statement is
that the layer's cost is not resolvable at this sample size rather than any specific figure.

**Scrape cost** at full label saturation for the exercised paths: 140 series, 13.7 KB,
0.9-1.2 ms per scrape.

## Compatibility

Additive. No existing family, label or endpoint changes, and no configuration is required —
the families register on the same registry and appear on the same `/metrics` port added in
 #645.

Recording is on whenever the server runs, including when the metrics listener is disabled
(`--metrics-port 0`); only the listener is conditional. The alternative — an `Option` at
every instrumentation site — costs a second, untested code path to save four `Arc`
allocations.

Handler behaviour is unchanged. The outcome tag is metrics-only: it does not touch the
response body or the status code, and dropping it degrades the metric to `outcome="ok"`
rather than breaking the call.


