### PR TITLE
fix(sglang): adopt container-held tensors, and survive SGLang's object graph

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -20,6 +20,7 @@ from ...accelerators import accelerator_backend_for
 from ...load_strategy.context import LoadContext, LoadResult
 from ...metadata.client_factory import create_metadata_client
 from ...tensor_utils import (
+    adopt_hidden_tensors,
     capture_tensor_attrs,
     collect_module_tensors,
 )
@@ -79,17 +80,20 @@ class SglangAdapter(EngineAdapter):
     def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
         if result.model is None:
             raise RuntimeError("SGLang tensor discovery requires result.model")
-        # adopt_hidden_tensors() would also register accelerator tensors stashed
-        # on non-Module objects (e.g. SGLang's MXFP4 FusedMoE quant_method, which
-        # holds swizzled weights after deleting the original params). It is left
-        # commented out for now: it is a no-op for DeepSeek-V2-Lite (whose derived
-        # w_kc/w_vc are direct Tensor attributes, already promoted by
-        # capture_tensor_attrs), and enabling it adds new _mx_* manifest names,
-        # i.e. a transfer-ABI change that needs a version bump to avoid mixed
-        # old/new source/target manifests plus MXFP4 + CUTLASS FP8/W4A8 smoke
-        # tests. Enable it (with those guards) when SGLang nested-object coverage
-        # is in scope.
-        # adopt_hidden_tensors(result.model, self.accelerator_backend)
+        # capture_tensor_attrs() only promotes bare Tensor attributes assigned
+        # onto Modules (self.w_kc = tensor). Accelerator tensors stashed inside
+        # containers on non-Module objects - dicts, lists, nested dataclasses -
+        # stay invisible to named_parameters()/named_buffers() and so never
+        # reach the manifest. Kimi-K3 is full of them: on the vLLM path the same
+        # scan adopts 553 per rank, 368 of which live in one dict
+        # (Mxfp4MoEMethod._cache_permute_indices, keyed by tuples), plus an
+        # attention-backend workspace buffer. A target that never receives them
+        # runs forward with whatever its own init left behind.
+        #
+        # This adds _mx_* names to the manifest, so source and target must run
+        # the same ModelExpress version; mixing old and new manifests fails
+        # tensor matching.
+        adopt_hidden_tensors(result.model, self.accelerator_backend)
         return collect_module_tensors(result.model, self.accelerator_backend)
 
     def before_rdma_receive(self, result: LoadResult) -> LoadResult:

--- a/modelexpress_client/python/modelexpress/tensor_utils.py
+++ b/modelexpress_client/python/modelexpress/tensor_utils.py
@@ -109,7 +109,7 @@ def _find_hidden_accel_tensors(
         if accelerator_backend.is_accel_tensor(tensor) and tensor.numel() > 0:
             results.append(("t", tensor))
     elif isinstance(obj, (list, tuple)):
-        for i, item in enumerate(obj):
+        for i, item in enumerate(list(obj)):
             for path, tensor in _find_hidden_accel_tensors(
                 item,
                 visited,
@@ -118,7 +118,9 @@ def _find_hidden_accel_tensors(
             ):
                 results.append((f"{i}_{path}", tensor))
     elif isinstance(obj, dict):
-        for k, v in obj.items():
+        # snapshot: traversal can trigger lazy attributes that mutate the
+        # container we are walking (seen on SGLang's K3 object graph)
+        for k, v in list(obj.items()):
             for path, tensor in _find_hidden_accel_tensors(
                 v,
                 visited,
@@ -127,7 +129,7 @@ def _find_hidden_accel_tensors(
             ):
                 results.append((f"{k}_{path}", tensor))
     elif hasattr(obj, "__dict__") and not isinstance(obj, (type, nn.Module)):
-        for attr_name, attr_val in vars(obj).items():
+        for attr_name, attr_val in list(vars(obj).items()):
             if attr_name.startswith("__"):
                 continue
             for path, tensor in _find_hidden_accel_tensors(

--- a/modelexpress_client/python/modelexpress/tensor_utils.py
+++ b/modelexpress_client/python/modelexpress/tensor_utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import types
 from contextlib import contextmanager
 from typing import cast
 
@@ -128,16 +129,32 @@ def _find_hidden_accel_tensors(
                 depth + 1,
             ):
                 results.append((f"{k}_{path}", tensor))
-    elif hasattr(obj, "__dict__") and not isinstance(obj, (type, nn.Module)):
+    elif hasattr(obj, "__dict__") and not isinstance(
+        obj, (type, nn.Module, types.ModuleType)
+    ):
+        # Module objects are import registries, not tensor containers, and
+        # walking them trips lazy-import machinery (transformers' _LazyModule
+        # raises for classes absent from the installed version). Any attribute
+        # may also be a property that raises, so failures skip that attribute
+        # rather than taking the whole registration down.
         for attr_name, attr_val in list(vars(obj).items()):
             if attr_name.startswith("__"):
                 continue
-            for path, tensor in _find_hidden_accel_tensors(
-                attr_val,
-                visited,
-                accelerator_backend,
-                depth + 1,
-            ):
+            try:
+                nested = _find_hidden_accel_tensors(
+                    attr_val,
+                    visited,
+                    accelerator_backend,
+                    depth + 1,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Skipping attribute %s on %s while scanning for hidden "
+                    "tensors: %s",
+                    attr_name, type(obj).__name__, exc,
+                )
+                continue
+            for path, tensor in nested:
                 results.append((f"{attr_name}_{path}", tensor))
 
     return results

--- a/modelexpress_client/python/modelexpress/tensor_utils.py
+++ b/modelexpress_client/python/modelexpress/tensor_utils.py
@@ -86,6 +86,19 @@ def capture_tensor_attrs(accelerator_backend: AcceleratorBackend):
         nn.Module.__setattr__ = original_setattr
 
 
+def _has_own_dict(obj: object) -> bool:
+    """Whether obj carries an instance dict worth walking.
+
+    ``hasattr`` reaches ``__getattr__`` on objects without a real ``__dict__``,
+    and a lazy proxy can raise there, so a raising probe means "not a
+    container" rather than aborting the whole scan.
+    """
+    try:
+        return hasattr(obj, "__dict__")
+    except Exception:
+        return False
+
+
 def _find_hidden_accel_tensors(
     obj: object,
     visited: set[int],
@@ -129,8 +142,8 @@ def _find_hidden_accel_tensors(
                 depth + 1,
             ):
                 results.append((f"{k}_{path}", tensor))
-    elif hasattr(obj, "__dict__") and not isinstance(
-        obj, (type, nn.Module, types.ModuleType)
+    elif not isinstance(obj, (type, nn.Module, types.ModuleType)) and _has_own_dict(
+        obj
     ):
         # Module objects are import registries, not tensor containers, and
         # walking them trips lazy-import machinery (transformers' _LazyModule

--- a/modelexpress_client/python/tests/test_tensor_utils.py
+++ b/modelexpress_client/python/tests/test_tensor_utils.py
@@ -3,6 +3,8 @@
 
 """Tests for tensor_utils: hidden tensor adoption, capture_tensor_attrs, checksums."""
 
+import types
+
 import torch
 import torch.nn as nn
 
@@ -347,3 +349,73 @@ class TestCollectModuleTensors:
         model.register_buffer("nc_view", view, persistent=False)
         tensors = collect_module_tensors(model, backend)
         assert "nc_view.__storage" in tensors
+
+
+# ---------------------------------------------------------------------------
+# Traversal robustness. Both shapes below were hit on SGLang + Kimi-K3, where
+# they aborted registration entirely and left the worker serving without its
+# container-held tensors. The trigger in each case is an attribute lookup made
+# by the walk itself: on an object with no real __dict__, the `hasattr` probe
+# reaches __getattr__, which is where lazy-import machinery runs.
+# ---------------------------------------------------------------------------
+
+
+class LazyProxy:
+    """No real __dict__; __getattr__ raises for anything it cannot resolve.
+
+    Mirrors transformers' _LazyModule asked for a class the installed version
+    does not ship:
+      Could not find VoxtralRealtimeTextModel neither in <module 'transformers.models'>
+    """
+
+    __slots__ = ()
+
+    def __getattr__(self, name):
+        raise RuntimeError(
+            f"Could not find {name} neither in <module 'transformers.models'>"
+        )
+
+
+class CachingProxy:
+    """No real __dict__; the lookup caches into the container being walked."""
+
+    __slots__ = ("_parent",)
+
+    def __init__(self, parent):
+        object.__setattr__(self, "_parent", parent)
+
+    def __getattr__(self, name):
+        self._parent[f"cached_{len(self._parent)}"] = torch.zeros(1)
+        raise AttributeError(name)
+
+
+class TestTraversalRobustness:
+    def test_raising_proxy_does_not_abort_the_scan(
+        self, mock_accelerator_backend_cls
+    ):
+        backend = mock_accelerator_backend_cls(torch_device_type="cpu")
+        holder = {"weight": torch.randn(4), "proxy": LazyProxy()}
+        found = _find_hidden_accel_tensors(
+            holder, visited=set(), accelerator_backend=backend
+        )
+        assert [t.numel() for _, t in found] == [4]
+
+    def test_container_mutated_during_scan(self, mock_accelerator_backend_cls):
+        backend = mock_accelerator_backend_cls(torch_device_type="cpu")
+        holder = {"weight": torch.randn(4)}
+        holder["proxy"] = CachingProxy(holder)
+        found = _find_hidden_accel_tensors(
+            holder, visited=set(), accelerator_backend=backend
+        )
+        assert any(t.numel() == 4 for _, t in found)
+
+    def test_module_objects_are_not_walked(self, mock_accelerator_backend_cls):
+        """A module is an import registry; walking it runs lazy imports."""
+        backend = mock_accelerator_backend_cls(torch_device_type="cpu")
+        mod = types.ModuleType("fake_transformers_models")
+        mod.lazy = LazyProxy()
+        holder = {"weight": torch.randn(4), "mod": mod}
+        found = _find_hidden_accel_tensors(
+            holder, visited=set(), accelerator_backend=backend
+        )
+        assert [t.numel() for _, t in found] == [4]


### PR DESCRIPTION
This is the code that was run on hardware and got Kimi-K3 transferring
correctly over SGLang. Both files match the build that produced the evidence
below byte-for-byte (`adapter.py` sha256 `113b3791f927…`, `tensor_utils.py`
`1d47358946d1…`).

## Problem

SGLang's adapter never adopted hidden tensors. `capture_tensor_attrs` only
promotes bare `Tensor` attributes, so weight-derived tensors held inside
containers or on non-`nn.Module` objects stay out of the RDMA manifest:
SGLang's MXFP4 FusedMoE `quant_method` holds swizzled weights after deleting
the original params, and Kimi-K3 keeps `_attn_res_cw_cache` in a dict and
`_k3_fused_decode_args` in a tuple.

Those arrive at dummy values on an RDMA target. Every manifest check passes,
and the model then produces garbage.

Simply calling `adopt_hidden_tensors` is not enough: the traversal it relies on
cannot survive SGLang's object graph. Three shapes took the whole registration
down instead of being skipped, all reached through the same probe,
`hasattr(obj, "__dict__")` — on an object without a real instance dict that
lookup runs `__getattr__`, which is where lazy-import machinery lives.

| shape | what happened |
|---|---|
| a lookup mutates the container being walked | `RuntimeError: dictionary changed size during iteration` |
| a proxy raises for an attribute it cannot resolve | `RuntimeError: Could not find VoxtralRealtimeTextModel neither in <module 'transformers.models'>` |
| a module object reached as a plain attribute | walking it triggers the lazy-import machinery above |

## Fix

**`engines/sglang/adapter.py`** — call `adopt_hidden_tensors`, matching the vLLM
adapter. The same tensor objects are registered, so the container entries alias
the transferred memory and the receive path stays "transfer the final state,
derive nothing afterwards".

**`tensor_utils.py`** — make the traversal survive that graph:

- snapshot containers (`list(obj.items())`, `list(vars(obj).items())`,
  `enumerate(list(obj))`) so a lazy attribute cannot invalidate the iterator
- skip `types.ModuleType`: a module is an import registry, not a tensor
  container
- per-attribute `try/except` so one bad attribute costs that attribute, not the
  scan
- probe for the instance dict through `_has_own_dict()`, which treats a raising
  probe as "not a container" instead of letting it escape

The last one is subtle: an earlier version wrapped the per-attribute recursion
but not the `hasattr` probe itself, which sits in the `elif` condition, so a
raising proxy still aborted everything. The regression tests caught that.

## Verification on hardware

Kimi-K3, TP16 across 4+4 GB200 nodes on GCP, SGLang, weights received over
RDMA, source loads from disk and publishes:

| | manifest entries | target output |
|---|---|---|
| without adoption | 3042 | garbage |
| with this change | 3417 (+375) | SHA1-identical to the source: `881189c3e5e2`, `0f9720e40314`, `d4313e09c000` |

Without the `tensor_utils.py` fixes, enabling adoption on that stack does not
produce garbage — it crashes during registration with the two errors above.

## Tests

Three regression tests, one per shape, reproducing the two production error
strings. Each **fails on `main`**:

```
FAILED test_tensor_utils.py::TestTraversalRobustness::test_raising_proxy_does_not_abort_the_scan
FAILED test_tensor_utils.py::TestTraversalRobustness::test_container_mutated_during_scan
FAILED test_tensor_utils.py::TestTraversalRobustness::test_module_objects_are_not_walked
3 failed, 29 deselected
```

and passes here (32 passed in that file, 68 with `test_pool_registration.py`).

Full client suite: 87 failed / 1230 passed on this branch versus 87 failed /
1227 passed on `main` — same failures (pre-existing and environmental), plus
the three new tests.

A first attempt at these tests passed on unfixed `main`, i.e. proved nothing:
the helpers hung `@property` and `__getattr__` on names the walk never touches
(a property lives on the class, so it is not in `vars(obj)`, and the walk reads
`__dict__` values rather than doing attribute lookups). They were rewritten
around the `hasattr` probe, which is the real trigger.

## Note

Supersedes #589, which enabled adoption without the traversal fixes it needs.
