### PR TITLE
feat(refit): map a native trainer layout into the vLLM loader on receive

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/vllm/refit/receiver.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/refit/receiver.py
@@ -7,10 +7,12 @@ Implements the two engine hooks of
 :class:`~modelexpress.refit.reshard.receiver.ReshardReceiver`
 for vLLM:
 
-  * :meth:`_capture` - build a fresh UNQUANTIZED meta twin of the model and drive
-    its ``load_weights`` with the record-only geometry capture, so we record where
-    each source lands in the bf16 load-time layout (the live params are post-quant
-    for a quantized model, so we can't capture on them).
+  * :meth:`_capture` - capture load geometry on the live model: revert its params
+    to their bf16 load-time skeletons via ``initialize_layerwise_reload`` (the
+    pre-quant layout we slice into), drive ``load_weights`` with the record-only
+    geometry capture, then restore the graph-bound tensors (without finalizing).
+    Recording on the real model keeps Expert-Parallel's expert map populated with
+    real values, which the FusedMoE loader reads while placing expert weights.
   * :meth:`_install` - install the RDMA'd receive buffers into the live params via
     vLLM's layerwise reload: ``initialize_layerwise_reload`` reverts the live
     params to bf16 load-time skeletons + snapshots the CUDA-graph-bound kernel
@@ -31,7 +33,9 @@ from typing import Any
 import torch
 from torch.nn import Module
 
-from modelexpress.refit.reshard.geometry import capture_geometry
+from collections.abc import Callable
+
+from modelexpress.refit.reshard.geometry import capture_weights, convert_source_weights
 from modelexpress.refit.reshard.receiver import ReshardReceiver
 from modelexpress.refit.reshard.types import CaptureResult
 
@@ -39,83 +43,81 @@ logger = logging.getLogger("modelexpress.engines.vllm.refit.receiver")
 
 
 class VllmReshardReceiver(ReshardReceiver):
-    """Slice-resharding weight receiver for a vLLM model."""
+    """Slice-resharding weight receiver for a vLLM model.
+
+    ``convert_native_to_hf`` handles a trainer that publishes weights under its own
+    native (non-HF) layout: it is that trainer's native -> HF mapping
+    (``dict[str, Tensor] -> dict[str, Tensor]``), run on lazy placeholders during
+    capture so only structure is traced (see :func:`convert_source_weights`). Leave
+    it ``None`` (the default) when the trainer already publishes HF-canonical names.
+    """
 
     def __init__(
-        self, *, model: Module, vllm_config: Any, model_config: Any, **base_kwargs: Any
+        self,
+        *,
+        model: Module,
+        vllm_config: Any,
+        model_config: Any,
+        convert_native_to_hf: Callable[[dict], dict] | None = None,
+        **base_kwargs: Any,
     ) -> None:
         self._model = model
         self._vllm_config = vllm_config
         self._model_config = model_config
+        self._convert_native_to_hf = convert_native_to_hf
         super().__init__(device=base_kwargs.pop("device"), **base_kwargs)
 
     @property
     def _is_quantized(self) -> bool:
         """True when the live model was quantized (fp8, etc.) - its live params are
-        then post-PWAL (Marlin-packed / kernel layout), not the bf16 load-time
-        layout, so capture runs on a meta twin and quantized layers re-quantize
-        via PWAL on install."""
+        then post-PWAL (Marlin-packed / kernel layout). Capture reverts them to the
+        bf16 load-time skeletons via layerwise reload, and install re-quantizes via
+        PWAL."""
         return getattr(self._vllm_config, "quant_config", None) is not None
 
     # ---------------------------------------------------------------- capture
-    def _build_meta_twin(self) -> Module:
-        """Build a fresh twin of the model on ``meta`` to capture the bf16
-        load-time slice geometry.
-
-        Stripped of quantization: vLLM's fp8 ``create_weights`` makes params
-        directly as ``float8_e4m3fn``, so a same-config twin would have fp8 params
-        and every source would be a dtype mismatch (no bf16 layout to slice into).
-        An unquantized twin has bf16 params with the same structural fusion =
-        the load-time layout; the live fp8 model is re-quantized separately on
-        install. ``meta`` -> zero storage, discarded after capture."""
-        import copy as _copy
-
-        from vllm.model_executor.model_loader.utils import initialize_model
-        from vllm.utils.torch_utils import set_default_torch_dtype
-
-        # Strip quantization so the twin builds Unquantized (bf16) params.
-        twin_config = _copy.copy(self._vllm_config)
-        twin_mc = _copy.copy(self._vllm_config.model_config)
-        twin_mc.quantization = None
-        twin_config.model_config = twin_mc
-        twin_config.quant_config = None
-        # Attention.__init__ rejects a duplicate layer prefix in
-        # compilation_config.static_forward_context - the live model already
-        # populated it, so the twin needs its OWN empty registry.
-        twin_cc = _copy.copy(self._vllm_config.compilation_config)
-        twin_cc.static_forward_context = {}
-        twin_config.compilation_config = twin_cc
-
-        # Without set_default_torch_dtype the layers create params at torch's
-        # default (fp32), not the model's bf16 (vLLM's loader wraps init the same).
-        with set_default_torch_dtype(self._model_config.dtype), torch.device("meta"):
-            twin = initialize_model(twin_config)
-        logger.info(
-            "[reshard] built unquantized meta-twin for bf16 load-time geometry capture"
-        )
-        return twin
-
     def _capture(self, manifest: list) -> "tuple[CaptureResult, dict]":
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader.reload.layerwise import (
+            LAYERWISE_INFO,
+            _get_original_loader,
+            _place_kernel_tensors,
+            initialize_layerwise_reload,
+        )
         from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
-        # Always capture on a fresh meta twin (uniform for bf16 + quantized): its
-        # load_weights is pre-PWAL (bf16 load-time), which for a quantized model is
-        # the layout we slice into, and for bf16 is identical to the live params.
-        # Pass default_weight_loader so params WITHOUT a custom weight_loader
-        # (norms) are stamped and their copies attributed rather than dropped.
-        twin = self._build_meta_twin()
-        capture = capture_geometry(
-            twin, manifest, default_weight_loader=default_weight_loader
-        )
+        # Capture on the LIVE model, params reverted to bf16 load-time skeletons via
+        # layerwise reload (see module docstring). No weight data moves; restored below.
+        model = self._model
+        with torch.device(self._device), set_current_vllm_config(self._vllm_config):
+            initialize_layerwise_reload(model)
+            try:
+                # Trace the ORIGINAL loaders, not the reload shims they were wrapped in.
+                for _, param in model.named_parameters():
+                    param.weight_loader = _get_original_loader(param)
+                capture = capture_weights(
+                    model,
+                    convert_source_weights(self._convert_native_to_hf, manifest),
+                    default_weight_loader=default_weight_loader,
+                )
+                param_layout = {
+                    n: (tuple(p.shape), p.dtype) for n, p in model.named_parameters()
+                }
+            finally:
+                # Restore graph-bound kernel tensors; do NOT finalize (would corrupt
+                # the live params by committing a reload of the empty skeletons).
+                for layer in model.modules():
+                    info = LAYERWISE_INFO.get(layer)
+                    if info is not None:
+                        if info.kernel_tensors is not None:
+                            _place_kernel_tensors(layer, info)
+                        info.reset()
         logger.info(
             "[reshard] captured %d copies, %d unsupported (quantized=%s)",
             len(capture.copies),
             len(capture.unsupported),
             self._is_quantized,
         )
-        param_layout = {
-            n: (tuple(p.shape), p.dtype) for n, p in twin.named_parameters()
-        }
         return capture, param_layout
 
     # ---------------------------------------------------------------- install

--- a/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/__init__.py
@@ -21,7 +21,10 @@ from modelexpress.refit.reshard.geometry import (
     OpChain,
     RecordedCopy,
     UnsupportedReshard,
+    build_lazy_weights,
     capture_geometry,
+    capture_weights,
+    convert_source_weights,
 )
 from modelexpress.refit.reshard.types import IncompleteRefit
 from modelexpress.refit.reshard.transfer_plan import (
@@ -77,7 +80,10 @@ __all__ = [
     "Transport",
     "TransferPlan",
     "UnsupportedReshard",
+    "build_lazy_weights",
     "capture_geometry",
+    "capture_weights",
+    "convert_source_weights",
     "classic_cuda_alloc",
     "execute_transfer",
     "gather_sources",

--- a/modelexpress_client/python/modelexpress/refit/reshard/geometry.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/geometry.py
@@ -273,11 +273,17 @@ def build_lazy_weights(
 
 
 def _shared_recorder(weights: dict) -> "_BakeRecorder":
-    recorders = {
-        id(w._recorder): w._recorder
-        for w in weights.values()
-        if isinstance(w, LazyWeight) and w._recorder is not None
-    }
+    # Every value must be a recording LazyWeight: an ordinary tensor would be sent
+    # to load_weights and its copies dropped (the copy_ sink only fires for a
+    # LazyWeight), silently under-capturing the model.
+    recorders: dict = {}
+    for name, w in weights.items():
+        if not isinstance(w, LazyWeight) or w._recorder is None:
+            raise ValueError(
+                f"capture_weights requires LazyWeights from build_lazy_weights; "
+                f"{name!r} is a {type(w).__name__}"
+            )
+        recorders[id(w._recorder)] = w._recorder
     if len(recorders) != 1:
         raise ValueError(
             "capture_weights expects LazyWeights that share one recorder "

--- a/modelexpress_client/python/modelexpress/refit/reshard/geometry.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/geometry.py
@@ -53,7 +53,10 @@ __all__ = [
     "OpSpec",
     "RecordedCopy",
     "UnsupportedReshard",
+    "build_lazy_weights",
     "capture_geometry",
+    "capture_weights",
+    "convert_source_weights",
 ]
 
 # Allowlist: pure view/slice/shape ops a weight loader may call. Maps
@@ -250,41 +253,77 @@ def _restore_stamps(saved: list) -> None:
             param.weight_loader = original
 
 
-def capture_geometry(
-    model: torch.nn.Module,
+def build_lazy_weights(
     manifest: list[tuple[str, Any, tuple]],
+) -> dict[str, "LazyWeight"]:
+    """One ``LazyWeight`` placeholder per published source, all sharing a recorder.
+
+    ``manifest`` is ``(name, dtype, shape)`` for every full source tensor. The
+    result can be passed straight to :func:`capture_weights`, or first through a
+    source conversion (a trainer-native -> HF ``dict -> dict`` mapping) whose view
+    ops each lazy records - so a converted lazy's ``_name`` stays its ORIGINAL
+    published source and its ``_ops`` carry the conversion prefix. The shared
+    recorder is what :func:`capture_weights` reads its recorded copies from.
+    """
+    recorder = _BakeRecorder()
+    return {
+        name: LazyWeight(name, torch.Size(shape), dtype, "meta", recorder=recorder)
+        for name, dtype, shape in manifest
+    }
+
+
+def _shared_recorder(weights: dict) -> "_BakeRecorder":
+    recorders = {
+        id(w._recorder): w._recorder
+        for w in weights.values()
+        if isinstance(w, LazyWeight) and w._recorder is not None
+    }
+    if len(recorders) != 1:
+        raise ValueError(
+            "capture_weights expects LazyWeights that share one recorder "
+            "(build them with build_lazy_weights)"
+        )
+    return next(iter(recorders.values()))
+
+
+def capture_weights(
+    model: torch.nn.Module,
+    weights: dict[str, Any],
     default_weight_loader: Callable | None = None,
 ) -> CaptureResult:
-    """Capture per-param slice geometry by dry-running ``load_weights`` with
-    ``LazyWeight`` placeholders against ``model`` (ideally a disposable meta twin).
+    """Capture per-param slice geometry by dry-running ``load_weights`` with the
+    pre-built ``weights`` against ``model`` (ideally a disposable meta twin).
 
     Args:
         model: the engine model exposing ``load_weights([(name, tensor)])`` and
             per-param ``weight_loader`` hooks. Should be on ``meta`` so no real
             storage is touched.
-        manifest: ``(name, dtype, shape)`` for every full source tensor.
+        weights: ``{name: LazyWeight}`` from :func:`build_lazy_weights` (optionally
+            passed through a source conversion first). ``name`` is what the loader
+            routes on (HF-canonical); the lazy's ``_name`` is the original source.
         default_weight_loader: the framework's default loader, used to attribute
             copies for params that have no explicit ``weight_loader`` (e.g. vLLM's
             ``default_weight_loader``). Optional.
 
     Returns a ``CaptureResult`` (recorded copies + unsupported/unattributed).
     """
-    recorder = _BakeRecorder()
+    recorder = _shared_recorder(weights)
     saved = _install_stamps(model, recorder, default_weight_loader)
     unsupported: list[str] = []
     unsupported_reasons: dict[str, str] = {}
     try:
         # One source at a time: a single unsupported loader is attributed only
-        # to that tensor, never the whole bake. Fused params
-        # (qkv/gate_up) still resolve - each source writes its own sub-region of
-        # the persistent (meta) dest param across separate calls.
-        for name, dtype, shape in manifest:
-            lazy = LazyWeight(name, torch.Size(shape), dtype, "meta", recorder=recorder)
+        # to that tensor, never the whole bake. Fused params (qkv/gate_up) still
+        # resolve - each source writes its own sub-region of the persistent (meta)
+        # dest param across separate calls. A converted lazy's ``_name`` is the
+        # original published source, so that is what an unsupported placement names.
+        for name, tensor in weights.items():
+            source = getattr(tensor, "_name", name)
             try:
-                model.load_weights([(name, lazy)])
+                model.load_weights([(name, tensor)])
             except UnsupportedReshard as exc:
-                unsupported.append(name)
-                unsupported_reasons[name] = str(exc)
+                unsupported.append(source)
+                unsupported_reasons[source] = str(exc)
     finally:
         _restore_stamps(saved)
 
@@ -307,3 +346,52 @@ def capture_geometry(
         unattributed=recorder.unattributed,
         unsupported_reasons=unsupported_reasons,
     )
+
+
+def capture_geometry(
+    model: torch.nn.Module,
+    manifest: list[tuple[str, Any, tuple]],
+    default_weight_loader: Callable | None = None,
+) -> CaptureResult:
+    """Convenience wrapper: build lazies from ``manifest`` (source names already
+    HF-canonical) and capture. See :func:`build_lazy_weights` + :func:`capture_weights`
+    for the pre-built-weights entry point used when a source conversion runs first."""
+    return capture_weights(
+        model,
+        build_lazy_weights(manifest),
+        default_weight_loader=default_weight_loader,
+    )
+
+
+def convert_source_weights(
+    convert_native_to_hf: Callable[[dict], dict] | None, manifest: list
+) -> dict:
+    """Build the source placeholders and map them into the HF-canonical layout the
+    inference loader consumes.
+
+    A trainer may publish its weights under its own native (non-HF) names/shapes.
+    ``convert_native_to_hf`` is that trainer's native -> HF mapping (a
+    ``dict[str, Tensor] -> dict[str, Tensor]``); we run it on ``LazyWeight``
+    placeholders so it traces STRUCTURE ONLY (renames + view ops like expert
+    unstack) - no weight data - and each output lazy keeps ``_name`` = its original
+    published source and ``_ops`` = the native -> HF prefix. Returns
+    ``{hf_name: LazyWeight}`` ready for :func:`capture_weights`.
+
+    ``None`` means the trainer already publishes HF-canonical names (identity). A
+    conversion output that is not a traced view of a source - a dtype cast (raised
+    while tracing, the op is not in the allowlist) or a synthesized tensor (a plain
+    tensor, not a ``LazyWeight``) - raises ``UnsupportedReshard`` rather than
+    mis-mapping.
+    """
+    weights = build_lazy_weights(manifest)
+    if convert_native_to_hf is None:
+        return weights
+    hf = convert_native_to_hf(weights)
+    for name, value in hf.items():
+        if not isinstance(value, LazyWeight):
+            raise UnsupportedReshard(
+                f"{name}: conversion produced a non-traced tensor "
+                f"({type(value).__name__}); dtype casts / synthesized tensors are "
+                "not yet supported"
+            )
+    return hf

--- a/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
@@ -6,7 +6,7 @@ Extracts the rank-local shards from an FSDP ``state_dict`` and emits MX's
 engine-neutral manifest (``PublishedTensor`` / ``PublishedShard`` +
 ``wrap_rendezvous_blob``). HF-name conversion is deliberately NOT done here: the
 receiver maps these native trainer-format sources into the HF/vLLM param layout
-(see ``VllmReshardReceiver``'s ``convert_native_to_hf`` in
+(see the ``convert_native_to_hf=`` argument to ``VllmReshardReceiver`` in
 ``modelexpress/engines/vllm/refit/receiver.py``).
 
 Extraction rules (per state_dict tensor, floating point only):

--- a/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
@@ -5,8 +5,9 @@
 Extracts the rank-local shards from an FSDP ``state_dict`` and emits MX's
 engine-neutral manifest (``PublishedTensor`` / ``PublishedShard`` +
 ``wrap_rendezvous_blob``). HF-name conversion is deliberately NOT done here: the
-receiver captures how these trainer-format sources land in the vLLM param layout
-(see ``modelexpress_rl/inference/reshard/fsdp``).
+receiver maps these native trainer-format sources into the HF/vLLM param layout
+(see ``VllmReshardReceiver``'s ``convert_native_to_hf`` in
+``modelexpress/engines/vllm/refit/receiver.py``).
 
 Extraction rules (per state_dict tensor, floating point only):
 - unsharded (not a DTensor): every rank holds + publishes the full tensor;

--- a/modelexpress_client/python/tests/test_reshard_refit_geometry.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_geometry.py
@@ -10,9 +10,20 @@ unsupported op is identified without producing an incorrect copy). Runs in any
 torch env: pytest tests/test_reshard_refit_geometry.py
 """
 
+import re
+
+import pytest
 import torch
 
-from modelexpress.refit.reshard.geometry import capture_geometry
+from modelexpress.refit.reshard.geometry import (
+    LazyWeight,
+    build_lazy_weights,
+    capture_geometry,
+    capture_weights,
+    convert_source_weights,
+)
+from modelexpress.refit.reshard.slice_plan import Shard, plan_pull
+from modelexpress.refit.reshard.types import UnsupportedReshard
 
 TP_RANK = 0
 
@@ -239,6 +250,184 @@ def test_default_loader_param_needs_default_weight_loader():
     assert got.copies[0].param_name == "norm"
     assert got.copies[0].op_chain == () and got.copies[0].dest_shape == (4,)
     assert got.unattributed == 0
+
+
+# ------------------------------------------------- pre-built (capture_weights)
+
+def test_capture_weights_records_the_converted_source_name():
+    """Pre-built weights whose keys were renamed (native -> loader name): the
+    recorded copy names the ORIGINAL source (the lazy's _name), not the key."""
+    f32 = torch.float32
+    with torch.device("meta"):
+        model = ToyModel()
+    lazies = build_lazy_weights([("native.col", f32, [8, 4]), ("native.norm", f32, [4])])
+    converted = {"col": lazies["native.col"], "norm": lazies["native.norm"]}
+
+    by_src = {c.src_name: c for c in capture_weights(model, converted).copies}
+
+    assert by_src["native.col"].op_chain == (("narrow", (0, 0, 4), ()),)
+    assert by_src["native.norm"].op_chain == ()
+    assert "col" not in by_src  # keyed by source, not the loader name
+
+
+def test_capture_weights_requires_a_shared_recorder():
+    """Weights from separate build_lazy_weights calls don't share a recorder."""
+    f32 = torch.float32
+    with torch.device("meta"):
+        model = ToyModel()
+    a = build_lazy_weights([("col", f32, [8, 4])])
+    b = build_lazy_weights([("norm", f32, [4])])
+
+    with pytest.raises(ValueError, match="share one recorder"):
+        capture_weights(model, {"col": a["col"], "norm": b["norm"]})
+
+
+# ----------------------------------------------- native -> HF source conversion
+
+_CONVERT_MANIFEST = [
+    ("model.router.gate.weight", torch.bfloat16, (2, 4)),
+    ("model.experts.w13", torch.bfloat16, (3, 2, 4)),
+]
+
+
+def test_convert_source_weights_identity_when_none():
+    weights = convert_source_weights(None, _CONVERT_MANIFEST)
+
+    assert set(weights) == {"model.router.gate.weight", "model.experts.w13"}
+    for name, lazy in weights.items():
+        assert isinstance(lazy, LazyWeight)
+        assert lazy._name == name and lazy._ops == ()
+
+
+def test_convert_source_weights_traces_a_rename():
+    def convert(sd):
+        return {"model.mlp.gate.weight": sd["model.router.gate.weight"]}  # rename
+
+    weights = convert_source_weights(convert, _CONVERT_MANIFEST)
+
+    (name,) = weights  # only the renamed source survives; the other is dropped
+    assert name == "model.mlp.gate.weight"
+    renamed = weights[name]
+    assert renamed._name == "model.router.gate.weight" and renamed._ops == ()
+
+
+def test_convert_source_weights_shares_one_recorder():
+    # capture_weights relies on this: every derived lazy shares the source recorder.
+    weights = convert_source_weights(
+        lambda sd: {"a": sd["model.router.gate.weight"], "b": sd["model.experts.w13"]},
+        _CONVERT_MANIFEST,
+    )
+    assert len({id(w._recorder) for w in weights.values()}) == 1
+
+
+def test_convert_source_weights_rejects_a_synthesized_tensor():
+    def convert(sd):
+        return {
+            "a": sd["model.router.gate.weight"],
+            "synth": torch.zeros(2, dtype=torch.bfloat16),
+        }
+
+    with pytest.raises(UnsupportedReshard, match="synthesized"):
+        convert_source_weights(convert, _CONVERT_MANIFEST)
+
+
+def test_convert_source_weights_rejects_a_dtype_cast():
+    def convert(sd):
+        return {"a": sd["model.router.gate.weight"].to(torch.float32)}
+
+    with pytest.raises(UnsupportedReshard):
+        convert_source_weights(convert, _CONVERT_MANIFEST)
+
+
+# --------------------------------------------- MoE convert -> capture -> reconstruct
+
+_E, _I, _H = 3, 2, 4  # experts, intermediate, hidden
+
+
+class ToyMoEModel(torch.nn.Module):
+    """Router + a vLLM-style STACKED fused expert param.
+
+    Per-expert HF weights land in ``w13[expert, half]`` (half 0 = gate, 1 = up),
+    mirroring how vLLM stacks gate/up experts into one param; the router is a
+    direct copy. Exercises the native->HF conversion all the way into the fused
+    destination slots.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.gate = torch.nn.Parameter(torch.empty(_E, _H))
+        self.gate.weight_loader = lambda p, loaded: p.data.copy_(loaded)
+        self.w13 = torch.nn.Parameter(torch.empty(_E, 2, _I, _H))
+        self.w13.weight_loader = self._expert_loader
+
+    def _expert_loader(self, param, loaded, expert_id, half):
+        param.data[expert_id, half].copy_(loaded)
+
+    def load_weights(self, weights):
+        for name, loaded in weights:
+            if name == "gate.weight":
+                self.gate.weight_loader(self.gate, loaded)
+                continue
+            m = re.fullmatch(r"experts\.(\d+)\.(gate|up)_proj\.weight", name)
+            expert_id, half = int(m.group(1)), (0 if m.group(2) == "gate" else 1)
+            self.w13.weight_loader(self.w13, loaded, expert_id, half)
+
+
+def _per_expert_rename_convert(sd):
+    """Rename per-expert native projections into the HF names vLLM's loader
+    consumes. The trainer here publishes each expert separately, so this is pure
+    renaming - the stacked-source case that needs an unstack (select) is covered
+    where the view ops are added."""
+    out = {"gate.weight": sd["router.gate"]}  # rename
+    for e in range(_E):
+        out[f"experts.{e}.gate_proj.weight"] = sd[f"experts.{e}.w1"]
+        out[f"experts.{e}.up_proj.weight"] = sd[f"experts.{e}.w3"]
+    return out
+
+
+def test_moe_convert_capture_plan_reconstructs_end_to_end():
+    """Full sequence for an MoE trainer: build lazies -> native->HF convert ->
+    vLLM loader capture -> plan_pull -> reconstruct, and assert every byte lands
+    in the right fused slot."""
+    f32 = torch.float32
+    router = torch.arange(_E * _H, dtype=f32).reshape(_E, _H)
+    w1 = {e: (torch.arange(_I * _H, dtype=f32) + 100 + e).reshape(_I, _H) for e in range(_E)}
+    w3 = {e: (torch.arange(_I * _H, dtype=f32) + 200 + e).reshape(_I, _H) for e in range(_E)}
+    src_buf = {"router.gate": router.reshape(-1)}
+    src_shape = {"router.gate": (_E, _H)}
+    for e in range(_E):
+        src_buf[f"experts.{e}.w1"] = w1[e].reshape(-1)
+        src_buf[f"experts.{e}.w3"] = w3[e].reshape(-1)
+        src_shape[f"experts.{e}.w1"] = (_I, _H)
+        src_shape[f"experts.{e}.w3"] = (_I, _H)
+    manifest = [(n, f32, s) for n, s in src_shape.items()]
+
+    with torch.device("meta"):
+        model = ToyMoEModel()
+    hf = convert_source_weights(_per_expert_rename_convert, manifest)
+    copies = capture_weights(model, hf).copies
+
+    dst = {
+        "gate": torch.zeros(_E, _H).reshape(-1),
+        "w13": torch.zeros(_E, 2, _I, _H).reshape(-1),
+    }
+    for copy in copies:
+        shape = src_shape[copy.src_name]
+        shard = Shard(
+            shard_offset=(0,) * len(shape), shape=shape, session="s", addr=0, elsize=4
+        )
+        segs = plan_pull(copy, global_shape=shape, src_dtype=f32, elsize=4, shards=[shard])
+        source, dest = src_buf[copy.src_name], dst[copy.param_name]
+        for seg in segs:
+            s0, d0, n = seg.src_addr // 4, seg.dst_byte // 4, seg.nbytes // 4
+            dest[d0 : d0 + n] = source[s0 : s0 + n]
+
+    gate_out = dst["gate"].reshape(_E, _H)
+    w13_out = dst["w13"].reshape(_E, 2, _I, _H)
+    assert torch.equal(gate_out, router)
+    for e in range(_E):
+        assert torch.equal(w13_out[e, 0], w1[e])  # gate_proj -> half 0
+        assert torch.equal(w13_out[e, 1], w3[e])  # up_proj -> half 1
 
 
 if __name__ == "__main__":

--- a/modelexpress_client/python/tests/test_reshard_refit_geometry.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_geometry.py
@@ -252,8 +252,6 @@ def test_default_loader_param_needs_default_weight_loader():
     assert got.unattributed == 0
 
 
-# ------------------------------------------------- pre-built (capture_weights)
-
 def test_capture_weights_records_the_converted_source_name():
     """Pre-built weights whose keys were renamed (native -> loader name): the
     recorded copy names the ORIGINAL source (the lazy's _name), not the key."""
@@ -281,8 +279,6 @@ def test_capture_weights_requires_a_shared_recorder():
     with pytest.raises(ValueError, match="share one recorder"):
         capture_weights(model, {"col": a["col"], "norm": b["norm"]})
 
-
-# ----------------------------------------------- native -> HF source conversion
 
 _CONVERT_MANIFEST = [
     ("model.router.gate.weight", torch.bfloat16, (2, 4)),
@@ -338,8 +334,6 @@ def test_convert_source_weights_rejects_a_dtype_cast():
     with pytest.raises(UnsupportedReshard):
         convert_source_weights(convert, _CONVERT_MANIFEST)
 
-
-# --------------------------------------------- MoE convert -> capture -> reconstruct
 
 _E, _I, _H = 3, 2, 4  # experts, intermediate, hidden
 


### PR DESCRIPTION
**Summary**
Lets a trainer that publishes its weights under its own native (non-HF) layout be resharded into a vLLM inference worker. The receiver runs the trainer's native to HF mapping on lazy placeholders during capture, so the same lazy picks up the native to HF ops and then the HF to vLLM loader ops in one pass, and the recorded copies read straight from the published native tensors. A trainer that already publishes HF-canonical names is unchanged (the mapping is identity).

Also switches capture to run on the live model instead of a throwaway meta stand-in, which is required for Expert-Parallel models.

**What changed**

- Split the reshard geometry capture so a source conversion can run before the loader dry-run. build_lazy_weights makes the placeholder sources, capture_weights drives load_weights on pre-built lazies, and capture_geometry stays as the thin wrapper over the two (unchanged behavior for existing callers).
- Added convert_source_weights, which traces a trainer's native to HF mapping (dict -> dict) on the lazies. It records structure only, renames and view ops, never weight data. A conversion that produces a dtype cast or a synthesized tensor fails closed with UnsupportedReshard rather than mis-mapping.
- VllmReshardReceiver gains a convert_native_to_hf hook. It is opaque to the receiver, which just runs whatever callable it is handed (or identity when omitted), so the receiver stays trainer-agnostic.
- Capture now runs on the live model via initialize_layerwise_reload (params reverted to their bf16 load-time skeletons) rather than a fresh no-storage stand-in. Expert-Parallel's fused-MoE loader reads real values from the expert map while placing weights, which a no-storage model cannot provide, and the failure it raises is not an UnsupportedReshard, so it would crash the whole capture.

**Testing**

- New geometry tests cover convert_source_weights (identity, rename, shared-recorder invariant, dtype-cast reject, synthesized-tensor reject) and capture_weights on pre-built lazies (records the original source name, shared-recorder guard).
- An end to end test builds a per-expert MoE trainer, runs convert to capture to plan to reconstruct, and asserts every byte lands in the right fused destination slot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting native model weights into the expected Hugging Face/vLLM format during refit and resharding.
  * Improved weight capture and layout handling for converted models, including mixture-of-experts architectures.
  * Exposed reusable weight preparation and capture capabilities for model integration workflows.

* **Reliability**
  * Added validation to detect inconsistent weight mappings, unsupported synthesized tensors, and incompatible data type conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->