### PR TITLE
feat(refit): add generator peer refit strategy

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -462,6 +462,17 @@ engine-specific parameter and CUDA-graph handling out of the transfer layer.
 | `DeleteVersionLease` | Release a generator's protection of the version shards |
 
 The final missing source slot atomically changes the version to `READY`.
+
+Peer generators reuse the existing inference P2P metadata service rather than
+creating a second Refit peer registry. A generator serving an exact version
+publishes its normal `SourceIdentity` with `revision=WeightVersion.uid`; another
+generator queries `P2pService.ListSources` with the same engine-compatible
+identity and selects a READY source for its worker rank before falling back to
+trainer shard publications. Applied generators publish their verified canonical
+staging buffers—not engine-specific packed kernel tensors—under that identity.
+An identical-rank peer pulls those buffers directly with NIXL, then uses the
+same graph-safe engine installer as a trainer update.
+
 `WeightVersion.uid` is MX's opaque identity. `version_number` is the optional
 framework-provided numeric label used for correlation; MX does not use it as an
 identity or ordering key.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -393,6 +393,7 @@ flowchart LR
     end
 
     S["MX server<br/>RefitService<br/>Redis metadata"]
+    P["MX server<br/>P2pService"]
 
     subgraph Trainer["Trainer rank"]
         TA["Trainer engine adapter"]
@@ -406,6 +407,8 @@ flowchart LR
         I["vLLM installer<br/>capture, apply"]
     end
 
+    PG["Peer generator rank<br/>verified canonical buffers"]
+
     O -->|"Create / Get / Delete version"| S
     O -->|"Framework-native RPC"| T
     O -->|"Framework-native RPC"| G
@@ -413,9 +416,12 @@ flowchart LR
     T -->|"Register worker; publish shard metadata"| S
     T --> M
     G -->|"Register worker; discover shards; lease version"| S
+    G -->|"Discover exact-version same-rank peer"| P
     G --> GA --> X --> I
     G -->|"Fetch exact-version manifest"| M
     B -->|"NIXL reads"| X
+    PG -->|"Publish READY version identity"| P
+    PG -->|"Peer manifest + NIXL reads"| X
 ```
 
 `RefitService` is the central metadata service defined by `refit.proto`. It
@@ -462,6 +468,17 @@ engine-specific parameter and CUDA-graph handling out of the transfer layer.
 | `DeleteVersionLease` | Release a generator's protection of the version shards |
 
 The final missing source slot atomically changes the version to `READY`.
+
+Peer generators reuse the existing inference P2P metadata service rather than
+creating a second Refit peer registry. A generator serving an exact version
+publishes its normal `SourceIdentity` with `revision=WeightVersion.uid`; another
+generator queries `P2pService.ListSources` with the same engine-compatible
+identity and selects a READY source for its worker rank before falling back to
+trainer shard publications. Applied generators publish their verified canonical
+staging buffers—not engine-specific packed kernel tensors—under that identity.
+An identical-rank peer pulls those buffers directly with NIXL, then uses the
+same graph-safe engine installer as a trainer update.
+
 `WeightVersion.uid` is MX's opaque identity. `version_number` is the optional
 framework-provided numeric label used for correlation; MX does not use it as an
 identity or ordering key.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -605,6 +605,7 @@ See [`K8S_SERVICE_BACKEND.md`](K8S_SERVICE_BACKEND.md) for the design rationale,
 | `MODEL_EXPRESS_LOG_LEVEL` | (inherits vLLM) | Override log level for `modelexpress.*` loggers. `DEBUG` enables per-tensor checksums and adopted tensor details |
 | `MX_P2P_METADATA` | `1` | Enable P2P metadata exchange (source workers only). Set to `0` to publish full metadata through a central-coordinator backend. This setting is ignored on backends that require P2P metadata, currently `k8s-service`. |
 | `MX_METADATA_PORT` | `5555` | Base NIXL listen port; effective port is `MX_METADATA_PORT + device_id` |
+| `MX_REFIT_METADATA_PORT` | `7555` | Base NIXL listen port for an RL generator's refit client; effective port is `MX_REFIT_METADATA_PORT + device_id`, separate from a boot-time loader manager |
 | `MX_WORKER_GRPC_PORT` | `6555` | Base worker gRPC port for P2P tensor and artifact manifest serving |
 | `MX_WORKER_HOST` | (auto-detect) | Override worker IP/hostname for P2P endpoints |
 | `MX_ARTIFACT_TRANSFER` | `0` | Opt in to cache artifact transfer. The vLLM loader uses it for torch compile, Triton, DeepGEMM, TileLang, CuTe DSL, and FlashInfer JIT caches, including persistent autotune files when supported by vLLM. The SGLang NIXL loader uses the same artifact path for compatible torch compile, Triton, TVM-FFI, DeepGEMM, TileLang, CuTe DSL, and FlashInfer caches. Requires the P2P metadata path; if `MX_P2P_METADATA=0`, the loader logs a warning and skips artifact transfer. |

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -199,6 +199,7 @@ register_modelexpress_loaders()
 | `MX_SYNC_START` | `1` | Target: wait for all source workers before transferring |
 | `MX_POOL_REG` | `0` | Allocation-level NIXL registration (registers cudaMalloc blocks instead of individual tensors) |
 | `MX_P2P_METADATA` | `1` | Serve tensor and artifact manifests directly from source workers; set to `0` to route full tensor metadata through the central server |
+| `MX_REFIT_METADATA_PORT` | `7555` | Base NIXL metadata-listener port for RL generator refit; each rank adds its local device ID. Kept separate from `MX_METADATA_PORT`, which may remain owned by the boot-time loader |
 | `MX_ARTIFACT_TRANSFER` | `0` | Transfer compatible vLLM TorchInductor, Triton, DeepGEMM, TileLang, CuTe DSL, and FlashInfer JIT caches, including persistent autotune files when supported by vLLM |
 | `MX_ARTIFACT_BUNDLE_ROOT` | `$TMPDIR/modelexpress-artifacts` | Staging root for tarred cache artifact bundles |
 | `MX_ARTIFACT_COMPILE_CONFIG_DIGEST` | empty | Optional compile-configuration compatibility digest for cache discovery |

--- a/modelexpress_client/python/modelexpress/load_strategy/base.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/base.py
@@ -261,24 +261,32 @@ def unpublish_metadata(ctx: LoadContext) -> None:
     Call publish_metadata() again after memory is valid to re-enter the
     P2P network.
     """
+    unpublish_metadata_for_worker(
+        worker_rank=ctx.worker_rank,
+        device_id=ctx.device_id,
+    )
+
+
+def unpublish_metadata_for_worker(*, worker_rank: int, device_id: int) -> None:
+    """Stop one worker's publication without requiring a boot-load context."""
     from ..metadata.publish import _heartbeat_threads, _worker_servers
 
-    hb = _heartbeat_threads.pop(ctx.worker_rank, None)
+    hb = _heartbeat_threads.pop(worker_rank, None)
     if hb is not None:
         try:
             hb.stop()  # also marks STALE on MX server
-            logger.info(f"[Worker {ctx.global_rank}] Heartbeat stopped")
+            logger.info(f"[Worker {worker_rank}] Heartbeat stopped")
         except Exception as e:
             logger.warning(
-                f"[Worker {ctx.global_rank}] Failed to stop heartbeat cleanly: {e}"
+                f"[Worker {worker_rank}] Failed to stop heartbeat cleanly: {e}"
             )
 
-    ws = _worker_servers.pop(ctx.device_id, None)
+    ws = _worker_servers.pop(device_id, None)
     if ws is not None:
         try:
             ws.stop()
-            logger.info(f"[Worker {ctx.global_rank}] Worker gRPC server stopped")
+            logger.info(f"[Worker {worker_rank}] Worker gRPC server stopped")
         except Exception as e:
             logger.warning(
-                f"[Worker {ctx.global_rank}] Failed to stop worker gRPC server cleanly: {e}"
+                f"[Worker {worker_rank}] Failed to stop worker gRPC server cleanly: {e}"
             )

--- a/modelexpress_client/python/modelexpress/metadata/publish.py
+++ b/modelexpress_client/python/modelexpress/metadata/publish.py
@@ -93,8 +93,7 @@ def publish_metadata_and_ready(
 
         host = _get_worker_host()
 
-        grpc_base = envs.MX_WORKER_GRPC_PORT
-        worker_grpc_port = grpc_base + device_id
+        worker_grpc_port = envs.MX_WORKER_GRPC_PORT + device_id
 
         grpc_server = WorkerGrpcServer(
             tensor_protos=tensor_protos,

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -773,6 +773,7 @@ class NixlTransferManager:
         timeout_seconds: float | None = None,
         remote_agent_name: str | None = None,
         require_exact_match: bool = False,
+        destination_tensors: dict[str, torch.Tensor] | None = None,
     ) -> tuple[int, int, float]:
         """
         Receive weights from a remote source via NIXL RDMA.
@@ -799,6 +800,8 @@ class NixlTransferManager:
                 derived tensors, which would otherwise leave part or all of the
                 target at dummy values while RDMA reports success. Same-family
                 transfers leave this False and tolerate subset transfers.
+            destination_tensors: Optional registered destination catalog used for
+                name matching. Defaults to the most recently registered catalog.
 
         Returns:
             Tuple of (total_bytes, total_tensors, duration)
@@ -813,6 +816,9 @@ class NixlTransferManager:
 
         start_time = time.perf_counter()
         self._accelerator_backend.set_device(self._device_id)
+        local_tensors = (
+            self._tensors if destination_tensors is None else destination_tensors
+        )
 
         if remote_agent_name is None:
             add_start = time.perf_counter()
@@ -833,7 +839,7 @@ class NixlTransferManager:
         total_bytes = 0
 
         for src_tensor in source_tensors:
-            local_tensor = self._tensors.get(src_tensor.name)
+            local_tensor = local_tensors.get(src_tensor.name)
             if local_tensor is None:
                 continue
             local_size = local_tensor.numel() * local_tensor.element_size()
@@ -866,8 +872,8 @@ class NixlTransferManager:
         # Name-set diff between the source manifest and the locally registered
         # tensors.
         src_names = {s.name for s in source_tensors}
-        local_only = sorted(set(self._tensors) - src_names)
-        source_only = sorted(src_names - set(self._tensors))
+        local_only = sorted(set(local_tensors) - src_names)
+        source_only = sorted(src_names - set(local_tensors))
         if local_only or source_only:
             if require_exact_match:
                 # Cross-family transfer: a name diff can mean vendor-specific

--- a/modelexpress_client/python/modelexpress_rl/envs.py
+++ b/modelexpress_client/python/modelexpress_rl/envs.py
@@ -3,9 +3,9 @@
 
 """RL-specific deployment policy.
 
-Model identity, server connectivity, worker endpoints, NIXL ports, and
-heartbeat timing use the shared :mod:`modelexpress.envs` configuration.
-Rank-local identity and endpoints are derived from the initialized engine.
+Model identity, server connectivity, worker endpoints, and heartbeat timing
+use the shared :mod:`modelexpress.envs` configuration. Rank-local identity and
+endpoints are derived from the initialized engine.
 """
 
 from __future__ import annotations
@@ -16,12 +16,17 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    MX_REFIT_METADATA_PORT: int
     MX_TRAINER_ENGINE: str
     MX_TRAINER_STAGING_MODE: str
     MX_WEIGHT_PAYLOAD_FORMAT: str
 
 
 environment_variables: dict[str, Callable[[], Any]] = {
+    "MX_REFIT_METADATA_PORT": lambda: require_positive_int(
+        int(os.environ.get("MX_REFIT_METADATA_PORT", "7555")),
+        "MX_REFIT_METADATA_PORT",
+    ),
     "MX_TRAINER_ENGINE": lambda: (
         os.environ.get("MX_TRAINER_ENGINE", "MEGATRON").strip().upper()
     ),

--- a/modelexpress_client/python/modelexpress_rl/inference/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/adapter.py
@@ -9,6 +9,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from modelexpress import p2p_pb2
+from modelexpress.client import MxClientBase
 from modelexpress_rl.train import WeightPayloadFormat
 
 
@@ -58,6 +60,30 @@ class GeneratorTransferInputs:
 
 class GeneratorEngineAdapter(ABC):
     """Engine-specific transfer planning and installation boundary."""
+
+    @property
+    @abstractmethod
+    def worker_rank(self) -> int:
+        """Return the rank used to match an inference P2P source."""
+
+    @abstractmethod
+    def build_p2p_identity(self, version_id: str) -> p2p_pb2.SourceIdentity:
+        """Build the engine-compatible P2P identity for an exact version."""
+
+    @abstractmethod
+    def stage_peer_weight(self, source: p2p_pb2.WorkerMetadata) -> object:
+        """Stage an exact version from a compatible inference peer."""
+
+    @abstractmethod
+    def publish_weight_version(
+        self,
+        *,
+        version_id: str,
+        staged: object,
+        p2p_client: MxClientBase,
+        worker_id: str,
+    ) -> None:
+        """Publish applied staging buffers as an exact-version P2P source."""
 
     @property
     @abstractmethod

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -5,30 +5,26 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import threading
 import uuid
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 
 import grpc
-
 from modelexpress import auth, envs
-from modelexpress.client import _get_server_url
+from modelexpress.client import MxClient, _get_server_url
+
 from modelexpress_rl import envs as rl_envs
-from modelexpress_rl.train import WeightPayloadFormat
 from modelexpress_rl.version import WeightVersionRef
 
 from .. import refit_pb2, refit_pb2_grpc
-from .adapter import (
-    GeneratorEngineContext,
-    GeneratorEngineAdapter,
-    GeneratorSource,
-    GeneratorTransferInputs,
-)
+from ..control import WeightVersion, WeightVersionState, _weight_version
+from .adapter import GeneratorEngineAdapter, GeneratorEngineContext
 from .engines import _create_generator_adapter
+from .refit_strategy import RefitStrategy
+from .refit_strategy.peer import _PeerRefitStrategy
+from .refit_strategy.trainer import _TrainerRefitStrategy
 
 logger = logging.getLogger("modelexpress_rl.inference.client")
 
@@ -39,15 +35,6 @@ def _required(value: str, name: str) -> str:
     return value
 
 
-def _payload_format(value: WeightPayloadFormat | None) -> WeightPayloadFormat:
-    try:
-        return value or WeightPayloadFormat(rl_envs.MX_WEIGHT_PAYLOAD_FORMAT)
-    except ValueError as error:
-        raise ValueError(
-            f"invalid MX_WEIGHT_PAYLOAD_FORMAT={rl_envs.MX_WEIGHT_PAYLOAD_FORMAT!r}"
-        ) from error
-
-
 @dataclass(frozen=True)
 class ModelExpressGeneratorConfig:
     """Immutable configuration for one rank-local generator client."""
@@ -56,8 +43,6 @@ class ModelExpressGeneratorConfig:
     engine_context: GeneratorEngineContext
     # Logical model identity; defaults to MODEL_NAME.
     model_name: str | None = None
-    # Weight representation accepted by this client; defaults to MX_WEIGHT_PAYLOAD_FORMAT.
-    payload_format: WeightPayloadFormat | None = None
     # Fresh process-lifetime identity; generated when omitted.
     worker_id: str | None = None
     # Address of the central ModelExpress server; uses the standard MX default.
@@ -73,8 +58,6 @@ class ModelExpressGeneratorConfig:
 
     def __post_init__(self) -> None:
         """Validate explicit settings before client initialization."""
-        if self.payload_format is WeightPayloadFormat.UNSPECIFIED:
-            raise ValueError("payload_format must be specified")
         if self.registration_ttl_seconds is not None:
             rl_envs.require_positive_int(
                 self.registration_ttl_seconds, "registration_ttl_seconds"
@@ -154,10 +137,10 @@ class ModelExpressGeneratorClient:
         self._registration_thread: threading.Thread | None = None
         self._operation_lock = threading.RLock()
         self._active_handle: StagedWeightHandle | None = None
-        self._cached_plan: Any = None
-        self._cached_fingerprint: tuple | None = None
         self._serving_version_id: str | None = None
         self._adapter: GeneratorEngineAdapter | None = None
+        self._p2p_client: MxClient | None = None
+        self._refit_strategies: tuple[RefitStrategy, ...] = ()
         self._closed = False
 
     @classmethod
@@ -173,11 +156,8 @@ class ModelExpressGeneratorClient:
         if not isinstance(config, ModelExpressGeneratorConfig):
             raise TypeError("config must be a ModelExpressGeneratorConfig")
         model_name = _required(config.model_name or envs.MODEL_NAME or "", "model_name")
-        payload_format = _payload_format(config.payload_format)
         worker_id = _required(config.worker_id or uuid.uuid4().hex[:8], "worker_id")
         server_url = _get_server_url(config.server_url)
-        if payload_format is WeightPayloadFormat.UNSPECIFIED:
-            raise ValueError("payload_format must be specified")
         registration_ttl_seconds = config.registration_ttl_seconds
         if registration_ttl_seconds is None:
             registration_ttl_seconds = envs.MX_HEARTBEAT_INTERVAL_SECS * 3
@@ -192,25 +172,30 @@ class ModelExpressGeneratorClient:
             engine_context=config.engine_context,
             worker_id=worker_id,
         )
-        try:
-            if payload_format not in adapter.supported_payload_formats:
-                raise ValueError(
-                    f"adapter does not support payload format {payload_format.value}"
-                )
-        except Exception:
-            adapter.close()
-            raise
-
         client = cls()
         client.model_name = model_name
-        client.payload_format = payload_format
         client.worker_id = worker_id
         client.server_url = server_url
         client._registration_ttl_seconds = registration_ttl_seconds
         client._lease_ttl_seconds = lease_ttl_seconds
-        client._max_transfer_attempts = config.max_transfer_attempts
         client._rpc_timeout_seconds = config.rpc_timeout_seconds
         client._adapter = adapter
+        client._p2p_client = MxClient(server_url=server_url)
+        client._refit_strategies = (
+            _PeerRefitStrategy(
+                adapter=adapter,
+                p2p_client=client._p2p_client,
+                worker_id=worker_id,
+                max_transfer_attempts=config.max_transfer_attempts,
+                rpc_timeout_seconds=config.rpc_timeout_seconds,
+            ),
+            _TrainerRefitStrategy(
+                adapter=adapter,
+                service=lambda: client._service,
+                max_transfer_attempts=config.max_transfer_attempts,
+                rpc_timeout_seconds=config.rpc_timeout_seconds,
+            ),
+        )
         try:
             client._register_worker()
             client._registration_thread = threading.Thread(
@@ -261,6 +246,29 @@ class ModelExpressGeneratorClient:
                 staged._apply_result = self._adapter.apply_weight(staged._staged)
                 staged._applied = True
                 self._serving_version_id = staged.version_id
+                for attempt in range(2):
+                    try:
+                        self._adapter.publish_weight_version(
+                            version_id=staged.version_id,
+                            staged=staged._staged,
+                            p2p_client=self._p2p_client,
+                            worker_id=self.worker_id,
+                        )
+                        break
+                    except Exception:
+                        if attempt == 0:
+                            logger.warning(
+                                "failed to publish applied version %s as a P2P "
+                                "source; retrying once",
+                                staged.version_id,
+                                exc_info=True,
+                            )
+                        else:
+                            logger.exception(
+                                "failed to publish applied version %s as a P2P "
+                                "source after retry",
+                                staged.version_id,
+                            )
                 return staged._apply_result
             except BaseException as error:
                 primary_error = error
@@ -296,6 +304,10 @@ class ModelExpressGeneratorClient:
         if self._adapter is not None:
             self._adapter.close()
             self._adapter = None
+        if self._p2p_client is not None:
+            self._p2p_client.close()
+            self._p2p_client = None
+        self._refit_strategies = ()
         self._closed = True
 
     def __enter__(self) -> ModelExpressGeneratorClient:
@@ -337,112 +349,18 @@ class ModelExpressGeneratorClient:
                 logger.exception("unexpected worker registration renewal failure")
                 continue
 
-    def _get_ready_version(self, version_id: str) -> refit_pb2.WeightVersion:
-        version = self._service.GetWeightVersion(
-            refit_pb2.GetWeightVersionRequest(uid=version_id),
-            timeout=self._rpc_timeout_seconds,
+    def _get_ready_version(self, version_id: str) -> WeightVersion:
+        version = _weight_version(
+            self._service.GetWeightVersion(
+                refit_pb2.GetWeightVersionRequest(uid=version_id),
+                timeout=self._rpc_timeout_seconds,
+            )
         )
-        if version.state != refit_pb2.WEIGHT_VERSION_STATE_READY:
+        if version.state is not WeightVersionState.READY:
             raise RuntimeError(f"weight version {version_id!r} is not READY")
         if version.model_name != self.model_name:
             raise RuntimeError("weight version model_name does not match the generator")
-        if version.payload_format != self._proto_payload_format:
-            raise RuntimeError(
-                "weight version payload_format does not match the generator"
-            )
         return version
-
-    @property
-    def _proto_payload_format(self) -> int:
-        return {
-            WeightPayloadFormat.FULL_TENSOR: refit_pb2.WEIGHT_PAYLOAD_FORMAT_FULL_TENSOR,
-            WeightPayloadFormat.XOR_DELTA: refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA,
-        }[self.payload_format]
-
-    def _fetch_manifest(self, shard) -> bytes:
-        with grpc.insecure_channel(shard.manifest_endpoint) as channel:
-            response = refit_pb2_grpc.RefitWorkerServiceStub(
-                channel
-            ).GetWeightVersionShardManifest(
-                refit_pb2.GetWeightVersionShardManifestRequest(
-                    version_id=shard.version_id,
-                    source_slot_id=shard.source_slot_id,
-                ),
-                timeout=self._rpc_timeout_seconds,
-            )
-        digest = hashlib.sha256(response.manifest).hexdigest()
-        if (
-            response.manifest_digest != shard.manifest_digest
-            or digest != shard.manifest_digest
-        ):
-            raise RuntimeError(
-                f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
-            )
-        return response.manifest
-
-    def _discover_sources(
-        self,
-        version: refit_pb2.WeightVersion,
-        *,
-        candidate_offset: int = 0,
-    ) -> GeneratorTransferInputs:
-        response = self._service.ListWeightVersionShards(
-            refit_pb2.ListWeightVersionShardsRequest(version_id=version.uid),
-            timeout=self._rpc_timeout_seconds,
-        )
-        candidates = defaultdict(list)
-        for shard in response.shards:
-            candidates[shard.source_slot_id].append(shard)
-
-        selected = []
-        for source_slot_id in version.expected_source_slots:
-            failures = []
-            ordered = sorted(
-                candidates[source_slot_id], key=lambda item: item.worker_id
-            )
-            if ordered:
-                offset = candidate_offset % len(ordered)
-                ordered = ordered[offset:] + ordered[:offset]
-            for shard in ordered:
-                try:
-                    manifest = self._fetch_manifest(shard)
-                except (grpc.RpcError, RuntimeError) as error:
-                    failures.append(str(error))
-                    continue
-                selected.append(
-                    GeneratorSource(
-                        source_slot_id=source_slot_id,
-                        worker_id=shard.worker_id,
-                        manifest_endpoint=shard.manifest_endpoint,
-                        manifest_digest=shard.manifest_digest,
-                        transport=shard.transport,
-                        manifest=manifest,
-                    )
-                )
-                break
-            else:
-                detail = f": {failures[-1]}" if failures else ""
-                raise RuntimeError(
-                    f"no usable source for required slot {source_slot_id!r}{detail}"
-                )
-
-        return GeneratorTransferInputs(
-            version_id=version.uid,
-            layout_signature=version.layout_signature,
-            payload_format=self.payload_format,
-            sources=tuple(selected),
-        )
-
-    def _transfer_plan(self, inputs: GeneratorTransferInputs) -> Any:
-        reusable = (
-            self._cached_plan is not None
-            and self._cached_fingerprint == inputs.physical_fingerprint
-            and self._adapter.validate_transfer_plan(self._cached_plan, inputs)
-        )
-        if not reusable:
-            self._cached_plan = self._adapter.create_transfer_plan(inputs)
-            self._cached_fingerprint = inputs.physical_fingerprint
-        return self._cached_plan
 
     def _register_lease(self, version_id: str):
         return self._service.RegisterVersionLease(
@@ -507,34 +425,24 @@ class ModelExpressGeneratorClient:
         )
 
     def _stage_with_lease(
-        self, version: refit_pb2.WeightVersion
-    ) -> tuple[Any, _VersionLease]:
-        lease = self._start_version_lease(version.uid)
+        self, version: WeightVersion
+    ) -> tuple[object, _VersionLease]:
+        lease = self._start_version_lease(version.version_id)
         try:
-            last_error: grpc.RpcError | RuntimeError | None = None
-            for attempt in range(self._max_transfer_attempts):
-                try:
-                    inputs = self._discover_sources(
-                        version,
-                        candidate_offset=attempt,
-                    )
-                    staged = self._adapter.stage_weight(self._transfer_plan(inputs))
+            for strategy in self._refit_strategies:
+                staged = strategy.stage(version)
+                if staged is not None:
                     return staged, lease
-                except (grpc.RpcError, RuntimeError) as error:
-                    last_error = error
-                    # A failed transfer may have invalidated transport state even
-                    # when the source metadata fingerprint is unchanged.
-                    self._cached_plan = None
-                    self._cached_fingerprint = None
-            assert last_error is not None
-            raise last_error
+            raise RuntimeError(
+                f"no usable refit source for weight version {version.version_id!r}"
+            )
         except BaseException as primary_error:
             try:
                 lease.close()
             except grpc.RpcError:
                 logger.warning(
                     "failed to release version %s lease while handling %s",
-                    version.uid,
+                    version.version_id,
                     type(primary_error).__name__,
                     exc_info=True,
                 )

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -5,30 +5,26 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import threading
 import uuid
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 
 import grpc
-
 from modelexpress import auth, envs
-from modelexpress.client import _get_server_url
+from modelexpress.client import MxClient, _get_server_url
+
 from modelexpress_rl import envs as rl_envs
-from modelexpress_rl.train import WeightPayloadFormat
 from modelexpress_rl.version import WeightVersionRef
 
 from .. import refit_pb2, refit_pb2_grpc
-from .adapter import (
-    GeneratorEngineContext,
-    GeneratorEngineAdapter,
-    GeneratorSource,
-    GeneratorTransferInputs,
-)
+from ..control import WeightVersion, WeightVersionState, _weight_version
+from .adapter import GeneratorEngineAdapter, GeneratorEngineContext
 from .engines import _create_generator_adapter
+from .refit_strategy import RefitStrategy
+from .refit_strategy.peer import _PeerRefitStrategy
+from .refit_strategy.trainer import _TrainerRefitStrategy
 
 logger = logging.getLogger("modelexpress_rl.inference.client")
 
@@ -39,15 +35,6 @@ def _required(value: str, name: str) -> str:
     return value
 
 
-def _payload_format(value: WeightPayloadFormat | None) -> WeightPayloadFormat:
-    try:
-        return value or WeightPayloadFormat(rl_envs.MX_WEIGHT_PAYLOAD_FORMAT)
-    except ValueError as error:
-        raise ValueError(
-            f"invalid MX_WEIGHT_PAYLOAD_FORMAT={rl_envs.MX_WEIGHT_PAYLOAD_FORMAT!r}"
-        ) from error
-
-
 @dataclass(frozen=True)
 class ModelExpressGeneratorConfig:
     """Immutable configuration for one rank-local generator client."""
@@ -56,8 +43,6 @@ class ModelExpressGeneratorConfig:
     engine_context: GeneratorEngineContext
     # Logical model identity; defaults to MODEL_NAME.
     model_name: str | None = None
-    # Weight representation accepted by this client; defaults to MX_WEIGHT_PAYLOAD_FORMAT.
-    payload_format: WeightPayloadFormat | None = None
     # Fresh process-lifetime identity; generated when omitted.
     worker_id: str | None = None
     # Address of the central ModelExpress server; uses the standard MX default.
@@ -73,8 +58,6 @@ class ModelExpressGeneratorConfig:
 
     def __post_init__(self) -> None:
         """Validate explicit settings before client initialization."""
-        if self.payload_format is WeightPayloadFormat.UNSPECIFIED:
-            raise ValueError("payload_format must be specified")
         if self.registration_ttl_seconds is not None:
             rl_envs.require_positive_int(
                 self.registration_ttl_seconds, "registration_ttl_seconds"
@@ -154,10 +137,10 @@ class ModelExpressGeneratorClient:
         self._registration_thread: threading.Thread | None = None
         self._operation_lock = threading.RLock()
         self._active_handle: StagedWeightHandle | None = None
-        self._cached_plan: Any = None
-        self._cached_fingerprint: tuple | None = None
         self._serving_version_id: str | None = None
         self._adapter: GeneratorEngineAdapter | None = None
+        self._p2p_client: MxClient | None = None
+        self._refit_strategies: tuple[RefitStrategy, ...] = ()
         self._closed = False
 
     @classmethod
@@ -173,11 +156,8 @@ class ModelExpressGeneratorClient:
         if not isinstance(config, ModelExpressGeneratorConfig):
             raise TypeError("config must be a ModelExpressGeneratorConfig")
         model_name = _required(config.model_name or envs.MODEL_NAME or "", "model_name")
-        payload_format = _payload_format(config.payload_format)
         worker_id = _required(config.worker_id or uuid.uuid4().hex[:8], "worker_id")
         server_url = _get_server_url(config.server_url)
-        if payload_format is WeightPayloadFormat.UNSPECIFIED:
-            raise ValueError("payload_format must be specified")
         registration_ttl_seconds = config.registration_ttl_seconds
         if registration_ttl_seconds is None:
             registration_ttl_seconds = envs.MX_HEARTBEAT_INTERVAL_SECS * 3
@@ -192,25 +172,30 @@ class ModelExpressGeneratorClient:
             engine_context=config.engine_context,
             worker_id=worker_id,
         )
-        try:
-            if payload_format not in adapter.supported_payload_formats:
-                raise ValueError(
-                    f"adapter does not support payload format {payload_format.value}"
-                )
-        except Exception:
-            adapter.close()
-            raise
-
         client = cls()
         client.model_name = model_name
-        client.payload_format = payload_format
         client.worker_id = worker_id
         client.server_url = server_url
         client._registration_ttl_seconds = registration_ttl_seconds
         client._lease_ttl_seconds = lease_ttl_seconds
-        client._max_transfer_attempts = config.max_transfer_attempts
         client._rpc_timeout_seconds = config.rpc_timeout_seconds
         client._adapter = adapter
+        client._p2p_client = MxClient(server_url=server_url)
+        client._refit_strategies = (
+            _PeerRefitStrategy(
+                adapter=adapter,
+                p2p_client=client._p2p_client,
+                worker_id=worker_id,
+                max_transfer_attempts=config.max_transfer_attempts,
+                rpc_timeout_seconds=config.rpc_timeout_seconds,
+            ),
+            _TrainerRefitStrategy(
+                adapter=adapter,
+                service=lambda: client._service,
+                max_transfer_attempts=config.max_transfer_attempts,
+                rpc_timeout_seconds=config.rpc_timeout_seconds,
+            ),
+        )
         try:
             client._register_worker()
             client._registration_thread = threading.Thread(
@@ -261,6 +246,18 @@ class ModelExpressGeneratorClient:
                 staged._apply_result = self._adapter.apply_weight(staged._staged)
                 staged._applied = True
                 self._serving_version_id = staged.version_id
+                try:
+                    self._adapter.publish_weight_version(
+                        version_id=staged.version_id,
+                        staged=staged._staged,
+                        p2p_client=self._p2p_client,
+                        worker_id=self.worker_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "failed to publish applied version %s as a P2P source",
+                        staged.version_id,
+                    )
                 return staged._apply_result
             except BaseException as error:
                 primary_error = error
@@ -296,6 +293,10 @@ class ModelExpressGeneratorClient:
         if self._adapter is not None:
             self._adapter.close()
             self._adapter = None
+        if self._p2p_client is not None:
+            self._p2p_client.close()
+            self._p2p_client = None
+        self._refit_strategies = ()
         self._closed = True
 
     def __enter__(self) -> ModelExpressGeneratorClient:
@@ -337,112 +338,18 @@ class ModelExpressGeneratorClient:
                 logger.exception("unexpected worker registration renewal failure")
                 continue
 
-    def _get_ready_version(self, version_id: str) -> refit_pb2.WeightVersion:
-        version = self._service.GetWeightVersion(
-            refit_pb2.GetWeightVersionRequest(uid=version_id),
-            timeout=self._rpc_timeout_seconds,
+    def _get_ready_version(self, version_id: str) -> WeightVersion:
+        version = _weight_version(
+            self._service.GetWeightVersion(
+                refit_pb2.GetWeightVersionRequest(uid=version_id),
+                timeout=self._rpc_timeout_seconds,
+            )
         )
-        if version.state != refit_pb2.WEIGHT_VERSION_STATE_READY:
+        if version.state is not WeightVersionState.READY:
             raise RuntimeError(f"weight version {version_id!r} is not READY")
         if version.model_name != self.model_name:
             raise RuntimeError("weight version model_name does not match the generator")
-        if version.payload_format != self._proto_payload_format:
-            raise RuntimeError(
-                "weight version payload_format does not match the generator"
-            )
         return version
-
-    @property
-    def _proto_payload_format(self) -> int:
-        return {
-            WeightPayloadFormat.FULL_TENSOR: refit_pb2.WEIGHT_PAYLOAD_FORMAT_FULL_TENSOR,
-            WeightPayloadFormat.XOR_DELTA: refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA,
-        }[self.payload_format]
-
-    def _fetch_manifest(self, shard) -> bytes:
-        with grpc.insecure_channel(shard.manifest_endpoint) as channel:
-            response = refit_pb2_grpc.RefitWorkerServiceStub(
-                channel
-            ).GetWeightVersionShardManifest(
-                refit_pb2.GetWeightVersionShardManifestRequest(
-                    version_id=shard.version_id,
-                    source_slot_id=shard.source_slot_id,
-                ),
-                timeout=self._rpc_timeout_seconds,
-            )
-        digest = hashlib.sha256(response.manifest).hexdigest()
-        if (
-            response.manifest_digest != shard.manifest_digest
-            or digest != shard.manifest_digest
-        ):
-            raise RuntimeError(
-                f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
-            )
-        return response.manifest
-
-    def _discover_sources(
-        self,
-        version: refit_pb2.WeightVersion,
-        *,
-        candidate_offset: int = 0,
-    ) -> GeneratorTransferInputs:
-        response = self._service.ListWeightVersionShards(
-            refit_pb2.ListWeightVersionShardsRequest(version_id=version.uid),
-            timeout=self._rpc_timeout_seconds,
-        )
-        candidates = defaultdict(list)
-        for shard in response.shards:
-            candidates[shard.source_slot_id].append(shard)
-
-        selected = []
-        for source_slot_id in version.expected_source_slots:
-            failures = []
-            ordered = sorted(
-                candidates[source_slot_id], key=lambda item: item.worker_id
-            )
-            if ordered:
-                offset = candidate_offset % len(ordered)
-                ordered = ordered[offset:] + ordered[:offset]
-            for shard in ordered:
-                try:
-                    manifest = self._fetch_manifest(shard)
-                except (grpc.RpcError, RuntimeError) as error:
-                    failures.append(str(error))
-                    continue
-                selected.append(
-                    GeneratorSource(
-                        source_slot_id=source_slot_id,
-                        worker_id=shard.worker_id,
-                        manifest_endpoint=shard.manifest_endpoint,
-                        manifest_digest=shard.manifest_digest,
-                        transport=shard.transport,
-                        manifest=manifest,
-                    )
-                )
-                break
-            else:
-                detail = f": {failures[-1]}" if failures else ""
-                raise RuntimeError(
-                    f"no usable source for required slot {source_slot_id!r}{detail}"
-                )
-
-        return GeneratorTransferInputs(
-            version_id=version.uid,
-            layout_signature=version.layout_signature,
-            payload_format=self.payload_format,
-            sources=tuple(selected),
-        )
-
-    def _transfer_plan(self, inputs: GeneratorTransferInputs) -> Any:
-        reusable = (
-            self._cached_plan is not None
-            and self._cached_fingerprint == inputs.physical_fingerprint
-            and self._adapter.validate_transfer_plan(self._cached_plan, inputs)
-        )
-        if not reusable:
-            self._cached_plan = self._adapter.create_transfer_plan(inputs)
-            self._cached_fingerprint = inputs.physical_fingerprint
-        return self._cached_plan
 
     def _register_lease(self, version_id: str):
         return self._service.RegisterVersionLease(
@@ -507,34 +414,24 @@ class ModelExpressGeneratorClient:
         )
 
     def _stage_with_lease(
-        self, version: refit_pb2.WeightVersion
-    ) -> tuple[Any, _VersionLease]:
-        lease = self._start_version_lease(version.uid)
+        self, version: WeightVersion
+    ) -> tuple[object, _VersionLease]:
+        lease = self._start_version_lease(version.version_id)
         try:
-            last_error: grpc.RpcError | RuntimeError | None = None
-            for attempt in range(self._max_transfer_attempts):
-                try:
-                    inputs = self._discover_sources(
-                        version,
-                        candidate_offset=attempt,
-                    )
-                    staged = self._adapter.stage_weight(self._transfer_plan(inputs))
+            for strategy in self._refit_strategies:
+                staged = strategy.stage(version)
+                if staged is not None:
                     return staged, lease
-                except (grpc.RpcError, RuntimeError) as error:
-                    last_error = error
-                    # A failed transfer may have invalidated transport state even
-                    # when the source metadata fingerprint is unchanged.
-                    self._cached_plan = None
-                    self._cached_fingerprint = None
-            assert last_error is not None
-            raise last_error
+            raise RuntimeError(
+                f"no usable refit source for weight version {version.version_id!r}"
+            )
         except BaseException as primary_error:
             try:
                 lease.close()
             except grpc.RpcError:
                 logger.warning(
                     "failed to release version %s lease while handling %s",
-                    version.uid,
+                    version.version_id,
                     type(primary_error).__name__,
                     exc_info=True,
                 )

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from modelexpress import p2p_pb2
+from modelexpress.client import MxClientBase
 from modelexpress.engines.vllm.adapter import VllmAdapter
-
+from modelexpress_rl import envs as rl_envs
 from modelexpress_rl.inference.adapter import (
     GeneratorEngineAdapter,
     GeneratorTransferInputs,
@@ -26,6 +28,7 @@ if TYPE_CHECKING:
     from torch.nn import Module
     from vllm.config import ModelConfig, VllmConfig
 
+
 class VllmGeneratorAdapter(GeneratorEngineAdapter):
     """Compose exact-version NIXL staging with graph-safe vLLM installation."""
 
@@ -38,6 +41,7 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
         worker_id: str,
     ) -> None:
         engine = VllmAdapter(vllm_config, model_config)
+        self._engine = engine
         device_id = engine.get_device_id()
         device = engine.get_target_device()
         self._installer = _VllmInstaller(
@@ -50,10 +54,52 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
             agent_name=f"mx-refit-{worker_id}",
             device_id=device_id,
             device=device,
+            listen_port=rl_envs.MX_REFIT_METADATA_PORT + device_id,
         )
         self._active_plan: _PreparedNixlTransfer | None = None
         self._active_fingerprint: tuple | None = None
         self._active_staged: _StagedNixlWeights | None = None
+
+    @property
+    def worker_rank(self) -> int:
+        return self._engine.get_worker_rank()
+
+    def build_p2p_identity(self, version_id: str) -> p2p_pb2.SourceIdentity:
+        identity = self._engine.build_identity()
+        identity.revision = version_id
+        return identity
+
+    def stage_peer_weight(
+        self, source: p2p_pb2.WorkerMetadata
+    ) -> _StagedNixlWeights:
+        self._active_plan = None
+        self._active_fingerprint = None
+        staged = self._transfer.stage_peer(
+            source=source,
+            parameter_layout=self._installer.parameter_layout(),
+        )
+        self._active_staged = staged
+        return staged
+
+    def publish_weight_version(
+        self,
+        *,
+        version_id: str,
+        staged: object,
+        p2p_client: MxClientBase,
+        worker_id: str,
+    ) -> None:
+        active_staged = self._active_staged
+        if active_staged is None or staged is not active_staged:
+            raise RuntimeError("vLLM staged weight is no longer active")
+        self._transfer.publish_peer(
+            staged=active_staged,
+            identity=self.build_p2p_identity(version_id),
+            p2p_client=p2p_client,
+            worker_rank=self.worker_rank,
+            worker_id=worker_id,
+            accelerator=self._engine.accelerator_backend.name,
+        )
 
     @property
     def supported_payload_formats(self) -> frozenset[WeightPayloadFormat]:
@@ -96,30 +142,21 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
     def stage_weight(self, plan: object) -> _StagedNixlWeights:
         if plan is not self._active_plan:
             raise RuntimeError("vLLM transfer plan is no longer active")
+        self._transfer.unpublish_peer()
         staged = self._transfer.stage(cast(_PreparedNixlTransfer, plan))
         self._active_staged = staged
         return staged
 
     def apply_weight(self, staged: object) -> dict[str, Any]:
         active_staged = self._active_staged
-        if (
-            active_staged is None
-            or staged is not active_staged
-            or self._active_plan is None
-            or active_staged.plan_revision != self._active_plan.plan_revision
-        ):
+        if active_staged is None or staged is not active_staged:
             raise RuntimeError("vLLM staged weight is no longer active")
         self._installer.install(active_staged.tensors)
         return active_staged.metrics
 
     def release_staged_weight(self, staged: object) -> None:
         active_staged = self._active_staged
-        if (
-            active_staged is None
-            or staged is not active_staged
-            or self._active_plan is None
-            or active_staged.plan_revision != self._active_plan.plan_revision
-        ):
+        if active_staged is None or staged is not active_staged:
             raise RuntimeError("vLLM staged weight is no longer active")
         # Registered buffers are reusable plan workspace; releasing a version
         # invalidates only this staged handle.

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from modelexpress import envs, p2p_pb2
+from modelexpress.client import MxClientBase
 from modelexpress.engines.vllm.adapter import VllmAdapter
 
 from modelexpress_rl.inference.adapter import (
@@ -26,6 +28,7 @@ if TYPE_CHECKING:
     from torch.nn import Module
     from vllm.config import ModelConfig, VllmConfig
 
+
 class VllmGeneratorAdapter(GeneratorEngineAdapter):
     """Compose exact-version NIXL staging with graph-safe vLLM installation."""
 
@@ -38,6 +41,7 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
         worker_id: str,
     ) -> None:
         engine = VllmAdapter(vllm_config, model_config)
+        self._engine = engine
         device_id = engine.get_device_id()
         device = engine.get_target_device()
         self._installer = _VllmInstaller(
@@ -50,10 +54,52 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
             agent_name=f"mx-refit-{worker_id}",
             device_id=device_id,
             device=device,
+            listen_port=envs.MX_METADATA_PORT + device_id,
         )
         self._active_plan: _PreparedNixlTransfer | None = None
         self._active_fingerprint: tuple | None = None
         self._active_staged: _StagedNixlWeights | None = None
+
+    @property
+    def worker_rank(self) -> int:
+        return self._engine.get_worker_rank()
+
+    def build_p2p_identity(self, version_id: str) -> p2p_pb2.SourceIdentity:
+        identity = self._engine.build_identity()
+        identity.revision = version_id
+        return identity
+
+    def stage_peer_weight(
+        self, source: p2p_pb2.WorkerMetadata
+    ) -> _StagedNixlWeights:
+        self._active_plan = None
+        self._active_fingerprint = None
+        staged = self._transfer.stage_peer(
+            source=source,
+            parameter_layout=self._installer.parameter_layout(),
+        )
+        self._active_staged = staged
+        return staged
+
+    def publish_weight_version(
+        self,
+        *,
+        version_id: str,
+        staged: object,
+        p2p_client: MxClientBase,
+        worker_id: str,
+    ) -> None:
+        active_staged = self._active_staged
+        if active_staged is None or staged is not active_staged:
+            raise RuntimeError("vLLM staged weight is no longer active")
+        self._transfer.publish_peer(
+            staged=active_staged,
+            identity=self.build_p2p_identity(version_id),
+            p2p_client=p2p_client,
+            worker_rank=self.worker_rank,
+            worker_id=worker_id,
+            accelerator=self._engine.accelerator_backend.name,
+        )
 
     @property
     def supported_payload_formats(self) -> frozenset[WeightPayloadFormat]:
@@ -96,30 +142,21 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
     def stage_weight(self, plan: object) -> _StagedNixlWeights:
         if plan is not self._active_plan:
             raise RuntimeError("vLLM transfer plan is no longer active")
+        self._transfer.unpublish_peer()
         staged = self._transfer.stage(cast(_PreparedNixlTransfer, plan))
         self._active_staged = staged
         return staged
 
     def apply_weight(self, staged: object) -> dict[str, Any]:
         active_staged = self._active_staged
-        if (
-            active_staged is None
-            or staged is not active_staged
-            or self._active_plan is None
-            or active_staged.plan_revision != self._active_plan.plan_revision
-        ):
+        if active_staged is None or staged is not active_staged:
             raise RuntimeError("vLLM staged weight is no longer active")
         self._installer.install(active_staged.tensors)
         return active_staged.metrics
 
     def release_staged_weight(self, staged: object) -> None:
         active_staged = self._active_staged
-        if (
-            active_staged is None
-            or staged is not active_staged
-            or self._active_plan is None
-            or active_staged.plan_revision != self._active_plan.plan_revision
-        ):
+        if active_staged is None or staged is not active_staged:
             raise RuntimeError("vLLM staged weight is no longer active")
         # Registered buffers are reusable plan workspace; releasing a version
         # invalidates only this staged handle.

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
@@ -44,6 +44,9 @@ class _VllmInstaller:
         self._vllm_config = vllm_config
         self._model_config = model_config
         self._device = device
+        self._parameter_layout: dict[
+            str, tuple[tuple[int, ...], torch.dtype]
+        ] | None = None
 
     @property
     def _is_quantized(self) -> bool:
@@ -85,6 +88,16 @@ class _VllmInstaller:
         with set_default_torch_dtype(self._model_config.dtype), torch.device("meta"):
             return initialize_model(twin_config)
 
+    @staticmethod
+    def _layout_of(
+        model: Module,
+    ) -> dict[str, tuple[tuple[int, ...], torch.dtype]]:
+        """Describe one model's named parameter shapes and dtypes."""
+        return {
+            name: (tuple(parameter.shape), parameter.dtype)
+            for name, parameter in model.named_parameters()
+        }
+
     def capture(
         self, manifest: list[tuple[str, torch.dtype, tuple[int, ...]]]
     ) -> tuple[
@@ -115,10 +128,15 @@ class _VllmInstaller:
             len(capture.unsupported),
             self._is_quantized,
         )
-        return capture, {
-            name: (tuple(parameter.shape), parameter.dtype)
-            for name, parameter in twin.named_parameters()
-        }
+        parameter_layout = self._layout_of(twin)
+        self._parameter_layout = parameter_layout
+        return capture, parameter_layout
+
+    def parameter_layout(self) -> dict[str, tuple[tuple[int, ...], torch.dtype]]:
+        """Return the canonical load-time layout used by peer staging buffers."""
+        if self._parameter_layout is None:
+            self._parameter_layout = self._layout_of(self._build_meta_twin())
+        return self._parameter_layout
 
     def install(self, tensors: dict[str, torch.Tensor]) -> None:
         """Install verified load-layout tensors without changing graph addresses."""

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
@@ -120,6 +120,14 @@ class _VllmInstaller:
             for name, parameter in twin.named_parameters()
         }
 
+    def parameter_layout(self) -> dict[str, tuple[tuple[int, ...], torch.dtype]]:
+        """Return the canonical load-time layout used by peer staging buffers."""
+        twin = self._build_meta_twin()
+        return {
+            name: (tuple(parameter.shape), parameter.dtype)
+            for name, parameter in twin.named_parameters()
+        }
+
     def install(self, tensors: dict[str, torch.Tensor]) -> None:
         """Install verified load-layout tensors without changing graph addresses."""
         self._process_and_commit(tensors)

--- a/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+from modelexpress import p2p_pb2
+from modelexpress.client import MxClientBase
+from modelexpress.load_strategy.base import unpublish_metadata_for_worker
+from modelexpress.metadata.payload import worker_tensor_descriptors
+from modelexpress.metadata.publish import publish_metadata_and_ready
 from modelexpress.nixl_transfer import NixlTransferManager
 from modelexpress.refit.reshard.cuda_pool import classic_cuda_alloc
 from modelexpress.refit.reshard.rendezvous import (
@@ -41,6 +46,7 @@ from modelexpress.refit.reshard.types import (
     summarize_unsupported,
 )
 from modelexpress.refit.reshard.verify import shard_region, tensor_digest
+from modelexpress.types import TensorDescriptor
 
 
 @dataclass(frozen=True)
@@ -53,27 +59,21 @@ class _ResolvedSources:
 
 @dataclass(frozen=True)
 class _PreparedNixlTransfer:
-    """One immutable physical plan over reusable registered destinations.
-
-    ``plan_revision`` is process-local and changes whenever ``prepare`` rebuilds
-    the plan. It is not a control-plane weight-version number.
-    """
+    """One immutable physical plan over reusable registered destinations."""
 
     plan: TransferPlan
     capture: CaptureResult
     sources: dict
     descriptors: tuple[ReadDescriptor, ...]
     transport: NixlReshardTransport
-    plan_revision: int
 
 
 @dataclass(frozen=True)
 class _StagedNixlWeights:
-    """Verified tensors tagged with the local plan revision that produced them."""
+    """Verified tensors ready for engine installation."""
 
     tensors: dict[str, torch.Tensor]
     metrics: dict[str, Any]
-    plan_revision: int
 
 
 def _resolve_sources(manifests: list[bytes]) -> _ResolvedSources:
@@ -241,28 +241,40 @@ class _NixlStagedTransfer:
         agent_name: str,
         device_id: int,
         device: torch.device,
+        listen_port: int,
         timeout_seconds: float = 1200.0,
     ) -> None:
+        self._device_id = device_id
         self._device = device
         self._timeout = timeout_seconds
         self._manager = NixlTransferManager(
             agent_name=agent_name,
             device_id=device_id,
+            listen_port=listen_port,
         )
         try:
             self._manager.initialize()
         except Exception:
             self._manager.shutdown()
             raise
+        # Canonical engine-layout staging buffers. Exact slices land directly
+        # here; reconstructed or converted values are copied here before these
+        # buffers are verified, installed, and advertised to peer generators.
         self._recv_buffers: dict[str, torch.Tensor] = {}
+        # Wire-dtype staging for sources whose dtype differs from the engine
+        # parameter. RDMA writes here first, then stage() casts into recv buffers.
         self._convert_buffers: dict[str, torch.Tensor] = {}
+        # Complete contiguous source tensors used when captured transforms must
+        # be replayed locally, or when direct slicing exceeds the descriptor
+        # budget. stage() reconstructs each source here, then copies its derived
+        # views into the canonical receive buffers.
         self._full_buffers: dict[str, torch.Tensor] = {}
         self._registered_recv_params: set[str] = set()
         self._convert_registered = False
         self._full_registered = False
         self._active: _PreparedNixlTransfer | None = None
         self._loaded_agent_metadata: dict[str, bytes] = {}
-        self._plan_revision = 0
+        self._published_peer_rank: int | None = None
         self._closed = False
 
     def prepare(
@@ -319,14 +331,12 @@ class _NixlStagedTransfer:
             for copy in capture.copies
             if copy.src_name in resolved.sources
         }
-        self._plan_revision += 1
         prepared = _PreparedNixlTransfer(
             plan=plan,
             capture=capture,
             sources=used_sources,
             descriptors=descriptors,
             transport=transport,
-            plan_revision=self._plan_revision,
         )
         self._active = prepared
         return prepared
@@ -403,19 +413,14 @@ class _NixlStagedTransfer:
             self._full_buffers, full_expected, label="full-pull buffer"
         )
 
-        segment_params = {segment.param_name for segment in plan.segments}
+        recv_params = set(recv_expected)
         if (
             self._registered_recv_params
-            and self._registered_recv_params != segment_params
+            and self._registered_recv_params != recv_params
         ):
             raise RuntimeError(
-                "direct receive parameter set changed; restart the generator engine"
+                "receive parameter set changed; restart the generator engine"
             )
-        if not self._registered_recv_params and segment_params:
-            self._manager.register_tensors(
-                {f"__recv__{name}": self._recv_buffers[name] for name in segment_params}
-            )
-            self._registered_recv_params = segment_params
         if convert_expected and not self._convert_registered:
             self._manager.register_tensors(
                 {
@@ -432,6 +437,9 @@ class _NixlStagedTransfer:
                 }
             )
             self._full_registered = True
+        if not self._registered_recv_params and recv_params:
+            self._manager.register_tensors(self._recv_buffers)
+            self._registered_recv_params = recv_params
 
     def _descriptors(self, plan: TransferPlan) -> list[ReadDescriptor]:
         descriptors = exact_descriptors(
@@ -498,8 +506,140 @@ class _NixlStagedTransfer:
                 "full_pull_sources": len(prepared.plan.full_pulls),
                 "converts": len(prepared.plan.converts),
             },
-            plan_revision=prepared.plan_revision,
         )
+
+    def stage_peer(
+        self,
+        *,
+        source: p2p_pb2.WorkerMetadata,
+        parameter_layout: dict[str, tuple[tuple[int, ...], torch.dtype]],
+    ) -> _StagedNixlWeights:
+        """Pull an identical-rank peer's canonical staging buffers."""
+        if self._closed:
+            raise RuntimeError("NIXL staged transfer is closed")
+        self.unpublish_peer()
+        self._ensure_buffers(
+            self._recv_buffers,
+            parameter_layout,
+            label="receive-buffer",
+        )
+        recv_params = set(parameter_layout)
+        if self._registered_recv_params and self._registered_recv_params != recv_params:
+            raise RuntimeError(
+                "receive parameter set changed; restart the generator engine"
+            )
+        if not self._registered_recv_params:
+            self._manager.register_tensors(self._recv_buffers)
+            self._registered_recv_params = recv_params
+
+        source_tensors = [
+            TensorDescriptor(
+                name=tensor.name,
+                addr=tensor.addr,
+                size=tensor.size,
+                device_id=tensor.device_id,
+                dtype=tensor.dtype,
+            )
+            for tensor in worker_tensor_descriptors(source)
+        ]
+        if not source_tensors:
+            raise RuntimeError("P2P source has no tensor descriptors")
+
+        remote_agent_name: str | None = None
+        started = time.perf_counter()
+        try:
+            if source.worker_grpc_endpoint:
+                endpoint = source.metadata_endpoint
+                try:
+                    host, port_text = endpoint.rsplit(":", 1)
+                    port = int(port_text)
+                except ValueError as error:
+                    raise RuntimeError(
+                        f"P2P source published an unusable metadata endpoint: "
+                        f"{endpoint!r}"
+                    ) from error
+                if not host or not 1 <= port <= 65535:
+                    raise RuntimeError(
+                        f"P2P source published an unusable metadata endpoint: "
+                        f"{endpoint!r}"
+                    )
+                remote_agent_name = source.agent_name
+                self._manager.fetch_remote_and_wait(
+                    remote_agent_name=remote_agent_name,
+                    ip=host,
+                    port=port,
+                    timeout_seconds=self._timeout,
+                )
+            else:
+                remote_agent_name = self._manager.add_remote_agent(
+                    source.nixl_metadata
+                )
+            bytes_received, tensor_count, wire_seconds = (
+                self._manager.receive_from_source(
+                    source_metadata=b"",
+                    source_tensors=source_tensors,
+                    timeout_seconds=self._timeout,
+                    remote_agent_name=remote_agent_name,
+                    require_exact_match=True,
+                    destination_tensors=self._recv_buffers,
+                )
+            )
+        finally:
+            if remote_agent_name is not None:
+                self._manager.remove_remote_agent(remote_agent_name)
+
+        self._active = None
+        return _StagedNixlWeights(
+            tensors=self._recv_buffers,
+            metrics={
+                "bytes_received": bytes_received,
+                "segments": tensor_count,
+                "wire_s": round(wire_seconds, 6),
+                "peer_s": round(time.perf_counter() - started, 6),
+            },
+        )
+
+    def publish_peer(
+        self,
+        *,
+        staged: _StagedNixlWeights,
+        identity: p2p_pb2.SourceIdentity,
+        p2p_client: MxClientBase,
+        worker_rank: int,
+        worker_id: str,
+        accelerator: str,
+    ) -> None:
+        """Advertise verified canonical buffers for the applied version."""
+        previous_rank = self._published_peer_rank
+        self.unpublish_peer()
+        # Supersede any boot-time source owned by this rank before binding the
+        # shared publication slot to the exact WeightVersion identity.
+        if previous_rank != worker_rank:
+            unpublish_metadata_for_worker(
+                worker_rank=worker_rank,
+                device_id=self._device_id,
+            )
+        publish_metadata_and_ready(
+            p2p_client,
+            self._manager,
+            staged.tensors,
+            worker_rank,
+            self._device_id,
+            identity,
+            worker_id,
+            accelerator=accelerator,
+        )
+        self._published_peer_rank = worker_rank
+
+    def unpublish_peer(self) -> None:
+        """Stop advertising buffers before they are reused by another stage."""
+        if self._published_peer_rank is None:
+            return
+        unpublish_metadata_for_worker(
+            worker_rank=self._published_peer_rank,
+            device_id=self._device_id,
+        )
+        self._published_peer_rank = None
 
     def _verification_tensor(self, prepared: _PreparedNixlTransfer, name: str):
         source = prepared.sources[name]
@@ -551,6 +691,7 @@ class _NixlStagedTransfer:
     def close(self) -> None:
         if self._closed:
             return
+        self.unpublish_peer()
         self._closed = True
         self._manager.shutdown()
 

--- a/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+from modelexpress import p2p_pb2
+from modelexpress.client import MxClientBase
+from modelexpress.load_strategy.base import unpublish_metadata_for_worker
+from modelexpress.metadata.payload import worker_tensor_descriptors
+from modelexpress.metadata.publish import publish_metadata_and_ready
 from modelexpress.nixl_transfer import NixlTransferManager
 from modelexpress.refit.reshard.cuda_pool import classic_cuda_alloc
 from modelexpress.refit.reshard.rendezvous import (
@@ -41,6 +46,7 @@ from modelexpress.refit.reshard.types import (
     summarize_unsupported,
 )
 from modelexpress.refit.reshard.verify import shard_region, tensor_digest
+from modelexpress.types import TensorDescriptor
 
 
 @dataclass(frozen=True)
@@ -53,27 +59,21 @@ class _ResolvedSources:
 
 @dataclass(frozen=True)
 class _PreparedNixlTransfer:
-    """One immutable physical plan over reusable registered destinations.
-
-    ``plan_revision`` is process-local and changes whenever ``prepare`` rebuilds
-    the plan. It is not a control-plane weight-version number.
-    """
+    """One immutable physical plan over reusable registered destinations."""
 
     plan: TransferPlan
     capture: CaptureResult
     sources: dict
     descriptors: tuple[ReadDescriptor, ...]
     transport: NixlReshardTransport
-    plan_revision: int
 
 
 @dataclass(frozen=True)
 class _StagedNixlWeights:
-    """Verified tensors tagged with the local plan revision that produced them."""
+    """Verified tensors ready for engine installation."""
 
     tensors: dict[str, torch.Tensor]
     metrics: dict[str, Any]
-    plan_revision: int
 
 
 def _resolve_sources(manifests: list[bytes]) -> _ResolvedSources:
@@ -241,28 +241,40 @@ class _NixlStagedTransfer:
         agent_name: str,
         device_id: int,
         device: torch.device,
+        listen_port: int,
         timeout_seconds: float = 1200.0,
     ) -> None:
+        self._device_id = device_id
         self._device = device
         self._timeout = timeout_seconds
         self._manager = NixlTransferManager(
             agent_name=agent_name,
             device_id=device_id,
+            listen_port=listen_port,
         )
         try:
             self._manager.initialize()
         except Exception:
             self._manager.shutdown()
             raise
+        # Canonical engine-layout staging buffers. Exact slices land directly
+        # here; reconstructed or converted values are copied here before these
+        # buffers are verified, installed, and advertised to peer generators.
         self._recv_buffers: dict[str, torch.Tensor] = {}
+        # Wire-dtype staging for sources whose dtype differs from the engine
+        # parameter. RDMA writes here first, then stage() casts into recv buffers.
         self._convert_buffers: dict[str, torch.Tensor] = {}
+        # Complete contiguous source tensors used when captured transforms must
+        # be replayed locally, or when direct slicing exceeds the descriptor
+        # budget. stage() reconstructs each source here, then copies its derived
+        # views into the canonical receive buffers.
         self._full_buffers: dict[str, torch.Tensor] = {}
         self._registered_recv_params: set[str] = set()
         self._convert_registered = False
         self._full_registered = False
         self._active: _PreparedNixlTransfer | None = None
         self._loaded_agent_metadata: dict[str, bytes] = {}
-        self._plan_revision = 0
+        self._published_peer_rank: int | None = None
         self._closed = False
 
     def prepare(
@@ -319,14 +331,12 @@ class _NixlStagedTransfer:
             for copy in capture.copies
             if copy.src_name in resolved.sources
         }
-        self._plan_revision += 1
         prepared = _PreparedNixlTransfer(
             plan=plan,
             capture=capture,
             sources=used_sources,
             descriptors=descriptors,
             transport=transport,
-            plan_revision=self._plan_revision,
         )
         self._active = prepared
         return prepared
@@ -403,19 +413,14 @@ class _NixlStagedTransfer:
             self._full_buffers, full_expected, label="full-pull buffer"
         )
 
-        segment_params = {segment.param_name for segment in plan.segments}
+        recv_params = set(recv_expected)
         if (
             self._registered_recv_params
-            and self._registered_recv_params != segment_params
+            and self._registered_recv_params != recv_params
         ):
             raise RuntimeError(
-                "direct receive parameter set changed; restart the generator engine"
+                "receive parameter set changed; restart the generator engine"
             )
-        if not self._registered_recv_params and segment_params:
-            self._manager.register_tensors(
-                {f"__recv__{name}": self._recv_buffers[name] for name in segment_params}
-            )
-            self._registered_recv_params = segment_params
         if convert_expected and not self._convert_registered:
             self._manager.register_tensors(
                 {
@@ -432,6 +437,9 @@ class _NixlStagedTransfer:
                 }
             )
             self._full_registered = True
+        if not self._registered_recv_params and recv_params:
+            self._manager.register_tensors(self._recv_buffers)
+            self._registered_recv_params = recv_params
 
     def _descriptors(self, plan: TransferPlan) -> list[ReadDescriptor]:
         descriptors = exact_descriptors(
@@ -498,8 +506,127 @@ class _NixlStagedTransfer:
                 "full_pull_sources": len(prepared.plan.full_pulls),
                 "converts": len(prepared.plan.converts),
             },
-            plan_revision=prepared.plan_revision,
         )
+
+    def stage_peer(
+        self,
+        *,
+        source: p2p_pb2.WorkerMetadata,
+        parameter_layout: dict[str, tuple[tuple[int, ...], torch.dtype]],
+    ) -> _StagedNixlWeights:
+        """Pull an identical-rank peer's canonical staging buffers."""
+        if self._closed:
+            raise RuntimeError("NIXL staged transfer is closed")
+        self.unpublish_peer()
+        self._ensure_buffers(
+            self._recv_buffers,
+            parameter_layout,
+            label="receive-buffer",
+        )
+        recv_params = set(parameter_layout)
+        if self._registered_recv_params and self._registered_recv_params != recv_params:
+            raise RuntimeError(
+                "receive parameter set changed; restart the generator engine"
+            )
+        if not self._registered_recv_params:
+            self._manager.register_tensors(self._recv_buffers)
+            self._registered_recv_params = recv_params
+
+        source_tensors = [
+            TensorDescriptor(
+                name=tensor.name,
+                addr=tensor.addr,
+                size=tensor.size,
+                device_id=tensor.device_id,
+                dtype=tensor.dtype,
+            )
+            for tensor in worker_tensor_descriptors(source)
+        ]
+        if not source_tensors:
+            raise RuntimeError("P2P source has no tensor descriptors")
+
+        remote_agent_name: str | None = None
+        started = time.perf_counter()
+        try:
+            if source.worker_grpc_endpoint:
+                host, port = source.metadata_endpoint.rsplit(":", 1)
+                remote_agent_name = source.agent_name
+                self._manager.fetch_remote_and_wait(
+                    remote_agent_name=remote_agent_name,
+                    ip=host,
+                    port=int(port),
+                    timeout_seconds=self._timeout,
+                )
+            else:
+                remote_agent_name = self._manager.add_remote_agent(
+                    source.nixl_metadata
+                )
+            bytes_received, tensor_count, wire_seconds = (
+                self._manager.receive_from_source(
+                    source_metadata=b"",
+                    source_tensors=source_tensors,
+                    timeout_seconds=self._timeout,
+                    remote_agent_name=remote_agent_name,
+                    require_exact_match=True,
+                    destination_tensors=self._recv_buffers,
+                )
+            )
+        finally:
+            if remote_agent_name is not None:
+                self._manager.remove_remote_agent(remote_agent_name)
+
+        self._active = None
+        return _StagedNixlWeights(
+            tensors=self._recv_buffers,
+            metrics={
+                "bytes_received": bytes_received,
+                "segments": tensor_count,
+                "wire_s": round(wire_seconds, 6),
+                "peer_s": round(time.perf_counter() - started, 6),
+            },
+        )
+
+    def publish_peer(
+        self,
+        *,
+        staged: _StagedNixlWeights,
+        identity: p2p_pb2.SourceIdentity,
+        p2p_client: MxClientBase,
+        worker_rank: int,
+        worker_id: str,
+        accelerator: str,
+    ) -> None:
+        """Advertise verified canonical buffers for the applied version."""
+        previous_rank = self._published_peer_rank
+        self.unpublish_peer()
+        # Supersede any boot-time source owned by this rank before binding the
+        # shared publication slot to the exact WeightVersion identity.
+        if previous_rank != worker_rank:
+            unpublish_metadata_for_worker(
+                worker_rank=worker_rank,
+                device_id=self._device_id,
+            )
+        publish_metadata_and_ready(
+            p2p_client,
+            self._manager,
+            staged.tensors,
+            worker_rank,
+            self._device_id,
+            identity,
+            worker_id,
+            accelerator=accelerator,
+        )
+        self._published_peer_rank = worker_rank
+
+    def unpublish_peer(self) -> None:
+        """Stop advertising buffers before they are reused by another stage."""
+        if self._published_peer_rank is None:
+            return
+        unpublish_metadata_for_worker(
+            worker_rank=self._published_peer_rank,
+            device_id=self._device_id,
+        )
+        self._published_peer_rank = None
 
     def _verification_tensor(self, prepared: _PreparedNixlTransfer, name: str):
         source = prepared.sources[name]
@@ -551,6 +678,7 @@ class _NixlStagedTransfer:
     def close(self) -> None:
         if self._closed:
             return
+        self.unpublish_peer()
         self._closed = True
         self._manager.shutdown()
 

--- a/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prioritized source strategies for ModelExpress RL refit."""
+
+from .base import RefitStrategy
+
+__all__ = ["RefitStrategy"]

--- a/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/base.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/base.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public source-strategy contract for ModelExpress RL refit."""
+
+from abc import ABC, abstractmethod
+
+from ...control import WeightVersion
+
+
+class RefitStrategy(ABC):
+    """Stage one exact weight version from a particular class of sources.
+
+    Strategies may populate adapter-owned staging buffers but must not install
+    weights into the live model. The generator client owns installation and
+    staged-buffer release, so strategies do not expose rollback or close hooks.
+    """
+
+    @abstractmethod
+    def stage(self, version: WeightVersion) -> object | None:
+        """Return verified staged weights, or ``None`` after a clean source miss."""
+
+
+__all__ = ["RefitStrategy"]

--- a/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/peer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/peer.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inference-peer refit strategy."""
+
+import logging
+import random
+
+import grpc
+
+from modelexpress import p2p_pb2
+from modelexpress.client import MxClient
+from modelexpress.metadata.worker_server import fetch_tensor_manifest
+from modelexpress.types import ManifestMismatchError
+
+from ...control import WeightVersion
+from ..adapter import GeneratorEngineAdapter
+from .base import RefitStrategy
+
+logger = logging.getLogger("modelexpress_rl.inference.refit_strategy.peer")
+
+
+class _PeerRefitStrategy(RefitStrategy):
+    """Prefer an already-updated generator with the same rank and version."""
+
+    def __init__(
+        self,
+        *,
+        adapter: GeneratorEngineAdapter,
+        p2p_client: MxClient,
+        worker_id: str,
+        max_transfer_attempts: int,
+        rpc_timeout_seconds: float,
+    ) -> None:
+        self._adapter = adapter
+        self._p2p_client = p2p_client
+        self._worker_id = worker_id
+        self._max_transfer_attempts = max_transfer_attempts
+        self._rpc_timeout_seconds = rpc_timeout_seconds
+
+    def stage(self, version: WeightVersion) -> object | None:
+        sources = list(self._list_ready_sources(version.version_id))
+        random.Random().shuffle(sources)
+        for source in sources[: self._max_transfer_attempts]:
+            try:
+                worker = self._fetch_source(source)
+                staged = self._adapter.stage_peer_weight(worker)
+            except (grpc.RpcError, RuntimeError, ManifestMismatchError) as error:
+                logger.warning(
+                    "P2P peer %s failed for version %s: %s",
+                    source.worker_id,
+                    version.version_id,
+                    error,
+                )
+                continue
+            logger.info(
+                "staged weight version %s from P2P peer %s",
+                version.version_id,
+                source.worker_id,
+            )
+            return staged
+        return None
+
+    def _list_ready_sources(
+        self, version_id: str
+    ) -> tuple[p2p_pb2.SourceInstanceRef, ...]:
+        try:
+            identity = self._adapter.build_p2p_identity(version_id)
+            response = self._p2p_client.list_sources(
+                identity=identity,
+                status_filter=p2p_pb2.SOURCE_STATUS_READY,
+            )
+        except (grpc.RpcError, RuntimeError) as error:
+            logger.warning(
+                "P2P peer discovery failed for version %s: %s",
+                version_id,
+                error,
+            )
+            return ()
+        return tuple(
+            source
+            for source in response.instances
+            if source.worker_rank == self._adapter.worker_rank
+            and source.worker_id != self._worker_id
+        )
+
+    def _fetch_source(
+        self, source: p2p_pb2.SourceInstanceRef
+    ) -> p2p_pb2.WorkerMetadata:
+        response = self._p2p_client.get_metadata(
+            mx_source_id=source.mx_source_id,
+            worker_id=source.worker_id,
+        )
+        if not response.found:
+            raise RuntimeError(
+                f"P2P metadata disappeared for worker {source.worker_id!r}"
+            )
+        worker = response.worker
+        if worker.worker_rank != self._adapter.worker_rank:
+            raise RuntimeError(
+                f"P2P worker rank changed for worker {source.worker_id!r}"
+            )
+        if worker.worker_grpc_endpoint:
+            tensors, _manifest_bytes = fetch_tensor_manifest(
+                endpoint=worker.worker_grpc_endpoint,
+                mx_source_id=source.mx_source_id,
+                worker_id=source.worker_id,
+                timeout=self._rpc_timeout_seconds,
+            )
+            worker.tensor_source.ClearField("tensors")
+            worker.tensor_source.tensors.extend(tensors)
+        return worker
+
+
+__all__: list[str] = []

--- a/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/peer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/peer.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inference-peer refit strategy."""
+
+import logging
+
+import grpc
+from modelexpress import p2p_pb2
+from modelexpress.client import MxClient
+from modelexpress.metadata.worker_server import fetch_tensor_manifest
+from modelexpress.types import ManifestMismatchError
+
+from ...control import WeightVersion
+from ..adapter import GeneratorEngineAdapter
+from .base import RefitStrategy
+
+logger = logging.getLogger("modelexpress_rl.inference.refit_strategy.peer")
+
+
+class _PeerRefitStrategy(RefitStrategy):
+    """Prefer an already-updated generator with the same rank and version."""
+
+    def __init__(
+        self,
+        *,
+        adapter: GeneratorEngineAdapter,
+        p2p_client: MxClient,
+        worker_id: str,
+        max_transfer_attempts: int,
+        rpc_timeout_seconds: float,
+    ) -> None:
+        self._adapter = adapter
+        self._p2p_client = p2p_client
+        self._worker_id = worker_id
+        self._max_transfer_attempts = max_transfer_attempts
+        self._rpc_timeout_seconds = rpc_timeout_seconds
+
+    def stage(self, version: WeightVersion) -> object | None:
+        sources = self._list_ready_sources(version.version_id)
+        for source in sources[: self._max_transfer_attempts]:
+            try:
+                worker = self._fetch_source(source)
+                staged = self._adapter.stage_peer_weight(worker)
+            except (grpc.RpcError, RuntimeError, ManifestMismatchError) as error:
+                logger.warning(
+                    "P2P peer %s failed for version %s: %s",
+                    source.worker_id,
+                    version.version_id,
+                    error,
+                )
+                continue
+            logger.info(
+                "staged weight version %s from P2P peer %s",
+                version.version_id,
+                source.worker_id,
+            )
+            return staged
+        return None
+
+    def _list_ready_sources(
+        self, version_id: str
+    ) -> tuple[p2p_pb2.SourceInstanceRef, ...]:
+        identity = self._adapter.build_p2p_identity(version_id)
+        try:
+            response = self._p2p_client.list_sources(
+                identity=identity,
+                status_filter=p2p_pb2.SOURCE_STATUS_READY,
+            )
+        except grpc.RpcError as error:
+            logger.warning(
+                "P2P peer discovery failed for version %s: %s",
+                version_id,
+                error,
+            )
+            return ()
+        return tuple(
+            source
+            for source in response.instances
+            if source.worker_rank == self._adapter.worker_rank
+            and source.worker_id != self._worker_id
+        )
+
+    def _fetch_source(
+        self, source: p2p_pb2.SourceInstanceRef
+    ) -> p2p_pb2.WorkerMetadata:
+        response = self._p2p_client.get_metadata(
+            mx_source_id=source.mx_source_id,
+            worker_id=source.worker_id,
+        )
+        if not response.found:
+            raise RuntimeError(
+                f"P2P metadata disappeared for worker {source.worker_id!r}"
+            )
+        worker = response.worker
+        if worker.worker_rank != self._adapter.worker_rank:
+            raise RuntimeError(
+                f"P2P worker rank changed for worker {source.worker_id!r}"
+            )
+        if worker.worker_grpc_endpoint:
+            tensors, _manifest_bytes = fetch_tensor_manifest(
+                endpoint=worker.worker_grpc_endpoint,
+                mx_source_id=source.mx_source_id,
+                worker_id=source.worker_id,
+                timeout=self._rpc_timeout_seconds,
+            )
+            worker.tensor_source.ClearField("tensors")
+            worker.tensor_source.tensors.extend(tensors)
+        return worker
+
+
+__all__: list[str] = []

--- a/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/trainer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/trainer.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trainer-publication refit strategy."""
+
+import hashlib
+from collections import defaultdict
+from collections.abc import Callable
+
+import grpc
+
+from ... import refit_pb2, refit_pb2_grpc
+from ...control import WeightVersion
+from ..adapter import GeneratorEngineAdapter, GeneratorSource, GeneratorTransferInputs
+from .base import RefitStrategy
+
+
+class _TrainerRefitStrategy(RefitStrategy):
+    """Stage from the trainer publications attached to a weight version."""
+
+    def __init__(
+        self,
+        *,
+        adapter: GeneratorEngineAdapter,
+        service: Callable[[], refit_pb2_grpc.RefitServiceStub],
+        max_transfer_attempts: int,
+        rpc_timeout_seconds: float,
+    ) -> None:
+        self._adapter = adapter
+        self._service = service
+        self._max_transfer_attempts = max_transfer_attempts
+        self._rpc_timeout_seconds = rpc_timeout_seconds
+        self._cached_plan: object | None = None
+        self._cached_fingerprint: tuple | None = None
+
+    def stage(self, version: WeightVersion) -> object:
+        if version.payload_format not in self._adapter.supported_payload_formats:
+            raise RuntimeError(
+                "generator adapter does not support weight version payload format "
+                f"{version.payload_format.value}"
+            )
+        last_error: grpc.RpcError | RuntimeError | None = None
+        for attempt in range(self._max_transfer_attempts):
+            try:
+                inputs = self._discover_sources(version, candidate_offset=attempt)
+                return self._adapter.stage_weight(self._transfer_plan(inputs))
+            except (grpc.RpcError, RuntimeError) as error:
+                last_error = error
+                # A failed transfer may have invalidated transport state even
+                # when the source metadata fingerprint is unchanged.
+                self._cached_plan = None
+                self._cached_fingerprint = None
+        assert last_error is not None
+        raise last_error
+
+    def _fetch_manifest(self, shard: refit_pb2.WeightVersionShard) -> bytes:
+        with grpc.insecure_channel(shard.manifest_endpoint) as channel:
+            response = refit_pb2_grpc.RefitWorkerServiceStub(
+                channel
+            ).GetWeightVersionShardManifest(
+                refit_pb2.GetWeightVersionShardManifestRequest(
+                    version_id=shard.version_id,
+                    source_slot_id=shard.source_slot_id,
+                ),
+                timeout=self._rpc_timeout_seconds,
+            )
+        digest = hashlib.sha256(response.manifest).hexdigest()
+        if (
+            response.manifest_digest != shard.manifest_digest
+            or digest != shard.manifest_digest
+        ):
+            raise RuntimeError(
+                f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
+            )
+        return response.manifest
+
+    def _discover_sources(
+        self,
+        version: WeightVersion,
+        *,
+        candidate_offset: int,
+    ) -> GeneratorTransferInputs:
+        response = self._service().ListWeightVersionShards(
+            refit_pb2.ListWeightVersionShardsRequest(version_id=version.version_id),
+            timeout=self._rpc_timeout_seconds,
+        )
+        candidates = defaultdict(list)
+        for shard in response.shards:
+            candidates[shard.source_slot_id].append(shard)
+
+        selected = []
+        for source_slot_id in version.expected_source_slots:
+            failures = []
+            ordered = sorted(
+                candidates[source_slot_id], key=lambda item: item.worker_id
+            )
+            if ordered:
+                offset = candidate_offset % len(ordered)
+                ordered = ordered[offset:] + ordered[:offset]
+            for shard in ordered:
+                try:
+                    manifest = self._fetch_manifest(shard)
+                except (grpc.RpcError, RuntimeError) as error:
+                    failures.append(str(error))
+                    continue
+                selected.append(
+                    GeneratorSource(
+                        source_slot_id=source_slot_id,
+                        worker_id=shard.worker_id,
+                        manifest_endpoint=shard.manifest_endpoint,
+                        manifest_digest=shard.manifest_digest,
+                        transport=shard.transport,
+                        manifest=manifest,
+                    )
+                )
+                break
+            else:
+                detail = f": {failures[-1]}" if failures else ""
+                raise RuntimeError(
+                    f"no usable source for required slot {source_slot_id!r}{detail}"
+                )
+
+        return GeneratorTransferInputs(
+            version_id=version.version_id,
+            layout_signature=version.layout_signature,
+            payload_format=version.payload_format,
+            sources=tuple(selected),
+        )
+
+    def _transfer_plan(self, inputs: GeneratorTransferInputs) -> object:
+        reusable = (
+            self._cached_plan is not None
+            and self._cached_fingerprint == inputs.physical_fingerprint
+            and self._adapter.validate_transfer_plan(self._cached_plan, inputs)
+        )
+        if not reusable:
+            self._cached_plan = self._adapter.create_transfer_plan(inputs)
+            self._cached_fingerprint = inputs.physical_fingerprint
+        assert self._cached_plan is not None
+        return self._cached_plan
+
+
+__all__: list[str] = []

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -509,6 +509,24 @@ class TestReceiveFromSourceManifestValidation:
                 require_exact_match=True,
             )
 
+    def test_explicit_destination_catalog_overrides_latest_registration(
+        self, monkeypatch
+    ):
+        canonical = torch.zeros(10, dtype=torch.float32)
+        auxiliary = torch.zeros(1, dtype=torch.float32)
+        mgr = self._make_manager(monkeypatch, {"__convert__w": auxiliary})
+        src = TensorDescriptor(
+            name="w", addr=0x1000, size=80, device_id=0, dtype=str(canonical.dtype),
+        )
+        with pytest.raises(ManifestMismatchError, match="size mismatch"):
+            mgr.receive_from_source(
+                source_metadata=b"",
+                source_tensors=[src],
+                remote_agent_name="dummy",
+                require_exact_match=True,
+                destination_tensors={"w": canonical},
+            )
+
 
 class TestWaitForXfer:
     @staticmethod

--- a/modelexpress_client/python/tests/test_refit_envs.py
+++ b/modelexpress_client/python/tests/test_refit_envs.py
@@ -11,16 +11,19 @@ def test_defaults_when_unset(monkeypatch):
     for name in envs.environment_variables:
         monkeypatch.delenv(name, raising=False)
 
+    assert envs.MX_REFIT_METADATA_PORT == 7555
     assert envs.MX_TRAINER_ENGINE == "MEGATRON"
     assert envs.MX_TRAINER_STAGING_MODE == "IN_PLACE"
     assert envs.MX_WEIGHT_PAYLOAD_FORMAT == "FULL_TENSOR"
 
 
 def test_values_are_normalized_and_read_live(monkeypatch):
+    monkeypatch.setenv("MX_REFIT_METADATA_PORT", "8000")
     monkeypatch.setenv("MX_TRAINER_ENGINE", " megatron ")
     monkeypatch.setenv("MX_TRAINER_STAGING_MODE", " copy_to_device ")
     monkeypatch.setenv("MX_WEIGHT_PAYLOAD_FORMAT", " xor_delta ")
 
+    assert envs.MX_REFIT_METADATA_PORT == 8000
     assert envs.MX_TRAINER_ENGINE == "MEGATRON"
     assert envs.MX_TRAINER_STAGING_MODE == "COPY_TO_DEVICE"
     assert envs.MX_WEIGHT_PAYLOAD_FORMAT == "XOR_DELTA"
@@ -29,6 +32,13 @@ def test_values_are_normalized_and_read_live(monkeypatch):
 def test_unknown_attribute_raises():
     with pytest.raises(AttributeError):
         _ = envs.NOT_A_REAL_ENV_VAR
+
+
+def test_refit_metadata_port_must_be_positive(monkeypatch):
+    monkeypatch.setenv("MX_REFIT_METADATA_PORT", "0")
+
+    with pytest.raises(ValueError, match="MX_REFIT_METADATA_PORT must be positive"):
+        _ = envs.MX_REFIT_METADATA_PORT
 
 
 def test_dir_lists_registered_names():

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -7,16 +7,20 @@ from concurrent import futures
 import grpc
 import modelexpress_rl.inference.client as generator_client_module
 import pytest
+from modelexpress import p2p_pb2, p2p_pb2_grpc
+from modelexpress.types import ManifestMismatchError
 from modelexpress_rl import (
     ModelExpressGeneratorClient,
     ModelExpressGeneratorConfig,
     VllmGeneratorContext,
     WeightPayloadFormat,
+    WeightVersion,
     WeightVersionRef,
     refit_pb2,
     refit_pb2_grpc,
 )
 from modelexpress_rl.inference.adapter import GeneratorEngineAdapter
+from modelexpress_rl.inference.refit_strategy import RefitStrategy
 
 
 class _RefitService(refit_pb2_grpc.RefitServiceServicer):
@@ -98,6 +102,23 @@ class _WorkerService(refit_pb2_grpc.RefitWorkerServiceServicer):
         )
 
 
+class _P2pService(p2p_pb2_grpc.P2pServiceServicer):
+    def __init__(self):
+        self.requests = []
+        self.instances = []
+        self.metadata = {}
+
+    def ListSources(self, request, _context):
+        self.requests.append(request)
+        return p2p_pb2.ListSourcesResponse(instances=self.instances)
+
+    def GetMetadata(self, request, _context):
+        worker = self.metadata.get((request.mx_source_id, request.worker_id))
+        if worker is None:
+            return p2p_pb2.GetMetadataResponse(found=False)
+        return p2p_pb2.GetMetadataResponse(found=True, worker=worker)
+
+
 class _Adapter(GeneratorEngineAdapter):
     supported_payload_formats = frozenset({WeightPayloadFormat.FULL_TENSOR})
 
@@ -106,11 +127,41 @@ class _Adapter(GeneratorEngineAdapter):
         self.create_calls = []
         self.validate_calls = []
         self.stage_calls = []
+        self.peer_stage_calls = []
         self.apply_calls = []
+        self.publish_calls = []
+        self.publish_attempts = 0
         self.release_calls = []
         self.close_calls = 0
+        self.identity_failure = False
+        self.publish_failures = 0
         self.stage_failures = 0
         self.apply_failure = False
+
+    @property
+    def worker_rank(self):
+        return 0
+
+    def build_p2p_identity(self, version_id):
+        if self.identity_failure:
+            raise RuntimeError("identity unavailable")
+        return p2p_pb2.SourceIdentity(
+            model_name="test/model",
+            revision=version_id,
+        )
+
+    def stage_peer_weight(self, source):
+        assert self.service.active_leases
+        self.peer_stage_calls.append(source)
+        return {"peer": source}
+
+    def publish_weight_version(self, **kwargs):
+        assert self.service.active_leases
+        self.publish_attempts += 1
+        if self.publish_failures:
+            self.publish_failures -= 1
+            raise RuntimeError("publication failed")
+        self.publish_calls.append(kwargs)
 
     def create_transfer_plan(self, inputs):
         self.create_calls.append(inputs)
@@ -153,11 +204,14 @@ def _start_server(*, state=None, manifest_digest=None):
     )
     refit_pb2_grpc.add_RefitServiceServicer_to_server(service, server)
     refit_pb2_grpc.add_RefitWorkerServiceServicer_to_server(_WorkerService(), server)
+    p2p_service = _P2pService()
+    p2p_pb2_grpc.add_P2pServiceServicer_to_server(p2p_service, server)
+    service.p2p = p2p_service
     server.start()
     return server, endpoint, service
 
 
-def _initialize(monkeypatch, endpoint, adapter):
+def _initialize(monkeypatch, endpoint, adapter, *, max_transfer_attempts=3):
     monkeypatch.setattr(
         generator_client_module,
         "_create_generator_adapter",
@@ -170,11 +224,11 @@ def _initialize(monkeypatch, endpoint, adapter):
                 vllm_config=object(),
             ),
             model_name="test/model",
-            payload_format=WeightPayloadFormat.FULL_TENSOR,
             worker_id="generator-0",
             server_url=endpoint,
             registration_ttl_seconds=60,
             lease_ttl_seconds=60,
+            max_transfer_attempts=max_transfer_attempts,
         )
     )
 
@@ -203,15 +257,34 @@ def test_generator_config_rejects_invalid_numeric_settings(setting, value, messa
         )
 
 
-def test_generator_config_rejects_unspecified_payload_format():
-    with pytest.raises(ValueError, match="payload_format must be specified"):
-        ModelExpressGeneratorConfig(
-            engine_context=VllmGeneratorContext(
-                model=object(),
-                vllm_config=object(),
-            ),
-            payload_format=WeightPayloadFormat.UNSPECIFIED,
-        )
+def test_generator_uses_refit_strategies_in_order(monkeypatch):
+    server, endpoint, service = _start_server()
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+    calls = []
+
+    class _Strategy(RefitStrategy):
+        def __init__(self, name, result):
+            self._name = name
+            self._result = result
+
+        def stage(self, version: WeightVersion) -> object | None:
+            calls.append((self._name, version.version_id))
+            return self._result
+
+    generator._refit_strategies = (
+        _Strategy("miss", None),
+        _Strategy("hit", "staged"),
+        _Strategy("not-reached", "unused"),
+    )
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert calls == [("miss", "version-a"), ("hit", "version-a")]
 
 
 def test_generator_stages_applies_releases_and_reuses_valid_plan(monkeypatch):
@@ -248,12 +321,34 @@ def test_generator_stages_applies_releases_and_reuses_valid_plan(monkeypatch):
     assert len(adapter.validate_calls) == 1
     assert len(adapter.stage_calls) == 3
     assert len(adapter.apply_calls) == 1
+    assert len(adapter.publish_calls) == 1
     assert len(adapter.release_calls) == 3
     assert adapter.close_calls == 1
     assert [source.source_slot_id for source in adapter.create_calls[0].sources] == [
         "rank:0",
         "rank:1",
     ]
+    assert (
+        adapter.create_calls[0].payload_format is WeightPayloadFormat.FULL_TENSOR
+    )
+
+
+def test_generator_retries_peer_publication_once(monkeypatch):
+    server, endpoint, service = _start_server()
+    adapter = _Adapter(service)
+    adapter.publish_failures = 1
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        assert generator.apply_weight(staged) == "installed"
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert adapter.publish_attempts == 2
+    assert len(adapter.publish_calls) == 1
 
 
 def test_generator_releases_lease_when_manifest_is_invalid(monkeypatch):
@@ -380,7 +475,242 @@ def test_generator_rejects_non_ready_version_before_leasing(monkeypatch):
         server.stop(grace=None).wait()
 
     assert service.lease_registrations == 0
-    assert service.lease_deletions == 0
+
+
+def test_generator_rejects_unsupported_payload_after_peer_miss(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "version-base"
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        with pytest.raises(RuntimeError, match=r"does not support.*XOR_DELTA"):
+            generator.stage_weight(version=WeightVersionRef("version-a"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.lease_registrations == 1
+    assert service.lease_deletions == 1
+
+
+def test_generator_falls_back_when_peer_identity_is_unavailable(monkeypatch):
+    server, endpoint, service = _start_server()
+    adapter = _Adapter(service)
+    adapter.identity_failure = True
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert len(adapter.stage_calls) == 1
+    assert service.p2p.requests == []
+
+
+def test_generator_discovers_rank_matched_p2p_peer(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.p2p.instances.extend(
+        [
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="wrong-rank",
+                worker_id="generator-rank-1",
+                worker_rank=1,
+            ),
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="same-worker",
+                worker_id="generator-0",
+                worker_rank=0,
+            ),
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="peer-source",
+                worker_id="generator-peer",
+                worker_rank=0,
+            ),
+        ]
+    )
+    service.p2p.metadata[("peer-source", "generator-peer")] = (
+        p2p_pb2.WorkerMetadata(
+            worker_rank=0,
+            tensors=[
+                p2p_pb2.TensorDescriptor(
+                    name="weight",
+                    addr=1234,
+                    size=16,
+                    device_id=0,
+                    dtype="torch.float32",
+                )
+            ],
+        )
+    )
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.p2p.requests[0].identity.revision == "version-a"
+    assert service.lease_registrations == 1
+    assert service.lease_deletions == 1
+    assert len(adapter.peer_stage_calls) == 1
+    assert adapter.create_calls == []
+
+
+def test_generator_tries_next_peer_after_manifest_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        "modelexpress_rl.inference.refit_strategy.peer.random.Random.shuffle",
+        lambda _random, _sources: None,
+    )
+    server, endpoint, service = _start_server()
+    service.p2p.instances.extend(
+        [
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="bad-source",
+                worker_id="bad-peer",
+                worker_rank=0,
+            ),
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="good-source",
+                worker_id="good-peer",
+                worker_rank=0,
+            ),
+        ]
+    )
+    for source_id, worker_id, agent_name in (
+        ("bad-source", "bad-peer", "bad-agent"),
+        ("good-source", "good-peer", "good-agent"),
+    ):
+        service.p2p.metadata[(source_id, worker_id)] = p2p_pb2.WorkerMetadata(
+            worker_rank=0,
+            agent_name=agent_name,
+            tensors=[
+                p2p_pb2.TensorDescriptor(
+                    name="weight",
+                    addr=1234,
+                    size=16,
+                    device_id=0,
+                    dtype="torch.float32",
+                )
+            ],
+        )
+
+    adapter = _Adapter(service)
+
+    def stage_peer(source):
+        adapter.peer_stage_calls.append(source)
+        if source.agent_name == "bad-agent":
+            raise ManifestMismatchError("incompatible peer manifest")
+        return {"peer": source}
+
+    adapter.stage_peer_weight = stage_peer
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert [source.agent_name for source in adapter.peer_stage_calls] == [
+        "bad-agent",
+        "good-agent",
+    ]
+    assert adapter.create_calls == []
+
+
+def test_generator_randomizes_and_limits_peers_before_trainer_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "modelexpress_rl.inference.refit_strategy.peer.random.Random.shuffle",
+        lambda _random, sources: sources.reverse(),
+    )
+    server, endpoint, service = _start_server()
+    service.p2p.instances.extend(
+        p2p_pb2.SourceInstanceRef(
+            mx_source_id=f"peer-source-{index}",
+            worker_id=f"peer-{index}",
+            worker_rank=0,
+        )
+        for index in range(3)
+    )
+    for index in range(3):
+        service.p2p.metadata[(f"peer-source-{index}", f"peer-{index}")] = (
+            p2p_pb2.WorkerMetadata(worker_rank=0, agent_name=f"peer-agent-{index}")
+        )
+
+    adapter = _Adapter(service)
+
+    def reject_peer(source):
+        adapter.peer_stage_calls.append(source)
+        raise ManifestMismatchError("incompatible peer manifest")
+
+    adapter.stage_peer_weight = reject_peer
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        max_transfer_attempts=2,
+    )
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert [source.agent_name for source in adapter.peer_stage_calls] == [
+        "peer-agent-2",
+        "peer-agent-1",
+    ]
+    assert len(adapter.create_calls) == 1
+
+
+def test_generator_can_use_full_peer_for_delta_version(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "version-base"
+    service.p2p.instances.append(
+        p2p_pb2.SourceInstanceRef(
+            mx_source_id="peer-source",
+            worker_id="generator-peer",
+            worker_rank=0,
+        )
+    )
+    service.p2p.metadata[("peer-source", "generator-peer")] = (
+        p2p_pb2.WorkerMetadata(
+            worker_rank=0,
+            tensors=[
+                p2p_pb2.TensorDescriptor(
+                    name="weight",
+                    addr=1234,
+                    size=16,
+                    device_id=0,
+                    dtype="torch.float32",
+                )
+            ],
+        )
+    )
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert len(adapter.peer_stage_calls) == 1
+    assert adapter.create_calls == []
 
 
 def test_generator_closes_adapter_when_registration_fails(monkeypatch):
@@ -405,7 +735,6 @@ def test_generator_closes_adapter_when_registration_fails(monkeypatch):
                     vllm_config=object(),
                 ),
                 model_name="test/model",
-                payload_format=WeightPayloadFormat.FULL_TENSOR,
                 worker_id="generator-0",
                 server_url="mx-server:9000",
             )

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -7,16 +7,20 @@ from concurrent import futures
 import grpc
 import modelexpress_rl.inference.client as generator_client_module
 import pytest
+from modelexpress import p2p_pb2, p2p_pb2_grpc
+from modelexpress.types import ManifestMismatchError
 from modelexpress_rl import (
     ModelExpressGeneratorClient,
     ModelExpressGeneratorConfig,
     VllmGeneratorContext,
     WeightPayloadFormat,
+    WeightVersion,
     WeightVersionRef,
     refit_pb2,
     refit_pb2_grpc,
 )
 from modelexpress_rl.inference.adapter import GeneratorEngineAdapter
+from modelexpress_rl.inference.refit_strategy import RefitStrategy
 
 
 class _RefitService(refit_pb2_grpc.RefitServiceServicer):
@@ -98,6 +102,23 @@ class _WorkerService(refit_pb2_grpc.RefitWorkerServiceServicer):
         )
 
 
+class _P2pService(p2p_pb2_grpc.P2pServiceServicer):
+    def __init__(self):
+        self.requests = []
+        self.instances = []
+        self.metadata = {}
+
+    def ListSources(self, request, _context):
+        self.requests.append(request)
+        return p2p_pb2.ListSourcesResponse(instances=self.instances)
+
+    def GetMetadata(self, request, _context):
+        worker = self.metadata.get((request.mx_source_id, request.worker_id))
+        if worker is None:
+            return p2p_pb2.GetMetadataResponse(found=False)
+        return p2p_pb2.GetMetadataResponse(found=True, worker=worker)
+
+
 class _Adapter(GeneratorEngineAdapter):
     supported_payload_formats = frozenset({WeightPayloadFormat.FULL_TENSOR})
 
@@ -106,11 +127,32 @@ class _Adapter(GeneratorEngineAdapter):
         self.create_calls = []
         self.validate_calls = []
         self.stage_calls = []
+        self.peer_stage_calls = []
         self.apply_calls = []
+        self.publish_calls = []
         self.release_calls = []
         self.close_calls = 0
         self.stage_failures = 0
         self.apply_failure = False
+
+    @property
+    def worker_rank(self):
+        return 0
+
+    def build_p2p_identity(self, version_id):
+        return p2p_pb2.SourceIdentity(
+            model_name="test/model",
+            revision=version_id,
+        )
+
+    def stage_peer_weight(self, source):
+        assert self.service.active_leases
+        self.peer_stage_calls.append(source)
+        return {"peer": source}
+
+    def publish_weight_version(self, **kwargs):
+        assert self.service.active_leases
+        self.publish_calls.append(kwargs)
 
     def create_transfer_plan(self, inputs):
         self.create_calls.append(inputs)
@@ -153,11 +195,14 @@ def _start_server(*, state=None, manifest_digest=None):
     )
     refit_pb2_grpc.add_RefitServiceServicer_to_server(service, server)
     refit_pb2_grpc.add_RefitWorkerServiceServicer_to_server(_WorkerService(), server)
+    p2p_service = _P2pService()
+    p2p_pb2_grpc.add_P2pServiceServicer_to_server(p2p_service, server)
+    service.p2p = p2p_service
     server.start()
     return server, endpoint, service
 
 
-def _initialize(monkeypatch, endpoint, adapter):
+def _initialize(monkeypatch, endpoint, adapter, *, max_transfer_attempts=3):
     monkeypatch.setattr(
         generator_client_module,
         "_create_generator_adapter",
@@ -170,11 +215,11 @@ def _initialize(monkeypatch, endpoint, adapter):
                 vllm_config=object(),
             ),
             model_name="test/model",
-            payload_format=WeightPayloadFormat.FULL_TENSOR,
             worker_id="generator-0",
             server_url=endpoint,
             registration_ttl_seconds=60,
             lease_ttl_seconds=60,
+            max_transfer_attempts=max_transfer_attempts,
         )
     )
 
@@ -203,15 +248,34 @@ def test_generator_config_rejects_invalid_numeric_settings(setting, value, messa
         )
 
 
-def test_generator_config_rejects_unspecified_payload_format():
-    with pytest.raises(ValueError, match="payload_format must be specified"):
-        ModelExpressGeneratorConfig(
-            engine_context=VllmGeneratorContext(
-                model=object(),
-                vllm_config=object(),
-            ),
-            payload_format=WeightPayloadFormat.UNSPECIFIED,
-        )
+def test_generator_uses_refit_strategies_in_order(monkeypatch):
+    server, endpoint, service = _start_server()
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+    calls = []
+
+    class _Strategy(RefitStrategy):
+        def __init__(self, name, result):
+            self._name = name
+            self._result = result
+
+        def stage(self, version: WeightVersion) -> object | None:
+            calls.append((self._name, version.version_id))
+            return self._result
+
+    generator._refit_strategies = (
+        _Strategy("miss", None),
+        _Strategy("hit", "staged"),
+        _Strategy("not-reached", "unused"),
+    )
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert calls == [("miss", "version-a"), ("hit", "version-a")]
 
 
 def test_generator_stages_applies_releases_and_reuses_valid_plan(monkeypatch):
@@ -248,12 +312,16 @@ def test_generator_stages_applies_releases_and_reuses_valid_plan(monkeypatch):
     assert len(adapter.validate_calls) == 1
     assert len(adapter.stage_calls) == 3
     assert len(adapter.apply_calls) == 1
+    assert len(adapter.publish_calls) == 1
     assert len(adapter.release_calls) == 3
     assert adapter.close_calls == 1
     assert [source.source_slot_id for source in adapter.create_calls[0].sources] == [
         "rank:0",
         "rank:1",
     ]
+    assert (
+        adapter.create_calls[0].payload_format is WeightPayloadFormat.FULL_TENSOR
+    )
 
 
 def test_generator_releases_lease_when_manifest_is_invalid(monkeypatch):
@@ -380,7 +448,217 @@ def test_generator_rejects_non_ready_version_before_leasing(monkeypatch):
         server.stop(grace=None).wait()
 
     assert service.lease_registrations == 0
-    assert service.lease_deletions == 0
+
+
+def test_generator_rejects_unsupported_payload_after_peer_miss(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "version-base"
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        with pytest.raises(RuntimeError, match="does not support.*XOR_DELTA"):
+            generator.stage_weight(version=WeightVersionRef("version-a"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.lease_registrations == 1
+    assert service.lease_deletions == 1
+
+
+def test_generator_discovers_rank_matched_p2p_peer(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.p2p.instances.extend(
+        [
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="wrong-rank",
+                worker_id="generator-rank-1",
+                worker_rank=1,
+            ),
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="same-worker",
+                worker_id="generator-0",
+                worker_rank=0,
+            ),
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="peer-source",
+                worker_id="generator-peer",
+                worker_rank=0,
+            ),
+        ]
+    )
+    service.p2p.metadata[("peer-source", "generator-peer")] = (
+        p2p_pb2.WorkerMetadata(
+            worker_rank=0,
+            tensors=[
+                p2p_pb2.TensorDescriptor(
+                    name="weight",
+                    addr=1234,
+                    size=16,
+                    device_id=0,
+                    dtype="torch.float32",
+                )
+            ],
+        )
+    )
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.p2p.requests[0].identity.revision == "version-a"
+    assert service.lease_registrations == 1
+    assert service.lease_deletions == 1
+    assert len(adapter.peer_stage_calls) == 1
+    assert adapter.create_calls == []
+
+
+def test_generator_tries_next_peer_after_manifest_mismatch(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.p2p.instances.extend(
+        [
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="bad-source",
+                worker_id="bad-peer",
+                worker_rank=0,
+            ),
+            p2p_pb2.SourceInstanceRef(
+                mx_source_id="good-source",
+                worker_id="good-peer",
+                worker_rank=0,
+            ),
+        ]
+    )
+    for source_id, worker_id, agent_name in (
+        ("bad-source", "bad-peer", "bad-agent"),
+        ("good-source", "good-peer", "good-agent"),
+    ):
+        service.p2p.metadata[(source_id, worker_id)] = p2p_pb2.WorkerMetadata(
+            worker_rank=0,
+            agent_name=agent_name,
+            tensors=[
+                p2p_pb2.TensorDescriptor(
+                    name="weight",
+                    addr=1234,
+                    size=16,
+                    device_id=0,
+                    dtype="torch.float32",
+                )
+            ],
+        )
+
+    adapter = _Adapter(service)
+
+    def stage_peer(source):
+        adapter.peer_stage_calls.append(source)
+        if source.agent_name == "bad-agent":
+            raise ManifestMismatchError("incompatible peer manifest")
+        return {"peer": source}
+
+    adapter.stage_peer_weight = stage_peer
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert [source.agent_name for source in adapter.peer_stage_calls] == [
+        "bad-agent",
+        "good-agent",
+    ]
+    assert adapter.create_calls == []
+
+
+def test_generator_limits_peer_attempts_before_trainer_fallback(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.p2p.instances.extend(
+        p2p_pb2.SourceInstanceRef(
+            mx_source_id=f"peer-source-{index}",
+            worker_id=f"peer-{index}",
+            worker_rank=0,
+        )
+        for index in range(3)
+    )
+    for index in range(3):
+        service.p2p.metadata[(f"peer-source-{index}", f"peer-{index}")] = (
+            p2p_pb2.WorkerMetadata(worker_rank=0, agent_name=f"peer-agent-{index}")
+        )
+
+    adapter = _Adapter(service)
+
+    def reject_peer(source):
+        adapter.peer_stage_calls.append(source)
+        raise ManifestMismatchError("incompatible peer manifest")
+
+    adapter.stage_peer_weight = reject_peer
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        max_transfer_attempts=2,
+    )
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert [source.agent_name for source in adapter.peer_stage_calls] == [
+        "peer-agent-0",
+        "peer-agent-1",
+    ]
+    assert len(adapter.create_calls) == 1
+
+
+def test_generator_can_use_full_peer_for_delta_version(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "version-base"
+    service.p2p.instances.append(
+        p2p_pb2.SourceInstanceRef(
+            mx_source_id="peer-source",
+            worker_id="generator-peer",
+            worker_rank=0,
+        )
+    )
+    service.p2p.metadata[("peer-source", "generator-peer")] = (
+        p2p_pb2.WorkerMetadata(
+            worker_rank=0,
+            tensors=[
+                p2p_pb2.TensorDescriptor(
+                    name="weight",
+                    addr=1234,
+                    size=16,
+                    device_id=0,
+                    dtype="torch.float32",
+                )
+            ],
+        )
+    )
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert len(adapter.peer_stage_calls) == 1
+    assert adapter.create_calls == []
 
 
 def test_generator_closes_adapter_when_registration_fails(monkeypatch):
@@ -405,7 +683,6 @@ def test_generator_closes_adapter_when_registration_fails(monkeypatch):
                     vllm_config=object(),
                 ),
                 model_name="test/model",
-                payload_format=WeightPayloadFormat.FULL_TENSOR,
                 worker_id="generator-0",
                 server_url="mx-server:9000",
             )

--- a/modelexpress_client/python/tests/test_refit_nixl_staged_transfer.py
+++ b/modelexpress_client/python/tests/test_refit_nixl_staged_transfer.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 import modelexpress_rl.inference.nixl_staged_transfer as transfer_module
 import pytest
 import torch
+from modelexpress import p2p_pb2
 from modelexpress.refit.reshard.rendezvous import (
     PublishedShard,
     PublishedTensor,
@@ -185,7 +186,6 @@ def _prepared(tensor: torch.Tensor, digest: str | None) -> _PreparedNixlTransfer
         sources={"weight": source},
         descriptors=(),
         transport=object(),
-        plan_revision=1,
     )
 
 
@@ -233,15 +233,114 @@ def test_transfer_manager_is_closed_after_failed_init_and_only_once(monkeypatch)
             agent_name="generator",
             device_id=0,
             device=torch.device("cpu"),
+            listen_port=19000,
         )
     assert calls == ["initialize", "shutdown"]
 
     transfer = object.__new__(_NixlStagedTransfer)
     transfer._manager = _Manager()
+    transfer._published_peer_rank = None
     transfer._closed = False
     transfer.close()
     transfer.close()
     assert calls == ["initialize", "shutdown", "shutdown"]
+
+
+def test_peer_stage_uses_exact_canonical_tensor_catalog(monkeypatch):
+    monkeypatch.setattr(transfer_module, "classic_cuda_alloc", nullcontext)
+    calls = []
+
+    class _Manager:
+        def register_tensors(self, tensors):
+            calls.append(("register", tuple(tensors)))
+
+        def add_remote_agent(self, metadata):
+            calls.append(("add", metadata))
+            return "peer-agent"
+
+        def receive_from_source(self, **kwargs):
+            calls.append(("receive", kwargs))
+            return 16, 1, 0.25
+
+        def remove_remote_agent(self, agent_name):
+            calls.append(("remove", agent_name))
+
+    transfer = object.__new__(_NixlStagedTransfer)
+    transfer._device = torch.device("cpu")
+    transfer._timeout = 30.0
+    transfer._manager = _Manager()
+    transfer._recv_buffers = {}
+    transfer._registered_recv_params = set()
+    transfer._published_peer_rank = None
+    transfer._active = None
+    transfer._closed = False
+    source = p2p_pb2.WorkerMetadata(
+        nixl_metadata=b"peer-metadata",
+        tensors=[
+            p2p_pb2.TensorDescriptor(
+                name="weight",
+                addr=1234,
+                size=16,
+                device_id=0,
+                dtype="torch.float32",
+            )
+        ],
+    )
+
+    staged = transfer.stage_peer(
+        source=source,
+        parameter_layout={"weight": ((4,), torch.float32)},
+    )
+
+    assert staged.metrics["bytes_received"] == 16
+    receive = next(value for name, value in calls if name == "receive")
+    assert receive["remote_agent_name"] == "peer-agent"
+    assert receive["require_exact_match"] is True
+    assert set(receive["destination_tensors"]) == {"weight"}
+    assert calls[-1] == ("remove", "peer-agent")
+
+
+def test_peer_publication_supersedes_previous_rank_source(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        transfer_module,
+        "unpublish_metadata_for_worker",
+        lambda **kwargs: calls.append(("unpublish", kwargs)),
+    )
+    monkeypatch.setattr(
+        transfer_module,
+        "publish_metadata_and_ready",
+        lambda *args, **kwargs: calls.append(("publish", args, kwargs)),
+    )
+    transfer = object.__new__(_NixlStagedTransfer)
+    transfer._manager = object()
+    transfer._device_id = 2
+    transfer._published_peer_rank = 7
+    staged = transfer_module._StagedNixlWeights(
+        tensors={"weight": torch.ones(1)},
+        metrics={},
+    )
+
+    transfer.publish_peer(
+        staged=staged,
+        identity=p2p_pb2.SourceIdentity(model_name="model", revision="version-a"),
+        p2p_client=object(),
+        worker_rank=7,
+        worker_id="generator-7",
+        accelerator="cuda",
+    )
+    transfer.unpublish_peer()
+
+    assert calls[0] == (
+        "unpublish",
+        {"worker_rank": 7, "device_id": 2},
+    )
+    assert calls[1][0] == "publish"
+    assert "worker_grpc_port" not in calls[1][2]
+    assert calls[2] == (
+        "unpublish",
+        {"worker_rank": 7, "device_id": 2},
+    )
 
 
 def test_registered_workspace_is_reused_only_for_the_same_layout(monkeypatch):

--- a/modelexpress_client/python/tests/test_refit_nixl_staged_transfer.py
+++ b/modelexpress_client/python/tests/test_refit_nixl_staged_transfer.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 import modelexpress_rl.inference.nixl_staged_transfer as transfer_module
 import pytest
 import torch
+from modelexpress import p2p_pb2
 from modelexpress.refit.reshard.rendezvous import (
     PublishedShard,
     PublishedTensor,
@@ -185,7 +186,6 @@ def _prepared(tensor: torch.Tensor, digest: str | None) -> _PreparedNixlTransfer
         sources={"weight": source},
         descriptors=(),
         transport=object(),
-        plan_revision=1,
     )
 
 
@@ -233,15 +233,177 @@ def test_transfer_manager_is_closed_after_failed_init_and_only_once(monkeypatch)
             agent_name="generator",
             device_id=0,
             device=torch.device("cpu"),
+            listen_port=19000,
         )
     assert calls == ["initialize", "shutdown"]
 
     transfer = object.__new__(_NixlStagedTransfer)
     transfer._manager = _Manager()
+    transfer._published_peer_rank = None
     transfer._closed = False
     transfer.close()
     transfer.close()
     assert calls == ["initialize", "shutdown", "shutdown"]
+
+
+def test_peer_stage_uses_exact_canonical_tensor_catalog(monkeypatch):
+    monkeypatch.setattr(transfer_module, "classic_cuda_alloc", nullcontext)
+    calls = []
+
+    class _Manager:
+        def register_tensors(self, tensors):
+            calls.append(("register", tuple(tensors)))
+
+        def add_remote_agent(self, metadata):
+            calls.append(("add", metadata))
+            return "peer-agent"
+
+        def fetch_remote_and_wait(self, **kwargs):
+            calls.append(("fetch", kwargs))
+
+        def receive_from_source(self, **kwargs):
+            calls.append(("receive", kwargs))
+            return 16, 1, 0.25
+
+        def remove_remote_agent(self, agent_name):
+            calls.append(("remove", agent_name))
+
+    transfer = object.__new__(_NixlStagedTransfer)
+    transfer._device = torch.device("cpu")
+    transfer._timeout = 30.0
+    transfer._manager = _Manager()
+    transfer._recv_buffers = {}
+    transfer._registered_recv_params = set()
+    transfer._published_peer_rank = None
+    transfer._active = None
+    transfer._closed = False
+    source = p2p_pb2.WorkerMetadata(
+        nixl_metadata=b"peer-metadata",
+        tensors=[
+            p2p_pb2.TensorDescriptor(
+                name="weight",
+                addr=1234,
+                size=16,
+                device_id=0,
+                dtype="torch.float32",
+            )
+        ],
+    )
+
+    staged = transfer.stage_peer(
+        source=source,
+        parameter_layout={"weight": ((4,), torch.float32)},
+    )
+
+    assert staged.metrics["bytes_received"] == 16
+    receive = next(value for name, value in calls if name == "receive")
+    assert receive["remote_agent_name"] == "peer-agent"
+    assert receive["require_exact_match"] is True
+    assert set(receive["destination_tensors"]) == {"weight"}
+    assert calls[-1] == ("remove", "peer-agent")
+
+    calls.clear()
+    source.worker_grpc_endpoint = "127.0.0.1:18000"
+    source.metadata_endpoint = "127.0.0.1:17000"
+    source.agent_name = "live-peer-agent"
+    transfer.stage_peer(
+        source=source,
+        parameter_layout={"weight": ((4,), torch.float32)},
+    )
+    fetch = next(value for name, value in calls if name == "fetch")
+    assert fetch == {
+        "remote_agent_name": "live-peer-agent",
+        "ip": "127.0.0.1",
+        "port": 17000,
+        "timeout_seconds": 30.0,
+    }
+
+    source.metadata_endpoint = ""
+    with pytest.raises(RuntimeError, match="unusable metadata endpoint"):
+        transfer.stage_peer(
+            source=source,
+            parameter_layout={"weight": ((4,), torch.float32)},
+        )
+
+
+def test_peer_republication_unpublishes_active_same_rank_source(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        transfer_module,
+        "unpublish_metadata_for_worker",
+        lambda **kwargs: calls.append(("unpublish", kwargs)),
+    )
+    monkeypatch.setattr(
+        transfer_module,
+        "publish_metadata_and_ready",
+        lambda *args, **kwargs: calls.append(("publish", args, kwargs)),
+    )
+    transfer = object.__new__(_NixlStagedTransfer)
+    transfer._manager = object()
+    transfer._device_id = 2
+    transfer._published_peer_rank = 7
+    staged = transfer_module._StagedNixlWeights(
+        tensors={"weight": torch.ones(1)},
+        metrics={},
+    )
+
+    transfer.publish_peer(
+        staged=staged,
+        identity=p2p_pb2.SourceIdentity(model_name="model", revision="version-a"),
+        p2p_client=object(),
+        worker_rank=7,
+        worker_id="generator-7",
+        accelerator="cuda",
+    )
+    transfer.unpublish_peer()
+
+    assert calls[0] == (
+        "unpublish",
+        {"worker_rank": 7, "device_id": 2},
+    )
+    assert calls[1][0] == "publish"
+    assert "worker_grpc_port" not in calls[1][2]
+    assert calls[2] == (
+        "unpublish",
+        {"worker_rank": 7, "device_id": 2},
+    )
+
+
+def test_first_peer_publication_supersedes_boot_time_rank_source(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        transfer_module,
+        "unpublish_metadata_for_worker",
+        lambda **kwargs: calls.append(("unpublish", kwargs)),
+    )
+    monkeypatch.setattr(
+        transfer_module,
+        "publish_metadata_and_ready",
+        lambda *args, **kwargs: calls.append(("publish", args, kwargs)),
+    )
+    transfer = object.__new__(_NixlStagedTransfer)
+    transfer._manager = object()
+    transfer._device_id = 2
+    transfer._published_peer_rank = None
+    staged = transfer_module._StagedNixlWeights(
+        tensors={"weight": torch.ones(1)},
+        metrics={},
+    )
+
+    transfer.publish_peer(
+        staged=staged,
+        identity=p2p_pb2.SourceIdentity(model_name="model", revision="version-a"),
+        p2p_client=object(),
+        worker_rank=7,
+        worker_id="generator-7",
+        accelerator="cuda",
+    )
+
+    assert calls[0] == (
+        "unpublish",
+        {"worker_rank": 7, "device_id": 2},
+    )
+    assert calls[1][0] == "publish"
 
 
 def test_registered_workspace_is_reused_only_for_the_same_layout(monkeypatch):

--- a/modelexpress_client/python/tests/test_refit_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_adapter.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import modelexpress_rl.inference.engines.vllm.adapter as vllm_adapter_module
 import pytest
 import torch
+from modelexpress import p2p_pb2
 from modelexpress_rl import WeightPayloadFormat
 from modelexpress_rl.inference.adapter import GeneratorSource, GeneratorTransferInputs
 from modelexpress_rl.inference.engines.vllm import VllmGeneratorAdapter
@@ -15,14 +17,13 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
     monkeypatch,
 ):
     events = []
-    native_plan = type("NativePlan", (), {"plan_revision": 1})()
+    native_plan = object()
     transferred = type(
         "Transferred",
         (),
         {
             "tensors": {"weight": object()},
             "metrics": {"bytes_received": 128},
-            "plan_revision": 1,
         },
     )()
 
@@ -30,6 +31,10 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
         def __init__(self, **kwargs):
             events.append(("installer_init", kwargs))
             self.capture = object()
+
+        def parameter_layout(self):
+            events.append(("parameter_layout",))
+            return {"weight": ((4,), torch.float32)}
 
         def install(self, tensors):
             events.append(("install", tensors))
@@ -46,6 +51,23 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
             events.append(("stage", plan))
             return transferred
 
+        def unpublish_peer(self):
+            events.append(("unpublish_peer",))
+
+        def stage_peer(self, **kwargs):
+            events.append(("stage_peer", kwargs))
+            return type(
+                "PeerTransferred",
+                (),
+                {
+                    "tensors": {"weight": object()},
+                    "metrics": {"bytes_received": 128},
+                },
+            )()
+
+        def publish_peer(self, **kwargs):
+            events.append(("publish_peer", kwargs))
+
         def close(self):
             events.append(("close",))
 
@@ -60,9 +82,22 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
         def get_target_device(self):
             return torch.device("cuda:2")
 
+        def get_worker_rank(self):
+            return 3
+
+        def build_identity(self):
+            return p2p_pb2.SourceIdentity(
+                model_name="test/model",
+                revision="checkpoint-revision",
+            )
+
+        accelerator_backend = SimpleNamespace(name="cuda")
+
     monkeypatch.setattr(vllm_adapter_module, "VllmAdapter", _Engine)
     monkeypatch.setattr(vllm_adapter_module, "_VllmInstaller", _Installer)
     monkeypatch.setattr(vllm_adapter_module, "_NixlStagedTransfer", _Transfer)
+    monkeypatch.setenv("MX_METADATA_PORT", "62000")
+    monkeypatch.setenv("MX_REFIT_METADATA_PORT", "61000")
     adapter = VllmGeneratorAdapter(
         model="model",
         vllm_config="vllm-config",
@@ -88,6 +123,10 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
     assert adapter.supported_payload_formats == frozenset(
         {WeightPayloadFormat.FULL_TENSOR}
     )
+    assert adapter.worker_rank == 3
+    identity = adapter.build_p2p_identity("version-a")
+    assert identity.model_name == "test/model"
+    assert identity.revision == "version-a"
     plan = adapter.create_transfer_plan(inputs)
     assert plan is native_plan
     assert adapter.validate_transfer_plan(plan, inputs)
@@ -99,7 +138,25 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
     with pytest.raises(RuntimeError, match="release staged weight"):
         adapter.create_transfer_plan(inputs)
     assert adapter.apply_weight(staged) == {"bytes_received": 128}
+    adapter.publish_weight_version(
+        version_id="version-a",
+        staged=staged,
+        p2p_client="p2p-client",
+        worker_id="generator-0",
+    )
     adapter.release_staged_weight(staged)
+    with pytest.raises(RuntimeError, match="no longer active"):
+        adapter.publish_weight_version(
+            version_id="version-a",
+            staged=staged,
+            p2p_client="p2p-client",
+            worker_id="generator-0",
+        )
+
+    peer_source = p2p_pb2.WorkerMetadata(worker_rank=3)
+    peer_staged = adapter.stage_peer_weight(peer_source)
+    assert adapter.apply_weight(peer_staged) == {"bytes_received": 128}
+    adapter.release_staged_weight(peer_staged)
 
     with pytest.raises(ValueError, match="does not support XOR_DELTA"):
         adapter.create_transfer_plan(
@@ -127,6 +184,7 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
                 "agent_name": "mx-refit-generator-0",
                 "device_id": 2,
                 "device": torch.device("cuda:2"),
+                "listen_port": 61002,
             },
         ),
         (
@@ -136,7 +194,28 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
                 "capture_layout": adapter._installer.capture,
             },
         ),
+        ("unpublish_peer",),
         ("stage", native_plan),
         ("install", transferred.tensors),
+        (
+            "publish_peer",
+            {
+                "staged": transferred,
+                "identity": identity,
+                "p2p_client": "p2p-client",
+                "worker_rank": 3,
+                "worker_id": "generator-0",
+                "accelerator": "cuda",
+            },
+        ),
+        ("parameter_layout",),
+        (
+            "stage_peer",
+            {
+                "source": peer_source,
+                "parameter_layout": {"weight": ((4,), torch.float32)},
+            },
+        ),
+        ("install", peer_staged.tensors),
         ("close",),
     ]

--- a/modelexpress_client/python/tests/test_refit_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_adapter.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import modelexpress_rl.inference.engines.vllm.adapter as vllm_adapter_module
 import pytest
 import torch
+from modelexpress import p2p_pb2
 from modelexpress_rl import WeightPayloadFormat
 from modelexpress_rl.inference.adapter import GeneratorSource, GeneratorTransferInputs
 from modelexpress_rl.inference.engines.vllm import VllmGeneratorAdapter
@@ -15,14 +17,13 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
     monkeypatch,
 ):
     events = []
-    native_plan = type("NativePlan", (), {"plan_revision": 1})()
+    native_plan = object()
     transferred = type(
         "Transferred",
         (),
         {
             "tensors": {"weight": object()},
             "metrics": {"bytes_received": 128},
-            "plan_revision": 1,
         },
     )()
 
@@ -30,6 +31,10 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
         def __init__(self, **kwargs):
             events.append(("installer_init", kwargs))
             self.capture = object()
+
+        def parameter_layout(self):
+            events.append(("parameter_layout",))
+            return {"weight": ((4,), torch.float32)}
 
         def install(self, tensors):
             events.append(("install", tensors))
@@ -46,6 +51,23 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
             events.append(("stage", plan))
             return transferred
 
+        def unpublish_peer(self):
+            events.append(("unpublish_peer",))
+
+        def stage_peer(self, **kwargs):
+            events.append(("stage_peer", kwargs))
+            return type(
+                "PeerTransferred",
+                (),
+                {
+                    "tensors": {"weight": object()},
+                    "metrics": {"bytes_received": 128},
+                },
+            )()
+
+        def publish_peer(self, **kwargs):
+            events.append(("publish_peer", kwargs))
+
         def close(self):
             events.append(("close",))
 
@@ -60,9 +82,21 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
         def get_target_device(self):
             return torch.device("cuda:2")
 
+        def get_worker_rank(self):
+            return 3
+
+        def build_identity(self):
+            return p2p_pb2.SourceIdentity(
+                model_name="test/model",
+                revision="checkpoint-revision",
+            )
+
+        accelerator_backend = SimpleNamespace(name="cuda")
+
     monkeypatch.setattr(vllm_adapter_module, "VllmAdapter", _Engine)
     monkeypatch.setattr(vllm_adapter_module, "_VllmInstaller", _Installer)
     monkeypatch.setattr(vllm_adapter_module, "_NixlStagedTransfer", _Transfer)
+    monkeypatch.setenv("MX_METADATA_PORT", "61000")
     adapter = VllmGeneratorAdapter(
         model="model",
         vllm_config="vllm-config",
@@ -88,6 +122,10 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
     assert adapter.supported_payload_formats == frozenset(
         {WeightPayloadFormat.FULL_TENSOR}
     )
+    assert adapter.worker_rank == 3
+    identity = adapter.build_p2p_identity("version-a")
+    assert identity.model_name == "test/model"
+    assert identity.revision == "version-a"
     plan = adapter.create_transfer_plan(inputs)
     assert plan is native_plan
     assert adapter.validate_transfer_plan(plan, inputs)
@@ -99,7 +137,18 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
     with pytest.raises(RuntimeError, match="release staged weight"):
         adapter.create_transfer_plan(inputs)
     assert adapter.apply_weight(staged) == {"bytes_received": 128}
+    adapter.publish_weight_version(
+        version_id="version-a",
+        staged=staged,
+        p2p_client="p2p-client",
+        worker_id="generator-0",
+    )
     adapter.release_staged_weight(staged)
+
+    peer_source = p2p_pb2.WorkerMetadata(worker_rank=3)
+    peer_staged = adapter.stage_peer_weight(peer_source)
+    assert adapter.apply_weight(peer_staged) == {"bytes_received": 128}
+    adapter.release_staged_weight(peer_staged)
 
     with pytest.raises(ValueError, match="does not support XOR_DELTA"):
         adapter.create_transfer_plan(
@@ -127,6 +176,7 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
                 "agent_name": "mx-refit-generator-0",
                 "device_id": 2,
                 "device": torch.device("cuda:2"),
+                "listen_port": 61002,
             },
         ),
         (
@@ -136,7 +186,28 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
                 "capture_layout": adapter._installer.capture,
             },
         ),
+        ("unpublish_peer",),
         ("stage", native_plan),
         ("install", transferred.tensors),
+        (
+            "publish_peer",
+            {
+                "staged": transferred,
+                "identity": identity,
+                "p2p_client": "p2p-client",
+                "worker_rank": 3,
+                "worker_id": "generator-0",
+                "accelerator": "cuda",
+            },
+        ),
+        ("parameter_layout",),
+        (
+            "stage_peer",
+            {
+                "source": peer_source,
+                "parameter_layout": {"weight": ((4,), torch.float32)},
+            },
+        ),
+        ("install", peer_staged.tensors),
         ("close",),
     ]

--- a/modelexpress_client/python/tests/test_refit_vllm_installer.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_installer.py
@@ -98,6 +98,30 @@ def test_installer_rejects_parameters_left_on_meta(monkeypatch):
         installer._process_and_commit({"weight": torch.tensor([7.0])})
 
 
+def test_installer_caches_parameter_layout():
+    twin = nn.Module()
+    twin.register_parameter(
+        "weight",
+        nn.Parameter(torch.empty((2, 3), dtype=torch.float16)),
+    )
+    calls = []
+    installer = object.__new__(_VllmInstaller)
+    installer._parameter_layout = None
+
+    def build_meta_twin():
+        calls.append("build")
+        return twin
+
+    installer._build_meta_twin = build_meta_twin
+
+    first = installer.parameter_layout()
+    second = installer.parameter_layout()
+
+    assert first == {"weight": ((2, 3), torch.float16)}
+    assert second is first
+    assert calls == ["build"]
+
+
 def test_installer_rejects_quantized_mla_derived_weight_refresh():
     model = nn.Module()
     mla = nn.Module()

--- a/modelexpress_client/python/uv.lock
+++ b/modelexpress_client/python/uv.lock
@@ -946,6 +946,7 @@ codegen = [
 dev = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -961,7 +962,7 @@ vmm = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cuda-python", marker = "extra == 'vmm'", specifier = ">=12.0" },
+    { name = "cuda-python", marker = "extra == 'vmm'", specifier = ">=12.4" },
     { name = "google-crc32c", specifier = ">=1.5.0" },
     { name = "grpcio", specifier = ">=1.66.2" },
     { name = "grpcio-tools", marker = "extra == 'codegen'", specifier = "==1.66.2" },
@@ -971,6 +972,7 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.41.1" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.41.1" },
+    { name = "prometheus-client", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20.0" },
     { name = "protobuf", specifier = ">=5.27.2,<7.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Overview

Add generator-to-generator fallback for immutable RL `WeightVersion`s. A generator first looks for an already-updated, same-rank peer under the existing ModelExpress inference P2P metadata service, then falls back to the trainer publications attached to the version.

This is the ModelExpress side of [NVIDIA-NeMo/RL#3704](https://github.com/NVIDIA-NeMo/RL/pull/3704).

## Architecture

```mermaid
flowchart LR
    C[RL control client] -->|Create WeightVersion| V[RefitService]
    T[Trainer publications] -->|Fallback manifests| G1[Generator A]
    G1 -->|Apply verified canonical buffers| E1[vLLM]
    G1 -->|Publish revision = WeightVersion.uid| P[P2P metadata]
    P -->|Discover same-rank READY peer| G2[Generator B]
    G1 -->|Manifest gRPC + NIXL transfer| G2
    T -->|Fallback when peer unavailable| G2
    G2 -->|Graph-safe apply| E2[vLLM]
```

The public `RefitStrategy` contract keeps source selection separate from engine installation:

1. `PeerRefitStrategy` queries existing P2P metadata using the engine identity with `revision=WeightVersion.uid`.
2. It fetches the selected peer's exact tensor manifest and pulls its verified canonical staging buffers over NIXL.
3. If no compatible peer is usable, `TrainerRefitStrategy` discovers the version's trainer shard publications and stages through the existing reshard path.
4. Both paths use the same vLLM graph-safe installer.

No object-store/S3 data plane is added in this PR.

## Main changes

- Add the refit source-strategy chain and peer-first fallback.
- Publish applied canonical staging buffers through the existing inference P2P service.
- Match peers by exact weight-version identity and generator worker rank.
- Reuse the inference `MX_METADATA_PORT` and `MX_WORKER_GRPC_PORT` configuration contract.
- Keep reusable transfer buffers registered while explicitly unpublishing them before reuse.
- Document the peer-source architecture and lifecycle.

## Testing

### Focused ModelExpress tests

```text
uv run --extra dev pytest -q \
  tests/test_refit_generator_client.py \
  tests/test_refit_nixl_staged_transfer.py \
  tests/test_refit_vllm_adapter.py \
  tests/test_vllm_loader.py

110 passed, 8 skipped in 2.66s
```

These tests cover strategy ordering and fallback, exact-version peer discovery, manifest retrieval and validation, canonical peer staging, publication lifecycle, transfer-buffer reuse, adapter composition, and graph-safe installation.

### NeMo-RL functional E2E

| Setting | Value |
|---|---|
| Model | `meta-llama/Llama-3.1-8B-Instruct` |
| Hardware | 4x NVIDIA B200 |
| Trainer topology | 2 Megatron workers, TP1 with two redundant DP publishers |
| Generator topology | 2 independent vLLM TP1 generators on the same host |
| Workload | Synchronous GRPO, 3 complete optimizer steps |
| Samples checked per step | 2 prompts x 2 generations = 4 outputs |
| Maximum sequence length | 512 tokens |
| Payload | Full tensor, 195 canonical tensors / 16.06 GB per generator update |

For every GRPO step the harness performed the complete version lifecycle:

1. Create an immutable `WeightVersion` with the trainer source slots.
2. Publish the trainer shards and wait for the version to become `READY`.
3. Update the first generator from trainer publications and publish its verified canonical buffers as an exact-version P2P source.
4. Update the second generator from that peer through manifest gRPC plus NIXL.
5. Generate deterministic probes on both generators and compare the full outputs.
6. Repeat the same-version update to exercise publication replacement and reusable-buffer lifecycle before retirement.

#### Correctness results

| Step | Trainer-path token digest | Peer-path token digest | Logprob digest | Maximum logprob difference | Result |
|---|---|---|---|---:|---|
| 1 | `d025c241db7ef67fa54c78711e7bfb84bb76c8a0f74e912c64a50819beba4351` | same | `1f74adcd152527bbf1bbdeab1d9926c458b73bb21e16b0b14177ad4100577059` | 0 | PASS |
| 2 | `d025c241db7ef67fa54c78711e7bfb84bb76c8a0f74e912c64a50819beba4351` | same | `1f74adcd152527bbf1bbdeab1d9926c458b73bb21e16b0b14177ad4100577059` | 0 | PASS |
| 3 | `1ab8584bf2b063c6f754a8d3e00e4eadac95b6bd9d713785cb1945f4075e3095` | same | `1a2cfeba5e05e36440756f0ade2b494f8a647ae830078746326f8e4b8794f6b6` | 0 | PASS |

The comparison required:

- Exact equality of generated token IDs.
- Exact equality of generation lengths and unpadded sequence lengths.
- Logprob equality within `rtol=1e-5`, `atol=1e-6`; the observed maximum difference was exactly zero on all steps.

#### Transfer and lifecycle evidence

- Every step completed both trainer-to-generator and generator-to-generator transfer paths.
- Peer transfers moved 195 tensors / 16.06 GB in approximately 0.61-0.63 seconds (about 205-212 Gbps as reported by NIXL).
- Same-host generators used deterministic, non-overlapping listeners:
  - Generator 0: NIXL metadata `7064`, P2P manifest gRPC `7080`.
  - Generator 1: NIXL metadata `7164`, P2P manifest gRPC `7180`.
- The peer manifest was fetched from the selected generator endpoint and the receiver connected to that peer's advertised NIXL endpoint.
- No port bind conflicts, peer-strategy fallback failures, stale worker-ID mismatches, or workload restarts occurred.
- The driver and all workers exited cleanly after step 3; temporary Kubernetes resources were removed.

These are functional E2E timings from one B200 run, not a controlled or comparative performance benchmark. This topology validates exact-version lifecycle, redundant trainer publications, peer selection, transfer, and output parity; it does not add MoE or cross-TP reshard qualification to this PR.

## Current scope

- vLLM full-tensor staged installation.
- Same-rank inference peers with compatible engine identity.
- Trainer publications remain the authoritative fallback.
- Object-store origins and delta-chain reconstruction remain out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added peer-to-peer weight refitting for faster transfer between compatible inference workers.
  - Added exact-version discovery and validation to ensure the correct model weights are staged.
  - Added automatic fallback to trainer-provided weight sources when peer transfer is unavailable.
  - Added support for publishing applied weights for reuse by other workers.

- **Bug Fixes**
  - Improved transfer retries, source selection, manifest validation, and cleanup after failed operations.
  - Corrected destination tensor matching during weight transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->