### PR TITLE
feat(refit): view-ops slice planning for reshard

### DIFF
--- a/modelexpress_client/python/modelexpress/refit/reshard/geometry.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/geometry.py
@@ -64,6 +64,10 @@ __all__ = [
 # ``__torch_dispatch__`` and raises UnsupportedReshard.
 _SUPPORTED_OPS: dict[Callable, str] = {
     torch.Tensor.narrow: "narrow",
+    # select/split unstack a stacked source (e.g. a trainer that publishes its
+    # experts stacked -> per-expert HF weights). select is rank-reducing; split is
+    # a multi-return view like chunk. slice_plan resolves both to a source box.
+    torch.Tensor.select: "select",
     torch.Tensor.view: "view",
     torch.Tensor.reshape: "reshape",
     torch.Tensor.__getitem__: "__getitem__",
@@ -75,6 +79,7 @@ _SUPPORTED_OPS: dict[Callable, str] = {
     torch.Tensor.flatten: "flatten",
     torch.Tensor.contiguous: "contiguous",
     torch.Tensor.chunk: "chunk",
+    torch.Tensor.split: "split",
     # vLLM's fused-MoE expert loader unifies its fused and per-expert paths by
     # doing `experts_shard.unbind()`, reached via `unsqueeze(0)` for a per-expert
     # source. Without this entry every expert weight in a MoE model is classified

--- a/modelexpress_client/python/modelexpress/refit/reshard/slice_plan.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/slice_plan.py
@@ -167,25 +167,31 @@ def _view_to_box_perm(
     v_offset: int, v_shape: tuple, v_stride: tuple, global_shape
 ) -> tuple:
     """From a replayed strided view ``(offset, shape, stride)``, derive the source
-    index box + the view-dim -> source-dim permutation, for a RANK-PRESERVING
-    permuted box (transpose/permute/t of a narrowed/sliced region). Raises
-    ``UnsupportedReshard`` for a rank change or a non-permutation stride (a
-    dim-merging reshape) and makes the current receiver fail closed.
+    index box + the view-dim -> source-dim permutation.
 
-    A permuted box has each ``v_stride[d]`` equal to some source dim's row-major
-    stride (the dim that view-dim ``d`` iterates); ``v_offset`` unravels to the
-    box's per-source-dim start."""
+    Handles rank-PRESERVING permuted boxes (transpose/permute/t of a
+    narrowed/sliced region) and rank-REDUCING views (select/unbind drop a dim).
+    A dropped source dim is not iterated by any view dim, so it contributes a
+    single fixed index decoded from the offset (its box is ``[idx, idx+1]``).
+    Raises ``UnsupportedReshard`` for a rank INCREASE (unsqueeze) or a
+    non-permutation stride (a dim-merging reshape) and makes the current receiver
+    fail closed.
+
+    A permuted box has each view dim's ``v_stride[d]`` equal to some source dim's
+    row-major stride (the dim that view-dim ``d`` iterates); ``v_offset`` unravels
+    to each source dim's start."""
     ndim = len(global_shape)
-    if len(v_shape) != ndim:
+    vdim = len(v_shape)
+    if vdim > ndim:
         raise UnsupportedReshard(
-            f"rank change {len(v_shape)}!={ndim} (reshape/squeeze) not box-derivable"
+            f"rank increase {vdim}>{ndim} (unsqueeze) not box-derivable"
         )
     gstrides = _row_major_strides(global_shape)
     stride_to_dim: dict = {}
     for s in range(ndim):
         stride_to_dim.setdefault(gstrides[s], s)
-    perm: list = [None] * ndim
-    for d in range(ndim):
+    perm: list = [None] * vdim
+    for d in range(vdim):
         if v_shape[d] == 1:
             continue  # size-1 dim: stride is ambiguous; assign a leftover dim below
         sdim = stride_to_dim.get(v_stride[d])
@@ -197,15 +203,18 @@ def _view_to_box_perm(
     used = {s for s in perm if s is not None}
     remaining = [s for s in range(ndim) if s not in used]
     ri = 0
-    for d in range(ndim):
+    for d in range(vdim):
         if perm[d] is None:
             perm[d] = remaining[ri]
             ri += 1
-    if sorted(perm) != list(range(ndim)):
+    # Each view dim maps to a distinct source dim. Any source dims still
+    # unassigned were COLLAPSED by a rank-reducing view (select/unbind) and keep
+    # their size-1 default box below.
+    if len(set(perm)) != vdim:
         raise UnsupportedReshard("view strides are not a permutation of source dims")
     box_lo = [(v_offset // gstrides[s]) % global_shape[s] for s in range(ndim)]
-    box = [[box_lo[s], box_lo[s]] for s in range(ndim)]
-    for d in range(ndim):
+    box = [[box_lo[s], box_lo[s] + 1] for s in range(ndim)]
+    for d in range(vdim):
         box[perm[d]][1] = box[perm[d]][0] + v_shape[d]
 
     # Self-consistency guard: the derived box must faithfully reconstruct the

--- a/modelexpress_client/python/tests/test_reshard_refit_geometry.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_geometry.py
@@ -424,6 +424,93 @@ def test_moe_convert_capture_plan_reconstructs_end_to_end():
         assert torch.equal(w13_out[e, 1], w3[e])  # up_proj -> half 1
 
 
+def test_capture_weights_composes_a_select_prefix_with_the_loader_op():
+    """A select in the conversion prefix survives into the recorded op-chain,
+    ahead of the loader's own ops."""
+    f32 = torch.float32
+    with torch.device("meta"):
+        model = ToyModel()
+    lazies = build_lazy_weights([("native.stack", f32, [2, 4])])
+    converted = {"norm": lazies["native.stack"].select(0, 1)}  # unstack row 1 -> [4]
+
+    (copy,) = capture_weights(model, converted).copies
+
+    assert copy.src_name == "native.stack"
+    assert copy.op_chain == (("select", (0, 1), ()),)  # prefix; copy_ is the sink
+    assert copy.dest_shape == (4,)
+
+
+def test_convert_source_weights_traces_expert_unstack():
+    def convert(sd):
+        stacked = sd["model.experts.w13"]
+        return {
+            f"model.experts.{e}.gate_proj.weight": stacked.select(0, e)
+            for e in range(stacked.shape[0])
+        }
+
+    weights = convert_source_weights(convert, _CONVERT_MANIFEST)
+
+    expert = weights["model.experts.2.gate_proj.weight"]
+    assert expert._name == "model.experts.w13"
+    assert expert._ops == (("select", (0, 2), ()),)
+    assert tuple(expert.shape) == (2, 4)
+
+
+def test_stacked_moe_convert_capture_plan_reconstructs_end_to_end():
+    """Stacked-source variant of the MoE e2e: the trainer publishes experts
+    stacked and the conversion unstacks them with select. Each per-expert slab is
+    a zero-copy sub-range that lands in the right fused destination slot."""
+    f32 = torch.float32
+    router = torch.arange(_E * _H, dtype=f32).reshape(_E, _H)
+    w1 = (torch.arange(_E * _I * _H, dtype=f32) + 100).reshape(_E, _I, _H)  # stacked gate
+    w3 = (torch.arange(_E * _I * _H, dtype=f32) + 200).reshape(_E, _I, _H)  # stacked up
+    src_buf = {
+        "router.gate": router.reshape(-1),
+        "experts.w1": w1.reshape(-1),
+        "experts.w3": w3.reshape(-1),
+    }
+    src_shape = {
+        "router.gate": (_E, _H),
+        "experts.w1": (_E, _I, _H),
+        "experts.w3": (_E, _I, _H),
+    }
+    manifest = [(n, f32, s) for n, s in src_shape.items()]
+
+    def convert(sd):
+        out = {"gate.weight": sd["router.gate"]}
+        for e in range(_E):
+            out[f"experts.{e}.gate_proj.weight"] = sd["experts.w1"].select(0, e)
+            out[f"experts.{e}.up_proj.weight"] = sd["experts.w3"].select(0, e)
+        return out
+
+    with torch.device("meta"):
+        model = ToyMoEModel()
+    hf = convert_source_weights(convert, manifest)
+    copies = capture_weights(model, hf).copies
+
+    dst = {
+        "gate": torch.zeros(_E, _H).reshape(-1),
+        "w13": torch.zeros(_E, 2, _I, _H).reshape(-1),
+    }
+    for copy in copies:
+        shape = src_shape[copy.src_name]
+        shard = Shard(
+            shard_offset=(0,) * len(shape), shape=shape, session="s", addr=0, elsize=4
+        )
+        segs = plan_pull(copy, global_shape=shape, src_dtype=f32, elsize=4, shards=[shard])
+        source, dest = src_buf[copy.src_name], dst[copy.param_name]
+        for seg in segs:
+            s0, d0, n = seg.src_addr // 4, seg.dst_byte // 4, seg.nbytes // 4
+            dest[d0 : d0 + n] = source[s0 : s0 + n]
+
+    gate_out = dst["gate"].reshape(_E, _H)
+    w13_out = dst["w13"].reshape(_E, 2, _I, _H)
+    assert torch.equal(gate_out, router)
+    for e in range(_E):
+        assert torch.equal(w13_out[e, 0], w1[e])
+        assert torch.equal(w13_out[e, 1], w3[e])
+
+
 if __name__ == "__main__":
     test_capture_op_chains_and_dest_offsets()
     test_unsupported_op_falls_back_per_source()

--- a/modelexpress_client/python/tests/test_reshard_refit_slice_plan.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_slice_plan.py
@@ -227,6 +227,84 @@ def test_dtype_mismatch_raises():
         )
 
 
+def test_select_expert_slab_reconstructs_bit_for_bit():
+    # MoE unstack: stacked experts [E=3, out=2, in=4]; select(0, 1) -> expert 1's
+    # [2,4] slab. Contiguous dim-0 slice -> a single run.
+    import torch
+
+    src = torch.arange(3 * 2 * 4, dtype=torch.float32).reshape(3, 2, 4)
+    ground_truth = src.select(0, 1)  # [2,4]
+    copy = _copy((("select", (0, 1), ()),), "e1", 0, (2, 4), (4, 1))
+    shard = Shard(
+        shard_offset=(0, 0, 0), shape=(3, 2, 4), session="s0", addr=0, elsize=EL
+    )
+    segs = plan_pull(
+        copy, global_shape=(3, 2, 4), src_dtype=F32, elsize=EL, shards=[shard]
+    )
+    assert len(segs) == 1  # contiguous slab
+    assert torch.equal(_reconstruct(src, copy, [shard], segs), ground_truth)
+
+
+def test_unbind_piece_reconstructs_bit_for_bit():
+    # unbind(0)[2] is select(0, 2): same rank-reducing slab, via the tuple path.
+    import torch
+
+    src = torch.arange(4 * 3, dtype=torch.float32).reshape(4, 3)
+    ground_truth = src.unbind(0)[2]  # [3]
+    copy = _copy(
+        (("unbind", (0,), ()), ("__getitem__", (2,), ())), "u2", 0, (3,), (1,)
+    )
+    shard = Shard(shard_offset=(0, 0), shape=(4, 3), session="s0", addr=0, elsize=EL)
+    segs = plan_pull(
+        copy, global_shape=(4, 3), src_dtype=F32, elsize=EL, shards=[shard]
+    )
+    assert torch.equal(_reconstruct(src, copy, [shard], segs), ground_truth)
+
+
+def test_split_piece_reconstructs_bit_for_bit():
+    # split(2, dim=1)[1] is the second column-block of [4,4] -> rank-preserving,
+    # strided (one run per row), like the existing column-slice case.
+    import torch
+
+    src = torch.arange(4 * 4, dtype=torch.float32).reshape(4, 4)
+    ground_truth = src.split(2, dim=1)[1]  # cols [2:4] -> [4,2]
+    copy = _copy(
+        (("split", (2, 1), ()), ("__getitem__", (1,), ())), "s1", 0, (4, 2), (2, 1)
+    )
+    shard = Shard(shard_offset=(0, 0), shape=(4, 4), session="s0", addr=0, elsize=EL)
+    segs = plan_pull(
+        copy, global_shape=(4, 4), src_dtype=F32, elsize=EL, shards=[shard]
+    )
+    assert len(segs) == 4  # strided column-block: one run per row
+    assert torch.equal(_reconstruct(src, copy, [shard], segs), ground_truth)
+
+
+def test_select_reads_only_the_expert_owning_shard():
+    # Experts sharded across EP ranks: 0-1 on 'a', 2-3 on 'b'. select(0, 3) must
+    # read only 'b', at its local slab, as one run.
+    copy = _copy((("select", (0, 3), ()),), "e3", 0, (2, 3), (3, 1))
+    a = Shard(shard_offset=(0, 0, 0), shape=(2, 2, 3), session="a", addr=0, elsize=EL)
+    b = Shard(
+        shard_offset=(2, 0, 0), shape=(2, 2, 3), session="b", addr=5000, elsize=EL
+    )
+    segs = plan_pull(
+        copy, global_shape=(4, 2, 3), src_dtype=F32, elsize=EL, shards=[a, b]
+    )
+    assert {s.session for s in segs} == {"b"}
+    assert len(segs) == 1
+    # expert 3 is local row 1 of shard b -> element offset (3-2)*2*3 = 6.
+    assert (segs[0].src_addr - 5000) // EL == 6
+    assert segs[0].nbytes == 6 * EL and segs[0].dst_byte == 0
+
+
+def test_unsqueeze_rank_increase_unsupported():
+    # A net rank INCREASE isn't a box scatter -> fail closed.
+    copy = _copy((("unsqueeze", (0,), ()),), "w", 0, (1, 4), (4, 1))
+    shard = Shard(shard_offset=(0,), shape=(4,), session="s0", addr=0, elsize=EL)
+    with pytest.raises(UnsupportedReshard):
+        plan_pull(copy, global_shape=(4,), src_dtype=F32, elsize=EL, shards=[shard])
+
+
 def test_int_index_collapse_unsupported():
     with pytest.raises(UnsupportedReshard):
         op_chain_to_box((("__getitem__", (0,), ()),), (8, 4))


### PR DESCRIPTION
## What
Extend reshard geometry capture and the slice planner to support **rank-reducing view ops**, so a trainer that publishes a *stacked* source (e.g. MoE experts stacked into one tensor) can be resharded into its per-slice destination weights.

## Changes
- **geometry.py** — add `select` and `split` to `_SUPPORTED_OPS`. `select` (rank-reducing) and `split` (multi-return view, like `chunk`) are how a stacked source is unstacked into per-expert / per-slice tensors. Without them, every such weight was classified unsupported and the receiver failed closed.
- **slice_plan.py** — `_view_to_box_perm` now derives the source box for **rank-reducing** views (select/unbind drop a dim): a dropped source dim is not iterated by any view dim, so it contributes a single fixed index (`[idx, idx+1]`) decoded from the offset. Rank *increase* (unsqueeze) and dim-merging reshapes still raise `UnsupportedReshard`.
- Tests: `test_reshard_refit_geometry.py`, `test_reshard_refit_slice_plan.py`.

## Why
Stacked-expert MoE layouts (and similar stacked sources) need select/split to map each slice onto its own destination box — closing that gap in view-op coverage.

Stacked on the receiver-mapping PR (base `tanushriyas/reshard-native-convert`); retarget to `main` once that merges.