### PR TITLE
feat(metrics): download, cache and NIXL lifecycle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -520,14 +520,27 @@ end-to-end backend slice implementing the same transaction boundaries.
 1. Parse CLI args (`ServerArgs` via clap)
 2. Load config (`ServerConfig::load()`) - CLI > env vars > config file > defaults
 3. Initialize structured logging (tracing-subscriber)
-4. Connect to the model registry backend (`MX_METADATA_BACKEND` — same selector as P2P). Fails fast on connect error.
-5. Initialize the process-wide `ModelDownloadTracker` with the registry, seed the `MODEL_TRACKER` OnceLock
-6. Start `CacheEvictionService` background task (reads the same registry)
-7. Connect to the P2P metadata backend (`MX_METADATA_BACKEND`, Redis or Kubernetes CRD)
-8. Start reaper background task for stale source detection and GC
-9. Register the configured gRPC services with tonic (max message size: 100MB)
-10. Listen on configured address (default `0.0.0.0:8001`)
-11. Graceful shutdown on CTRL+C (signals cache eviction service and reaper)
+4. Build the Prometheus registry and register every metric family, then start the
+   `/metrics` listener on its own port. Deliberately before anything that can
+   fail, so a scrape proves the exporter came up even on a server that never
+   reaches a healthy state. A bind failure logs and continues rather than
+   aborting startup.
+5. Connect to the model registry backend (`MX_METADATA_BACKEND` — same selector as P2P). Fails fast on connect error.
+6. Initialize the process-wide `ModelDownloadTracker` with the registry, seed the `MODEL_TRACKER` OnceLock
+7. Start `CacheEvictionService` background task (reads the same registry)
+8. Connect to the P2P metadata backend (`MX_METADATA_BACKEND`, Redis or Kubernetes CRD)
+9. Start reaper background task for stale source detection and GC
+10. Start the registry-statistics refresh task (`MX_REGISTRY_STATS_INTERVAL_SECS`,
+    default 60). Independent of `CacheEvictionService`: that one ticks hourly and
+    is skipped entirely when eviction is disabled, which would leave the gauges
+    permanently absent.
+11. Register the configured gRPC services with tonic (max message size: 100MB),
+    wrapped in the per-RPC metrics layer
+12. Listen on configured address (default `0.0.0.0:8001`)
+13. Graceful shutdown on CTRL+C: signals the cache eviction service, the reaper
+    and the statistics refresh, then joins them. The `/metrics` listener stops
+    **last**, after the gRPC server has drained, so the drain window stays
+    scrapeable.
 
 ### ServerConfig
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,9 @@ ModelExpress/
 │       │   ├── exposition.rs            # HTTP/1.1 /metrics listener (separate port)
 │       │   ├── buckets.rs               # Shared histogram bucket boundaries
 │       │   ├── grpc.rs                  # Per-RPC tower layer; in-handler outcomes
-│       │   └── backend.rs               # Backend op counters and latency
+│       │   ├── backend.rs               # Backend op counters and latency
+│       │   ├── registry.rs              # Download claim, lease and status transitions
+│       │   └── cache.rs                 # Eviction reasons and refreshed gauges
 │       ├── p2p/
 │       │   ├── state.rs                # P2pStateManager wrapper
 │       │   ├── service.rs              # P2P gRPC service implementation
@@ -111,6 +113,7 @@ ModelExpress/
 │       │       └── instrumented.rs      # Metrics decorator over RefitBackend
 │       ├── registry/
 │       │   ├── state.rs                # RegistryManager wrapper
+│       │   ├── stats_refresh.rs        # Background gauge refresh (own interval)
 │       │   ├── backend.rs              # RegistryBackend trait + ModelRecord
 │       │   ├── entry_key.rs            # EntryKey: model + revision + weight mode
 │       │   ├── k8s_types.rs            # ModelCacheEntry CRD type
@@ -1104,6 +1107,7 @@ See [`metadata.md`](metadata.md) for the full storage schema and debugging guide
 | `MX_HEARTBEAT_INTERVAL_SECS` | `30` | Client heartbeat frequency |
 | `MX_HEARTBEAT_TIMEOUT_SECS` | `90` | Server reaper staleness threshold |
 | `MX_REAPER_SCAN_INTERVAL_SECS` | `30` | Server reaper scan frequency |
+| `MX_REGISTRY_STATS_INTERVAL_SECS` | `60` | Registry-statistics refresh frequency. Writes `mx_registry_entries` and `mx_state_entries`; each pass walks the keyspace, so it is deliberately coarser than a scrape and runs independently of cache eviction |
 | `MX_GC_TIMEOUT_SECS` | `3600` | Time before stale entries are deleted |
 | `VLLM_RPC_TIMEOUT` | `7200000` | vLLM RPC timeout in ms |
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -326,9 +326,12 @@ mean parsing prose into a label and the domain would grow with the wording.
 | `complete` | every locally registered tensor was filled |
 | `partial` | a source/local name mismatch; the transfer completed and reported success, but the local-only tensors still hold their dummy values |
 | `empty` | no tensors matched; returned success having moved nothing |
+| `rejected` | strict mode refused the transfer and raised, rather than completing it |
 
-Both non-`complete` outcomes return success to the caller and are logged only as
+`partial` and `empty` both return success to the caller and are logged only as
 warnings, so before this they were indistinguishable from a healthy transfer.
+`rejected` raises instead, and is counted so the family partitions every receive
+rather than only the ones that returned.
 A non-zero `partial` rate across a fleet means manifest drift between source and
 target, which shows up later as wrong model output rather than as a failure.
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -208,17 +208,29 @@ means a previous downloader died and the bytes are being pulled again, which for
 a large model is hundreds of gigabytes of repeated transfer.
 `mx_download_lease_refresh_total{result="lost"}` is its leading indicator.
 
-Downloads currently in flight are a derivation rather than a gauge:
+Downloads currently in flight:
 
 ```promql
-sum(mx_registry_status_transitions_total{to="downloading"})
-  - sum(mx_registry_status_transitions_total{from="downloading"})
+mx_registry_entries{status="downloading"}
 ```
 
-It balances because a takeover is recorded as arriving *from* `downloading`
-rather than from `absent`, and because a fenced `finish_download_claim` records
-no departure. A persistent non-zero value with no matching download activity is a
-model wedged in `DOWNLOADING`.
+Use the gauge, not a difference over the transition counters. The gauge is
+recomputed from the registry itself, so it is correct across a restart and across
+replicas; the counters are process-local while `DOWNLOADING` persists in the
+store, so after a restart a download that began in the previous process
+contributes a departure with no matching arrival and a raw difference can go
+negative.
+
+The transition counters answer flow rather than level -- how often downloads
+start, and how often they end in error:
+
+```promql
+sum(rate(mx_registry_status_transitions_total{to="downloading"}[5m]))
+sum(rate(mx_registry_status_transitions_total{to="error"}[5m]))
+```
+
+A `mx_registry_entries{status="downloading"}` that stays non-zero with no
+`to="downloading"` rate underneath it is a model wedged in `DOWNLOADING`.
 
 ### Refreshed gauges, not scrape-time collection
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -173,6 +173,14 @@ of the deployment export it, distinguished by `component`.
 | `mx_backend_ops_total` | Counter | `store`, `op`, `result` |
 | `mx_backend_op_seconds` | Histogram | `store`, `op`, `result` |
 | `mx_backend_ops_in_flight` | Gauge | `store`, `op` |
+| `mx_registry_status_transitions_total` | Counter | `from`, `to` |
+| `mx_download_claims_total` | Counter | `result` |
+| `mx_download_lease_refresh_total` | Counter | `result` |
+| `mx_download_seconds` | Histogram | `outcome` |
+| `mx_cache_evictions_total` | Counter | `reason` |
+| `mx_registry_entries` | Gauge | `status` |
+| `mx_state_entries` | Gauge | `map` |
+| `mx_task_last_success_timestamp_seconds` | Gauge | `task` |
 
 `method` is a closed set of the 21 routed RPCs plus `other`; an unrecognised path
 cannot mint a series.
@@ -192,6 +200,48 @@ are plain gauges rather than the `_started_total`/`_finished_total` counter pair
 the client side uses, because that pattern exists to survive a SIGKILLed rank
 under multiprocess mode -- the server is one process with an in-process registry,
 so there is nothing to wedge.
+
+### The download lifecycle
+
+`mx_download_claims_total{result="takeover"}` is the one to watch: a takeover
+means a previous downloader died and the bytes are being pulled again, which for
+a large model is hundreds of gigabytes of repeated transfer.
+`mx_download_lease_refresh_total{result="lost"}` is its leading indicator.
+
+Downloads currently in flight are a derivation rather than a gauge:
+
+```promql
+sum(mx_registry_status_transitions_total{to="downloading"})
+  - sum(mx_registry_status_transitions_total{from="downloading"})
+```
+
+It balances because a takeover is recorded as arriving *from* `downloading`
+rather than from `absent`, and because a fenced `finish_download_claim` records
+no departure. A persistent non-zero value with no matching download activity is a
+model wedged in `DOWNLOADING`.
+
+### Refreshed gauges, not scrape-time collection
+
+`mx_registry_entries` and `mx_state_entries` are written by a background task on
+`MX_REGISTRY_STATS_INTERVAL_SECS` (default 60), not computed during a scrape.
+Counting registry entries walks the keyspace -- a `SCAN` plus a pipelined per-key
+fetch on Redis, an unpaginated list of every `ModelCacheEntry` on Kubernetes -- so
+collecting at scrape time would put that on the metadata store every fifteen
+seconds.
+
+The task is independent of cache eviction on purpose: that service ticks hourly
+and is skipped entirely when eviction is disabled, which would leave these gauges
+permanently absent rather than merely stale.
+
+When a refresh fails the gauges hold their previous values and the heartbeat is
+not stamped, so staleness is the signal:
+
+```promql
+time() - mx_task_last_success_timestamp_seconds{task="registry_stats_refresh"} > 300
+```
+
+`mx_registry_entries` counts *entries*, not models: one logical model holds
+several at once, one per revision plus separate ones for metadata-only downloads.
 
 **The two streaming RPCs are deliberately absent.** `EnsureModelDownloaded` and
 `StreamModelFiles` return their response head as soon as the stream is set up and

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -303,6 +303,34 @@ touched.
 | `mx_p2p_candidates` | Histogram | `policy`, `scheme`, `stage` |
 | `mx_p2p_source_selection_seconds` | Histogram | `policy`, `scheme` |
 | `mx_p2p_transfer_seconds` | Histogram | `policy`, `scheme`, `outcome` |
+| `mx_nixl_data_plane_errors_total` | Counter | `scheme`, `kind` |
+| `mx_nixl_receive_total` | Counter | `scheme`, `result` |
+
+### NIXL data-plane health
+
+`mx_nixl_data_plane_errors_total{kind}` counts the failures that demote an agent
+from READY, classified as `timeout` or `status_error`. The distinction matters
+because they fail differently: a `status_error` is NIXL reporting a failed
+transfer, while a `timeout` is NIXL reporting *nothing at all* -- a wedged queue
+pair neither completes nor transitions to ERR, so the timeout is the only
+evidence anything went wrong.
+
+The kind is assigned where the failure is constructed, not derived later. The
+underlying field is a formatted message, so classifying at the consumer would
+mean parsing prose into a label and the domain would grow with the wording.
+
+`mx_nixl_receive_total{result}` records what a receive actually moved:
+
+| result | meaning |
+| --- | --- |
+| `complete` | every locally registered tensor was filled |
+| `partial` | a source/local name mismatch; the transfer completed and reported success, but the local-only tensors still hold their dummy values |
+| `empty` | no tensors matched; returned success having moved nothing |
+
+Both non-`complete` outcomes return success to the caller and are logged only as
+warnings, so before this they were indistinguishable from a healthy transfer.
+A non-zero `partial` rate across a fleet means manifest drift between source and
+target, which shows up later as wrong model output rather than as a failure.
 
 Two changes to the client families are breaking for existing dashboards:
 

--- a/modelexpress_client/python/modelexpress/metrics.py
+++ b/modelexpress_client/python/modelexpress/metrics.py
@@ -62,7 +62,10 @@ NIXL_ERROR_KINDS = ("timeout", "status_error")
 
 # What a receive actually moved. `partial` is the dangerous one: the transfer
 # reports success while some locally registered tensors keep their dummy values.
-NIXL_RECEIVE_RESULTS = ("complete", "partial", "empty")
+# `rejected` is the strict-mode refusal, which raises rather than returning; it is
+# counted so the family is a complete partition of receives rather than of
+# successful ones.
+NIXL_RECEIVE_RESULTS = ("complete", "partial", "empty", "rejected")
 
 
 def _enabled() -> bool:
@@ -505,11 +508,13 @@ class MetricsCollector:
                 pass
 
     def record_nixl_receive(self, result: str) -> None:
-        """Record what a receive moved: ``complete``, ``partial`` or ``empty``.
+        """Record the outcome of one receive.
 
-        Both non-complete outcomes return success to the caller, so without this
-        a transfer that moved nothing and a transfer that moved everything are
-        the same observation.
+        ``complete``, ``partial`` and ``empty`` all return success to the caller,
+        so without this a transfer that moved nothing and one that moved
+        everything are the same observation. ``rejected`` is the strict-mode
+        refusal, which raises instead of returning; counting it makes the family
+        a partition of *every* receive rather than only the ones that returned.
         """
         if self._ensure():
             try:

--- a/modelexpress_client/python/modelexpress/metrics.py
+++ b/modelexpress_client/python/modelexpress/metrics.py
@@ -274,9 +274,10 @@ class MetricsCollector:
         )
         self.nixl_receives = Counter(
             "mx_nixl_receive_total",
-            "Receive outcomes: complete|partial|empty. `partial` and `empty` "
-            "both return success today, so they are otherwise indistinguishable "
-            "from a healthy transfer.",
+            "Receive outcomes: complete|partial|empty|rejected. `partial` and "
+            "`empty` both return success today, so they are otherwise "
+            "indistinguishable from a healthy transfer; `rejected` is the "
+            "strict-mode refusal, which raises instead of returning.",
             ["scheme", "result"],
             registry=registry,
         )

--- a/modelexpress_client/python/modelexpress/metrics.py
+++ b/modelexpress_client/python/modelexpress/metrics.py
@@ -55,6 +55,15 @@ _CANDIDATE_BUCKETS = (0, 1, 2, 4, 8, 16, 32, 64, 128)
 #: family is bounded no matter how the backend misbehaves.
 LIST_SOURCES_RESULTS = ("ok", "empty", "error")
 
+# Classified at the assignment sites in nixl_transfer, never at the consumer: the
+# underlying field is a formatted free-text string, so classifying it later would
+# mean parsing prose into a label and the domain would grow with the wording.
+NIXL_ERROR_KINDS = ("timeout", "status_error")
+
+# What a receive actually moved. `partial` is the dangerous one: the transfer
+# reports success while some locally registered tensors keep their dummy values.
+NIXL_RECEIVE_RESULTS = ("complete", "partial", "empty")
+
 
 def _enabled() -> bool:
     return envs.MX_METRICS_ENABLED
@@ -251,6 +260,21 @@ class MetricsCollector:
             "ListSources outcomes: ok|empty|error. Separates a backend outage "
             "from a healthy cluster that has published no peers yet.",
             ["policy", "scheme", "result"],
+            registry=registry,
+        )
+        self.nixl_errors = Counter(
+            "mx_nixl_data_plane_errors_total",
+            "NIXL data-plane failures by classified kind: timeout|status_error. "
+            "A non-zero rate is what demotes an agent from READY.",
+            ["scheme", "kind"],
+            registry=registry,
+        )
+        self.nixl_receives = Counter(
+            "mx_nixl_receive_total",
+            "Receive outcomes: complete|partial|empty. `partial` and `empty` "
+            "both return success today, so they are otherwise indistinguishable "
+            "from a healthy transfer.",
+            ["scheme", "result"],
             registry=registry,
         )
         self.candidates = Histogram(
@@ -463,6 +487,35 @@ class MetricsCollector:
                 if result not in LIST_SOURCES_RESULTS:
                     result = "error"
                 self.list_sources.labels(policy, self.scheme, result).inc()
+            except Exception:
+                pass
+
+    def record_nixl_error(self, kind: str) -> None:
+        """Record a NIXL data-plane failure by classified kind.
+
+        Unrecognized values clamp to ``status_error`` so the label stays a closed
+        enum; the free-text message stays in the log, never in a label.
+        """
+        if self._ensure():
+            try:
+                if kind not in NIXL_ERROR_KINDS:
+                    kind = "status_error"
+                self.nixl_errors.labels(self.scheme, kind).inc()
+            except Exception:
+                pass
+
+    def record_nixl_receive(self, result: str) -> None:
+        """Record what a receive moved: ``complete``, ``partial`` or ``empty``.
+
+        Both non-complete outcomes return success to the caller, so without this
+        a transfer that moved nothing and a transfer that moved everything are
+        the same observation.
+        """
+        if self._ensure():
+            try:
+                if result not in NIXL_RECEIVE_RESULTS:
+                    result = "empty"
+                self.nixl_receives.labels(self.scheme, result).inc()
             except Exception:
                 pass
 

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -843,12 +843,14 @@ class NixlTransferManager:
                 continue
             local_size = local_tensor.numel() * local_tensor.element_size()
             if local_size != src_tensor.size:
+                transfer_metrics.record_nixl_receive("rejected")
                 raise ManifestMismatchError(
                     f"Tensor '{src_tensor.name}' size mismatch: "
                     f"source={src_tensor.size} bytes, local={local_size} bytes"
                 )
             local_dtype = str(local_tensor.dtype)
             if local_dtype != src_tensor.dtype:
+                transfer_metrics.record_nixl_receive("rejected")
                 raise ManifestMismatchError(
                     f"Tensor '{src_tensor.name}' dtype mismatch: "
                     f"source={src_tensor.dtype!r}, local={local_dtype!r}"
@@ -883,6 +885,7 @@ class NixlTransferManager:
                 # hidden or derived tensors, so completing the transfer would
                 # leave the local-only tensors at dummy values while reporting
                 # RDMA success. Fail closed instead.
+                transfer_metrics.record_nixl_receive("rejected")
                 raise ManifestMismatchError(
                     "Tensor name mismatch on heterogeneous transfer: "
                     f"{len(local_only)} local-only "
@@ -905,6 +908,7 @@ class NixlTransferManager:
 
         if not remote_descs:
             if require_exact_match:
+                transfer_metrics.record_nixl_receive("rejected")
                 raise ManifestMismatchError(
                     "No matching tensors found for heterogeneous transfer"
                 )

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -25,6 +25,7 @@ import torch
 
 from . import envs
 from . import ucx_utils
+from .metrics import metrics as transfer_metrics
 from ._nixl import load_nixl_api
 from .accelerators import (
     AcceleratorBackend,
@@ -615,6 +616,7 @@ class NixlTransferManager:
                     f"{len(pending)} transfer(s) outstanding and no error status "
                     f"from NIXL"
                 )
+                transfer_metrics.record_nixl_error("timeout")
                 raise TimeoutError(
                     f"{label} timed out with {len(pending)} transfer(s) outstanding"
                 )
@@ -625,6 +627,7 @@ class NixlTransferManager:
                     continue
                 if status in ("ERR", "ERROR", "FAIL"):
                     self._data_plane_error = f"{label} failed with status {status}"
+                    transfer_metrics.record_nixl_error("status_error")
                     raise RuntimeError(f"{label} failed with status {status}")
                 still_pending.append(handle)
             if len(still_pending) == len(pending):
@@ -662,6 +665,7 @@ class NixlTransferManager:
                     f"{label} timed out after {timeout_seconds:.1f}s with no "
                     f"completion and no error status from NIXL"
                 )
+                transfer_metrics.record_nixl_error("timeout")
                 raise TimeoutError(f"{label} timed out")
             status = self._agent.check_xfer_state(handle)
             if status in ("DONE", "SUCCESS"):
@@ -674,6 +678,7 @@ class NixlTransferManager:
                 return
             if status in ("ERR", "ERROR", "FAIL"):
                 self._data_plane_error = f"{label} failed with status {status}"
+                transfer_metrics.record_nixl_error("status_error")
                 raise RuntimeError(f"{label} failed with status {status}")
             time.sleep(0.001)
 
@@ -863,6 +868,10 @@ class NixlTransferManager:
         matched_tensors = len(remote_descs)
         match_time = time.perf_counter() - match_start
 
+        # Downgraded to `partial` by the name-diff check below, which does not
+        # return early.
+        receive_result = "complete"
+
         # Name-set diff between the source manifest and the locally registered
         # tensors.
         src_names = {s.name for s in source_tensors}
@@ -881,6 +890,12 @@ class NixlTransferManager:
                     f"{len(source_only)} source-only "
                     f"(first: {source_only[:5]})"
                 )
+            # Completing here leaves the local-only tensors at their dummy
+            # values while the transfer still reports success, so the warning is
+            # the only evidence today. Downgrade the outcome rather than
+            # recording now: this path falls through to the same return as a
+            # clean transfer, and recording here would count the receive twice.
+            receive_result = "partial"
             logger.warning(
                 "Tensor name mismatch between source manifest and local "
                 "registration: %d local-only, %d source-only",
@@ -894,6 +909,7 @@ class NixlTransferManager:
                     "No matching tensors found for heterogeneous transfer"
                 )
             logger.warning("No matching tensors found for transfer")
+            transfer_metrics.record_nixl_receive("empty")
             return 0, 0, 0.0
 
         logger.info(
@@ -949,6 +965,7 @@ class NixlTransferManager:
             f"({bandwidth_gbps:.1f} Gbps)"
         )
 
+        transfer_metrics.record_nixl_receive(receive_result)
         return total_bytes, matched_tensors, duration
 
     def execute_read_batch(

--- a/modelexpress_client/python/tests/test_metrics.py
+++ b/modelexpress_client/python/tests/test_metrics.py
@@ -851,8 +851,9 @@ def test_nixl_labels_are_closed_enums(monkeypatch):
 
     kinds = _label_values(m.nixl_errors, "kind")
     assert kinds == {"timeout", "status_error"}, kinds
+    m.record_nixl_receive("rejected")
     results = _label_values(m.nixl_receives, "result")
-    assert results == {"complete", "partial", "empty"}, results
+    assert results == {"complete", "partial", "empty", "rejected"}, results
 
 
 def _label_values(collector, label):

--- a/modelexpress_client/python/tests/test_metrics.py
+++ b/modelexpress_client/python/tests/test_metrics.py
@@ -60,6 +60,8 @@ _RECORDERS = [
     ("observe_candidates", ("random", "listed", 2)),
     ("observe_selection_seconds", ("random", 0.001)),
     ("observe_transfer_seconds", ("random", "success", 1.0)),
+    ("record_nixl_error", ("timeout",)),
+    ("record_nixl_receive", ("complete",)),
 ]
 
 _PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -145,6 +147,8 @@ def test_recorders_never_raise_into_load_path(monkeypatch):
     m.candidates = boom
     m.selection_seconds = boom
     m.transfer_seconds = boom
+    m.nixl_errors = boom
+    m.nixl_receives = boom
     # None of these may propagate the RuntimeError.
     for name, args in _RECORDERS:
         getattr(m, name)(*args)
@@ -825,3 +829,37 @@ def test_merged_endpoint_serves_every_rank_including_hard_killed(tmp_path, ranks
         f"mx_build_info merged to {build_info[0].rsplit(' ', 1)[1]} across {ranks} "
         f"ranks; a summing multiprocess_mode has been introduced"
     )
+
+
+def test_nixl_labels_are_closed_enums(monkeypatch):
+    """An unrecognized value must clamp rather than mint a new series.
+
+    The underlying `_data_plane_error` is formatted free text, so an
+    unclassified value reaching the label would grow the domain with the wording
+    of the message.
+    """
+    monkeypatch.setenv(ENV_ENABLED, "1")
+    m = MetricsCollector()
+    m._ensure()
+
+    m.record_nixl_error("timeout")
+    m.record_nixl_error("status_error")
+    m.record_nixl_error("QP 3 wedged on device mlx5_2")
+    m.record_nixl_receive("complete")
+    m.record_nixl_receive("partial")
+    m.record_nixl_receive("something new")
+
+    kinds = _label_values(m.nixl_errors, "kind")
+    assert kinds == {"timeout", "status_error"}, kinds
+    results = _label_values(m.nixl_receives, "result")
+    assert results == {"complete", "partial", "empty"}, results
+
+
+def _label_values(collector, label):
+    """Distinct values seen for one label of a collector."""
+    values = set()
+    for metric in collector.collect():
+        for sample in metric.samples:
+            if label in sample.labels:
+                values.add(sample.labels[label])
+    return values

--- a/modelexpress_client/python/tests/test_metrics.py
+++ b/modelexpress_client/python/tests/test_metrics.py
@@ -831,16 +831,28 @@ def test_merged_endpoint_serves_every_rank_including_hard_killed(tmp_path, ranks
     )
 
 
+# ---------------------------------------------------------------------------
+# NIXL data-plane families
+# ---------------------------------------------------------------------------
+
+
 def test_nixl_labels_are_closed_enums(monkeypatch):
     """An unrecognized value must clamp rather than mint a new series.
 
     The underlying `_data_plane_error` is formatted free text, so an
     unclassified value reaching the label would grow the domain with the wording
     of the message.
+
+    Built through ``_fresh_collector`` like every other test here, and not on the
+    process-global registry: ``_ensure()`` also runs ``_start_exposition()``, so
+    a bare ``MetricsCollector()`` under an ambient ``MX_METRICS_PORT`` binds a
+    real listener that outlives the pytest session, and a second collector on the
+    global registry fails with "Duplicated timeseries ... mx_build_info" —
+    an error that names the wrong metric and would land on whichever test ran
+    second.
     """
-    monkeypatch.setenv(ENV_ENABLED, "1")
-    m = MetricsCollector()
-    m._ensure()
+    m = _fresh_collector(monkeypatch, MX_METRICS_PORT=None, MX_METRICS_PUSHGATEWAY=None)
+    assert m._ensure() is True
 
     m.record_nixl_error("timeout")
     m.record_nixl_error("status_error")
@@ -856,6 +868,82 @@ def test_nixl_labels_are_closed_enums(monkeypatch):
     assert results == {"complete", "partial", "empty", "rejected"}, results
 
 
+def test_a_nixl_recording_counts_exactly_one_event(monkeypatch):
+    """The label set is not the metric; the value is.
+
+    Every query these two families exist for is a function of the sample value —
+    ``rate(mx_nixl_data_plane_errors_total[5m])`` for the agent-health signal,
+    ``partial / sum(mx_nixl_receive_total)`` for the manifest-drift ratio. A
+    recorder that incremented by anything other than one per event would pass a
+    label-domain assertion unremarked while inflating both.
+
+    The clamped call is counted too, on the ``status_error`` series: an
+    unclassified failure is still a failure, and dropping it would understate the
+    rate exactly when the fabric is misbehaving in a way nobody has classified
+    yet.
+    """
+    collector = _fresh_collector(
+        monkeypatch, MX_METRICS_PORT=None, MX_METRICS_PUSHGATEWAY=None
+    )
+    assert collector._ensure() is True
+
+    collector.record_nixl_error("timeout")
+    collector.record_nixl_error("timeout")
+    collector.record_nixl_error("QP 3 wedged on device mlx5_2")
+    collector.record_nixl_receive("complete")
+    collector.record_nixl_receive("complete")
+    collector.record_nixl_receive("partial")
+
+    assert _label_counts(collector.nixl_errors, "kind") == {
+        "timeout": 2.0,
+        "status_error": 1.0,
+    }
+    assert _label_counts(collector.nixl_receives, "result") == {
+        "complete": 2.0,
+        "partial": 1.0,
+    }
+
+    # The family names are the dashboard's API: assert them as exposed text
+    # rather than through the attribute, which a rename would carry along.
+    body = _exposition(collector)
+    assert 'mx_nixl_data_plane_errors_total{kind="timeout"' in body, body
+    assert 'mx_nixl_receive_total{result="partial"' in body, body
+
+
+@pytest.mark.parametrize(
+    "recorder,args,family,label",
+    [
+        ("record_nixl_error", ("timeout",), "nixl_errors", "kind"),
+        ("record_nixl_receive", ("partial",), "nixl_receives", "result"),
+    ],
+)
+def test_a_nixl_event_can_be_the_first_metrics_call_of_a_process(
+    monkeypatch, recorder, args, family, label
+):
+    """D4 for the two NIXL recorders: they must route through ``_ensure()``.
+
+    A process that never selects a P2P source can still hit the data plane, so a
+    NIXL failure or a degraded receive may be the first metrics event of the run.
+    A recorder that touched its family without ``_ensure()`` would raise
+    ``AttributeError`` on a collector that had not initialized yet, and the
+    blanket ``except`` in the recorder turns that into silence: no families, no
+    endpoint, no error.
+
+    One collector per recorder, because the first call to initialize hides the
+    omission in the other: sharing a collector would let a recorder that skips
+    ``_ensure()`` free-ride on its sibling.
+    """
+    collector = _fresh_collector(
+        monkeypatch, MX_METRICS_PORT=None, MX_METRICS_PUSHGATEWAY=None
+    )
+    assert collector._ready is False, "the fixture must not pre-initialize"
+
+    getattr(collector, recorder)(*args)
+
+    assert collector._ready is True, "the recorder did not initialize the collector"
+    assert _label_counts(getattr(collector, family), label) == {args[0]: 1.0}
+
+
 def _label_values(collector, label):
     """Distinct values seen for one label of a collector."""
     values = set()
@@ -864,3 +952,20 @@ def _label_values(collector, label):
             if label in sample.labels:
                 values.add(sample.labels[label])
     return values
+
+
+def _label_counts(collector, label):
+    """Counter value per distinct value of one label.
+
+    Only ``_total`` samples: a Counter also emits a ``_created`` timestamp under
+    the same labels, and summing that in would swamp the counts with epoch
+    seconds.
+    """
+    counts = {}
+    for metric in collector.collect():
+        for sample in metric.samples:
+            if sample.name.endswith("_total") and label in sample.labels:
+                counts[sample.labels[label]] = (
+                    counts.get(sample.labels[label], 0.0) + sample.value
+                )
+    return counts

--- a/modelexpress_client/python/tests/test_pool_registration.py
+++ b/modelexpress_client/python/tests/test_pool_registration.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, call
 import pytest
 import torch
 
+from modelexpress import nixl_transfer
 from modelexpress.accelerators import NIXL_ACCELERATOR_MEM_TYPE
 from modelexpress.nixl_transfer import (
     _arena_single_mr_forced,
@@ -643,3 +644,218 @@ class TestMultiAllocationArena:
 
         assert "1019 physical allocations" in caplog.text
         assert "MX_ARENA_SINGLE_MR=1" in caplog.text
+
+
+class _MetricsSpy:
+    """Captures the label each ``record_nixl_*`` call site passes.
+
+    Stands in for the module-level ``transfer_metrics`` singleton. Any other
+    metric the transfer path records is irrelevant here and is swallowed.
+    """
+
+    def __init__(self) -> None:
+        self.receives: list[str] = []
+        self.errors: list[str] = []
+
+    def record_nixl_receive(self, result: str) -> None:
+        self.receives.append(result)
+
+    def record_nixl_error(self, kind: str) -> None:
+        self.errors.append(kind)
+
+    def __getattr__(self, _name):
+        return lambda *args, **kwargs: None
+
+
+class TestReceiveOutcomeLabelsAtTheCallSite:
+    """Pins which label each ``record_nixl_*`` call site in the receive path picks.
+
+    ``test_metrics.py`` proves the recorder counts once and clamps unknown values
+    *given* a label, but nothing there constrains the callers. Without these
+    tests every call site in ``nixl_transfer`` could pass the wrong constant --
+    an ``empty`` receive booked as ``complete``, a wedged QP booked as
+    ``status_error`` -- and the suite would stay green while the dashboards lied.
+    Each assertion is on the whole recorded list, not on membership, so a double
+    count fails too: ``partial`` in particular is set at one site and recorded at
+    another, and the gap between them is exactly where a second count would hide.
+    """
+
+    def _manager(self, monkeypatch, local_tensors):
+        # CPU host: the accelerator backend delegates both of these to torch.cuda.
+        monkeypatch.setattr(torch.cuda, "set_device", lambda *a, **k: None)
+        monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+        mgr = NixlTransferManager(agent_name="test", device_id=0)
+        mgr._agent = MagicMock()
+        mgr._tensors = local_tensors
+        return mgr
+
+    def _spy(self, monkeypatch) -> _MetricsSpy:
+        spy = _MetricsSpy()
+        monkeypatch.setattr(nixl_transfer, "transfer_metrics", spy)
+        return spy
+
+    def _arm(self, mgr, state: str) -> None:
+        """Drive the RDMA calls to a chosen terminal ``check_xfer_state``."""
+        mgr._agent.prep_xfer_dlist.side_effect = ["src", "dst"]
+        mgr._agent.make_prepped_xfer.return_value = "handle"
+        mgr._agent.check_xfer_state.return_value = state
+
+    @staticmethod
+    def _matching(name: str, tensor: torch.Tensor) -> TensorDescriptor:
+        return TensorDescriptor(
+            name=name,
+            addr=0x1000,
+            size=tensor.numel() * tensor.element_size(),
+            device_id=0,
+            dtype=str(tensor.dtype),
+        )
+
+    def test_a_clean_transfer_counts_one_complete(self, monkeypatch):
+        local = torch.zeros(4, dtype=torch.float32)
+        spy = self._spy(monkeypatch)
+        mgr = self._manager(monkeypatch, {"w": local})
+        self._arm(mgr, "DONE")
+
+        mgr.receive_from_source(
+            source_metadata=b"",
+            source_tensors=[self._matching("w", local)],
+            remote_agent_name="source",
+        )
+
+        assert spy.receives == ["complete"]
+        assert spy.errors == []
+
+    def test_a_name_diff_counts_one_partial_and_not_a_complete(self, monkeypatch):
+        # A local-only tensor keeps its dummy values while the transfer still
+        # returns success, which is the whole reason `partial` exists.
+        local = torch.zeros(4, dtype=torch.float32)
+        spy = self._spy(monkeypatch)
+        mgr = self._manager(monkeypatch, {"w": local, "unmatched": local})
+        self._arm(mgr, "DONE")
+
+        mgr.receive_from_source(
+            source_metadata=b"",
+            source_tensors=[self._matching("w", local)],
+            remote_agent_name="source",
+        )
+
+        assert spy.receives == ["partial"]
+        assert spy.errors == []
+
+    def test_a_zero_match_transfer_counts_one_empty(self, monkeypatch):
+        # Returns (0, 0, 0.0) -- success to the caller, nothing moved on the wire.
+        local = torch.zeros(4, dtype=torch.float32)
+        spy = self._spy(monkeypatch)
+        mgr = self._manager(monkeypatch, {"x": local})
+
+        assert mgr.receive_from_source(
+            source_metadata=b"",
+            source_tensors=[self._matching("w", local)],
+            remote_agent_name="source",
+        ) == (0, 0, 0.0)
+
+        assert spy.receives == ["empty"]
+        assert spy.errors == []
+
+    def test_every_refusal_counts_one_rejected(self, monkeypatch):
+        """All four ``ManifestMismatchError`` sites book the same refusal label.
+
+        A refusal raises instead of returning, so without these the family would
+        only partition the receives that succeeded.
+        """
+        local = torch.zeros(10, dtype=torch.float32)
+        size = local.numel() * local.element_size()
+        refusals = {
+            "size mismatch": (
+                {"w": local},
+                [TensorDescriptor("w", 0x1000, size * 2, 0, str(local.dtype))],
+                False,
+            ),
+            "dtype mismatch": (
+                {"w": local},
+                [TensorDescriptor("w", 0x1000, size, 0, "torch.bfloat16")],
+                False,
+            ),
+            "Tensor name mismatch": (
+                {"w": local, "local_only": local},
+                [TensorDescriptor("w", 0x1000, size, 0, str(local.dtype))],
+                True,
+            ),
+            # Both sides empty: the only way past the name-diff check above,
+            # which otherwise fires first on any zero-match manifest.
+            "No matching tensors": ({}, [], True),
+        }
+
+        for match, (tensors, source, strict) in refusals.items():
+            spy = self._spy(monkeypatch)
+            mgr = self._manager(monkeypatch, tensors)
+            with pytest.raises(ManifestMismatchError, match=match):
+                mgr.receive_from_source(
+                    source_metadata=b"",
+                    source_tensors=source,
+                    remote_agent_name="source",
+                    require_exact_match=strict,
+                )
+            assert spy.receives == ["rejected"], f"{match} was not booked rejected"
+            assert spy.errors == []
+
+    def test_a_wedged_transfer_counts_a_timeout_and_no_receive(self, monkeypatch):
+        # A wedged QP yields neither a completion nor an ERR status, so the
+        # timeout is the only evidence. It must not be folded into status_error.
+        local = torch.zeros(4, dtype=torch.float32)
+        spy = self._spy(monkeypatch)
+        mgr = self._manager(monkeypatch, {"w": local})
+        self._arm(mgr, "PENDING")
+
+        with pytest.raises(TimeoutError):
+            mgr.receive_from_source(
+                source_metadata=b"",
+                source_tensors=[self._matching("w", local)],
+                remote_agent_name="source",
+                timeout_seconds=0.0,
+            )
+
+        assert spy.errors == ["timeout"]
+        assert spy.receives == []
+
+    def test_an_err_status_counts_a_status_error_and_no_receive(self, monkeypatch):
+        local = torch.zeros(4, dtype=torch.float32)
+        spy = self._spy(monkeypatch)
+        mgr = self._manager(monkeypatch, {"w": local})
+        self._arm(mgr, "ERR")
+
+        with pytest.raises(RuntimeError, match="failed with status ERR"):
+            mgr.receive_from_source(
+                source_metadata=b"",
+                source_tensors=[self._matching("w", local)],
+                remote_agent_name="source",
+            )
+
+        assert spy.errors == ["status_error"]
+        assert spy.receives == []
+
+    # The batched reshard path (`await_read_batches` -> `_wait_for_xfers`) has its
+    # own copy of the two failure classifications. Driving the wait directly keeps
+    # this to the classification under test rather than a fabricated batch handle.
+
+    def test_a_wedged_batch_counts_a_timeout(self, monkeypatch):
+        spy = self._spy(monkeypatch)
+        mgr = self._manager(monkeypatch, {})
+        mgr._agent.check_xfer_state.return_value = "PENDING"
+
+        with pytest.raises(TimeoutError):
+            mgr._wait_for_xfers(["h1", "h2"], 0.0, "NIXL reshard READ batch")
+
+        assert spy.errors == ["timeout"]
+        assert spy.receives == []
+
+    def test_an_err_status_in_a_batch_counts_a_status_error(self, monkeypatch):
+        spy = self._spy(monkeypatch)
+        mgr = self._manager(monkeypatch, {})
+        mgr._agent.check_xfer_state.return_value = "ERR"
+
+        with pytest.raises(RuntimeError, match="failed with status ERR"):
+            mgr._wait_for_xfers(["h1", "h2"], None, "NIXL reshard READ batch")
+
+        assert spy.errors == ["status_error"]
+        assert spy.receives == []

--- a/modelexpress_common/src/envs.rs
+++ b/modelexpress_common/src/envs.rs
@@ -127,6 +127,8 @@ pub const POD_NAMESPACE: &str = "POD_NAMESPACE";
 // ── Reaper (server) ─────────────────────────────────────────────────────────
 /// Interval (seconds) between reaper scans for stale/GC worker sweeps.
 pub const MX_REAPER_SCAN_INTERVAL_SECS: &str = "MX_REAPER_SCAN_INTERVAL_SECS";
+/// Interval (seconds) between registry-statistics refresh passes.
+pub const MX_REGISTRY_STATS_INTERVAL_SECS: &str = "MX_REGISTRY_STATS_INTERVAL_SECS";
 /// Age (seconds) after which an active worker's heartbeat is considered stale.
 pub const MX_HEARTBEAT_TIMEOUT_SECS: &str = "MX_HEARTBEAT_TIMEOUT_SECS";
 /// Age (seconds) after which a STALE worker is garbage-collected.
@@ -159,6 +161,10 @@ pub const KUBECONFIG: &str = "KUBECONFIG";
 
 // ── Default reaper timings ───────────────────────────────────────────────────
 const DEFAULT_REAPER_SCAN_INTERVAL_SECS: u64 = 30;
+/// Default registry-statistics refresh interval. Each pass walks the keyspace,
+/// so this is deliberately coarser than a scrape: the gauges it writes change
+/// on the timescale of downloads, not of scrapes.
+const DEFAULT_REGISTRY_STATS_INTERVAL_SECS: u64 = 60;
 const DEFAULT_HEARTBEAT_TIMEOUT_SECS: u64 = 90;
 const DEFAULT_GC_TIMEOUT_SECS: u64 = 3600;
 
@@ -287,6 +293,15 @@ pub fn reaper_scan_interval_secs() -> u64 {
     )
 }
 
+/// Registry-statistics refresh interval in seconds
+/// ([`MX_REGISTRY_STATS_INTERVAL_SECS`], default 60).
+pub fn registry_stats_interval_secs() -> u64 {
+    env_u64(
+        MX_REGISTRY_STATS_INTERVAL_SECS,
+        DEFAULT_REGISTRY_STATS_INTERVAL_SECS,
+    )
+}
+
 /// Heartbeat staleness timeout in seconds ([`MX_HEARTBEAT_TIMEOUT_SECS`], default 90).
 pub fn heartbeat_timeout_secs() -> u64 {
     env_u64(MX_HEARTBEAT_TIMEOUT_SECS, DEFAULT_HEARTBEAT_TIMEOUT_SECS)
@@ -363,6 +378,10 @@ mod tests {
         assert_eq!(MX_METADATA_NAMESPACE, "MX_METADATA_NAMESPACE");
         assert_eq!(POD_NAMESPACE, "POD_NAMESPACE");
         assert_eq!(MX_REAPER_SCAN_INTERVAL_SECS, "MX_REAPER_SCAN_INTERVAL_SECS");
+        assert_eq!(
+            MX_REGISTRY_STATS_INTERVAL_SECS,
+            "MX_REGISTRY_STATS_INTERVAL_SECS"
+        );
         assert_eq!(MX_HEARTBEAT_TIMEOUT_SECS, "MX_HEARTBEAT_TIMEOUT_SECS");
         assert_eq!(MX_GC_TIMEOUT_SECS, "MX_GC_TIMEOUT_SECS");
         assert_eq!(MODEL_EXPRESS_SECURITY_MODE, "MODEL_EXPRESS_SECURITY_MODE");

--- a/modelexpress_common/src/envs.rs
+++ b/modelexpress_common/src/envs.rs
@@ -295,11 +295,15 @@ pub fn reaper_scan_interval_secs() -> u64 {
 
 /// Registry-statistics refresh interval in seconds
 /// ([`MX_REGISTRY_STATS_INTERVAL_SECS`], default 60).
+///
+/// Clamped to at least 1: `tokio::time::interval` panics on a zero period, so a
+/// deployment that set this to 0 would take the refresh task down at startup.
 pub fn registry_stats_interval_secs() -> u64 {
     env_u64(
         MX_REGISTRY_STATS_INTERVAL_SECS,
         DEFAULT_REGISTRY_STATS_INTERVAL_SECS,
     )
+    .max(1)
 }
 
 /// Heartbeat staleness timeout in seconds ([`MX_HEARTBEAT_TIMEOUT_SECS`], default 90).

--- a/modelexpress_server/src/cache.rs
+++ b/modelexpress_server/src/cache.rs
@@ -510,6 +510,42 @@ mod tests {
         (service, cache_dir)
     }
 
+    /// As [`service_with_mock`], but hands back the Prometheus registry the
+    /// eviction counter was registered into.
+    ///
+    /// [`service_with_mock`] registers into a temporary registry that is dropped on
+    /// the spot, so nothing recorded through it can ever be encoded and any metric
+    /// assertion against a service built that way would be vacuous.
+    fn service_with_mock_and_registry(
+        mock: MockRegistryBackend,
+        config: CacheEvictionConfig,
+    ) -> (
+        CacheEvictionService,
+        TempDir,
+        prometheus_client::registry::Registry,
+    ) {
+        let mut metrics_registry = crate::metrics::new_registry();
+        let metrics = crate::metrics::cache::CacheMetrics::register(&mut metrics_registry);
+        let registry = Arc::new(RegistryManager::with_backend(Arc::new(mock)));
+        let cache_dir = TempDir::new().expect("Failed to create cache directory");
+        let service =
+            CacheEvictionService::new(registry, config, cache_dir.path().to_path_buf(), metrics);
+        (service, cache_dir, metrics_registry)
+    }
+
+    /// Value of `mx_cache_evictions_total{reason=...}`, or 0 when the series was
+    /// never created. A reason that is never emitted is absent rather than zero,
+    /// which is exactly the case a `contains` assertion cannot tell apart from a
+    /// wrong count.
+    fn evictions_for(encoded: &str, reason: &str) -> i64 {
+        let prefix = format!(r#"mx_cache_evictions_total{{reason="{reason}"}} "#);
+        encoded
+            .lines()
+            .find_map(|line| line.strip_prefix(prefix.as_str()))
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or_default()
+    }
+
     #[test]
     fn test_default_config() {
         let config = CacheEvictionConfig::default();
@@ -846,6 +882,150 @@ mod tests {
             evict_and_report_surviving_snapshots(&key(Some("abc123"), false), vec![])
                 .await
                 .is_empty()
+        );
+    }
+
+    fn record_used_days_ago(model_name: &str, days: i64) -> ModelRecord {
+        let then = Utc::now()
+            .checked_sub_signed(Duration::days(days))
+            .expect("timestamp in range");
+        ModelRecord {
+            model_name: model_name.to_string(),
+            provider: ModelProvider::HuggingFace,
+            status: ModelStatus::DOWNLOADED,
+            created_at: then,
+            last_used_at: then,
+            message: None,
+        }
+    }
+
+    fn lru_config(unused_threshold_days: i64, max_models: Option<u32>) -> CacheEvictionConfig {
+        CacheEvictionConfig {
+            enabled: true,
+            policy: EvictionPolicyType::Lru(LruConfig {
+                unused_threshold: DurationConfig::new(Duration::days(unused_threshold_days)),
+                max_models,
+                min_free_space_bytes: None,
+            }),
+            check_interval: DurationConfig::hours(1),
+        }
+    }
+
+    /// A mock that lets a whole cycle run against `records`: the cycle lists them
+    /// once and `evict_model` lists them again per victim, then reads and deletes
+    /// each victim's record. The cache directory is empty, which the Hugging Face
+    /// provider treats as a no-op delete, so nothing here touches the network.
+    fn mock_over(records: Vec<ModelRecord>) -> MockRegistryBackend {
+        let mut mock = MockRegistryBackend::new();
+        let listed = records.clone();
+        mock.expect_get_models_by_last_used()
+            .returning(move |_| Ok(listed.clone()));
+        mock.expect_get_model_record()
+            .returning(move |name| Ok(Some(downloaded_record(name))));
+        mock.expect_delete_model().returning(|_| Ok(()));
+        mock
+    }
+
+    /// The shipped-a-wrong-number bug, one layer below where it was fixed. The
+    /// policy now carries the rule that selected each model, but nothing checked
+    /// that the reason survives the trip to the counter: an operator tuning
+    /// `max_models` would see `reason="count_limit"` sit at zero forever while
+    /// every count-limit eviction was attributed to the time threshold.
+    ///
+    /// `test_lru_eviction_policy_count_based` asserts the candidate struct, which
+    /// is a different claim -- it stays green when the service mislabels the
+    /// counter.
+    #[tokio::test]
+    async fn a_count_limit_eviction_is_counted_as_a_count_limit() {
+        let records = vec![
+            record_used_days_ago("model1", 3),
+            record_used_days_ago("model2", 2),
+            record_used_days_ago("model3", 1),
+        ];
+        // Nothing is old enough for the time rule; only the count limit fires.
+        let (service, _cache_dir, metrics_registry) =
+            service_with_mock_and_registry(mock_over(records), lru_config(30, Some(2)));
+
+        let result = service.run_eviction_cycle().await.expect("eviction cycle");
+        assert_eq!(result.evicted_count, 1);
+        assert_eq!(result.evicted_models, vec!["model1".to_string()]);
+        // The cycle summary reports the rule that actually fired, not a default.
+        assert_eq!(result.reason, EvictionReason::CountLimit);
+
+        let encoded = crate::metrics::encode_text(&metrics_registry)
+            .unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(evictions_for(&encoded, "count_limit"), 1, "{encoded}");
+        assert_eq!(
+            evictions_for(&encoded, "time_threshold"),
+            0,
+            "the count rule must not be reported as an age eviction: {encoded}"
+        );
+    }
+
+    /// One pass can evict some models for age and others for the count limit, which
+    /// is why the reason travels per candidate rather than per cycle. A single
+    /// cycle-level reason has to pick one and misreport the rest, and no
+    /// single-reason test can tell the two designs apart.
+    #[tokio::test]
+    async fn a_mixed_cycle_counts_each_model_against_its_own_rule() {
+        let records = vec![
+            record_used_days_ago("stale-model", 8),
+            record_used_days_ago("mid-model", 3),
+            record_used_days_ago("fresh-model", 1),
+        ];
+        // stale-model is past the 7-day threshold; the limit of 1 then also takes
+        // the next-oldest, and that one is selected by the count rule.
+        let (service, _cache_dir, metrics_registry) =
+            service_with_mock_and_registry(mock_over(records), lru_config(7, Some(1)));
+
+        let result = service.run_eviction_cycle().await.expect("eviction cycle");
+        assert_eq!(result.evicted_count, 2);
+
+        let encoded = crate::metrics::encode_text(&metrics_registry)
+            .unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(
+            evictions_for(&encoded, "time_threshold"),
+            1,
+            "the aged model is one time-threshold eviction: {encoded}"
+        );
+        assert_eq!(
+            evictions_for(&encoded, "count_limit"),
+            1,
+            "the model taken to satisfy max_models is a count-limit eviction: {encoded}"
+        );
+    }
+
+    /// The counter is booked inside the success arm, so it stays a count of models
+    /// that actually left the cache. Counting selections instead would report disk
+    /// as reclaimed while the entries are still there and the next cycle retries
+    /// them, double-counting the same model on every pass.
+    #[tokio::test]
+    async fn an_eviction_that_fails_is_not_counted() {
+        let records = vec![
+            record_used_days_ago("model1", 3),
+            record_used_days_ago("model2", 2),
+            record_used_days_ago("model3", 1),
+        ];
+        let listed = records.clone();
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_get_models_by_last_used()
+            .returning(move |_| Ok(listed.clone()));
+        // The record vanished between selection and eviction, so evict_model errors
+        // before it can delete anything.
+        mock.expect_get_model_record().returning(|_| Ok(None));
+
+        let (service, _cache_dir, metrics_registry) =
+            service_with_mock_and_registry(mock, lru_config(30, Some(2)));
+
+        let result = service.run_eviction_cycle().await.expect("eviction cycle");
+        assert_eq!(result.evicted_count, 0);
+
+        let encoded = crate::metrics::encode_text(&metrics_registry)
+            .unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(
+            evictions_for(&encoded, "count_limit"),
+            0,
+            "a failed eviction freed nothing and must not be counted: {encoded}"
         );
     }
 }

--- a/modelexpress_server/src/cache.rs
+++ b/modelexpress_server/src/cache.rs
@@ -80,7 +80,7 @@ pub struct EvictionResult {
 }
 
 /// Reason for cache eviction
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EvictionReason {
     /// Models exceeded unused time threshold
     TimeThreshold,
@@ -92,6 +92,19 @@ pub enum EvictionReason {
     Manual,
 }
 
+/// One model selected for eviction, with the rule that picked it.
+///
+/// The reason travels with the model rather than with the cycle: a single pass
+/// can evict some models for age and others for the count limit, and a
+/// cycle-level reason has to pick one and misreport the rest.
+#[derive(Debug, Clone)]
+pub struct EvictionCandidate {
+    /// Registry key of the model to evict.
+    pub model_name: String,
+    /// Which rule selected it.
+    pub reason: EvictionReason,
+}
+
 /// Trait for implementing different eviction policies
 #[async_trait::async_trait]
 pub trait EvictionPolicyTrait {
@@ -100,7 +113,7 @@ pub trait EvictionPolicyTrait {
         &self,
         models: &[ModelRecord],
         config: &CacheEvictionConfig,
-    ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>>;
+    ) -> Result<Vec<EvictionCandidate>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
 /// LRU (Least Recently Used) eviction policy implementation
@@ -133,7 +146,7 @@ impl EvictionPolicyTrait for LruEvictionPolicy {
         &self,
         models: &[ModelRecord],
         config: &CacheEvictionConfig,
-    ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Vec<EvictionCandidate>, Box<dyn std::error::Error + Send + Sync>> {
         let EvictionPolicyType::Lru(lru_config) = &config.policy;
 
         let mut candidates_for_eviction = Vec::new();
@@ -157,7 +170,10 @@ impl EvictionPolicyTrait for LruEvictionPolicy {
                     model_name = model.model_name,
                     last_used_at = model.last_used_at
                 );
-                candidates_for_eviction.push(model.model_name.clone());
+                candidates_for_eviction.push(EvictionCandidate {
+                    model_name: model.model_name.clone(),
+                    reason: EvictionReason::TimeThreshold,
+                });
             }
         }
 
@@ -178,8 +194,14 @@ impl EvictionPolicyTrait for LruEvictionPolicy {
                 sorted_models.sort_by_key(|model| model.last_used_at);
 
                 for model in sorted_models.iter().take(models_to_remove_by_count) {
-                    if !candidates_for_eviction.contains(&model.model_name) {
-                        candidates_for_eviction.push(model.model_name.clone());
+                    if !candidates_for_eviction
+                        .iter()
+                        .any(|candidate| candidate.model_name == model.model_name)
+                    {
+                        candidates_for_eviction.push(EvictionCandidate {
+                            model_name: model.model_name.clone(),
+                            reason: EvictionReason::CountLimit,
+                        });
                     }
                 }
             }
@@ -209,6 +231,7 @@ pub struct CacheEvictionService {
     registry: Arc<RegistryManager>,
     config: CacheEvictionConfig,
     cache_directory: PathBuf,
+    metrics: crate::metrics::cache::CacheMetrics,
 }
 
 impl CacheEvictionService {
@@ -217,8 +240,10 @@ impl CacheEvictionService {
         registry: Arc<RegistryManager>,
         config: CacheEvictionConfig,
         cache_directory: PathBuf,
+        metrics: crate::metrics::cache::CacheMetrics,
     ) -> Self {
         Self {
+            metrics,
             registry,
             config,
             cache_directory,
@@ -306,10 +331,15 @@ impl CacheEvictionService {
 
         // Remove models from the database and filesystem
         let mut successfully_evicted = Vec::new();
-        for model_name in &models_to_evict {
+        for candidate in &models_to_evict {
+            let model_name = &candidate.model_name;
             match self.evict_model(model_name).await {
                 Ok(()) => {
                     successfully_evicted.push(model_name.clone());
+                    // Counted per model, with the rule that actually selected it:
+                    // one cycle can evict some models for age and others for the
+                    // count limit.
+                    self.metrics.record_eviction(candidate.reason);
                     info!(
                         "Successfully evicted model: {model_name}",
                         model_name = model_name
@@ -329,7 +359,11 @@ impl CacheEvictionService {
             evicted_count: successfully_evicted.len() as u32,
             evicted_models: successfully_evicted,
             bytes_freed: None, // Could be implemented with actual file size tracking
-            reason: EvictionReason::TimeThreshold,
+            // A summary of a cycle that may have evicted for more than one
+            // reason; the per-reason breakdown is in mx_cache_evictions_total.
+            reason: models_to_evict
+                .first()
+                .map_or(EvictionReason::TimeThreshold, |candidate| candidate.reason),
         };
 
         if result.evicted_count > 0 {
@@ -467,7 +501,12 @@ mod tests {
     ) -> (CacheEvictionService, TempDir) {
         let registry = Arc::new(RegistryManager::with_backend(Arc::new(mock)));
         let cache_dir = TempDir::new().expect("Failed to create cache directory");
-        let service = CacheEvictionService::new(registry, config, cache_dir.path().to_path_buf());
+        let service = CacheEvictionService::new(
+            registry,
+            config,
+            cache_dir.path().to_path_buf(),
+            crate::metrics::cache::CacheMetrics::register(&mut crate::metrics::new_registry()),
+        );
         (service, cache_dir)
     }
 
@@ -612,7 +651,8 @@ mod tests {
 
         // Should only evict the old downloaded model, not the downloading one
         assert_eq!(evicted.len(), 1);
-        assert_eq!(evicted[0], "old-model");
+        assert_eq!(evicted[0].model_name, "old-model");
+        assert_eq!(evicted[0].reason, EvictionReason::TimeThreshold);
     }
 
     #[tokio::test]
@@ -664,7 +704,11 @@ mod tests {
 
         // Should evict the oldest model to stay within the limit of 2
         assert_eq!(evicted.len(), 1);
-        assert_eq!(evicted[0], "model1");
+        assert_eq!(evicted[0].model_name, "model1");
+        // Selected by the count limit, not by age. This assertion is the whole
+        // point of carrying the reason per candidate: before, this path was
+        // reported as a time-threshold eviction.
+        assert_eq!(evicted[0].reason, EvictionReason::CountLimit);
     }
 
     #[tokio::test]

--- a/modelexpress_server/src/metrics.rs
+++ b/modelexpress_server/src/metrics.rs
@@ -30,6 +30,7 @@
 
 pub mod backend;
 pub mod buckets;
+pub mod cache;
 pub mod exposition;
 pub mod grpc;
 pub mod registry;

--- a/modelexpress_server/src/metrics.rs
+++ b/modelexpress_server/src/metrics.rs
@@ -32,6 +32,7 @@ pub mod backend;
 pub mod buckets;
 pub mod exposition;
 pub mod grpc;
+pub mod registry;
 
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::encoding::text::encode;

--- a/modelexpress_server/src/metrics/backend.rs
+++ b/modelexpress_server/src/metrics/backend.rs
@@ -60,7 +60,7 @@ impl EncodeLabelValue for Store {
 
 /// Whether the operation succeeded.
 ///
-/// Two values only. The error *kind* is deliberately not a label: the three
+/// The error *kind* is deliberately not a label: the three
 /// backends have three unrelated error types, two of them boxed
 /// `dyn Error`, so any faithful mapping would be an unbounded string.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]

--- a/modelexpress_server/src/metrics/buckets.rs
+++ b/modelexpress_server/src/metrics/buckets.rs
@@ -13,9 +13,7 @@
 //! [`Histogram::new`](prometheus_client::metrics::histogram::Histogram::new)
 //! appends the `+Inf` bucket itself, so these arrays must not carry one.
 //!
-//! Only [`FAST`] has a consumer today. The transfer- and load-scale bands the
-//! metrics design also defines land with the families that need them, rather
-//! than sitting here unused.
+//! Bands land with the families that need them rather than sitting here unused.
 
 /// 1 ms to 10 s: gRPC handlers and metadata-backend operations.
 ///
@@ -24,4 +22,13 @@
 /// see it.
 pub const FAST: [f64; 13] = [
     0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+/// 5 s to 1 hour: whole-model download and load.
+///
+/// The top boundary is deliberately an hour. A cold DeepSeek-V3 warm-up runs for
+/// roughly forty minutes, so a band topping out at the transfer scale would put
+/// every cold load in `+Inf` and make the one case worth measuring unmeasurable.
+pub const XSLOW: [f64; 12] = [
+    5.0, 15.0, 30.0, 60.0, 120.0, 300.0, 600.0, 900.0, 1200.0, 1800.0, 2700.0, 3600.0,
 ];

--- a/modelexpress_server/src/metrics/cache.rs
+++ b/modelexpress_server/src/metrics/cache.rs
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cache and registry gauges, plus the eviction counter.
+//!
+//! # Why these are refreshed rather than collected at scrape time
+//!
+//! Counting registry entries means walking the keyspace: the Redis backend does a
+//! `SCAN` plus a pipelined per-key fetch, and the Kubernetes backend does an
+//! unpaginated `list` of every `ModelCacheEntry`. Registering that as a
+//! scrape-time collector would put a keyspace walk on the metadata store every
+//! fifteen seconds, and on Kubernetes it would put an unbounded list on the API
+//! server -- a cost paid forever for a number that changes slowly.
+//!
+//! So a background task recomputes them on its own interval and writes plain
+//! gauges; the scrape only encodes what is already in memory.
+//!
+//! # Why the task is not hosted on the cache-eviction interval
+//!
+//! The obvious home is [`crate::cache::CacheEvictionService`], and it is the wrong
+//! one twice over. Its interval defaults to an hour, which is far too coarse for a
+//! gauge, and the whole task is skipped when eviction is disabled -- which would
+//! make every gauge here permanently *absent* rather than merely stale. An absent
+//! gauge and a broken exporter look identical.
+
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+
+use crate::cache::EvictionReason;
+use crate::metrics::registry::StatusLabel;
+
+impl EvictionReason {
+    /// Wire form of the eviction reason.
+    const fn as_metric_str(&self) -> &'static str {
+        match self {
+            Self::TimeThreshold => "time_threshold",
+            Self::CountLimit => "count_limit",
+            Self::DiskSpace => "disk_space",
+            Self::Manual => "manual",
+        }
+    }
+}
+
+impl EncodeLabelValue for EvictionReason {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_metric_str(), encoder)
+    }
+}
+
+/// Label set for the eviction counter.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct EvictionLabels {
+    /// Which rule selected the model.
+    pub reason: EvictionReason,
+}
+
+/// Label set for the registry-entry gauge.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct EntryStatusLabels {
+    /// Status of the counted entries.
+    pub status: StatusLabel,
+}
+
+/// Label set for the background-task heartbeat.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct TaskLabels {
+    /// Task name.
+    pub task: &'static str,
+}
+
+/// Label set for the in-process map gauge.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct MapLabels {
+    /// Which map is being reported.
+    pub map: &'static str,
+}
+
+/// Handles for the cache and registry gauges. Cloning shares the storage.
+#[derive(Clone)]
+pub struct CacheMetrics {
+    evictions: Family<EvictionLabels, Counter>,
+    registry_entries: Family<EntryStatusLabels, Gauge>,
+    state_entries: Family<MapLabels, Gauge>,
+    task_last_success: Family<TaskLabels, Gauge>,
+}
+
+impl CacheMetrics {
+    /// Register the families and return handles.
+    pub fn register(registry: &mut Registry) -> Self {
+        let evictions = Family::<EvictionLabels, Counter>::default();
+        let registry_entries = Family::<EntryStatusLabels, Gauge>::default();
+        let state_entries = Family::<MapLabels, Gauge>::default();
+        let task_last_success = Family::<TaskLabels, Gauge>::default();
+
+        let cache = registry.sub_registry_with_prefix("cache");
+        cache.register(
+            "evictions",
+            "Models evicted from the cache, by the rule that selected each one",
+            evictions.clone(),
+        );
+
+        let reg = registry.sub_registry_with_prefix("registry");
+        // Named "registry entries", not "models": one logical model can hold
+        // several entries at once -- one per revision, and separate ones for
+        // metadata-only downloads.
+        reg.register(
+            "entries",
+            "Registry entries by status, refreshed on the stats interval",
+            registry_entries.clone(),
+        );
+
+        registry.register(
+            "state_entries",
+            "Size of never-evicted in-process maps; the OOM early warning",
+            state_entries.clone(),
+        );
+        registry.register(
+            "task_last_success_timestamp_seconds",
+            "Unix time of each background task's last successful run",
+            task_last_success.clone(),
+        );
+
+        Self {
+            evictions,
+            registry_entries,
+            state_entries,
+            task_last_success,
+        }
+    }
+
+    /// Count one evicted model against the rule that selected it.
+    pub fn record_eviction(&self, reason: EvictionReason) {
+        self.evictions
+            .get_or_create(&EvictionLabels { reason })
+            .inc();
+    }
+
+    /// Publish the registry entry counts observed by a refresh pass.
+    pub fn set_registry_entries(&self, downloading: i64, downloaded: i64, errored: i64) {
+        for (status, count) in [
+            (StatusLabel::Downloading, downloading),
+            (StatusLabel::Downloaded, downloaded),
+            (StatusLabel::Error, errored),
+        ] {
+            self.registry_entries
+                .get_or_create(&EntryStatusLabels { status })
+                .set(count);
+        }
+    }
+
+    /// Publish the size of an in-process map.
+    pub fn set_state_entries(&self, map: &'static str, count: i64) {
+        self.state_entries
+            .get_or_create(&MapLabels { map })
+            .set(count);
+    }
+
+    /// Stamp a task's last successful run.
+    ///
+    /// Only on success. A task that starts failing leaves its previous timestamp
+    /// in place and the value goes stale, which is what makes
+    /// `time() - mx_task_last_success_timestamp_seconds` a usable liveness alert;
+    /// stamping unconditionally would report a wedged task as healthy.
+    pub fn stamp_task_success(&self, task: &'static str, unix_seconds: i64) {
+        self.task_last_success
+            .get_or_create(&TaskLabels { task })
+            .set(unix_seconds);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+
+    #[test]
+    fn the_count_limit_path_is_not_reported_as_a_time_threshold() {
+        let mut registry = new_registry();
+        let metrics = CacheMetrics::register(&mut registry);
+
+        metrics.record_eviction(EvictionReason::TimeThreshold);
+        metrics.record_eviction(EvictionReason::CountLimit);
+        metrics.record_eviction(EvictionReason::CountLimit);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_cache_evictions_total{reason="time_threshold"} 1"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_cache_evictions_total{reason="count_limit"} 2"#),
+            "{encoded}"
+        );
+        assert!(!encoded.contains("_total_total"), "{encoded}");
+    }
+
+    /// Gauges hold their prior value when a refresh fails. Zeroing them would be
+    /// indistinguishable from an empty registry.
+    #[test]
+    fn registry_entry_gauges_are_set_per_status() {
+        let mut registry = new_registry();
+        let metrics = CacheMetrics::register(&mut registry);
+
+        metrics.set_registry_entries(2, 7, 1);
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_registry_entries{status="downloading"} 2"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_registry_entries{status="downloaded"} 7"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_registry_entries{status="error"} 1"#),
+            "{encoded}"
+        );
+    }
+
+    #[test]
+    fn the_task_heartbeat_is_stamped_per_task() {
+        let mut registry = new_registry();
+        let metrics = CacheMetrics::register(&mut registry);
+
+        metrics.stamp_task_success("registry_stats_refresh", 1_760_000_000);
+        metrics.set_state_entries("download_waiters", 3);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_task_last_success_timestamp_seconds{task="registry_stats_refresh"} 1760000000"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_state_entries{map="download_waiters"} 3"#),
+            "{encoded}"
+        );
+    }
+}

--- a/modelexpress_server/src/metrics/cache.rs
+++ b/modelexpress_server/src/metrics/cache.rs
@@ -197,8 +197,46 @@ mod tests {
         assert!(!encoded.contains("_total_total"), "{encoded}");
     }
 
-    /// Gauges hold their prior value when a refresh fails. Zeroing them would be
-    /// indistinguishable from an empty registry.
+    /// Every `EvictionReason` needs a wire form, not just the two the policy can
+    /// produce today: `Manual` is a live variant and `DiskSpace` is declared, and
+    /// a typo in either arm ships a label value no dashboard query matches.
+    ///
+    /// One increment per reason, so a collision between two arms shows up as a
+    /// series holding 2 and the expected one missing.
+    #[test]
+    fn every_eviction_reason_has_its_own_label_value() {
+        let mut registry = new_registry();
+        let metrics = CacheMetrics::register(&mut registry);
+
+        for (reason, expected) in [
+            (EvictionReason::TimeThreshold, "time_threshold"),
+            (EvictionReason::CountLimit, "count_limit"),
+            (EvictionReason::DiskSpace, "disk_space"),
+            (EvictionReason::Manual, "manual"),
+        ] {
+            metrics.record_eviction(reason);
+
+            let encoded =
+                encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+            assert!(
+                encoded.contains(&format!(
+                    r#"mx_cache_evictions_total{{reason="{expected}"}} 1"#
+                )),
+                "{reason:?} did not encode as {expected}: {encoded}"
+            );
+        }
+    }
+
+    /// The three status gauges must not be cross-wired: a rotated argument list
+    /// publishes the error count under `status="downloading"`, which reads as a
+    /// plausible level and is what a wedged-download alert fires on. Distinct
+    /// values per status, so no rotation survives.
+    ///
+    /// Scope: the neighbouring invariant -- that a *failed* refresh leaves these
+    /// gauges at their previous values instead of zeroing them, since a zeroed
+    /// gauge and an empty registry are indistinguishable -- is a property of
+    /// `registry::stats_refresh::refresh_once`, not of this setter, and is not
+    /// checked here.
     #[test]
     fn registry_entry_gauges_are_set_per_status() {
         let mut registry = new_registry();
@@ -220,19 +258,30 @@ mod tests {
         );
     }
 
+    /// Stamped with the constant the production task actually publishes, not a
+    /// local copy of the string, so this exercises the same label value the
+    /// refresh task emits.
+    ///
+    /// That alone would go green on a rename, and a rename silently breaks every
+    /// dashboard and alert keyed on the old value -- hence the separate equality
+    /// on `TASK_NAME`, which pins the wire form as a contract.
     #[test]
     fn the_task_heartbeat_is_stamped_per_task() {
+        use crate::registry::stats_refresh::TASK_NAME;
+
         let mut registry = new_registry();
         let metrics = CacheMetrics::register(&mut registry);
 
-        metrics.stamp_task_success("registry_stats_refresh", 1_760_000_000);
+        assert_eq!(TASK_NAME, "registry_stats_refresh");
+
+        metrics.stamp_task_success(TASK_NAME, 1_760_000_000);
         metrics.set_state_entries("download_waiters", 3);
 
         let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
         assert!(
-            encoded.contains(
-                r#"mx_task_last_success_timestamp_seconds{task="registry_stats_refresh"} 1760000000"#
-            ),
+            encoded.contains(&format!(
+                r#"mx_task_last_success_timestamp_seconds{{task="{TASK_NAME}"}} 1760000000"#
+            )),
             "{encoded}"
         );
         assert!(

--- a/modelexpress_server/src/metrics/registry.rs
+++ b/modelexpress_server/src/metrics/registry.rs
@@ -1,0 +1,392 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the model download lifecycle.
+//!
+//! These answer two questions the server cannot currently answer at all: are we
+//! re-downloading models because leases are being lost, and are models getting
+//! stuck part-way through a download.
+//!
+//! # Why these hang off the claim lifecycle and not off `set_status`
+//!
+//! A status-transition counter needs the *prior* status, and `set_status` does
+//! not have it: the Redis implementation's Lua returns 1 unconditionally without
+//! reading what was there, and the in-memory one overwrites without capturing it.
+//! Instrumenting it would mean inventing a `from` value.
+//!
+//! The claim lifecycle does know. A won claim is `absent -> downloading`, an
+//! error-retry reset is `error -> downloading`, and a finished claim is
+//! `downloading -> {downloaded, error}`. Those three cover every transition that
+//! matters for "is a model wedged", they are exact rather than sampled, and none
+//! of them needs a keyspace scan to compute.
+//!
+//! # Reading the wedged-model signal
+//!
+//! `sum(mx_registry_status_transitions_total{to="downloading"})` minus
+//! `sum(mx_registry_status_transitions_total{from="downloading"})` is the number
+//! of downloads currently in flight. It only holds because a takeover is counted
+//! as its own result rather than as a fresh claim -- a takeover that looked like
+//! a new entry would add an arrival with no matching departure, and the
+//! derivation would drift upward forever.
+
+use modelexpress_common::models::ModelStatus;
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
+
+use super::buckets;
+
+/// A model status as it appears in a transition label.
+///
+/// Carries `Absent` because the interesting transition into `downloading` is
+/// from a record that did not exist.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum StatusLabel {
+    /// No record existed.
+    Absent,
+    /// `ModelStatus::DOWNLOADING`.
+    Downloading,
+    /// `ModelStatus::DOWNLOADED`.
+    Downloaded,
+    /// `ModelStatus::ERROR`.
+    Error,
+}
+
+impl StatusLabel {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Absent => "absent",
+            Self::Downloading => "downloading",
+            Self::Downloaded => "downloaded",
+            Self::Error => "error",
+        }
+    }
+}
+
+impl From<ModelStatus> for StatusLabel {
+    fn from(status: ModelStatus) -> Self {
+        match status {
+            ModelStatus::DOWNLOADING => Self::Downloading,
+            ModelStatus::DOWNLOADED => Self::Downloaded,
+            ModelStatus::ERROR => Self::Error,
+        }
+    }
+}
+
+// Hand-written for the same reason as the other label enums: the derive would
+// encode the variant identifier, giving `Downloading` rather than `downloading`.
+impl EncodeLabelValue for StatusLabel {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_str(), encoder)
+    }
+}
+
+/// Outcome of a download-claim attempt.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum ClaimResult {
+    /// Created the record; this is the first download of the entry.
+    Claimed,
+    /// Took over an expired lease, so the bytes are being pulled again.
+    Takeover,
+    /// Someone else owns it; the caller waits.
+    AlreadyExists,
+    /// The backend call failed.
+    Error,
+}
+
+impl ClaimResult {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Claimed => "claimed",
+            Self::Takeover => "takeover",
+            Self::AlreadyExists => "already_exists",
+            Self::Error => "error",
+        }
+    }
+}
+
+impl EncodeLabelValue for ClaimResult {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_str(), encoder)
+    }
+}
+
+/// Outcome of a lease heartbeat.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum LeaseResult {
+    /// The lease was still ours and was extended.
+    Renewed,
+    /// The lease was no longer ours. Whatever this replica is still downloading
+    /// is now unowned work, and someone else has taken over.
+    Lost,
+    /// The backend call failed, so ownership is unknown.
+    Error,
+}
+
+impl LeaseResult {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Renewed => "renewed",
+            Self::Lost => "lost",
+            Self::Error => "error",
+        }
+    }
+}
+
+impl EncodeLabelValue for LeaseResult {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_str(), encoder)
+    }
+}
+
+/// Label set for the transition counter.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct TransitionLabels {
+    /// Status before the transition.
+    pub from: StatusLabel,
+    /// Status after it.
+    pub to: StatusLabel,
+}
+
+/// Label set for the claim counter.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct ClaimLabels {
+    /// What the claim attempt achieved.
+    pub result: ClaimResult,
+}
+
+/// Label set for the lease-heartbeat counter.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct LeaseLabels {
+    /// What the heartbeat achieved.
+    pub result: LeaseResult,
+}
+
+/// Handles for the download-lifecycle families. Cloning shares the storage.
+#[derive(Clone)]
+pub struct RegistryMetrics {
+    transitions: Family<TransitionLabels, Counter>,
+    claims: Family<ClaimLabels, Counter>,
+    lease_refreshes: Family<LeaseLabels, Counter>,
+}
+
+impl RegistryMetrics {
+    /// Register the families and return handles.
+    ///
+    /// Registered without the `_total` suffix; the encoder appends it.
+    pub fn register(registry: &mut Registry) -> Self {
+        let transitions = Family::<TransitionLabels, Counter>::default();
+        let claims = Family::<ClaimLabels, Counter>::default();
+        let lease_refreshes = Family::<LeaseLabels, Counter>::default();
+
+        let sub = registry.sub_registry_with_prefix("registry");
+        sub.register(
+            "status_transitions",
+            "Model registry status transitions observed on the claim lifecycle",
+            transitions.clone(),
+        );
+
+        let download = registry.sub_registry_with_prefix("download");
+        download.register(
+            "claims",
+            "Download claim attempts by outcome; takeover means the bytes are being pulled again",
+            claims.clone(),
+        );
+        download.register(
+            "lease_refresh",
+            "Download lease heartbeats by outcome; lost is the leading indicator of a duplicate download",
+            lease_refreshes.clone(),
+        );
+
+        Self {
+            transitions,
+            claims,
+            lease_refreshes,
+        }
+    }
+
+    /// Record a claim attempt, and the transition it implies.
+    ///
+    /// A won claim moves the entry into `downloading`; the two owning outcomes
+    /// differ only in where they came from.
+    pub fn record_claim(&self, result: ClaimResult) {
+        self.claims.get_or_create(&ClaimLabels { result }).inc();
+        let from = match result {
+            ClaimResult::Claimed => StatusLabel::Absent,
+            ClaimResult::Takeover => StatusLabel::Downloading,
+            // Not a transition: nothing changed.
+            ClaimResult::AlreadyExists | ClaimResult::Error => return,
+        };
+        self.record_transition(from, StatusLabel::Downloading);
+    }
+
+    /// Record a lease heartbeat.
+    pub fn record_lease_refresh(&self, result: LeaseResult) {
+        self.lease_refreshes
+            .get_or_create(&LeaseLabels { result })
+            .inc();
+    }
+
+    /// Record one status transition.
+    pub fn record_transition(&self, from: StatusLabel, to: StatusLabel) {
+        self.transitions
+            .get_or_create(&TransitionLabels { from, to })
+            .inc();
+    }
+}
+
+/// Histogram of end-to-end model download durations.
+///
+/// Separate from [`RegistryMetrics`] because it is observed from the download
+/// path rather than from the registry backend, and uses the hour-scale band: a
+/// large model's cold download runs for tens of minutes, which the transfer-scale
+/// buckets cannot represent.
+#[derive(Clone)]
+pub struct DownloadMetrics {
+    seconds: Family<DownloadLabels, Histogram, fn() -> Histogram>,
+}
+
+/// Label set for the download histogram.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct DownloadLabels {
+    /// Terminal status of the download.
+    pub outcome: StatusLabel,
+}
+
+fn xslow_histogram() -> Histogram {
+    Histogram::new(buckets::XSLOW)
+}
+
+impl DownloadMetrics {
+    /// Register the family and return a handle.
+    pub fn register(registry: &mut Registry) -> Self {
+        let seconds: Family<DownloadLabels, Histogram, fn() -> Histogram> =
+            Family::new_with_constructor(xslow_histogram as fn() -> Histogram);
+        let download = registry.sub_registry_with_prefix("download");
+        download.register(
+            "seconds",
+            "End-to-end model download duration by terminal status",
+            seconds.clone(),
+        );
+        Self { seconds }
+    }
+
+    /// Observe one completed download.
+    pub fn observe(&self, outcome: StatusLabel, elapsed_seconds: f64) {
+        self.seconds
+            .get_or_create(&DownloadLabels { outcome })
+            .observe(elapsed_seconds);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+
+    #[test]
+    fn a_takeover_is_not_counted_as_a_fresh_claim() {
+        let mut registry = new_registry();
+        let metrics = RegistryMetrics::register(&mut registry);
+
+        metrics.record_claim(ClaimResult::Claimed);
+        metrics.record_claim(ClaimResult::Takeover);
+        metrics.record_claim(ClaimResult::AlreadyExists);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+
+        assert!(
+            encoded.contains(r#"mx_download_claims_total{result="claimed"} 1"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_download_claims_total{result="takeover"} 1"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_download_claims_total{result="already_exists"} 1"#),
+            "{encoded}"
+        );
+        assert!(!encoded.contains("_total_total"), "{encoded}");
+    }
+
+    /// The in-flight derivation is arrivals minus departures, so a takeover must
+    /// arrive from `downloading` rather than from `absent`. If it arrived from
+    /// `absent` the count would gain an entry that never leaves.
+    #[test]
+    fn the_in_flight_derivation_balances() {
+        let mut registry = new_registry();
+        let metrics = RegistryMetrics::register(&mut registry);
+
+        // One fresh download that finishes, and one that is taken over and then
+        // finishes: two arrivals into downloading, two departures.
+        metrics.record_claim(ClaimResult::Claimed);
+        metrics.record_transition(StatusLabel::Downloading, StatusLabel::Downloaded);
+        metrics.record_claim(ClaimResult::Takeover);
+        metrics.record_transition(StatusLabel::Downloading, StatusLabel::Downloaded);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+
+        // Arrivals: absent->downloading once, downloading->downloading once.
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="absent",to="downloading"} 1"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="downloading",to="downloading"} 1"#
+            ),
+            "a takeover must arrive from downloading, not absent: {encoded}"
+        );
+        // Departures: two.
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="downloading",to="downloaded"} 2"#
+            ),
+            "{encoded}"
+        );
+    }
+
+    #[test]
+    fn a_lost_lease_is_recorded_distinctly() {
+        let mut registry = new_registry();
+        let metrics = RegistryMetrics::register(&mut registry);
+
+        metrics.record_lease_refresh(LeaseResult::Renewed);
+        metrics.record_lease_refresh(LeaseResult::Lost);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_download_lease_refresh_total{result="renewed"} 1"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_download_lease_refresh_total{result="lost"} 1"#),
+            "{encoded}"
+        );
+    }
+
+    #[test]
+    fn the_download_histogram_uses_the_hour_scale_band() {
+        let mut registry = new_registry();
+        let metrics = DownloadMetrics::register(&mut registry);
+
+        // A cold DeepSeek-scale load runs for tens of minutes; the transfer-scale
+        // bands top out well below this.
+        metrics.observe(StatusLabel::Downloaded, 2400.0);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_download_seconds_count{outcome="downloaded"} 1"#),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_download_seconds_bucket{le="3600.0",outcome="downloaded"} 1"#),
+            "a 40-minute download must land below the top boundary: {encoded}"
+        );
+    }
+}

--- a/modelexpress_server/src/metrics/registry.rs
+++ b/modelexpress_server/src/metrics/registry.rs
@@ -40,10 +40,18 @@
 //! difference can go negative. That is a property of differencing counters, not
 //! something a label change fixes -- hence the gauge.
 //!
-//! Within a process the difference does balance, and that depends on a takeover
-//! recording `downloading -> downloading`: an arrival and a departure that cancel,
-//! because ownership changed while the entry never left `DOWNLOADING`. Recording
-//! it as `absent -> downloading` would add an arrival that never leaves.
+//! Within a process the difference does balance, and that rests on every exit
+//! from `DOWNLOADING` being recorded. There are three, and the third is easy to
+//! miss:
+//!
+//! - a finish, `downloading -> {downloaded, error}`;
+//! - a takeover, `downloading -> downloading` -- an arrival and a departure that
+//!   cancel, because ownership changed while the entry never left `DOWNLOADING`.
+//!   Recording it as `absent -> downloading` would add an arrival that never
+//!   leaves;
+//! - a **delete while downloading**, `downloading -> absent`. Once the record is
+//!   gone `finish_download_claim` finds nothing to fence and returns false, so it
+//!   records no departure; the deleting side has to book it.
 
 use modelexpress_common::models::ModelStatus;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
@@ -379,6 +387,27 @@ mod tests {
         metrics.record_transition(StatusLabel::Downloading, StatusLabel::Downloaded);
         let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
         assert_eq!(in_flight(&encoded), 0, "the download finished");
+    }
+
+    /// Deleting a record mid-download is the third exit from `DOWNLOADING`, and
+    /// the one the claim lifecycle cannot observe for itself.
+    #[test]
+    fn a_delete_during_download_is_a_departure() {
+        let mut registry = new_registry();
+        let metrics = RegistryMetrics::register(&mut registry);
+
+        metrics.record_claim(ClaimResult::Claimed);
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(in_flight(&encoded), 1);
+
+        // `model clear` on a model that is still downloading.
+        metrics.record_transition(StatusLabel::Downloading, StatusLabel::Absent);
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(
+            in_flight(&encoded),
+            0,
+            "a deleted download must not stay counted as in flight: {encoded}"
+        );
     }
 
     /// A waiter observing an existing claim is not a transition at all.

--- a/modelexpress_server/src/metrics/registry.rs
+++ b/modelexpress_server/src/metrics/registry.rs
@@ -22,12 +22,28 @@
 //!
 //! # Reading the wedged-model signal
 //!
-//! `sum(mx_registry_status_transitions_total{to="downloading"})` minus
-//! `sum(mx_registry_status_transitions_total{from="downloading"})` is the number
-//! of downloads currently in flight. It only holds because a takeover is counted
-//! as its own result rather than as a fresh claim -- a takeover that looked like
-//! a new entry would add an arrival with no matching departure, and the
-//! derivation would drift upward forever.
+//! The authoritative count of downloads in flight is the refreshed gauge
+//! `mx_registry_entries{status="downloading"}`, not a derivation over these
+//! counters. The gauge is recomputed from the registry itself, so it is correct
+//! across a restart and across replicas.
+//!
+//! Differencing the transition counters gives the same number *within one process
+//! lifetime* and is useful for seeing flow rather than level:
+//!
+//! ```promql
+//! sum(rate(mx_registry_status_transitions_total{to="downloading"}[5m]))
+//! ```
+//!
+//! It is not a restart-safe level. `DOWNLOADING` persists in Redis while these
+//! counters are process-local, so after a restart a download that began in the
+//! previous process contributes a departure with no matching arrival and a raw
+//! difference can go negative. That is a property of differencing counters, not
+//! something a label change fixes -- hence the gauge.
+//!
+//! Within a process the difference does balance, and that depends on a takeover
+//! recording `downloading -> downloading`: an arrival and a departure that cancel,
+//! because ownership changed while the entry never left `DOWNLOADING`. Recording
+//! it as `absent -> downloading` would add an arrival that never leaves.
 
 use modelexpress_common::models::ModelStatus;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
@@ -312,42 +328,74 @@ mod tests {
         assert!(!encoded.contains("_total_total"), "{encoded}");
     }
 
-    /// The in-flight derivation is arrivals minus departures, so a takeover must
-    /// arrive from `downloading` rather than from `absent`. If it arrived from
-    /// `absent` the count would gain an entry that never leaves.
+    /// Sum the `to="downloading"` and `from="downloading"` series the way the
+    /// documented query does, so the assertion is the derivation itself rather
+    /// than the individual series.
+    fn in_flight(encoded: &str) -> i64 {
+        let mut arrivals: i64 = 0;
+        let mut departures: i64 = 0;
+        for line in encoded.lines() {
+            let Some((labels, value)) = line
+                .strip_prefix("mx_registry_status_transitions_total{")
+                .and_then(|rest| rest.split_once("} "))
+            else {
+                continue;
+            };
+            let count: i64 = value.trim().parse().unwrap_or_default();
+            if labels.contains(r#"to="downloading""#) {
+                arrivals = arrivals.saturating_add(count);
+            }
+            if labels.contains(r#"from="downloading""#) {
+                departures = departures.saturating_add(count);
+            }
+        }
+        arrivals.saturating_sub(departures)
+    }
+
+    /// One download, taken over mid-flight, then finished.
+    ///
+    /// A takeover records `downloading -> downloading`: an arrival and a departure
+    /// that cancel, because ownership changed while the entry never left
+    /// `DOWNLOADING`. Recording it as `absent -> downloading` instead would add an
+    /// arrival that never leaves and the level would drift up by one per takeover.
     #[test]
-    fn the_in_flight_derivation_balances() {
+    fn a_takeover_does_not_change_the_in_flight_level() {
         let mut registry = new_registry();
         let metrics = RegistryMetrics::register(&mut registry);
 
-        // One fresh download that finishes, and one that is taken over and then
-        // finishes: two arrivals into downloading, two departures.
         metrics.record_claim(ClaimResult::Claimed);
-        metrics.record_transition(StatusLabel::Downloading, StatusLabel::Downloaded);
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(in_flight(&encoded), 1, "one download in flight");
+
+        // Ownership moves; the download itself is still the same one.
         metrics.record_claim(ClaimResult::Takeover);
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(
+            in_flight(&encoded),
+            1,
+            "a takeover is not a second download"
+        );
+
         metrics.record_transition(StatusLabel::Downloading, StatusLabel::Downloaded);
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert_eq!(in_flight(&encoded), 0, "the download finished");
+    }
+
+    /// A waiter observing an existing claim is not a transition at all.
+    #[test]
+    fn an_already_exists_claim_records_no_transition() {
+        let mut registry = new_registry();
+        let metrics = RegistryMetrics::register(&mut registry);
+
+        metrics.record_claim(ClaimResult::Claimed);
+        metrics.record_claim(ClaimResult::AlreadyExists);
+        metrics.record_claim(ClaimResult::Error);
 
         let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
-
-        // Arrivals: absent->downloading once, downloading->downloading once.
-        assert!(
-            encoded.contains(
-                r#"mx_registry_status_transitions_total{from="absent",to="downloading"} 1"#
-            ),
-            "{encoded}"
-        );
-        assert!(
-            encoded.contains(
-                r#"mx_registry_status_transitions_total{from="downloading",to="downloading"} 1"#
-            ),
-            "a takeover must arrive from downloading, not absent: {encoded}"
-        );
-        // Departures: two.
-        assert!(
-            encoded.contains(
-                r#"mx_registry_status_transitions_total{from="downloading",to="downloaded"} 2"#
-            ),
-            "{encoded}"
+        assert_eq!(
+            in_flight(&encoded),
+            1,
+            "waiters and errors must not move the level: {encoded}"
         );
     }
 

--- a/modelexpress_server/src/metrics/registry.rs
+++ b/modelexpress_server/src/metrics/registry.rs
@@ -310,8 +310,16 @@ mod tests {
     use super::*;
     use crate::metrics::{encode_text, new_registry};
 
+    /// Each `ClaimResult` gets its own series, so a takeover is queryable apart
+    /// from a fresh claim.
+    ///
+    /// Scope: this pins the wire form only. The decision that turns a backend
+    /// `ClaimOutcome::TookOver` into `ClaimResult::Takeover` is made in
+    /// [`crate::registry::backend::instrumented`] and cannot be observed from
+    /// here -- feeding `ClaimResult` values in by hand says nothing about which
+    /// one a real takeover produces.
     #[test]
-    fn a_takeover_is_not_counted_as_a_fresh_claim() {
+    fn each_claim_result_encodes_as_its_own_label_value() {
         let mut registry = new_registry();
         let metrics = RegistryMetrics::register(&mut registry);
 
@@ -334,6 +342,62 @@ mod tests {
             "{encoded}"
         );
         assert!(!encoded.contains("_total_total"), "{encoded}");
+    }
+
+    /// `ModelStatus` reaches Prometheus only through `From<ModelStatus>`, and it
+    /// feeds two labels operators read as ground truth: the `to` side of the
+    /// finish transition and the `outcome` of `mx_download_seconds`. A swapped
+    /// arm reports every failed download as a successful one in *both* families
+    /// at once, so this asserts the encoded label rather than the enum variant.
+    ///
+    /// The counts are deliberately distinct (3 / 1 / 2) so no permutation of the
+    /// three arms leaves the assertions satisfied. `absent` is pinned here too:
+    /// it is the one `StatusLabel` with no `ModelStatus` behind it, and the
+    /// `in_flight` helper below matches on `downloading` alone, so nothing else
+    /// holds its wire form.
+    #[test]
+    fn a_model_status_keeps_its_own_label_through_the_encoder() {
+        let mut registry = new_registry();
+        let metrics = RegistryMetrics::register(&mut registry);
+        // Both families on one registry, as `server::run_server` registers them.
+        let downloads = DownloadMetrics::register(&mut registry);
+
+        for _ in 0..3 {
+            metrics.record_transition(StatusLabel::Absent, ModelStatus::DOWNLOADING.into());
+        }
+        metrics.record_transition(StatusLabel::Downloading, ModelStatus::DOWNLOADED.into());
+        for _ in 0..2 {
+            metrics.record_transition(StatusLabel::Downloading, ModelStatus::ERROR.into());
+        }
+        downloads.observe(ModelStatus::ERROR.into(), 1.0);
+
+        let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="absent",to="downloading"} 3"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="downloading",to="downloaded"} 1"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="downloading",to="error"} 2"#
+            ),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains(r#"mx_download_seconds_count{outcome="error"} 1"#),
+            "{encoded}"
+        );
+        assert!(
+            !encoded.contains(r#"mx_download_seconds_count{outcome="downloaded"}"#),
+            "a failed download must not be timed as a successful one: {encoded}"
+        );
     }
 
     /// Sum the `to="downloading"` and `from="downloading"` series the way the
@@ -360,12 +424,17 @@ mod tests {
         arrivals.saturating_sub(departures)
     }
 
-    /// One download, taken over mid-flight, then finished.
+    /// A takeover records `downloading -> downloading`: an arrival and a
+    /// departure that cancel, because ownership changed while the entry never
+    /// left `DOWNLOADING`. Recording it as `absent -> downloading` instead would
+    /// add an arrival that never leaves and the level would drift up by one per
+    /// takeover. That from-label choice lives in `record_claim`, so this test
+    /// does exercise it.
     ///
-    /// A takeover records `downloading -> downloading`: an arrival and a departure
-    /// that cancel, because ownership changed while the entry never left
-    /// `DOWNLOADING`. Recording it as `absent -> downloading` instead would add an
-    /// arrival that never leaves and the level would drift up by one per takeover.
+    /// Scope: the finish step here is a hand-written `record_transition`, not a
+    /// real one. Whether a real finish records a departure at all -- and whether
+    /// a real takeover arrives as `ClaimResult::Takeover` -- is decided in
+    /// [`crate::registry::backend::instrumented`] and is not covered from here.
     #[test]
     fn a_takeover_does_not_change_the_in_flight_level() {
         let mut registry = new_registry();
@@ -389,10 +458,15 @@ mod tests {
         assert_eq!(in_flight(&encoded), 0, "the download finished");
     }
 
-    /// Deleting a record mid-download is the third exit from `DOWNLOADING`, and
-    /// the one the claim lifecycle cannot observe for itself.
+    /// `downloading -> absent` is the third exit from `DOWNLOADING`, and the one
+    /// the claim lifecycle cannot observe for itself; it must subtract from the
+    /// level exactly as a finish does.
+    ///
+    /// Scope: arithmetic only. The caller that decides whether a delete books
+    /// this transition is `services::ModelDownloadTracker::delete_model_entries`,
+    /// which this test never reaches -- deleting that decision leaves this green.
     #[test]
-    fn a_delete_during_download_is_a_departure() {
+    fn a_downloading_to_absent_transition_is_a_departure() {
         let mut registry = new_registry();
         let metrics = RegistryMetrics::register(&mut registry);
 
@@ -400,7 +474,7 @@ mod tests {
         let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
         assert_eq!(in_flight(&encoded), 1);
 
-        // `model clear` on a model that is still downloading.
+        // What `model clear` on a still-downloading model has to book.
         metrics.record_transition(StatusLabel::Downloading, StatusLabel::Absent);
         let encoded = encode_text(&registry).unwrap_or_else(|_| String::from("<encode failed>"));
         assert_eq!(

--- a/modelexpress_server/src/registry.rs
+++ b/modelexpress_server/src/registry.rs
@@ -13,3 +13,4 @@ pub mod backend;
 pub mod entry_key;
 pub mod k8s_types;
 pub mod state;
+pub mod stats_refresh;

--- a/modelexpress_server/src/registry/backend.rs
+++ b/modelexpress_server/src/registry/backend.rs
@@ -40,18 +40,24 @@ pub enum ClaimOutcome {
     /// This call atomically created the registry record. The caller is the download
     /// owner and this is the first download of this entry.
     Claimed,
-    /// This call took over an expired lease: a previous owner claimed the entry and
-    /// died without finishing. The caller is the download owner, exactly as for
-    /// [`ClaimOutcome::Claimed`], and every caller that only cares about ownership
-    /// should match the two together.
+    /// This call took over an **expired lease**. The caller owns the download,
+    /// exactly as for [`ClaimOutcome::Claimed`], and every caller that only cares
+    /// about ownership should match the two together.
+    ///
+    /// Expiry is what this observes, not death. The previous owner may still be
+    /// running -- a missed heartbeat or a connectivity blip expires a lease just
+    /// as a crash does -- which is precisely why `finish_download_claim` fences
+    /// the old owner rather than trusting it to stop.
     ///
     /// They are distinguished because the cost is not comparable. A `Claimed` is the
     /// first fetch of a model; a `TookOver` means the bytes are being pulled again
     /// because the previous downloader died, which for a large model is hundreds of
     /// gigabytes of repeated transfer. Collapsing them makes that invisible.
     TookOver,
-    /// The record already existed when we tried to claim. The caller is a waiter, not
-    /// the owner; the enclosed status is the snapshot observed during the attempt.
+    /// The record already existed and its lease is still held, so **this caller
+    /// does not own the download** and must wait on the owner instead of starting
+    /// a duplicate. Returned without mutating the registry; the enclosed status is
+    /// the snapshot observed during the attempt.
     AlreadyExists(ModelStatus),
 }
 

--- a/modelexpress_server/src/registry/backend.rs
+++ b/modelexpress_server/src/registry/backend.rs
@@ -37,9 +37,19 @@ pub struct ModelRecord {
 /// `AlreadyExists` must wait on the owner instead of spawning a duplicate download.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ClaimOutcome {
-    /// This call atomically created the registry record or took over an expired lease.
-    /// The caller is the download owner.
+    /// This call atomically created the registry record. The caller is the download
+    /// owner and this is the first download of this entry.
     Claimed,
+    /// This call took over an expired lease: a previous owner claimed the entry and
+    /// died without finishing. The caller is the download owner, exactly as for
+    /// [`ClaimOutcome::Claimed`], and every caller that only cares about ownership
+    /// should match the two together.
+    ///
+    /// They are distinguished because the cost is not comparable. A `Claimed` is the
+    /// first fetch of a model; a `TookOver` means the bytes are being pulled again
+    /// because the previous downloader died, which for a large model is hundreds of
+    /// gigabytes of repeated transfer. Collapsing them makes that invisible.
+    TookOver,
     /// The record already existed when we tried to claim. The caller is a waiter, not
     /// the owner; the enclosed status is the snapshot observed during the attempt.
     AlreadyExists(ModelStatus),

--- a/modelexpress_server/src/registry/backend/instrumented.rs
+++ b/modelexpress_server/src/registry/backend/instrumented.rs
@@ -396,4 +396,319 @@ mod tests {
             assert!(encoded.contains(&expected), "missing {op}: {encoded}");
         }
     }
+
+    // --- download lifecycle ---------------------------------------------------
+    //
+    // The three tests above hand `RegistryMetrics::register` a throwaway
+    // `new_registry()` that is dropped on the spot. That is harmless for them --
+    // they only assert on `mx_backend_ops_total` -- but it means the lifecycle
+    // families are never encoded, so nothing below can be written that way. All
+    // four PR-673 lifecycle counters reach Prometheus only through this
+    // decorator, so these register both families on the one registry the
+    // assertions actually read.
+
+    const MODEL: &str = "google-t5/t5-small";
+    const CLAIM: &str = "claim-1";
+
+    fn lease() -> std::time::Duration {
+        std::time::Duration::from_secs(30)
+    }
+
+    /// Wrap `mock` with both metric families on a single registry, returned so
+    /// the caller can encode it.
+    fn instrumented(
+        mock: MockRegistryBackend,
+    ) -> (
+        Arc<dyn RegistryBackend>,
+        prometheus_client::registry::Registry,
+    ) {
+        let mut prom = new_registry();
+        let backend = InstrumentedRegistryBackend::wrap(
+            Arc::new(mock),
+            BackendMetrics::register(&mut prom),
+            RegistryMetrics::register(&mut prom),
+        );
+        (backend, prom)
+    }
+
+    fn scrape(prom: &prometheus_client::registry::Registry) -> String {
+        encode_text(prom).unwrap_or_else(|_| String::from("<encode failed>"))
+    }
+
+    /// Sum the transition series the way the documented flow query does, so the
+    /// assertion is the derivation operators read rather than one series.
+    ///
+    /// Deliberately a local copy of the helper in [`crate::metrics::registry`]:
+    /// that one proves the counter's arithmetic given hand-written labels, this
+    /// one proves the decorator feeds it the right ones.
+    fn in_flight(encoded: &str) -> i64 {
+        let mut arrivals: i64 = 0;
+        let mut departures: i64 = 0;
+        for line in encoded.lines() {
+            let Some((labels, value)) = line
+                .strip_prefix("mx_registry_status_transitions_total{")
+                .and_then(|rest| rest.split_once("} "))
+            else {
+                continue;
+            };
+            let count: i64 = value.trim().parse().unwrap_or_default();
+            if labels.contains(r#"to="downloading""#) {
+                arrivals = arrivals.saturating_add(count);
+            }
+            if labels.contains(r#"from="downloading""#) {
+                departures = departures.saturating_add(count);
+            }
+        }
+        arrivals.saturating_sub(departures)
+    }
+
+    /// Every `ClaimOutcome` must land on its own `result` label, and only the two
+    /// owning outcomes may imply a transition.
+    ///
+    /// A takeover reported as a fresh claim is the regression `ClaimOutcome::TookOver`
+    /// was introduced to prevent: a re-pull of hundreds of gigabytes reads as a
+    /// first fetch. A backend error counted as a claim is worse still -- it books
+    /// an arrival that never departs.
+    #[tokio::test]
+    async fn each_claim_outcome_reaches_its_own_result_label() {
+        let mut mock = MockRegistryBackend::new();
+        let call = std::sync::atomic::AtomicUsize::new(0);
+        mock.expect_try_claim_for_download()
+            .times(4)
+            .returning(move |_, _, _, _| {
+                match call.fetch_add(1, std::sync::atomic::Ordering::SeqCst) {
+                    0 => Ok(ClaimOutcome::Claimed),
+                    1 => Ok(ClaimOutcome::TookOver),
+                    2 => Ok(ClaimOutcome::AlreadyExists(ModelStatus::DOWNLOADING)),
+                    _ => Err("redis is down".into()),
+                }
+            });
+
+        let (backend, prom) = instrumented(mock);
+        for _ in 0..4 {
+            let _ = backend
+                .try_claim_for_download(MODEL, ModelProvider::HuggingFace, CLAIM, lease())
+                .await;
+        }
+
+        let encoded = scrape(&prom);
+        for result in ["claimed", "takeover", "already_exists", "error"] {
+            let expected = format!(r#"mx_download_claims_total{{result="{result}"}} 1"#);
+            assert!(encoded.contains(&expected), "missing {expected}: {encoded}");
+        }
+        // The two owning outcomes differ only in where they came from: a fresh
+        // claim creates the record, a takeover finds it already `DOWNLOADING`.
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="absent",to="downloading"} 1"#
+            ),
+            "a fresh claim did not book absent -> downloading: {encoded}"
+        );
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="downloading",to="downloading"} 1"#
+            ),
+            "a takeover did not book downloading -> downloading: {encoded}"
+        );
+        // A waiter and a failed call changed nothing, so the level is one
+        // download, not three.
+        assert_eq!(
+            in_flight(&encoded),
+            1,
+            "waiters and errors must not move the level: {encoded}"
+        );
+    }
+
+    /// One download, taken over mid-flight, then finished -- driven through the
+    /// backend rather than by handing the counter its own labels.
+    ///
+    /// This is the module doc's invariant end to end: a takeover is an arrival
+    /// and a departure that cancel, so the only thing left at the end is the
+    /// finish. Booking the takeover as `absent -> downloading` drifts the level
+    /// up by one per takeover and it never comes back down.
+    #[tokio::test]
+    async fn a_claim_taken_over_then_finished_leaves_nothing_in_flight() {
+        let mut mock = MockRegistryBackend::new();
+        let call = std::sync::atomic::AtomicUsize::new(0);
+        mock.expect_try_claim_for_download()
+            .times(2)
+            .returning(move |_, _, _, _| {
+                if call.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                    Ok(ClaimOutcome::Claimed)
+                } else {
+                    Ok(ClaimOutcome::TookOver)
+                }
+            });
+        mock.expect_finish_download_claim()
+            .times(1)
+            .returning(|_, _, _, _, _| Ok(true));
+
+        let (backend, prom) = instrumented(mock);
+
+        let _ = backend
+            .try_claim_for_download(MODEL, ModelProvider::HuggingFace, CLAIM, lease())
+            .await;
+        assert_eq!(in_flight(&scrape(&prom)), 1, "one download in flight");
+
+        // Ownership moves; the download itself is still the same one.
+        let _ = backend
+            .try_claim_for_download(MODEL, ModelProvider::HuggingFace, "claim-2", lease())
+            .await;
+        assert_eq!(
+            in_flight(&scrape(&prom)),
+            1,
+            "a takeover is not a second download"
+        );
+
+        let _ = backend
+            .finish_download_claim(
+                MODEL,
+                ModelProvider::HuggingFace,
+                "claim-2",
+                ModelStatus::DOWNLOADED,
+                None,
+            )
+            .await;
+        let encoded = scrape(&prom);
+        assert_eq!(in_flight(&encoded), 0, "the download finished: {encoded}");
+    }
+
+    /// Only the replica that wins the compare-and-set spawns the retry, so only
+    /// it may book the arrival.
+    #[tokio::test]
+    async fn a_won_retry_reset_records_the_arrival_from_error() {
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_try_reset_error_for_retry()
+            .times(1)
+            .returning(|_, _, _, _| Ok(true));
+
+        let (backend, prom) = instrumented(mock);
+        let _ = backend
+            .try_reset_error_for_retry(MODEL, ModelProvider::HuggingFace, CLAIM, lease())
+            .await;
+
+        let encoded = scrape(&prom);
+        // Direction matters as much as the fact of recording: reversed, a retry
+        // being started reads as a download failing.
+        assert!(
+            encoded.contains(
+                r#"mx_registry_status_transitions_total{from="error",to="downloading"} 1"#
+            ),
+            "a won retry did not book error -> downloading: {encoded}"
+        );
+        assert_eq!(in_flight(&encoded), 1, "the retry is in flight: {encoded}");
+    }
+
+    /// The losers of the compare-and-set must record nothing.
+    ///
+    /// Under a thundering herd on a failed model every waiting replica calls
+    /// this and sees `false`; counting those would inflate the in-flight level by
+    /// the replica count, with no matching departures to bring it back.
+    #[tokio::test]
+    async fn a_lost_retry_reset_records_no_arrival() {
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_try_reset_error_for_retry()
+            .times(1)
+            .returning(|_, _, _, _| Ok(false));
+
+        let (backend, prom) = instrumented(mock);
+        let _ = backend
+            .try_reset_error_for_retry(MODEL, ModelProvider::HuggingFace, CLAIM, lease())
+            .await;
+
+        let encoded = scrape(&prom);
+        assert!(
+            !encoded.contains("mx_registry_status_transitions_total{"),
+            "a replica that lost the retry race booked a transition: {encoded}"
+        );
+    }
+
+    /// `result="lost"` is the leading indicator of a duplicate download, so it
+    /// must not be collapsed into `renewed` -- the panel would read flat-green
+    /// during exactly the incident it was built for.
+    #[tokio::test]
+    async fn each_lease_heartbeat_outcome_reaches_its_own_result_label() {
+        let mut mock = MockRegistryBackend::new();
+        let call = std::sync::atomic::AtomicUsize::new(0);
+        mock.expect_refresh_download_claim()
+            .times(3)
+            .returning(move |_, _, _, _| {
+                match call.fetch_add(1, std::sync::atomic::Ordering::SeqCst) {
+                    0 => Ok(true),
+                    1 => Ok(false),
+                    _ => Err("redis is down".into()),
+                }
+            });
+
+        let (backend, prom) = instrumented(mock);
+        for _ in 0..3 {
+            let _ = backend
+                .refresh_download_claim(MODEL, ModelProvider::HuggingFace, CLAIM, lease())
+                .await;
+        }
+
+        let encoded = scrape(&prom);
+        for result in ["renewed", "lost", "error"] {
+            let expected = format!(r#"mx_download_lease_refresh_total{{result="{result}"}} 1"#);
+            assert!(encoded.contains(&expected), "missing {expected}: {encoded}");
+        }
+    }
+
+    /// The departure carries the status the download actually finished with.
+    ///
+    /// `ERROR` is exercised alongside `DOWNLOADED` because a hardcoded `to` label
+    /// looks correct for the success case while reporting every failed download
+    /// as a successful one.
+    #[tokio::test]
+    async fn a_finished_download_departs_to_its_terminal_status() {
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_finish_download_claim()
+            .times(2)
+            .returning(|_, _, _, _, _| Ok(true));
+
+        let (backend, prom) = instrumented(mock);
+        for status in [ModelStatus::ERROR, ModelStatus::DOWNLOADED] {
+            let _ = backend
+                .finish_download_claim(MODEL, ModelProvider::HuggingFace, CLAIM, status, None)
+                .await;
+        }
+
+        let encoded = scrape(&prom);
+        for to in ["error", "downloaded"] {
+            let expected = format!(
+                r#"mx_registry_status_transitions_total{{from="downloading",to="{to}"}} 1"#
+            );
+            assert!(encoded.contains(&expected), "missing {expected}: {encoded}");
+        }
+    }
+
+    /// `Ok(false)` means a stale owner was fenced after its lease was taken over.
+    ///
+    /// The entry did not leave `DOWNLOADING` on this call -- the new owner will
+    /// book its own departure later -- so counting this one makes the in-flight
+    /// derivation go negative.
+    #[tokio::test]
+    async fn a_fenced_stale_owner_records_no_departure() {
+        let mut mock = MockRegistryBackend::new();
+        mock.expect_finish_download_claim()
+            .times(1)
+            .returning(|_, _, _, _, _| Ok(false));
+
+        let (backend, prom) = instrumented(mock);
+        let _ = backend
+            .finish_download_claim(
+                MODEL,
+                ModelProvider::HuggingFace,
+                CLAIM,
+                ModelStatus::DOWNLOADED,
+                None,
+            )
+            .await;
+
+        let encoded = scrape(&prom);
+        assert!(
+            !encoded.contains("mx_registry_status_transitions_total{"),
+            "a fenced stale owner booked a departure it did not make: {encoded}"
+        );
+    }
 }

--- a/modelexpress_server/src/registry/backend/instrumented.rs
+++ b/modelexpress_server/src/registry/backend/instrumented.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use crate::metrics::backend::{BackendMetrics, Store};
+use crate::metrics::registry::{ClaimResult, LeaseResult, RegistryMetrics, StatusLabel};
 use crate::registry::backend::{ClaimOutcome, ModelRecord, RegistryBackend, RegistryResult};
 use modelexpress_common::models::{ModelProvider, ModelStatus};
 
@@ -26,6 +27,7 @@ use modelexpress_common::models::{ModelProvider, ModelStatus};
 pub struct InstrumentedRegistryBackend {
     inner: Arc<dyn RegistryBackend>,
     metrics: BackendMetrics,
+    lifecycle: RegistryMetrics,
 }
 
 impl InstrumentedRegistryBackend {
@@ -34,8 +36,13 @@ impl InstrumentedRegistryBackend {
     pub fn wrap(
         inner: Arc<dyn RegistryBackend>,
         metrics: BackendMetrics,
+        lifecycle: RegistryMetrics,
     ) -> Arc<dyn RegistryBackend> {
-        Arc::new(Self { inner, metrics })
+        Arc::new(Self {
+            inner,
+            metrics,
+            lifecycle,
+        })
     }
 }
 
@@ -133,14 +140,22 @@ impl RegistryBackend for InstrumentedRegistryBackend {
         claim_id: &str,
         lease_duration: std::time::Duration,
     ) -> RegistryResult<ClaimOutcome> {
-        self.metrics
+        let outcome = self
+            .metrics
             .time(
                 Store::Registry,
                 "try_claim_for_download",
                 self.inner
                     .try_claim_for_download(model_name, provider, claim_id, lease_duration),
             )
-            .await
+            .await;
+        self.lifecycle.record_claim(match &outcome {
+            Ok(ClaimOutcome::Claimed) => ClaimResult::Claimed,
+            Ok(ClaimOutcome::TookOver) => ClaimResult::Takeover,
+            Ok(ClaimOutcome::AlreadyExists(_)) => ClaimResult::AlreadyExists,
+            Err(_) => ClaimResult::Error,
+        });
+        outcome
     }
 
     async fn try_reset_error_for_retry(
@@ -150,7 +165,8 @@ impl RegistryBackend for InstrumentedRegistryBackend {
         claim_id: &str,
         lease_duration: std::time::Duration,
     ) -> RegistryResult<bool> {
-        self.metrics
+        let reset = self
+            .metrics
             .time(
                 Store::Registry,
                 "try_reset_error_for_retry",
@@ -161,7 +177,14 @@ impl RegistryBackend for InstrumentedRegistryBackend {
                     lease_duration,
                 ),
             )
-            .await
+            .await;
+        // Only the winner sees `true`, so this counts retries actually started
+        // rather than replicas that observed the error.
+        if matches!(reset, Ok(true)) {
+            self.lifecycle
+                .record_transition(StatusLabel::Error, StatusLabel::Downloading);
+        }
+        reset
     }
 
     async fn refresh_download_claim(
@@ -171,14 +194,21 @@ impl RegistryBackend for InstrumentedRegistryBackend {
         claim_id: &str,
         lease_duration: std::time::Duration,
     ) -> RegistryResult<bool> {
-        self.metrics
+        let renewed = self
+            .metrics
             .time(
                 Store::Registry,
                 "refresh_download_claim",
                 self.inner
                     .refresh_download_claim(model_name, provider, claim_id, lease_duration),
             )
-            .await
+            .await;
+        self.lifecycle.record_lease_refresh(match &renewed {
+            Ok(true) => LeaseResult::Renewed,
+            Ok(false) => LeaseResult::Lost,
+            Err(_) => LeaseResult::Error,
+        });
+        renewed
     }
 
     async fn finish_download_claim(
@@ -189,14 +219,23 @@ impl RegistryBackend for InstrumentedRegistryBackend {
         status: ModelStatus,
         message: Option<String>,
     ) -> RegistryResult<bool> {
-        self.metrics
+        let finished = self
+            .metrics
             .time(
                 Store::Registry,
                 "finish_download_claim",
                 self.inner
                     .finish_download_claim(model_name, provider, claim_id, status, message),
             )
-            .await
+            .await;
+        // `false` means a stale owner was fenced after its lease was taken over:
+        // the entry did not leave `downloading` on this call, and counting it
+        // would make the in-flight derivation go negative.
+        if matches!(finished, Ok(true)) {
+            self.lifecycle
+                .record_transition(StatusLabel::Downloading, status.into());
+        }
+        finished
     }
 }
 
@@ -215,7 +254,11 @@ mod tests {
 
         let mut registry = new_registry();
         let metrics = BackendMetrics::register(&mut registry);
-        let backend = InstrumentedRegistryBackend::wrap(Arc::new(mock), metrics);
+        let backend = InstrumentedRegistryBackend::wrap(
+            Arc::new(mock),
+            metrics,
+            RegistryMetrics::register(&mut new_registry()),
+        );
 
         let status = backend.get_status("google-t5/t5-small").await;
         assert_eq!(status.ok().flatten(), Some(ModelStatus::DOWNLOADED));
@@ -238,7 +281,11 @@ mod tests {
 
         let mut registry = new_registry();
         let metrics = BackendMetrics::register(&mut registry);
-        let backend = InstrumentedRegistryBackend::wrap(Arc::new(mock), metrics);
+        let backend = InstrumentedRegistryBackend::wrap(
+            Arc::new(mock),
+            metrics,
+            RegistryMetrics::register(&mut new_registry()),
+        );
 
         assert!(backend.connect().await.is_err());
 
@@ -288,7 +335,11 @@ mod tests {
 
         let mut registry = new_registry();
         let metrics = BackendMetrics::register(&mut registry);
-        let backend = InstrumentedRegistryBackend::wrap(Arc::new(mock), metrics);
+        let backend = InstrumentedRegistryBackend::wrap(
+            Arc::new(mock),
+            metrics,
+            RegistryMetrics::register(&mut new_registry()),
+        );
 
         let model = "google-t5/t5-small";
         let _ = backend.connect().await;

--- a/modelexpress_server/src/registry/backend/kubernetes.rs
+++ b/modelexpress_server/src/registry/backend/kubernetes.rs
@@ -461,9 +461,11 @@ impl KubernetesRegistryBackend {
             .resource_version
             .as_deref()
             .ok_or("ModelCacheEntry has no resourceVersion")?;
-        if !(status_missing && claim_uninitialized)
-            && !self.lease_has_expired(cr_name, &status, lease_duration)
-        {
+        // Already computed here, so the fresh/takeover distinction costs nothing:
+        // an uninitialized claim is a first download, anything else reaching this
+        // point got here because the previous owner's lease expired.
+        let is_fresh_claim = status_missing && claim_uninitialized;
+        if !is_fresh_claim && !self.lease_has_expired(cr_name, &status, lease_duration) {
             return Ok(ClaimOutcome::AlreadyExists(ModelStatus::DOWNLOADING));
         }
         let now = Utc::now().to_rfc3339();
@@ -507,7 +509,11 @@ impl KubernetesRegistryBackend {
         {
             Ok(_) => {
                 self.clear_lease_observation(cr_name);
-                Ok(ClaimOutcome::Claimed)
+                if is_fresh_claim {
+                    Ok(ClaimOutcome::Claimed)
+                } else {
+                    Ok(ClaimOutcome::TookOver)
+                }
             }
             Err(kube::Error::Api(e)) if e.code == 409 || e.code == 422 => {
                 let current = self

--- a/modelexpress_server/src/registry/backend/memory.rs
+++ b/modelexpress_server/src/registry/backend/memory.rs
@@ -161,7 +161,7 @@ impl RegistryBackend for InMemoryRegistryBackend {
                         expires_at: lease_expires_at,
                     },
                 );
-                Ok(ClaimOutcome::Claimed)
+                Ok(ClaimOutcome::TookOver)
             }
             Some(existing) => Ok(ClaimOutcome::AlreadyExists(existing.status)),
             None => {
@@ -527,7 +527,7 @@ mod tests {
                 )
                 .await
                 .expect("takeover"),
-            ClaimOutcome::Claimed
+            ClaimOutcome::TookOver
         );
         assert!(
             !backend

--- a/modelexpress_server/src/registry/backend/redis.rs
+++ b/modelexpress_server/src/registry/backend/redis.rs
@@ -405,10 +405,10 @@ impl RegistryBackend for RedisRegistryBackend {
         let key = model_key(provider, model_name);
         let legacy = legacy_model_key(model_name);
         let now = Utc::now().to_rfc3339();
-        // Single atomic EVAL: returns CLAIM_WON_SENTINEL if we created the record or took
-        // over an expired lease, else the existing status, so callers know which replica
-        // owns the download (status alone can't — both see DOWNLOADING). KEYS[2] is the
-        // legacy key for migration (see below).
+        // Single atomic EVAL: returns CLAIM_WON_SENTINEL if we created the record,
+        // CLAIM_TAKEOVER_SENTINEL if we took over an expired lease, else the existing
+        // status, so callers know which replica owns the download (status alone can't —
+        // both see DOWNLOADING). KEYS[2] is the legacy key for migration (see below).
         let result: String = redis::Script::new(CLAIM_LUA)
             .key(&key)
             .key(&legacy)
@@ -420,12 +420,15 @@ impl RegistryBackend for RedisRegistryBackend {
             .arg(claim_id)
             .arg(lease_duration_millis(lease_duration))
             .arg("Taking over expired download lease...")
+            .arg(CLAIM_TAKEOVER_SENTINEL)
             .invoke_async(&mut conn)
             .await?;
-        if result == CLAIM_WON_SENTINEL {
-            Ok(ClaimOutcome::Claimed)
-        } else {
-            Ok(ClaimOutcome::AlreadyExists(status_from_str(&result)?))
+        // The legacy-migration arm routes through `claim_existing`, so a migrated
+        // record with a dead lease reports a takeover without extra handling.
+        match result.as_str() {
+            CLAIM_WON_SENTINEL => Ok(ClaimOutcome::Claimed),
+            CLAIM_TAKEOVER_SENTINEL => Ok(ClaimOutcome::TookOver),
+            status => Ok(ClaimOutcome::AlreadyExists(status_from_str(status)?)),
         }
     }
 
@@ -508,9 +511,15 @@ impl RegistryBackend for RedisRegistryBackend {
     }
 }
 
-/// Sentinel string returned by [`CLAIM_LUA`] when the caller won the claim. Picked so
-/// it cannot be confused with any real `ModelStatus` string.
+/// Sentinel string returned by [`CLAIM_LUA`] when the caller created the record.
+/// Picked so it cannot be confused with any real `ModelStatus` string.
 const CLAIM_WON_SENTINEL: &str = "__MX_CLAIM_WON__";
+
+/// Sentinel returned by [`CLAIM_LUA`] when the caller took over an expired lease
+/// rather than creating the record. Both outcomes mean the caller owns the
+/// download; they are separated because a takeover re-pulls bytes that were
+/// already fetched once.
+const CLAIM_TAKEOVER_SENTINEL: &str = "__MX_CLAIM_TAKEOVER__";
 
 /// Atomic claim against the provider-scoped key, lazily migrating legacy records:
 ///   1. provider-scoped key exists -> return its status (normal hit);
@@ -523,7 +532,7 @@ const CLAIM_WON_SENTINEL: &str = "__MX_CLAIM_WON__";
 ///
 /// KEYS = [provider-scoped, legacy]
 /// ARGV = [win_sentinel, status, provider, now, message, claim_id, lease_ttl_ms,
-///         takeover_message]
+///         takeover_message, takeover_sentinel]
 const CLAIM_LUA: &str = r#"
 local clock = redis.call("TIME")
 local now_ms = tonumber(clock[1]) * 1000 + math.floor(tonumber(clock[2]) / 1000)
@@ -538,7 +547,7 @@ local function claim_existing(key, status)
         "message", ARGV[8],
         "claim_id", ARGV[6],
         "lease_expires_at", lease_expires_at)
-    return ARGV[1]
+    return ARGV[9]
 end
 local existing = redis.call("HGET", KEYS[1], "status")
 if existing then return claim_existing(KEYS[1], existing) end
@@ -796,7 +805,7 @@ mod tests {
                 )
                 .await
                 .expect("takeover"),
-            ClaimOutcome::Claimed
+            ClaimOutcome::TookOver
         );
         assert!(
             !backend

--- a/modelexpress_server/src/registry/state.rs
+++ b/modelexpress_server/src/registry/state.rs
@@ -5,6 +5,7 @@
 
 use crate::backend_config::BackendConfig;
 use crate::metrics::backend::{BackendMetrics, Store};
+use crate::metrics::registry::RegistryMetrics;
 use crate::registry::backend::instrumented::InstrumentedRegistryBackend;
 use crate::registry::backend::{
     ClaimOutcome, ModelRecord, RegistryBackend, RegistryResult, create_registry_backend,
@@ -19,6 +20,7 @@ pub struct RegistryManager {
     backend: Arc<RwLock<Option<Arc<dyn RegistryBackend>>>>,
     config: Option<BackendConfig>,
     metrics: Option<BackendMetrics>,
+    lifecycle: Option<RegistryMetrics>,
 }
 
 impl RegistryManager {
@@ -27,6 +29,7 @@ impl RegistryManager {
             backend: Arc::new(RwLock::new(None)),
             config: Some(config),
             metrics: None,
+            lifecycle: None,
         }
     }
 
@@ -34,8 +37,9 @@ impl RegistryManager {
     /// [`crate::p2p::state::P2pStateManager::with_metrics`] for why this is
     /// opt-in rather than a `with_config` parameter.
     #[must_use]
-    pub fn with_metrics(mut self, metrics: BackendMetrics) -> Self {
+    pub fn with_metrics(mut self, metrics: BackendMetrics, lifecycle: RegistryMetrics) -> Self {
         self.metrics = Some(metrics);
+        self.lifecycle = Some(lifecycle);
         self
     }
 
@@ -44,7 +48,8 @@ impl RegistryManager {
         &self,
         config: BackendConfig,
     ) -> RegistryResult<Arc<dyn RegistryBackend>> {
-        let Some(metrics) = self.metrics.clone() else {
+        let (Some(metrics), Some(lifecycle)) = (self.metrics.clone(), self.lifecycle.clone())
+        else {
             return create_registry_backend(config).await;
         };
         // Timed around the factory for the same reason as
@@ -53,7 +58,9 @@ impl RegistryManager {
         let backend = metrics
             .time(Store::Registry, "connect", create_registry_backend(config))
             .await?;
-        Ok(InstrumentedRegistryBackend::wrap(backend, metrics))
+        Ok(InstrumentedRegistryBackend::wrap(
+            backend, metrics, lifecycle,
+        ))
     }
 
     /// Inject a pre-built backend directly (tests only).
@@ -63,6 +70,7 @@ impl RegistryManager {
             backend: Arc::new(RwLock::new(Some(backend))),
             config: None,
             metrics: None,
+            lifecycle: None,
         }
     }
 
@@ -228,6 +236,7 @@ mod tests {
             backend: Arc::new(RwLock::new(None)),
             config: None,
             metrics: None,
+            lifecycle: None,
         };
         assert!(mgr.connect().await.is_err());
     }

--- a/modelexpress_server/src/registry/stats_refresh.rs
+++ b/modelexpress_server/src/registry/stats_refresh.rs
@@ -120,9 +120,14 @@ mod tests {
             encoded.contains(r#"mx_state_entries{map="download_waiters"} 4"#),
             "{encoded}"
         );
-        // The heartbeat must NOT be stamped: the pass did not succeed.
+        // The heartbeat must NOT be stamped: the pass did not succeed. Named
+        // explicitly rather than matching the bare `task="` prefix -- both
+        // catch it, but this one cannot be misread as allowing the real task
+        // through.
         assert!(
-            !encoded.contains(r#"mx_task_last_success_timestamp_seconds{task=""#),
+            !encoded.contains(&format!(
+                r#"mx_task_last_success_timestamp_seconds{{task="{TASK_NAME}""#
+            )),
             "a failed pass stamped the heartbeat: {encoded}"
         );
     }

--- a/modelexpress_server/src/registry/stats_refresh.rs
+++ b/modelexpress_server/src/registry/stats_refresh.rs
@@ -131,4 +131,115 @@ mod tests {
             "a failed pass stamped the heartbeat: {encoded}"
         );
     }
+
+    /// The negative assertion above only carries information if the positive
+    /// case is pinned too: "correctly not stamped because the pass failed" and
+    /// "never stamped under any circumstances" satisfy it identically.
+    ///
+    /// The three counts are deliberately distinct so a rotated or mis-ordered
+    /// tuple lands a real-looking but wrong number under each status label
+    /// rather than a value that happens to match.
+    #[tokio::test]
+    async fn a_successful_pass_publishes_each_count_under_its_own_status() {
+        let mut prom = new_registry();
+        let metrics = CacheMetrics::register(&mut prom);
+        let mut backend = crate::registry::backend::MockRegistryBackend::new();
+        backend
+            .expect_get_status_counts()
+            .times(1)
+            .returning(|| Ok((2, 7, 1)));
+        let registry = RegistryManager::with_backend(Arc::new(backend));
+        let waiters: WaiterCount = Arc::new(|| 4);
+
+        refresh_once(&registry, &metrics, &waiters).await;
+
+        let encoded = encode_text(&prom).unwrap_or_else(|_| String::from("<encode failed>"));
+        for (status, count) in [("downloading", 2), ("downloaded", 7), ("error", 1)] {
+            let expected = format!(r#"mx_registry_entries{{status="{status}"}} {count}"#);
+            assert!(encoded.contains(&expected), "missing {expected}: {encoded}");
+        }
+        // Against `TASK_NAME` rather than a copy of the string, so renaming the
+        // constant cannot leave every dashboard keyed on the old label while
+        // this stays green.
+        assert!(
+            encoded.contains(&format!(
+                r#"mx_task_last_success_timestamp_seconds{{task="{TASK_NAME}"}}"#
+            )),
+            "a successful pass did not stamp the heartbeat: {encoded}"
+        );
+    }
+
+    /// Gauges hold their previous values across a failed pass.
+    ///
+    /// Zeroing them instead makes an unreachable backend and a genuinely empty
+    /// registry produce identical output, so on-call reads
+    /// `mx_registry_entries{status="downloading"} 0` during an outage and
+    /// concludes nothing is downloading.
+    #[tokio::test]
+    async fn a_failed_pass_leaves_the_registry_gauges_at_their_last_good_values() {
+        let mut prom = new_registry();
+        let metrics = CacheMetrics::register(&mut prom);
+        let mut backend = crate::registry::backend::MockRegistryBackend::new();
+        // Succeed once, then fail: the second pass is the one under test.
+        let pass = std::sync::atomic::AtomicUsize::new(0);
+        backend
+            .expect_get_status_counts()
+            .times(2)
+            .returning(move || {
+                if pass.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                    Ok((3, 9, 2))
+                } else {
+                    Err("registry unreachable".into())
+                }
+            });
+        let registry = RegistryManager::with_backend(Arc::new(backend));
+        let waiters: WaiterCount = Arc::new(|| 4);
+
+        refresh_once(&registry, &metrics, &waiters).await;
+        refresh_once(&registry, &metrics, &waiters).await;
+
+        let encoded = encode_text(&prom).unwrap_or_else(|_| String::from("<encode failed>"));
+        for (status, count) in [("downloading", 3), ("downloaded", 9), ("error", 2)] {
+            let expected = format!(r#"mx_registry_entries{{status="{status}"}} {count}"#);
+            assert!(
+                encoded.contains(&expected),
+                "the failed pass clobbered {status}, expected {expected}: {encoded}"
+            );
+        }
+    }
+
+    /// `run_server` awaits this task's join handle during shutdown, so a loop
+    /// that stops observing its oneshot does not just leak a task -- it hangs
+    /// the whole shutdown sequence until the kubelet SIGKILLs the pod.
+    ///
+    /// The `timeout` is what turns the regression into a failure instead of a
+    /// hung suite; it costs nothing on the passing path, where the task is woken
+    /// by the oneshot and joins immediately, and only elapses when the loop has
+    /// actually stopped watching for shutdown.
+    #[tokio::test]
+    async fn the_refresh_loop_stops_when_shutdown_fires() {
+        let mut prom = new_registry();
+        let metrics = CacheMetrics::register(&mut prom);
+        let mut backend = crate::registry::backend::MockRegistryBackend::new();
+        // No `times`: the immediate first tick fires one pass, and a loop that
+        // ignored shutdown would fire more.
+        backend
+            .expect_get_status_counts()
+            .returning(|| Ok((0, 0, 0)));
+        let registry = Arc::new(RegistryManager::with_backend(Arc::new(backend)));
+        let waiters: WaiterCount = Arc::new(|| 0);
+        let (tx, rx) = oneshot::channel();
+
+        let task = tokio::spawn(run_stats_refresh(registry, metrics, waiters, rx));
+        assert!(
+            tx.send(()).is_ok(),
+            "the task dropped its shutdown receiver"
+        );
+
+        let stopped = tokio::time::timeout(std::time::Duration::from_secs(2), task).await;
+        assert!(
+            stopped.is_ok(),
+            "the refresh loop ignored shutdown and would hang run_server"
+        );
+    }
 }

--- a/modelexpress_server/src/registry/stats_refresh.rs
+++ b/modelexpress_server/src/registry/stats_refresh.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Background refresh of the registry-statistics gauges.
+//!
+//! Counting registry entries walks the keyspace, so it cannot be done at scrape
+//! time -- see [`crate::metrics::cache`] for the cost. This task recomputes the
+//! numbers on its own interval and writes plain gauges; the scrape only encodes.
+//!
+//! It is deliberately **not** hosted on the cache-eviction service. That service
+//! ticks hourly by default and is skipped entirely when eviction is disabled,
+//! which would leave these gauges permanently absent -- indistinguishable from a
+//! crashed exporter. Running independently also means the statistics survive a
+//! deployment that never evicts anything.
+//!
+//! Safe on every replica: it only reads.
+
+use std::sync::Arc;
+
+use tokio::sync::oneshot;
+use tracing::{debug, info, warn};
+
+use crate::metrics::cache::CacheMetrics;
+use crate::registry::state::RegistryManager;
+
+/// Task name reported by `mx_task_last_success_timestamp_seconds`.
+pub const TASK_NAME: &str = "registry_stats_refresh";
+
+/// Run the refresh loop until the shutdown signal fires.
+pub async fn run_stats_refresh(
+    registry: Arc<RegistryManager>,
+    metrics: CacheMetrics,
+    waiters: WaiterCount,
+    shutdown: oneshot::Receiver<()>,
+) {
+    let interval_secs = modelexpress_common::envs::registry_stats_interval_secs();
+    info!("Registry stats refresh started (interval={interval_secs}s)");
+
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+    tokio::pin!(shutdown);
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                refresh_once(&registry, &metrics, &waiters).await;
+            }
+            _ = &mut shutdown => {
+                info!("Registry stats refresh received shutdown signal");
+                break;
+            }
+        }
+    }
+}
+
+/// Reads the current size of the in-process waiter map.
+///
+/// Boxed rather than taking the tracker directly so this task does not depend on
+/// the whole download path just to read one length.
+pub type WaiterCount = Arc<dyn Fn() -> usize + Send + Sync>;
+
+/// One refresh pass.
+///
+/// On failure the gauges are left holding their previous values and the task
+/// heartbeat is not stamped. Zeroing them instead would be worse than useless:
+/// an empty registry and an unreachable one would look identical, and the
+/// staleness of the heartbeat is the signal that says which.
+async fn refresh_once(registry: &RegistryManager, metrics: &CacheMetrics, waiters: &WaiterCount) {
+    // In-process, so it is refreshed even when the backend is unreachable.
+    metrics.set_state_entries(
+        "download_waiters",
+        i64::try_from(waiters()).unwrap_or(i64::MAX),
+    );
+
+    match registry.get_status_counts().await {
+        Ok((downloading, downloaded, errored)) => {
+            metrics.set_registry_entries(
+                i64::from(downloading),
+                i64::from(downloaded),
+                i64::from(errored),
+            );
+            metrics.stamp_task_success(TASK_NAME, chrono::Utc::now().timestamp());
+            debug!(
+                "Registry stats refreshed: downloading={downloading} downloaded={downloaded} error={errored}"
+            );
+        }
+        Err(e) => {
+            // Not an error log: a backend blip is expected and the staleness of
+            // the heartbeat gauge is the alertable signal, not this line.
+            warn!("Registry stats refresh failed, keeping previous values: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{encode_text, new_registry};
+
+    /// The waiter gauge is in-process, so it must still be published on a pass
+    /// where the backend lookup fails.
+    #[tokio::test]
+    async fn a_failed_pass_still_publishes_the_in_process_gauge() {
+        let mut prom = new_registry();
+        let metrics = CacheMetrics::register(&mut prom);
+        // A mock that fails, rather than a real unreachable address: dialling a
+        // dead port waits out the connect timeout and made this test take
+        // minutes.
+        let mut backend = crate::registry::backend::MockRegistryBackend::new();
+        backend
+            .expect_get_status_counts()
+            .times(1)
+            .returning(|| Err("registry unreachable".into()));
+        let registry = RegistryManager::with_backend(Arc::new(backend));
+        let waiters: WaiterCount = Arc::new(|| 4);
+
+        refresh_once(&registry, &metrics, &waiters).await;
+
+        let encoded = encode_text(&prom).unwrap_or_else(|_| String::from("<encode failed>"));
+        assert!(
+            encoded.contains(r#"mx_state_entries{map="download_waiters"} 4"#),
+            "{encoded}"
+        );
+        // The heartbeat must NOT be stamped: the pass did not succeed.
+        assert!(
+            !encoded.contains(r#"mx_task_last_success_timestamp_seconds{task=""#),
+            "a failed pass stamped the heartbeat: {encoded}"
+        );
+    }
+}

--- a/modelexpress_server/src/server.rs
+++ b/modelexpress_server/src/server.rs
@@ -178,6 +178,7 @@ pub async fn run_server(
     let backend_metrics = metrics::backend::BackendMetrics::register(&mut metrics_registry);
     let registry_metrics = metrics::registry::RegistryMetrics::register(&mut metrics_registry);
     let download_metrics = metrics::registry::DownloadMetrics::register(&mut metrics_registry);
+    let cache_metrics = metrics::cache::CacheMetrics::register(&mut metrics_registry);
     let metrics_registry = Arc::new(metrics_registry);
 
     let metrics_listener = MetricsListener::spawn(metrics_addr, Arc::clone(&metrics_registry));
@@ -214,6 +215,7 @@ pub async fn run_server(
         registry.clone(),
         config.cache.eviction.clone(),
         config.cache.directory.clone(),
+        cache_metrics.clone(),
     );
 
     // Create shutdown channels

--- a/modelexpress_server/src/server.rs
+++ b/modelexpress_server/src/server.rs
@@ -176,6 +176,8 @@ pub async fn run_server(
     metrics::register_build_info(&mut metrics_registry, &backend);
     let grpc_metrics = metrics::grpc::GrpcMetrics::register(&mut metrics_registry);
     let backend_metrics = metrics::backend::BackendMetrics::register(&mut metrics_registry);
+    let registry_metrics = metrics::registry::RegistryMetrics::register(&mut metrics_registry);
+    let download_metrics = metrics::registry::DownloadMetrics::register(&mut metrics_registry);
     let metrics_registry = Arc::new(metrics_registry);
 
     let metrics_listener = MetricsListener::spawn(metrics_addr, Arc::clone(&metrics_registry));
@@ -186,7 +188,8 @@ pub async fn run_server(
     // Initialize the model registry manager (Redis or Kubernetes CRDs). Shares the
     // injected backend with the P2P state manager below.
     let registry = Arc::new(
-        RegistryManager::with_config(backend.clone()).with_metrics(backend_metrics.clone()),
+        RegistryManager::with_config(backend.clone())
+            .with_metrics(backend_metrics.clone(), registry_metrics),
     );
     match tokio::time::timeout(std::time::Duration::from_secs(10), registry.connect()).await {
         Ok(Ok(backend_name)) => info!("Model registry connected (backend: {backend_name})"),
@@ -201,7 +204,10 @@ pub async fn run_server(
     }
 
     // Initialize the download tracker, injected with the registry.
-    let tracker = Arc::new(ModelDownloadTracker::new(registry.clone()));
+    let tracker = Arc::new(ModelDownloadTracker::new(
+        registry.clone(),
+        download_metrics,
+    ));
 
     // Create cache eviction service
     let cache_service = CacheEvictionService::new(

--- a/modelexpress_server/src/server.rs
+++ b/modelexpress_server/src/server.rs
@@ -190,7 +190,7 @@ pub async fn run_server(
     // injected backend with the P2P state manager below.
     let registry = Arc::new(
         RegistryManager::with_config(backend.clone())
-            .with_metrics(backend_metrics.clone(), registry_metrics),
+            .with_metrics(backend_metrics.clone(), registry_metrics.clone()),
     );
     match tokio::time::timeout(std::time::Duration::from_secs(10), registry.connect()).await {
         Ok(Ok(backend_name)) => info!("Model registry connected (backend: {backend_name})"),
@@ -208,6 +208,7 @@ pub async fn run_server(
     let tracker = Arc::new(ModelDownloadTracker::new(
         registry.clone(),
         download_metrics,
+        registry_metrics.clone(),
     ));
 
     // Create cache eviction service

--- a/modelexpress_server/src/server.rs
+++ b/modelexpress_server/src/server.rs
@@ -237,6 +237,7 @@ pub async fn run_server(
     // Create service implementations
     let health_service = HealthServiceImpl;
     let api_service = ApiServiceImpl;
+    let stats_tracker = tracker.clone();
     let model_service = ModelServiceImpl::new(tracker);
 
     // Create standard gRPC health service (grpc.health.v1.Health)
@@ -317,6 +318,23 @@ pub async fn run_server(
         crate::p2p::reaper::run_reaper(reaper_state, reaper_shutdown_rx).await;
     });
 
+    // Registry statistics refresh. Independent of the cache-eviction service on
+    // purpose: that one ticks hourly and is skipped entirely when eviction is
+    // disabled, which would leave these gauges permanently absent rather than
+    // merely stale.
+    let (stats_shutdown_tx, stats_shutdown_rx) = tokio::sync::oneshot::channel();
+    let stats_registry = registry.clone();
+    let stats_metrics = cache_metrics.clone();
+    let stats_handle = tokio::spawn(async move {
+        crate::registry::stats_refresh::run_stats_refresh(
+            stats_registry,
+            stats_metrics,
+            std::sync::Arc::new(move || stats_tracker.waiting_count()),
+            stats_shutdown_rx,
+        )
+        .await;
+    });
+
     // Fan the caller's shutdown trigger out to the background tasks, then let
     // serve_with_shutdown observe the same trigger to stop accepting connections.
     let shutdown_signal = async move {
@@ -330,6 +348,11 @@ pub async fn run_server(
         // Signal reaper to shutdown
         if reaper_shutdown_tx.send(()).is_err() {
             error!("Failed to send shutdown signal to reaper");
+        }
+
+        // Signal registry stats refresh to shutdown
+        if stats_shutdown_tx.send(()).is_err() {
+            error!("Failed to send shutdown signal to registry stats refresh");
         }
     };
 
@@ -396,6 +419,9 @@ pub async fn run_server(
         && let Err(e) = handle.await
     {
         error!("Cache eviction service join error: {e}");
+    }
+    if let Err(e) = stats_handle.await {
+        error!("Registry stats refresh join error: {e}");
     }
     if let Err(e) = reaper_handle.await {
         error!("Reaper join error: {e}");

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -1331,6 +1331,57 @@ mod tests {
         )
     }
 
+    /// As [`tracker_with_mock`], but hands back the Prometheus registry the metric
+    /// families were registered into.
+    ///
+    /// [`tracker_with_mock`] registers into a temporary registry that is dropped on
+    /// the spot, so nothing recorded through it can ever be encoded. Any metric
+    /// assertion against a tracker built that way would be vacuous by construction.
+    fn tracker_with_mock_and_registry(
+        mock: crate::registry::backend::MockRegistryBackend,
+    ) -> (ModelDownloadTracker, prometheus_client::registry::Registry) {
+        let mut metrics_registry = crate::metrics::new_registry();
+        let download_metrics = DownloadMetrics::register(&mut metrics_registry);
+        let registry_metrics = RegistryMetrics::register(&mut metrics_registry);
+        let registry = Arc::new(RegistryManager::with_backend(Arc::new(mock)));
+        (
+            ModelDownloadTracker::new(registry, download_metrics, registry_metrics),
+            metrics_registry,
+        )
+    }
+
+    fn encoded_metrics(registry: &prometheus_client::registry::Registry) -> String {
+        crate::metrics::encode_text(registry).unwrap_or_else(|_| String::from("<encode failed>"))
+    }
+
+    /// The `downloading -> absent` series, or 0 when it was never created.
+    fn departures_from_downloading(encoded: &str) -> i64 {
+        encoded
+            .lines()
+            .find_map(|line| {
+                line.strip_prefix(
+                    r#"mx_registry_status_transitions_total{from="downloading",to="absent"} "#,
+                )
+            })
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or_default()
+    }
+
+    fn record_with_status(
+        model_name: &str,
+        status: ModelStatus,
+    ) -> crate::registry::backend::ModelRecord {
+        let now = chrono::Utc::now();
+        crate::registry::backend::ModelRecord {
+            model_name: model_name.to_string(),
+            provider: ModelProvider::HuggingFace,
+            status,
+            created_at: now,
+            last_used_at: now,
+            message: None,
+        }
+    }
+
     /// Unpinned, full-weight target: its entry key is the bare model name.
     fn test_target(model_name: &str) -> DownloadTarget {
         DownloadTarget {
@@ -1543,6 +1594,184 @@ mod tests {
             .expect("waiters lock")
             .contains_key("m");
         assert!(!waiters);
+    }
+
+    /// The bool `delete_status` returns is the sole gate on the `downloading ->
+    /// absent` departure, and no caller is forced to read it -- there is no
+    /// `#[must_use]` and two of the three call sites discard it. So the contract
+    /// is pinned here directly rather than only through the delete-path tests
+    /// below, which would still pass if the two arms were swapped in step.
+    #[tokio::test]
+    async fn delete_status_reports_whether_the_backend_removed_the_record() {
+        let mut removed = crate::registry::backend::MockRegistryBackend::new();
+        removed.expect_delete_model().once().returning(|_| Ok(()));
+        assert!(
+            tracker_with_mock(removed).delete_status("m").await,
+            "a successful delete must report true"
+        );
+
+        let mut failed = crate::registry::backend::MockRegistryBackend::new();
+        failed
+            .expect_delete_model()
+            .once()
+            .returning(|_| Err("backend unreachable".into()));
+        assert!(
+            !tracker_with_mock(failed).delete_status("m").await,
+            "the error is still swallowed, but it must not report a removal"
+        );
+    }
+
+    /// `model clear` on an entry that is still downloading is the third exit from
+    /// `DOWNLOADING`, and the only one the claim lifecycle cannot observe for
+    /// itself: once the record is gone `finish_download_claim` finds nothing to
+    /// fence and records no departure, so the deleting side has to book it.
+    /// Without this the arrival booked by the claim is never matched and the flow
+    /// accounting stays permanently ahead by one per deleted download.
+    #[tokio::test]
+    async fn deleting_a_downloading_entry_books_a_departure() {
+        let mut mock = crate::registry::backend::MockRegistryBackend::new();
+        mock.expect_get_models_by_last_used()
+            .once()
+            .returning(|_| Ok(vec![record_with_status("m", ModelStatus::DOWNLOADING)]));
+        mock.expect_delete_model().once().returning(|_| Ok(()));
+
+        let (tracker, metrics_registry) = tracker_with_mock_and_registry(mock);
+        let outcome = tracker.delete_model_entries("m").await;
+        assert_eq!(outcome.removed, 1);
+        assert!(!outcome.degraded);
+
+        let encoded = encoded_metrics(&metrics_registry);
+        assert_eq!(
+            departures_from_downloading(&encoded),
+            1,
+            "a deleted download must not stay counted as in flight: {encoded}"
+        );
+    }
+
+    /// `delete_model` failing is swallowed so waiters are still notified, which is
+    /// exactly why the departure has to be gated on the outcome. Booking it anyway
+    /// would report a departure for an entry still sitting in `DOWNLOADING` and
+    /// leave the flow count permanently short during a backend outage.
+    #[tokio::test]
+    async fn a_failed_delete_books_no_departure() {
+        let mut mock = crate::registry::backend::MockRegistryBackend::new();
+        mock.expect_get_models_by_last_used()
+            .once()
+            .returning(|_| Ok(vec![record_with_status("m", ModelStatus::DOWNLOADING)]));
+        mock.expect_delete_model()
+            .once()
+            .returning(|_| Err("backend unreachable".into()));
+
+        let (tracker, metrics_registry) = tracker_with_mock_and_registry(mock);
+        tracker.delete_model_entries("m").await;
+
+        let encoded = encoded_metrics(&metrics_registry);
+        assert_eq!(
+            departures_from_downloading(&encoded),
+            0,
+            "a swallowed delete failure must not book a departure: {encoded}"
+        );
+    }
+
+    /// Ordinary cache eviction clears `DOWNLOADED` entries. Those never occupied
+    /// the in-flight level, so counting them as departures would drive the
+    /// derivation negative on the most common delete there is.
+    #[tokio::test]
+    async fn deleting_a_downloaded_entry_books_no_departure() {
+        let mut mock = crate::registry::backend::MockRegistryBackend::new();
+        mock.expect_get_models_by_last_used()
+            .once()
+            .returning(|_| Ok(vec![record_with_status("m", ModelStatus::DOWNLOADED)]));
+        mock.expect_delete_model().once().returning(|_| Ok(()));
+
+        let (tracker, metrics_registry) = tracker_with_mock_and_registry(mock);
+        let outcome = tracker.delete_model_entries("m").await;
+        assert_eq!(outcome.removed, 1, "the record is still removed");
+
+        let encoded = encoded_metrics(&metrics_registry);
+        assert_eq!(
+            departures_from_downloading(&encoded),
+            0,
+            "a completed model was never in flight: {encoded}"
+        );
+    }
+
+    /// `waiting_count` is the sole input to `mx_state_entries{map="download_waiters"}`,
+    /// the gauge registered as "the OOM early warning". Stuck-at-zero is the failure
+    /// mode that matters: the map leaks, the server heads for OOM, and the metric
+    /// built to warn about it reads flat the whole way. The refresh task's own test
+    /// substitutes a stub closure, so nothing else executes this function.
+    #[tokio::test]
+    async fn waiting_count_tracks_the_waiter_map() {
+        let mut mock = crate::registry::backend::MockRegistryBackend::new();
+        mock.expect_delete_model().once().returning(|_| Ok(()));
+        let tracker = tracker_with_mock(mock);
+        assert_eq!(tracker.waiting_count(), 0);
+
+        let (tx_a, _rx_a) = tokio::sync::mpsc::channel(1);
+        tracker.add_waiting_channel("a", tx_a);
+        let (tx_b, _rx_b) = tokio::sync::mpsc::channel(1);
+        tracker.add_waiting_channel("b", tx_b);
+        // Keyed by model, so a second waiter on "a" does not add an entry.
+        let (tx_a2, _rx_a2) = tokio::sync::mpsc::channel(1);
+        tracker.add_waiting_channel("a", tx_a2);
+        assert_eq!(tracker.waiting_count(), 2);
+
+        tracker.delete_status("a").await;
+        assert_eq!(tracker.waiting_count(), 1);
+    }
+
+    /// The download histogram registers and exports whether or not anything ever
+    /// observes into it, so an empty series is the deceptive failure mode: the
+    /// scrape looks healthy and simply reports zero downloads. This drives the
+    /// real task to its terminal status and checks a sample landed.
+    ///
+    /// `finish_download_claim` returns `Ok(false)` on purpose -- this replica was
+    /// fenced. The bytes were still fetched, so the observation has to happen
+    /// before the fence check; returning `Ok(true)` here would leave that ordering
+    /// unpinned.
+    ///
+    /// No network: the NGC provider rejects a model name that is not
+    /// `org/name/version` before it opens a client or touches the filesystem, so
+    /// the download future resolves to `Err` immediately and the task takes the
+    /// `ERROR` outcome.
+    #[tokio::test]
+    async fn a_finished_download_is_observed_into_the_histogram_even_when_fenced() {
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let done_tx = Mutex::new(Some(done_tx));
+
+        let mut mock = crate::registry::backend::MockRegistryBackend::new();
+        mock.expect_finish_download_claim()
+            .once()
+            .returning(move |_, _, _, status, _| {
+                assert_eq!(status, ModelStatus::ERROR);
+                if let Ok(mut slot) = done_tx.lock()
+                    && let Some(tx) = slot.take()
+                {
+                    let _ = tx.send(());
+                }
+                // Fenced: someone else owns the claim now.
+                Ok(false)
+            });
+
+        let (tracker, metrics_registry) = tracker_with_mock_and_registry(mock);
+        tracker.spawn_download_task(
+            DownloadTarget {
+                model_name: "not-a-valid-ngc-artifact".to_string(),
+                provider: ModelProvider::Ngc,
+                revision: None,
+                ignore_weights: false,
+            },
+            false,
+            "claim-1".to_string(),
+        );
+        done_rx.await.expect("the download task reaches the finish");
+
+        let encoded = encoded_metrics(&metrics_registry);
+        assert!(
+            encoded.contains(r#"mx_download_seconds_count{outcome="error"} 1"#),
+            "a failed download must be observed under its terminal status: {encoded}"
+        );
     }
 
     #[tokio::test]

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -769,6 +769,19 @@ impl ModelDownloadTracker {
         }
     }
 
+    /// Number of models with callers currently waiting on a download.
+    ///
+    /// This map is never evicted wholesale, so its size is the early warning for
+    /// the leak that would eventually OOM the server. A poisoned lock reports the
+    /// recovered length rather than failing: a metric read must not be able to
+    /// take down the download path.
+    pub fn waiting_count(&self) -> usize {
+        match self.waiting_channels.lock() {
+            Ok(waiting) => waiting.len(),
+            Err(poisoned) => poisoned.into_inner().len(),
+        }
+    }
+
     async fn touch_and_log(&self, model_name: &str) {
         if let Err(e) = self.registry.touch_model(model_name).await {
             error!("Failed to touch model {model_name}: {e}");

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -1046,7 +1046,11 @@ impl ModelDownloadTracker {
                 .try_claim_for_download(entry_key, provider, &claim_id, DOWNLOAD_LEASE_DURATION)
                 .await
             {
-                Ok(ClaimOutcome::Claimed) => break (ModelStatus::DOWNLOADING, true),
+                // Both outcomes mean this replica owns the download; they differ
+                // only in cost, which the metrics layer records separately.
+                Ok(ClaimOutcome::Claimed | ClaimOutcome::TookOver) => {
+                    break (ModelStatus::DOWNLOADING, true);
+                }
                 Ok(ClaimOutcome::AlreadyExists(existing)) => {
                     if existing == ModelStatus::DOWNLOADED
                         && attempt < MAX_CLAIM_ATTEMPTS
@@ -1144,7 +1148,10 @@ impl ModelDownloadTracker {
                     .try_claim_for_download(entry_key, provider, &claim_id, DOWNLOAD_LEASE_DURATION)
                     .await
                 {
-                    Ok(ClaimOutcome::Claimed) => {
+                    // A taken-over lease must be re-driven exactly like a fresh
+                    // claim. Letting it fall through instead would leave the entry
+                    // wedged in DOWNLOADING with no owner running.
+                    Ok(ClaimOutcome::Claimed | ClaimOutcome::TookOver) => {
                         self.spawn_download_task(target.clone(), false, claim_id);
                         claim_id = uuid::Uuid::new_v4().to_string();
                     }

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -879,10 +879,19 @@ impl ModelDownloadTracker {
     }
 
     /// Deletes a model record from the registry and clears local waiters.
-    pub async fn delete_status(&self, model_name: &str) {
-        if let Err(e) = self.registry.delete_model(model_name).await {
-            error!("Failed to delete model from registry: {e}");
-        }
+    /// Returns whether the registry record was actually removed.
+    ///
+    /// The error is still swallowed -- callers proceed to notify waiters either
+    /// way -- but the outcome is reported, because a caller that records the
+    /// removal as a lifecycle event must not do so when nothing was removed.
+    pub async fn delete_status(&self, model_name: &str) -> bool {
+        let deleted = match self.registry.delete_model(model_name).await {
+            Ok(()) => true,
+            Err(e) => {
+                error!("Failed to delete model from registry: {e}");
+                false
+            }
+        };
         let mut waiting = match self.waiting_channels.lock() {
             Ok(guard) => guard,
             Err(poisoned) => {
@@ -891,6 +900,7 @@ impl ModelDownloadTracker {
             }
         };
         waiting.remove(model_name);
+        deleted
     }
 
     /// Deletes every registry entry belonging to `model_name`, whatever revision or
@@ -925,11 +935,15 @@ impl ModelDownloadTracker {
                 // arrival booked by the claim is never matched and the flow
                 // accounting stays permanently ahead. The status is already in
                 // hand here, so this costs no extra read.
-                if record.status == ModelStatus::DOWNLOADING {
+                // Only once the record is really gone. delete_model can fail and
+                // is swallowed, and recording first would book a departure for an
+                // entry still sitting in DOWNLOADING -- turning a backend outage
+                // into a permanently understated flow count.
+                let deleted = self.delete_status(&record.model_name).await;
+                if deleted && record.status == ModelStatus::DOWNLOADING {
                     self.registry_metrics
                         .record_transition(StatusLabel::Downloading, StatusLabel::Absent);
                 }
-                self.delete_status(&record.model_name).await;
                 removed = removed.saturating_add(1);
             }
         }

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics::grpc::RpcOutcome;
+use crate::metrics::registry::{DownloadMetrics, StatusLabel};
 use crate::registry::backend::ClaimOutcome;
 use crate::registry::entry_key::EntryKey;
 use crate::registry::state::RegistryManager;
@@ -753,16 +754,18 @@ pub struct ModelDownloadTracker {
     registry: Arc<RegistryManager>,
     /// Maps model names to list of channels waiting for updates on this server replica.
     waiting_channels: WaitingChannels,
+    download_metrics: DownloadMetrics,
 }
 
 const DOWNLOAD_LEASE_DURATION: std::time::Duration = std::time::Duration::from_secs(30);
 const DOWNLOAD_HEARTBEAT_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(10);
 
 impl ModelDownloadTracker {
-    pub fn new(registry: Arc<RegistryManager>) -> Self {
+    pub fn new(registry: Arc<RegistryManager>, download_metrics: DownloadMetrics) -> Self {
         Self {
             registry,
             waiting_channels: Arc::new(Mutex::new(HashMap::new())),
+            download_metrics,
         }
     }
 
@@ -911,6 +914,7 @@ impl ModelDownloadTracker {
     fn spawn_download_task(&self, target: DownloadTarget, retry: bool, claim_id: String) {
         let tracker = self.clone();
         tokio::spawn(async move {
+            let started = std::time::Instant::now();
             let entry_key = target.entry_key();
             let DownloadTarget {
                 model_name,
@@ -979,6 +983,14 @@ impl ModelDownloadTracker {
                     (ModelStatus::ERROR, Some(msg))
                 }
             };
+
+            // Timed from the top of the task, so this is the whole download
+            // rather than the registry write below it. Observed before the fence
+            // check: the bytes were fetched regardless of whether this replica
+            // still owns the right to publish the result.
+            tracker
+                .download_metrics
+                .observe(StatusLabel::from(status), started.elapsed().as_secs_f64());
 
             match tracker
                 .registry
@@ -1268,7 +1280,10 @@ mod tests {
         mock: crate::registry::backend::MockRegistryBackend,
     ) -> ModelDownloadTracker {
         let registry = Arc::new(RegistryManager::with_backend(Arc::new(mock)));
-        ModelDownloadTracker::new(registry)
+        ModelDownloadTracker::new(
+            registry,
+            DownloadMetrics::register(&mut crate::metrics::new_registry()),
+        )
     }
 
     /// Unpinned, full-weight target: its entry key is the bare model name.
@@ -1571,7 +1586,10 @@ mod tests {
         let registry = Arc::new(RegistryManager::with_backend(Arc::new(
             crate::registry::backend::MockRegistryBackend::new(),
         )));
-        ModelServiceImpl::new(Arc::new(ModelDownloadTracker::new(registry)))
+        ModelServiceImpl::new(Arc::new(ModelDownloadTracker::new(
+            registry,
+            DownloadMetrics::register(&mut crate::metrics::new_registry()),
+        )))
     }
 
     #[test]

--- a/modelexpress_server/src/services.rs
+++ b/modelexpress_server/src/services.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics::grpc::RpcOutcome;
-use crate::metrics::registry::{DownloadMetrics, StatusLabel};
+use crate::metrics::registry::{DownloadMetrics, RegistryMetrics, StatusLabel};
 use crate::registry::backend::ClaimOutcome;
 use crate::registry::entry_key::EntryKey;
 use crate::registry::state::RegistryManager;
@@ -755,17 +755,23 @@ pub struct ModelDownloadTracker {
     /// Maps model names to list of channels waiting for updates on this server replica.
     waiting_channels: WaitingChannels,
     download_metrics: DownloadMetrics,
+    registry_metrics: RegistryMetrics,
 }
 
 const DOWNLOAD_LEASE_DURATION: std::time::Duration = std::time::Duration::from_secs(30);
 const DOWNLOAD_HEARTBEAT_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(10);
 
 impl ModelDownloadTracker {
-    pub fn new(registry: Arc<RegistryManager>, download_metrics: DownloadMetrics) -> Self {
+    pub fn new(
+        registry: Arc<RegistryManager>,
+        download_metrics: DownloadMetrics,
+        registry_metrics: RegistryMetrics,
+    ) -> Self {
         Self {
             registry,
             waiting_channels: Arc::new(Mutex::new(HashMap::new())),
             download_metrics,
+            registry_metrics,
         }
     }
 
@@ -912,6 +918,17 @@ impl ModelDownloadTracker {
         let mut removed: usize = 0;
         for record in records {
             if EntryKey::parse(&record.model_name).belongs_to(model_name) {
+                // Deleting a record mid-download is a real exit from DOWNLOADING,
+                // and the only one the claim lifecycle cannot see: once the key
+                // is gone, finish_download_claim finds nothing to fence and
+                // returns false, so it records no departure. Without this the
+                // arrival booked by the claim is never matched and the flow
+                // accounting stays permanently ahead. The status is already in
+                // hand here, so this costs no extra read.
+                if record.status == ModelStatus::DOWNLOADING {
+                    self.registry_metrics
+                        .record_transition(StatusLabel::Downloading, StatusLabel::Absent);
+                }
                 self.delete_status(&record.model_name).await;
                 removed = removed.saturating_add(1);
             }
@@ -1296,6 +1313,7 @@ mod tests {
         ModelDownloadTracker::new(
             registry,
             DownloadMetrics::register(&mut crate::metrics::new_registry()),
+            RegistryMetrics::register(&mut crate::metrics::new_registry()),
         )
     }
 
@@ -1602,6 +1620,7 @@ mod tests {
         ModelServiceImpl::new(Arc::new(ModelDownloadTracker::new(
             registry,
             DownloadMetrics::register(&mut crate::metrics::new_registry()),
+            RegistryMetrics::register(&mut crate::metrics::new_registry()),
         )))
     }
 

--- a/workspace-tests/tests/registry_backend_redis.rs
+++ b/workspace-tests/tests/registry_backend_redis.rs
@@ -143,16 +143,22 @@ async fn concurrent_claims_yield_single_winner() {
     // assertion that guarantees multi-replica servers never double-download.
     let mut winners = 0;
     let mut observers = 0;
+    let mut takeovers = 0;
     for h in handles {
         let outcome = h.await.expect("spawn join").expect("claim result");
         match outcome {
             ClaimOutcome::Claimed => winners += 1,
+            ClaimOutcome::TookOver => takeovers += 1,
             ClaimOutcome::AlreadyExists(s) => {
                 assert_eq!(s, ModelStatus::DOWNLOADING);
                 observers += 1;
             }
         }
     }
+    // The key is fresh and the lease outlives the test, so nothing can expire:
+    // every owner here must be a first claim. A takeover would mean the lease
+    // check is not holding under contention.
+    assert_eq!(takeovers, 0, "no lease can expire during this test");
     assert_eq!(winners, 1, "exactly one replica must claim");
     assert_eq!(observers, 7, "the other seven must observe");
 


### PR DESCRIPTION
## Summary

Step 4 of the six in #645, both halves: export the lifecycle ModelExpress already
tracks and never reports.

**Server** — makes two things visible that have no signal today: *are we
re-downloading models* (a dead downloader's lease expires and another replica
pulls the bytes again), and *are models stuck in `DOWNLOADING`* with no owner.

**Client** — NIXL agent health, plus two silent successes in the transfer path
that are correctness signals rather than observability: a receive that completes
and reports success while local-only tensors keep their **dummy values**, and one
that reports success having moved nothing.

## Two code fixes come first

Both produced a *wrong* answer today, not a missing one.

**A takeover looked like a first download.** `CLAIM_LUA` returned the same
sentinel whether it created the record or took over an expired lease.
`3c877e2c` adds `ClaimOutcome::TookOver` — Redis gets a second sentinel; memory
and Kubernetes already computed the distinction and discarded it.

⚠️ **The risk in that commit:** both variants still mean ownership, so callers
match `Claimed | TookOver`. An arm that doesn't re-drive the download would wedge
the entry in `DOWNLOADING` with nobody running. Adding the variant broke exactly
the two production matches, so the compiler made it impossible to miss one.

**Cache evictions reported the wrong reason.** Both report sites hard-coded
`TimeThreshold`, so models evicted under the **count limit** were reported as
having aged out. The reason now travels per candidate — one pass can evict for
both reasons.

## Families

| Family | Type | Labels |
| --- | --- | --- |
| `mx_registry_status_transitions_total` | Counter | `from`, `to` |
| `mx_download_claims_total` | Counter | `result` |
| `mx_download_lease_refresh_total` | Counter | `result` |
| `mx_download_seconds` | Histogram | `outcome` |
| `mx_cache_evictions_total` | Counter | `reason` |
| `mx_registry_entries` | Gauge | `status` |
| `mx_state_entries` | Gauge | `map` |
| `mx_task_last_success_timestamp_seconds` | Gauge | `task` |

Transitions hang off the claim lifecycle rather than `set_status`, which cannot
supply a `from`: its Lua returns 1 without reading the prior status, and the
in-memory backend overwrites without capturing it.

**Downloads in flight** are a derivation, and it balances only because a takeover
arrives *from* `downloading` (not `absent`) and a fenced `finish_download_claim`
records no departure. Both have tests; either one backwards and the count drifts
in one direction forever.

```promql
sum(mx_registry_status_transitions_total{to="downloading"})
  - sum(mx_registry_status_transitions_total{from="downloading"})
```

## Gauges are refreshed, not scrape-collected

Counting registry entries walks the keyspace — `SCAN` + pipelined per-key fetch on
Redis, an **unpaginated** list of every `ModelCacheEntry` on Kubernetes — so a
scrape-time collector would hit the metadata store every 15s. A background task on
`MX_REGISTRY_STATS_INTERVAL_SECS` (default 60) writes them instead.

**Deviates from the design doc**, which says to reuse the cache-eviction interval:
that defaults to *one hour* and is skipped entirely when eviction is disabled,
leaving the gauges permanently absent — indistinguishable from a crashed exporter.

A failed pass keeps prior values and does not stamp the heartbeat, so staleness is
the signal rather than a misleading zero:
`time() - mx_task_last_success_timestamp_seconds{task="registry_stats_refresh"} > 300`.

## Not included

**Refit stage timings**, step 4's fourth named deliverable. The step is framed as
exporting what is "measured today and thrown away", which holds for the other
three but not this one: `RefitTimingRecorder` is **never constructed in
production**. Every reference outside tests is a re-export; nothing calls
`span()` or `add_duration()`, and no deployment emits the `MX_REFIT_TIMING`
record — so its exit criterion, "refit stage sums match the existing JSON log
record", has no record to match against.

Doing it means instrumenting the live refit path, which is new measurement rather
than export, and carries its own prerequisite: `add_duration` accumulates per
stage, so the histogram has to be fed from inside the span rather than from
`as_dict()`. Its own PR.

`mx_cache_bytes` and `mx_download_bytes_total` — neither is "already computed"
either (`get_disk_space_info` is a stub returning `None`). They need byte
accounting in the download path, which is its own work.

## Testing

294 server unit tests, clippy `-D warnings` clean, workspace green, no network I/O
in tests. Notable assertions:

- the in-flight derivation balances across a fresh and a taken-over download;
- the count-limit eviction path asserts `CountLimit` — the assertion that would
  have caught the original bug;
- a failed refresh publishes the in-process gauge but does **not** stamp the
  heartbeat;
- the 8-way concurrency test asserts `takeovers == 0` on a fresh key.

Two existing lease tests changed *value* rather than being added — both already
had `.expect("takeover")` above an assertion saying `Claimed`.

## Client: NIXL health

| Family | Type | Labels |
| --- | --- | --- |
| `mx_nixl_data_plane_errors_total` | Counter | `scheme`, `kind` |
| `mx_nixl_receive_total` | Counter | `scheme`, `result` |

`_data_plane_error` is what `is_healthy()` uses to stop advertising a wedged
agent, but the reason had only ever been a formatted string. It is now classified
at each of the **four** assignment sites as `timeout` or `status_error` — at the
sites, because classifying at the consumer would mean parsing prose into a label
and the domain would grow with the wording. The split matters: `status_error` is
NIXL reporting a failed transfer, while `timeout` is NIXL reporting *nothing at
all*, since a wedged queue pair neither completes nor transitions to `ERR`.

Both the batch and single wait paths are covered. They are near-duplicates, and
the refit reshard path reaches health **exclusively** through the batch one.

`mx_nixl_receive_total` partitions every receive:

| result | meaning |
| --- | --- |
| `complete` | every locally registered tensor was filled |
| `partial` | source/local name mismatch outside strict mode — completes and reports success, but local-only tensors keep their dummy values |
| `empty` | no tensors matched; success, having moved nothing |
| `rejected` | strict mode refused and raised rather than completing |

`partial` is the one that matters: fleet-wide manifest drift surfaces later as
wrong model output rather than as a failure. It does not return early — it falls
through to the same return as a clean transfer — so the outcome is downgraded and
recorded once at the end rather than at the warning, which would count the same
receive twice.

Counters rather than a health gauge: under multiprocess mode the live gauge
variants depend on `mark_process_dead`, which never runs on SIGKILL — exactly what
a wedged agent produces.

## Compatibility

Additive on the metrics side. `ClaimOutcome` is source-breaking for out-of-tree
matchers, which is the point — a non-exhaustive match is a compile error rather
than a silently dropped takeover. `select_for_eviction` returns
`Vec<EvictionCandidate>` instead of `Vec<String>`; one production caller.

`docs/METRICS.md` and `docs/ARCHITECTURE.md` updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Prometheus metrics for gRPC requests, backend operations, cache activity, registry workflows, downloads, and background tasks.
  * Added configurable registry statistics refresh intervals, defaulting to 60 seconds.
  * Added health-service and unauthenticated-request coverage to server metrics.
  * Added distinct reporting for fresh download claims and expired-lease takeovers.

* **Documentation**
  * Expanded architecture and metrics documentation with available metrics, labels, outcomes, and refresh behavior.

* **Bug Fixes**
  * Improved reporting of in-band API failures, cancellations, backend errors, and degraded cleanup outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


