### PR TITLE
fix(vllm): support DeepSeek V4 finalization in v0.26

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -27,11 +27,18 @@ from ...tensor_utils import adopt_hidden_tensors, capture_tensor_attrs, collect_
 
 logger = logging.getLogger("modelexpress.engines.vllm.adapter")
 
-_VLLM_POST_LOAD_FINALIZER_NAMES = (
-    # DeepSeek V4 finalizes MegaMoE expert layouts from load_weights().
-    # The RDMA target path uses vLLM's dummy loader, which bypasses the
-    # model load_weights() method, so mirror the model-level hook here.
+_VLLM_PRE_RDMA_FINALIZER_NAMES = (
+    # MegaMoE changes the model's tensor layout. It must run before tensor
+    # discovery and RDMA registration so the target exposes the same regions
+    # that the source published.
     "finalize_mega_moe_weights",
+)
+
+_VLLM_POST_RDMA_FINALIZER_NAMES = (
+    # DeepSeek V4 derives this tensor from hc_attn_fn. Unlike MegaMoE, it is
+    # target-local and is not sent by RDMA, so it must be built only after
+    # hc_attn_fn has received its real weight values.
+    "finalize_mhc_broadcast_weights",
 )
 
 # MTP draft weights live under an "mtp." prefix in the shared checkpoint. The
@@ -203,8 +210,16 @@ class VllmAdapter(EngineAdapter):
         # post-load processing. RDMA targets use the dummy loader, so run
         # those hooks before receiving tensors to expose the same target
         # tensor layout and hidden buffers that the source published.
-        result = self._finalize_model_specific_weights(result)
+        result = self._finalize_model_specific_weights(
+            result, _VLLM_PRE_RDMA_FINALIZER_NAMES
+        )
         return self._process_weights_after_loading(result)
+
+    def after_rdma_receive(self, result: LoadResult) -> LoadResult:
+        """Build target-local tensors derived from the received weights."""
+        return self._finalize_model_specific_weights(
+            result, _VLLM_POST_RDMA_FINALIZER_NAMES
+        )
 
     def apply_weight_iter(
         self,
@@ -360,8 +375,9 @@ class VllmAdapter(EngineAdapter):
     def _finalize_model_specific_weights(
         self,
         result: LoadResult,
+        finalizer_names: tuple[str, ...],
     ) -> LoadResult:
-        """Run model finalizers that vLLM normally calls in load_weights()."""
+        """Run selected model finalizers that vLLM normally calls in load_weights()."""
 
         if result.model is None:
             raise RuntimeError("vLLM RDMA post-load processing requires result.model")
@@ -379,13 +395,13 @@ class VllmAdapter(EngineAdapter):
                     continue
 
                 module_finalized = False
-                for finalizer_name in _VLLM_POST_LOAD_FINALIZER_NAMES:
+                for finalizer_name in finalizer_names:
                     finalizer = getattr(module, finalizer_name, None)
                     if not callable(finalizer):
                         continue
 
                     logger.info(
-                        "Running vLLM model-specific post-load finalizer %s on %s",
+                        "Running vLLM model finalizer %s on %s",
                         finalizer_name,
                         name or type(module).__name__,
                     )

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -163,7 +163,7 @@ def test_build_vllm_load_context_uses_node_rank_as_node_rank(monkeypatch):
     assert ctx.node_rank == 1
 
 
-def test_before_rdma_receive_runs_model_specific_finalizers(monkeypatch):
+def test_before_rdma_receive_runs_layout_finalizers(monkeypatch):
     events = []
 
     def process_weights_after_loading(model, model_config, target_device):
@@ -182,11 +182,27 @@ def test_before_rdma_receive_runs_model_specific_finalizers(monkeypatch):
     ]
 
 
-def test_finalize_model_specific_weights_requires_model():
+def test_after_rdma_receive_runs_derived_weight_finalizers(monkeypatch):
+    events = []
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    model = _TopLevelModel(events)
+
+    result = adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+    assert result.model is model
+    assert events == [
+        ("finalize", "model", "finalize_mhc_broadcast_weights"),
+    ]
+
+
+def test_finalize_model_specific_weights_requires_explicit_names_and_model():
     adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
 
-    with pytest.raises(RuntimeError, match="RDMA post-load processing"):
+    with pytest.raises(TypeError, match="finalizer_names"):
         adapter._finalize_model_specific_weights(LoadResult(value=object()))
+
+    with pytest.raises(RuntimeError, match="RDMA post-load processing"):
+        adapter._finalize_model_specific_weights(LoadResult(value=object()), ())
 
 
 def test_after_weight_iter_load_does_not_rerun_model_specific_finalizers(monkeypatch):
@@ -273,6 +289,11 @@ class _MegaMoeModel(torch.nn.Module):
 
     def finalize_mega_moe_weights(self) -> None:
         self.events.append(("finalize", "model", "finalize_mega_moe_weights"))
+
+    def finalize_mhc_broadcast_weights(self) -> None:
+        self.events.append(
+            ("finalize", "model", "finalize_mhc_broadcast_weights")
+        )
 
 
 class _MegaMoeLayer(torch.nn.Module):

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -195,6 +195,41 @@ def test_after_rdma_receive_runs_derived_weight_finalizers(monkeypatch):
     ]
 
 
+def test_rdma_lifecycle_discovers_prepared_tensors_and_finalizes_received_weights(
+    monkeypatch,
+    mock_accelerator_backend_cls,
+):
+    """RDMA discovers the pre-finalized layout before applying source weights."""
+    events = []
+
+    def process_weights_after_loading(model, model_config, target_device):
+        events.append(("process", target_device))
+
+    _stub_vllm_process_weights_after_loading(monkeypatch, process_weights_after_loading)
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(torch_device_type="cpu")
+    model = _RdmaLifecycleTopLevelModel(events)
+    result = LoadResult(value=model, model=model)
+
+    result = adapter.before_rdma_receive(result)
+    tensors = adapter.discover_tensors(result)
+    events.append(("discover", sorted(tensors)))
+
+    # Simulate RDMA applying the source tensor into the region registered above.
+    tensors["model.hc_attn_fn"].fill_(7)
+    events.append(("rdma_receive", 7))
+    result = adapter.after_rdma_receive(result)
+
+    assert result.model is model
+    assert events == [
+        ("finalize", "model", "finalize_mega_moe_weights"),
+        ("process", torch.device("cpu")),
+        ("discover", ["model.hc_attn_fn"]),
+        ("rdma_receive", 7),
+        ("finalize", "model", "finalize_mhc_broadcast_weights", 7),
+    ]
+
+
 def test_finalize_model_specific_weights_requires_explicit_names_and_model():
     adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
 
@@ -303,6 +338,32 @@ class _MegaMoeLayer(torch.nn.Module):
 
     def finalize_mega_moe_weights(self) -> None:
         self.events.append(("finalize", "layer", "finalize_mega_moe_weights"))
+
+
+class _RdmaLifecycleTopLevelModel(torch.nn.Module):
+    def __init__(self, events):
+        super().__init__()
+        self.model = _RdmaLifecycleModel(events)
+
+
+class _RdmaLifecycleModel(torch.nn.Module):
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+        self.register_buffer("hc_attn_fn", torch.zeros(1))
+
+    def finalize_mega_moe_weights(self) -> None:
+        self.events.append(("finalize", "model", "finalize_mega_moe_weights"))
+
+    def finalize_mhc_broadcast_weights(self) -> None:
+        self.events.append(
+            (
+                "finalize",
+                "model",
+                "finalize_mhc_broadcast_weights",
+                int(self.hc_attn_fn.item()),
+            )
+        )
 
 
 class _StandaloneFinalizer(torch.nn.Module):


### PR DESCRIPTION
vLLM v0.26 adds finalize_mhc_broadcast_weights() after finalize_mega_moe_weights() in DeepSeek V4 loading. RDMA targets bypass model.load_weights() through the dummy loader.

Run the MegaMoE layout finalizer before RDMA registration so source and target expose the same tensors. Run the MHC broadcast finalizer after RDMA receives the real hc_attn_fn weights, because the derived broadcast tensor is target-local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading for vLLM by applying model-specific weight processing at the correct stage of RDMA transfer.
  * Improved support for MegaMoE and DeepSeek V4 models, including broadcast-weight handling.

* **Tests**
  * Expanded validation of model weight finalization across pre- and post-RDMA processing.
  * Added coverage for broadcast-weight finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->