### PR TITLE
fix(artifacts): skip symlinks when sealing cache artifacts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1082,6 +1082,12 @@ graph TD
 7. **Target becomes source**: After receiving weights or installing a cache artifact, publishes own metadata and starts its own heartbeat
 8. **Stale detection**: Server-side reaper marks workers STALE if `updated_at` > 90s old; `ListSources(READY)` also applies this heartbeat freshness check at query time so expired READY records are not returned while waiting for the next reaper pass. GC deletes STALE workers after 1 hour
 
+Tarred cache artifacts carry regular files and directories only. The source
+side enumerates members explicitly and hands tar that list, so nothing else can
+enter the archive regardless of how a cache directory is laid out; the target
+side enforces the same invariant in `_validate_tar_members` before extraction.
+Symlinks are skipped at packaging time (see [`DEPLOYMENT.md`](DEPLOYMENT.md#p2p-metadata-exchange)).
+
 Cache artifact checksums protect transfer integrity but do not authenticate the
 source or attest the contents. TorchInductor, Triton, DeepGEMM, TileLang, CuTe
 DSL, and FlashInfer caches may

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -752,6 +752,18 @@ vLLM publishes torch compile (`VLLM_CACHE_ROOT/torch_compile_cache`), Triton (`T
 
 SGLang's NIXL loader publishes torch compile (`TORCHINDUCTOR_CACHE_DIR`, or PyTorch Inductor's runtime `cache_dir()`), Triton (`TRITON_CACHE_DIR`, or `~/.triton/cache`), TVM-FFI (`TVM_FFI_CACHE_DIR`, or `~/.cache/tvm-ffi`), DeepGEMM (`SGLANG_DG_CACHE_DIR`, or `~/.cache/deep_gemm`), TileLang (`TILELANG_CACHE_DIR`, or `~/.tilelang/cache`), CuTe DSL (`CUTE_DSL_CACHE_DIR`, or `$TMPDIR/<user>/cutlass_python_cache`), and FlashInfer (`FLASHINFER_WORKSPACE_BASE/.cache/flashinfer`, or `~/.cache/flashinfer`) caches. The FlashInfer artifact also includes SGLang's persistent autotune directory from `SGLANG_CACHE_DIR/flashinfer/autotune`, or `~/.cache/sglang/flashinfer/autotune` when unset. SGLang runs that autotuner only for eligible FlashInfer MoE or FP4 backends; DeepGEMM + DeepEP does not produce an autotune cache. SGLang TransferEngine transport currently remains weight-only for ModelExpress artifact transfer because cache artifact bytes move through the NIXL artifact path.
 
+Artifacts are sealed as tar archives holding regular files and directories
+only. Symlinks in a cache directory are left out of the archive rather than
+followed or copied verbatim, because engines treat them as derived state and
+rebuild them on demand: FlashInfer, for example, relinks each
+`trtllmGen_*_export` include path to its cubin directory on every JIT module
+lookup, so a link carried across pods would be deleted and recreated anyway.
+Skipping one costs the link entry alone -- neither the packaging walk nor tar
+descends through a symlinked directory, so no subtree is lost. A link that
+resolves inside the cache root is logged at debug (its target is archived under
+its real path); a link that leaves the root or dangles is logged as a warning
+naming the paths. Symlinks never fail an artifact publish.
+
 #### Pairing workers by compile configuration
 
 A torch compile cache is only reusable by a worker whose compile configuration

--- a/modelexpress_client/python/modelexpress/metadata/artifact_transfer.py
+++ b/modelexpress_client/python/modelexpress/metadata/artifact_transfer.py
@@ -9,6 +9,7 @@ import logging
 import os
 import subprocess
 import tarfile
+import tempfile
 import threading
 import time
 from concurrent import futures
@@ -48,6 +49,7 @@ _DEFAULT_MAX_INFLIGHT_CHUNKS = 4
 _DEFAULT_LEASE_TTL_SECONDS = 300.0
 _RESOURCE_EXHAUSTED_PREPARE_ATTEMPTS = 3
 _RESOURCE_EXHAUSTED_PREPARE_DELAY_SECONDS = 0.05
+_SKIPPED_ENTRY_PREVIEW = 5
 
 
 @dataclass
@@ -233,8 +235,9 @@ class TarredP2PArtifactTransfer(P2PArtifactTransfer):
                 with tarfile.open(tar_path, "w"):
                     pass
                 continue
-            _reject_symlinked_source_entries(resolved_source)
-            _run_tar(["-cf", str(tar_path), "-C", str(resolved_source), "."])
+            entries, skipped = _tar_source_entries(resolved_source)
+            _log_skipped_entries(tar_name, skipped)
+            _write_tar_from_entries(tar_path, resolved_source, entries)
 
         manifest = build_artifact_manifest(
             bundle_path,
@@ -1021,10 +1024,125 @@ def _close_target_buffers(
             logger.warning("Failed to deregister target artifact buffer", exc_info=True)
 
 
-def _reject_symlinked_source_entries(source_root: Path) -> None:
-    for path in source_root.rglob("*"):
-        if path.is_symlink():
-            raise ValueError(f"tarred artifact source contains symlink: {path}")
+@dataclass(frozen=True)
+class _SkippedEntry:
+    path: Path
+    kind: str
+    detail: str
+
+
+def _tar_source_entries(source_root: Path) -> tuple[bytes, list[_SkippedEntry]]:
+    """Enumerate the archive members under source_root for tar --null -T.
+
+    Only regular files and directories are listed, which keeps the
+    file-or-directory invariant that _validate_tar_members enforces on the
+    receiving side. Anything else is reported back so the caller can log it.
+
+    Symlinks are left out rather than followed or copied verbatim: in the JIT
+    caches this packs they are derived state that the engine rebuilds. Both
+    this walk and tar stop at a symlinked directory, so dropping one costs the
+    link entry alone, never a subtree tar would otherwise have archived.
+    """
+    names: list[str] = []
+    skipped: list[_SkippedEntry] = []
+    for dirpath, dirnames, filenames in os.walk(source_root, followlinks=False):
+        directory = Path(dirpath)
+        names.append(_tar_member_name(directory, source_root))
+        kept: list[str] = []
+        for name in sorted(dirnames):
+            path = directory / name
+            if path.is_symlink():
+                skipped.append(_classify_skipped_entry(path, source_root))
+                continue
+            kept.append(name)
+        dirnames[:] = kept
+        for name in sorted(filenames):
+            path = directory / name
+            if path.is_symlink() or not path.is_file():
+                skipped.append(_classify_skipped_entry(path, source_root))
+                continue
+            names.append(_tar_member_name(path, source_root))
+    return b"\0".join(name.encode() for name in names) + b"\0", skipped
+
+
+def _tar_member_name(path: Path, source_root: Path) -> str:
+    relative = path.relative_to(source_root).as_posix()
+    return "./" if relative == "." else f"./{relative}"
+
+
+def _classify_skipped_entry(path: Path, source_root: Path) -> _SkippedEntry:
+    if not path.is_symlink():
+        return _SkippedEntry(path=path, kind="not a file or directory", detail="")
+    try:
+        detail = os.readlink(path)
+    except OSError:
+        detail = ""
+    resolved = path.resolve()
+    if not resolved.exists():
+        return _SkippedEntry(path=path, kind="broken symlink", detail=detail)
+    if resolved.is_relative_to(source_root):
+        return _SkippedEntry(path=path, kind="internal symlink", detail=detail)
+    return _SkippedEntry(path=path, kind="external symlink", detail=detail)
+
+
+def _log_skipped_entries(archive_name: str, skipped: list[_SkippedEntry]) -> None:
+    if not skipped:
+        return
+    internal = [entry for entry in skipped if entry.kind == "internal symlink"]
+    if internal:
+        logger.debug(
+            "Artifact archive %s skipped %d symlink(s) resolving inside the "
+            "source root; their targets are archived under their real paths",
+            archive_name,
+            len(internal),
+        )
+    notable = [entry for entry in skipped if entry.kind != "internal symlink"]
+    if not notable:
+        return
+    preview = ", ".join(
+        f"{entry.path} ({entry.kind}{f' -> {entry.detail}' if entry.detail else ''})"
+        for entry in notable[:_SKIPPED_ENTRY_PREVIEW]
+    )
+    remaining = len(notable) - _SKIPPED_ENTRY_PREVIEW
+    if remaining > 0:
+        preview = f"{preview}, ... {remaining} more"
+    logger.warning(
+        "Artifact archive %s skipped %d path(s) that a tar archive cannot "
+        "carry as a file or directory; engines that need them rebuild them on "
+        "demand: %s",
+        archive_name,
+        len(notable),
+        preview,
+    )
+
+
+def _write_tar_from_entries(
+    tar_path: Path,
+    source_root: Path,
+    entries: bytes,
+) -> None:
+    with tempfile.NamedTemporaryFile(
+        prefix="mx-artifact-",
+        suffix=".members",
+        delete=False,
+    ) as handle:
+        handle.write(entries)
+        member_list = Path(handle.name)
+    try:
+        _run_tar(
+            [
+                "-cf",
+                str(tar_path),
+                "-C",
+                str(source_root),
+                "--null",
+                "--no-recursion",
+                "-T",
+                str(member_list),
+            ]
+        )
+    finally:
+        member_list.unlink(missing_ok=True)
 
 
 def _validate_tar_members(tar_path: Path) -> None:

--- a/modelexpress_client/python/tests/test_artifact_transfer.py
+++ b/modelexpress_client/python/tests/test_artifact_transfer.py
@@ -592,20 +592,89 @@ def test_tarred_p2p_artifact_transfer_rejects_target_bundle_symlink(tmp_path):
     assert outside.read_bytes() == b"keep-me"
 
 
-def test_tarred_p2p_artifact_transfer_rejects_symlink(tmp_path):
+def _prepare_and_install(source, target, bundle):
+    transfer = torch_compile_cache_artifact_transfer(source, target, bundle)
+    installed = transfer.prepare_source()
+    transfer.install(
+        p2p_pb2.GetArtifactManifestHeaderResponse(files=installed.manifest.files)
+    )
+    return transfer
+
+
+def test_tarred_p2p_artifact_transfer_skips_internal_symlink(tmp_path):
     source = tmp_path / "source"
     source.mkdir()
-    target = source / "target.txt"
-    target.write_text("target")
-    (source / "link.txt").symlink_to(target)
-    transfer = torch_compile_cache_artifact_transfer(
-        source,
-        tmp_path / "target",
-        tmp_path / "bundle",
-    )
+    (source / "target.txt").write_text("target")
+    (source / "link.txt").symlink_to(source / "target.txt")
+    target = tmp_path / "target"
 
-    with pytest.raises(ValueError, match="symlink"):
-        transfer.prepare_source()
+    _prepare_and_install(source, target, tmp_path / "bundle")
+
+    assert (target / "target.txt").read_text() == "target"
+    assert not (target / "link.txt").exists()
+
+
+def test_tarred_p2p_artifact_transfer_skips_external_symlink(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="modelexpress.metadata.artifact_transfer")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "header.h").write_text("outside")
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "kernel.so").write_bytes(b"compiled")
+    (source / "include").symlink_to(outside, target_is_directory=True)
+    target = tmp_path / "target"
+
+    _prepare_and_install(source, target, tmp_path / "bundle")
+
+    assert (target / "kernel.so").read_bytes() == b"compiled"
+    assert not (target / "include").exists()
+    assert (outside / "header.h").read_text() == "outside"
+    assert "external symlink" in caplog.text
+
+
+def test_tarred_p2p_artifact_transfer_survives_broken_symlink(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="modelexpress.metadata.artifact_transfer")
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "kernel.so").write_bytes(b"compiled")
+    (source / "dangling").symlink_to(tmp_path / "never-created")
+    target = tmp_path / "target"
+
+    _prepare_and_install(source, target, tmp_path / "bundle")
+
+    assert (target / "kernel.so").read_bytes() == b"compiled"
+    assert not (target / "dangling").is_symlink()
+    assert "broken symlink" in caplog.text
+
+
+def test_tarred_p2p_artifact_transfer_archives_awkward_member_names(tmp_path):
+    source = tmp_path / "source"
+    (source / "gen").mkdir(parents=True)
+    (source / "gen" / "config[sm100].inc").write_text("kept")
+    (source / "gen" / "new\nline.cu").write_text("also kept")
+    (source / "gen" / "link[sm100]").symlink_to(tmp_path / "never-created")
+    (source / "gen" / "new\nline_link").symlink_to(tmp_path / "never-created")
+    target = tmp_path / "target"
+
+    _prepare_and_install(source, target, tmp_path / "bundle")
+
+    assert (target / "gen" / "config[sm100].inc").read_text() == "kept"
+    assert (target / "gen" / "new\nline.cu").read_text() == "also kept"
+    assert not (target / "gen" / "link[sm100]").is_symlink()
+    assert not (target / "gen" / "new\nline_link").is_symlink()
+
+
+def test_tarred_p2p_artifact_transfer_keeps_empty_directories(tmp_path):
+    source = tmp_path / "source"
+    (source / "cached_ops" / "tmp").mkdir(parents=True)
+    (source / "cached_ops" / "kernel.so").write_bytes(b"compiled")
+    target = tmp_path / "target"
+
+    _prepare_and_install(source, target, tmp_path / "bundle")
+
+    assert (target / "cached_ops" / "tmp").is_dir()
+    assert (target / "cached_ops" / "kernel.so").read_bytes() == b"compiled"
 
 
 def test_extract_tarred_artifact_rejects_unsafe_member(tmp_path):


### PR DESCRIPTION
## Problem

Artifact packaging raised on the first symlink found under a cache root:

```python
def _reject_symlinked_source_entries(source_root: Path) -> None:
    for path in source_root.rglob("*"):
        if path.is_symlink():
            raise ValueError(f"tarred artifact source contains symlink: {path}")
```

A user running Nemotron-3-Ultra on B200 (vLLM 0.27.1, disagg) hit this and read it as a harmless warning. It is not: `prepare_source()` throws, `PublisherThread` retries every 5s until `MX_ARTIFACT_READY_TIMEOUT_SECS` (default 1800s) and gives up, so **that worker never publishes its FlashInfer artifact at all** — the JIT-compiled modules the artifact exists to share go with it, and every decode worker recompiles them itself. Weight transfer is unaffected (140 GB in 8.84s in their logs); this is only the artifact path.

```
WARNING [publisher.py:278] [Worker 2] Source publish attempt failed (121s elapsed,
timeout=1800s), will retry next tick: tarred artifact source contains symlink:
~/.cache/flashinfer/0.6.16.post3/100a/generated/trtllm_export/fused_moe_trtllm_sm100/
flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export
```

This is not an edge case on Blackwell. FlashInfer's trtllm-gen kernels ship as
prebuilt cubins plus headers stored content-addressed under a hash directory,
while generated `.cu` files include them from a fixed layout, so
`jit/fused_moe.py` bridges the two with a symlink on every JIT module lookup.
Any SM100 worker using trtllm-gen fused MoE hits it.

## Fix

Enumerate archive members explicitly and hand tar that list, instead of letting
tar walk the tree:

```
tar -cf <tar> -C <src> --null --no-recursion -T <member list>
```

Symlinks are left out of the list. They are derived state that engines rebuild:
FlashInfer's `ensure_symlink()` removes whatever sits at the path (including a
real directory, via `shutil.rmtree`) and recreates the link, and it runs before
`build_and_load()`'s cache-hit check, so it executes in every process that
touches the op. A link carried across pods would be deleted and recreated
anyway.

Skipping a symlink costs the link entry alone. Neither `os.walk(followlinks=False)`
nor tar descends through a symlinked directory, so no subtree that tar would
otherwise have archived is lost.

Logging is graded and never fatal: a link resolving inside the cache root logs
at debug (its target is archived under its real path); a link that leaves the
root or dangles logs one warning naming the paths.

### Why an explicit member list rather than `--exclude`

tar reads exclude patterns as globs, so an entry whose name contains glob
metacharacters slips past its own exclusion:

```
$ ln -s /nowhere 'src/gen/tricky[a]link'
$ tar -cf o.tar -C src --exclude='./gen/tricky[a]link' .
$ tar -tf o.tar
./gen/tricky[a]link          # not excluded
```

That symlink would then reach the target and fail `_validate_tar_members`
*after* a full transfer, turning a source-side problem into a target-side one.
`--exclude-from` fixes the metacharacter case but still cannot express a name
containing a newline (`--null` only applies to `-T`). An explicit member list
is an allowlist: nothing that is not listed can enter the archive, whatever it
is named. That keeps the file-or-directory invariant on the source side, where
it can be enforced, and leaves the extraction path untouched — no new
validation code, no new attack surface.

### Other approaches considered

- **`tar -h` (dereference).** The bytes would be deleted by the target's
  `ensure_symlink()`, so it is pure waste. It also breaks on dangling links
  (tar exits 1) and on symlink cycles — GNU tar 1.35 segfaults on
  `a/loop -> ../a` after expanding 5625 levels.
- **Storing symlinks as symlinks.** Requires new linkname validation on the
  extraction side for zero benefit, since the target rebuilds the link itself.

Non-regular files (fifo, socket, device nodes) are skipped the same way. They
serve the same invariant: previously the source accepted them and the target
rejected them after a full transfer.

## Testing

Replaces `test_tarred_p2p_artifact_transfer_rejects_symlink` with five cases:
internal symlink, external symlink, broken symlink, awkward member names
(`config[sm100].inc` and a name containing a newline, alongside symlinks with
the same shapes), and empty-directory preservation.

`test_artifact_transfer.py`, `test_vllm_artifacts.py`, `test_sglang_artifacts.py`,
`test_artifact_health_url.py`: 119 passed.

Also verified end to end against a reproduction of the reported layout (cubin
include tree under site-packages, cache under
`0.6.16.post3/100a/generated/trtllm_export/fused_moe_trtllm_sm100/...`): publish
succeeds with one warning naming the skipped link, and the target receives
`cached_ops/fused_moe_trtllm_sm100/module.so`, the empty `cached_ops/tmp`, and
the link's parent directory.

Pre-existing unrelated failures in `test_vmm_*` (the `modelexpress.vmm._alloc_ext`
C extension is not built in this environment) reproduce identically with these
changes stashed.

## Behavior change

Symlinks under a cache root are no longer an error for any artifact type. The
worst case is a target cache missing one derived entry, which degrades to a
recompile — these are all regenerable JIT caches. The current worst case is the
entire cache failing to publish, every time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Artifact packaging now safely excludes symlinks and unsupported entries while preserving regular files and empty directories.
  - Archive creation supports filenames containing brackets or newlines.

- **Bug Fixes**
  - Artifact publication no longer fails when source directories contain symlinks.
  - Broken and external symlinks are skipped with appropriate warnings.

- **Documentation**
  - Documented artifact packaging, extraction safeguards, and symlink handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->