### PR TITLE
feat(rl): integrate vLLM weight transfer engine

### DIFF
--- a/examples/rl/dynamo_vllm_refit/Dockerfile.vllm
+++ b/examples/rl/dynamo_vllm_refit/Dockerfile.vllm
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Current vLLM nightly, built from a9a17e7095a66ef6c6685a1c7ddd657781a78d3c.
+# It contains the post-v0.27.1 RL Control service required by Dynamo main.
+ARG VLLM_IMAGE=vllm/vllm-openai@sha256:3578c1fa6a9676e1de068b9d75c777cc865d251fadfbe6175ae82278739c6674
+FROM ${VLLM_IMAGE}
+
+COPY modelexpress_client/python /opt/modelexpress
+RUN python3 -m pip install --no-cache-dir --no-deps /opt/modelexpress

--- a/examples/rl/dynamo_vllm_refit/README.md
+++ b/examples/rl/dynamo_vllm_refit/README.md
@@ -1,0 +1,87 @@
+# Dynamo + vLLM ModelExpress refit
+
+This example validates the complete inference-side lifecycle designed for
+ModelExpress `WeightVersion` updates:
+
+1. A GPU trainer job loads `Qwen/Qwen3-0.6B`, publishes one immutable full-weight
+   version through `modelexpress_rl`, and waits as the NIXL source.
+2. Dynamo discovers the vLLM worker and pauses generation.
+3. vLLM invokes the `modelexpress` weight-transfer backend for initialization,
+   `start_weight_update`, `update_weights`, and `finish_weight_update`.
+4. The RL coordinator verifies the exact UID on every worker, resumes generation,
+   and compares deterministic inference before and after the refit.
+
+The DGD uses the current `nvidia.com/v1beta1` schema and Dynamo's native Rust
+vLLM sidecar. Dynamo main is pinned because the weight-transfer route forwarding
+is newer than the latest v1.4.1 release. The engine image pins the current vLLM
+nightly digest built from commit `a9a17e7095a66ef6c6685a1c7ddd657781a78d3c`.
+The latest vLLM v0.27.1 release predates the merged RL Control gRPC service, so
+it cannot serve this Dynamo sidecar flow.
+
+## Build
+
+From the ModelExpress repository root, build and push the server and engine
+images. Use immutable tags in a registry visible to the cluster.
+
+```bash
+export REGISTRY=registry.example.com/your-project
+export MX_COMMIT=$(git rev-parse --short HEAD)
+
+docker build -f ci/k8s/server/Dockerfile.server \
+  -t "$REGISTRY/modelexpress-server:$MX_COMMIT-dynamo-refit" .
+docker push "$REGISTRY/modelexpress-server:$MX_COMMIT-dynamo-refit"
+
+docker build -f examples/rl/dynamo_vllm_refit/Dockerfile.vllm \
+  -t "$REGISTRY/modelexpress-vllm:a9a17e7-$MX_COMMIT-dynamo-refit" .
+docker push "$REGISTRY/modelexpress-vllm:a9a17e7-$MX_COMMIT-dynamo-refit"
+```
+
+Build Dynamo's experimental sidecar from the pinned live-main revision:
+
+```bash
+git clone https://github.com/ai-dynamo/dynamo.git
+cd dynamo
+git checkout ff959852b740ee5981e58a5fcf18d0d4ca2d5079
+docker build -f lib/sidecar/vllm/Dockerfile \
+  -t "$REGISTRY/dynamo-vllm-sidecar:ff95985" .
+docker push "$REGISTRY/dynamo-vllm-sidecar:ff95985"
+```
+
+## Deploy and test
+
+Use a user-owned namespace. The commands require the Dynamo operator and an
+`hf-token-secret` in that namespace. If the images are in a private registry,
+configure image-pull credentials on the namespace's ServiceAccount or add your
+own `imagePullSecrets` entries to the pod specs.
+
+```bash
+export NAMESPACE=your-namespace
+export MODEL_NAME=Qwen/Qwen3-0.6B
+export MX_SERVER_IMAGE="$REGISTRY/modelexpress-server:$MX_COMMIT-dynamo-refit"
+export VLLM_ENGINE_IMAGE="$REGISTRY/modelexpress-vllm:a9a17e7-$MX_COMMIT-dynamo-refit"
+export DYNAMO_SIDECAR_IMAGE="$REGISTRY/dynamo-vllm-sidecar:ff95985"
+
+envsubst < examples/rl/dynamo_vllm_refit/server.yaml |
+  kubectl apply -n "$NAMESPACE" -f -
+envsubst < examples/rl/dynamo_vllm_refit/dgd.yaml |
+  kubectl apply -n "$NAMESPACE" -f -
+
+kubectl wait -n "$NAMESPACE" --for=condition=Ready \
+  dgd/mx-vllm-refit --timeout=15m
+
+export RL_COORDINATOR="$(sed 's/^/    /' \
+  examples/rl/dynamo_vllm_refit/rl_coordinator.py)"
+envsubst < examples/rl/dynamo_vllm_refit/rl-job.yaml |
+  kubectl apply -n "$NAMESPACE" -f -
+kubectl wait -n "$NAMESPACE" --for=condition=complete \
+  job/mx-vllm-rl-job --timeout=15m
+kubectl logs -n "$NAMESPACE" job/mx-vllm-rl-job
+```
+
+A successful run ends with `E2E PASS` and includes the installed WeightVersion
+UID, worker count, and post-refit generation. Keep worker, server, and coordinator
+logs as separate evidence; the pass line does not by itself qualify throughput
+or delta/S3 behavior. This first slice is the full-weight NIXL lifecycle needed
+by the existing `modelexpress_rl` protocol. XOR/ADD artifact-backed S3 deltas
+require the planned protocol extension for an artifact URI and are not claimed
+by this example.

--- a/examples/rl/dynamo_vllm_refit/dgd.yaml
+++ b/examples/rl/dynamo_vllm_refit/dgd.yaml
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Latest DynamoGraphDeployment schema with Dynamo's native vLLM sidecar shape.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: mx-vllm-refit
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.1
+          env:
+          - name: DYN_ENABLE_RL
+            value: "true"
+          - name: DYN_RL_PORT
+            value: "8001"
+          ports:
+          - name: http
+            containerPort: 8000
+          - name: rl-discovery
+            containerPort: 8001
+  - name: VLLMWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+        initContainers:
+        - name: vllm-engine
+          image: ${VLLM_ENGINE_IMAGE}
+          restartPolicy: Always
+          command:
+          - /bin/sh
+          - -c
+          - >-
+            exec "$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            serve ${MODEL_NAME} --host 127.0.0.1 --grpc-port 50051
+            --enable-sleep-mode
+            --weight-transfer-config '{"backend":"modelexpress"}'
+            --gpu-memory-utilization 0.45
+            --max-model-len 2048
+            --max-num-seqs 8
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          env:
+          - name: MODEL_NAME
+            value: ${MODEL_NAME}
+          - name: MX_SERVER_ADDRESS
+            value: mx-vllm-refit-server:8000
+          - name: VLLM_PLUGINS
+            value: modelexpress
+          - name: MX_RDMA_NIC_PIN
+            value: auto
+          - name: UCX_RNDV_SCHEME
+            value: get_zcopy
+          - name: UCX_RNDV_THRESH
+            value: "0"
+          resources:
+            requests:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 120
+        containers:
+        - name: main
+          image: ${DYNAMO_SIDECAR_IMAGE}
+          command: ["dynamo-vllm-sidecar"]
+          args: ["--vllm-endpoint", "127.0.0.1:50051", "--enable-rl"]
+          env:
+          - name: DYN_SYSTEM_PORT
+            value: "8081"
+          - name: DYN_ENABLE_RL
+            value: "true"
+          ports:
+          - name: system
+            containerPort: 8081
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+---
+# The operator's inference Service does not expose the separate RL discovery
+# listener, so this Service selects the DGD frontend and publishes both ports.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mx-vllm-refit-frontend-admin
+spec:
+  selector:
+    nvidia.com/dynamo-graph-deployment-name: mx-vllm-refit
+    nvidia.com/dynamo-component: Frontend
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000
+  - name: rl-discovery
+    port: 8001
+    targetPort: 8001

--- a/examples/rl/dynamo_vllm_refit/rl-job.yaml
+++ b/examples/rl/dynamo_vllm_refit/rl-job.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mx-vllm-rl-coordinator
+data:
+  rl_coordinator.py: |
+${RL_COORDINATOR}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mx-vllm-rl-job
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: rl-coordinator
+        image: ${VLLM_ENGINE_IMAGE}
+        command: ["python3", "/opt/e2e/rl_coordinator.py"]
+        envFrom:
+        - secretRef:
+            name: hf-token-secret
+        env:
+        - name: MODEL_NAME
+          value: ${MODEL_NAME}
+        - name: MX_SERVER_ADDRESS
+          value: mx-vllm-refit-server:8000
+        - name: MX_TRAINER_ENGINE
+          value: FSDP
+        - name: MX_TRAINER_STAGING_MODE
+          value: COPY_TO_DEVICE
+        - name: MX_WEIGHT_PAYLOAD_FORMAT
+          value: FULL_TENSOR
+        - name: MX_RESHARD_PUBLISH_DIGEST
+          value: "1"
+        - name: MX_WORKER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: LOCAL_RANK
+          value: "0"
+        - name: MX_RDMA_NIC_PIN
+          value: auto
+        - name: UCX_RNDV_SCHEME
+          value: get_zcopy
+        - name: UCX_RNDV_THRESH
+          value: "0"
+        resources:
+          requests:
+            cpu: "4"
+            memory: 16Gi
+            nvidia.com/gpu: "1"
+            rdma/ib: "1"
+          limits:
+            nvidia.com/gpu: "1"
+            rdma/ib: "1"
+        volumeMounts:
+        - name: coordinator
+          mountPath: /opt/e2e
+      volumes:
+      - name: coordinator
+        configMap:
+          name: mx-vllm-rl-coordinator

--- a/examples/rl/dynamo_vllm_refit/rl_coordinator.py
+++ b/examples/rl/dynamo_vllm_refit/rl_coordinator.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coordinate a full WeightVersion update through Dynamo RL routes."""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Any
+
+import requests
+import torch
+import torch.distributed as dist
+from transformers import AutoModelForCausalLM
+
+from modelexpress_rl import (
+    ModelExpressControlClient,
+    ModelExpressTrainerClient,
+    ModelExpressTrainerConfig,
+    WeightPayloadFormat,
+    WeightVersionRef,
+    WeightVersionState,
+)
+
+MODEL_NAME = os.environ["MODEL_NAME"]
+FRONTEND_URL = os.environ.get(
+    "DYNAMO_FRONTEND_URL", "http://mx-vllm-refit-frontend-admin:8000"
+).rstrip("/")
+RL_DISCOVERY_URL = os.environ.get(
+    "DYNAMO_RL_DISCOVERY_URL", "http://mx-vllm-refit-frontend-admin:8001"
+).rstrip("/")
+MX_SERVER_ADDRESS = os.environ.get(
+    "MX_SERVER_ADDRESS", "mx-vllm-refit-server:8000"
+)
+
+
+def _post(url: str, body: dict[str, Any], timeout: int = 300) -> dict[str, Any]:
+    response = requests.post(url, json=body, timeout=timeout)
+    if not response.ok:
+        raise RuntimeError(f"{url} failed ({response.status_code}): {response.text}")
+    payload = response.json()
+    if payload.get("status") == "error":
+        raise RuntimeError(f"{url} failed: {payload}")
+    return payload
+
+
+def _discover_workers(timeout: int = 600) -> list[dict[str, Any]]:
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f"{RL_DISCOVERY_URL}/v1/rl/workers", timeout=10)
+            last = response.text
+            if response.ok:
+                workers = [
+                    worker
+                    for worker in response.json().get("workers", [])
+                    if worker.get("system_url")
+                ]
+                if workers:
+                    return workers
+        except requests.RequestException as error:
+            last = str(error)
+        time.sleep(3)
+    raise RuntimeError(f"timed out discovering Dynamo RL workers: {last}")
+
+
+def _inference(timeout: int = 120) -> str:
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        try:
+            response = requests.post(
+                f"{FRONTEND_URL}/v1/chat/completions",
+                json={
+                    "model": MODEL_NAME,
+                    "messages": [
+                        {"role": "user", "content": "Reply with exactly: ready"}
+                    ],
+                    "temperature": 0,
+                    "max_tokens": 8,
+                },
+                timeout=30,
+            )
+            if response.ok:
+                return response.json()["choices"][0]["message"]["content"]
+            last = f"{response.status_code}: {response.text}"
+            if response.status_code != 503:
+                raise RuntimeError(f"inference failed: {last}")
+        except requests.RequestException as error:
+            last = str(error)
+        time.sleep(2)
+    raise RuntimeError(f"timed out waiting for inference routing: {last}")
+
+
+def _route(worker: dict[str, Any], group: str, name: str) -> str:
+    return f"{worker['system_url'].rstrip('/')}/engine/{group}/{name}"
+
+
+def main() -> None:
+    dist.init_process_group(
+        "nccl",
+        init_method="tcp://127.0.0.1:29500",
+        rank=0,
+        world_size=1,
+    )
+    torch.cuda.set_device(0)
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_NAME,
+        torch_dtype=torch.bfloat16,
+    ).cuda().eval()
+
+    workers = _discover_workers()
+    baseline = _inference()
+    trainer = ModelExpressTrainerClient.initialize(
+        ModelExpressTrainerConfig(
+            device_id=0,
+            model_name=MODEL_NAME,
+            server_url=MX_SERVER_ADDRESS,
+        )
+    )
+    control = ModelExpressControlClient.connect(server_url=MX_SERVER_ADDRESS)
+    version = None
+    try:
+        source_slot = trainer.bind_tensors(model.state_dict())
+        version = control.create_weight_version(
+            model_name=MODEL_NAME,
+            idempotency_key=f"dynamo-vllm-e2e-{uuid.uuid4().hex}",
+            payload_format=WeightPayloadFormat.FULL_TENSOR,
+            expected_source_slots=[source_slot],
+        )
+        trainer.publish_version(version=version.ref)
+        ready = control.get_weight_version(version.version_id)
+        if ready.state is not WeightVersionState.READY:
+            raise RuntimeError(f"published version is not READY: {ready}")
+
+        paused = []
+        try:
+            for worker in workers:
+                _post(
+                    _route(worker, "control", "pause_generation"),
+                    {"mode": "keep", "clear_cache": False},
+                )
+                paused.append(worker)
+            for worker in workers:
+                _post(
+                    _route(worker, "update", "init_weight_transfer_engine"),
+                    {"init_info": {}},
+                )
+                _post(_route(worker, "update", "start_weight_update"), {})
+                _post(
+                    _route(worker, "update", "update_weights"),
+                    {"update_info": {"version_id": version.version_id}},
+                    timeout=600,
+                )
+                _post(
+                    _route(worker, "update", "finish_weight_update"),
+                    {"weight_version": version.version_id},
+                )
+            for worker in workers:
+                installed = _post(
+                    _route(worker, "control", "get_weight_version"), {}
+                )
+                observed = installed.get("version", installed.get("weight_version"))
+                if observed != version.version_id:
+                    raise RuntimeError(
+                        f"worker installed {observed!r}, expected {version.version_id!r}"
+                    )
+        finally:
+            for worker in paused:
+                _post(_route(worker, "control", "resume_generation"), {})
+
+        updated = _inference()
+        if updated != baseline:
+            raise RuntimeError(
+                f"deterministic generation changed: before={baseline!r}, after={updated!r}"
+            )
+        print(
+            f"E2E PASS: version={version.version_id} workers={len(workers)} "
+            f"generation={updated!r}",
+            flush=True,
+        )
+    finally:
+        if version is not None:
+            control.delete_weight_version(version.version_id)
+            trainer.release_version(version=WeightVersionRef(version.version_id))
+        control.close()
+        trainer.close()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rl/dynamo_vllm_refit/server.yaml
+++ b/examples/rl/dynamo_vllm_refit/server.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mx-vllm-refit-server
+spec:
+  selector:
+    app: mx-vllm-refit-server
+  ports:
+  - name: grpc
+    port: 8000
+    targetPort: grpc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mx-vllm-refit-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mx-vllm-refit-server
+  template:
+    metadata:
+      labels:
+        app: mx-vllm-refit-server
+    spec:
+      initContainers:
+      - name: redis
+        image: redis:7-alpine
+        args: ["--save", "", "--appendonly", "no"]
+        restartPolicy: Always
+        startupProbe:
+          tcpSocket:
+            port: 6379
+          periodSeconds: 1
+          failureThreshold: 30
+      containers:
+      - name: modelexpress-server
+        image: ${MX_SERVER_IMAGE}
+        command: ["./modelexpress-server"]
+        args: ["--port", "8000"]
+        env:
+        - name: MX_METADATA_BACKEND
+          value: redis
+        - name: REDIS_URL
+          value: redis://localhost:6379
+        ports:
+        - name: grpc
+          containerPort: 8000
+        readinessProbe:
+          grpc:
+            port: 8000
+          periodSeconds: 2
+          failureThreshold: 30

--- a/modelexpress_client/python/modelexpress/__init__.py
+++ b/modelexpress_client/python/modelexpress/__init__.py
@@ -57,9 +57,9 @@ def configure_trtllm_logging() -> None:
     _configure_engine_logging("TRT-LLM")
 
 
-def register_modelexpress_loaders():
+def register_modelexpress():
     """
-    Register ModelExpress loaders with vLLM.
+    Register ModelExpress integrations with vLLM.
 
     This function ensures loaders are registered exactly once. It can be called
     multiple times safely (idempotent).
@@ -67,6 +67,7 @@ def register_modelexpress_loaders():
     Enables:
         --load-format modelexpress  (auto-detect: RDMA -> InstantTensor -> ModelStreamer -> GDS -> disk)
         --load-format mx            (backward-compatible alias)
+        --weight-transfer-config '{"backend":"modelexpress"}'
     """
     global _loaders_registered
     if _loaders_registered:
@@ -77,7 +78,12 @@ def register_modelexpress_loaders():
     register_vllm_loaders()
 
     _loaders_registered = True
-    _logger.debug("ModelExpress loaders registered")
+    _logger.debug("ModelExpress vLLM integrations registered")
+
+
+def register_modelexpress_loaders():
+    """Backward-compatible alias for :func:`register_modelexpress`."""
+    register_modelexpress()
 
 
 from .client import MxClient  # noqa: F401
@@ -94,5 +100,6 @@ __all__ = [
     "PublisherThread",
     "configure_trtllm_logging",
     "configure_vllm_logging",
+    "register_modelexpress",
     "register_modelexpress_loaders",
 ]

--- a/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/__init__.py
@@ -17,7 +17,10 @@ def register_modelexpress_loaders() -> None:
     global _loaders_registered
     if _loaders_registered:
         return
-    from .registration import register_plugin_model_loader
+    from .registration import (
+        register_plugin_model_loader,
+        register_plugin_weight_transfer_engine,
+    )
 
     configure_vllm_logging()
     apply_patches(VLLM_PATCHES)
@@ -25,6 +28,7 @@ def register_modelexpress_loaders() -> None:
     # Needed for older vLLM versions before native ModelExpress loader
     # registration is available.
     register_plugin_model_loader()
+    register_plugin_weight_transfer_engine()
 
     _loaders_registered = True
 

--- a/modelexpress_client/python/modelexpress/engines/vllm/registration.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/registration.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 _PLUGIN_LOAD_FORMATS = ("modelexpress", "mx")
+_WEIGHT_TRANSFER_BACKEND = "modelexpress"
 
 
 def register_plugin_model_loader() -> None:
@@ -28,3 +29,26 @@ def register_plugin_model_loader() -> None:
             )
             continue
         register_model_loader(load_format)(MxModelLoader)
+
+
+def register_plugin_weight_transfer_engine() -> None:
+    """Register the ModelExpress backend when vLLM exposes weight transfer."""
+    try:
+        from vllm.distributed.weight_transfer.factory import (
+            WeightTransferEngineFactory,
+        )
+    except ImportError:
+        logger.debug("vLLM does not expose the weight-transfer engine factory")
+        return
+
+    if _WEIGHT_TRANSFER_BACKEND in WeightTransferEngineFactory._registry:
+        logger.debug(
+            "vLLM already provides '%s' weight-transfer registration",
+            _WEIGHT_TRANSFER_BACKEND,
+        )
+        return
+    WeightTransferEngineFactory.register_engine(
+        _WEIGHT_TRANSFER_BACKEND,
+        "modelexpress_rl.inference.engines.vllm.weight_transfer_engine",
+        "ModelExpressWeightTransferEngine",
+    )

--- a/modelexpress_client/python/modelexpress_rl/envs.py
+++ b/modelexpress_client/python/modelexpress_rl/envs.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     MX_TRAINER_ENGINE: str
     MX_TRAINER_STAGING_MODE: str
     MX_WEIGHT_PAYLOAD_FORMAT: str
+    RANK: str | None
 
 
 environment_variables: dict[str, Callable[[], Any]] = {
@@ -36,6 +37,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_WEIGHT_PAYLOAD_FORMAT": lambda: (
         os.environ.get("MX_WEIGHT_PAYLOAD_FORMAT", "FULL_TENSOR").strip().upper()
     ),
+    "RANK": lambda: os.environ.get("RANK"),
 }
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM weight-transfer backend backed by ModelExpress WeightVersions."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.distributed.weight_transfer import WeightTransferEngine
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferInitInfo,
+    WeightTransferUpdateInfo,
+)
+
+from modelexpress_rl.inference.client import (
+    ModelExpressGeneratorClient,
+    ModelExpressGeneratorConfig,
+    StagedWeightHandle,
+)
+from modelexpress_rl.version import WeightVersionRef
+
+from .context import VllmGeneratorContext
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelExpressWeightTransferInitInfo(WeightTransferInitInfo):
+    """ModelExpress initializes from the vLLM worker's live model context."""
+
+
+@dataclass
+class ModelExpressWeightTransferUpdateInfo(WeightTransferUpdateInfo):
+    """Reference to one immutable READY ModelExpress WeightVersion."""
+
+    version_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.version_id, str) or not self.version_id.strip():
+            raise ValueError("version_id is required")
+
+
+class ModelExpressWeightTransferEngine(WeightTransferEngine):
+    """Install an exact ModelExpress WeightVersion at vLLM's safe point."""
+
+    init_info_cls = ModelExpressWeightTransferInitInfo
+    update_info_cls = ModelExpressWeightTransferUpdateInfo
+    supports_draft_weight_update = False
+
+    @staticmethod
+    def trainer_send_weights(
+        iterator: Iterator[Any],
+        trainer_args: dict[str, Any] | Any,
+    ) -> None:
+        """Ignore vLLM's trainer transport; ModelExpress publishes versions."""
+        logger.warning(
+            "vLLM trainer transport is ignored; publish WeightVersions with "
+            "ModelExpressTrainerClient instead"
+        )
+
+    def __init__(self, config, vllm_config, device, model) -> None:
+        super().__init__(config, vllm_config, device, model)
+        self._generator_config = ModelExpressGeneratorConfig(
+            engine_context=VllmGeneratorContext(
+                model=model,
+                vllm_config=vllm_config,
+            ),
+            model_name=getattr(vllm_config.model_config, "model", None),
+        )
+        self._client: ModelExpressGeneratorClient | None = None
+        self._update_active = False
+        self._staged: StagedWeightHandle | None = None
+        self._closed = False
+
+    def init_transfer_engine(
+        self, _init_info: ModelExpressWeightTransferInitInfo
+    ) -> None:
+        """Initialize ModelExpress from the rank-local vLLM model context."""
+        if self._closed:
+            logger.warning("weight transfer engine is shut down")
+            return
+        if self._client is not None:
+            logger.warning("weight transfer engine is already initialized")
+            return
+        self._client = ModelExpressGeneratorClient.initialize(self._generator_config)
+
+    def start_weight_update(self) -> None:
+        if self._closed:
+            logger.warning("weight transfer engine is shut down")
+            return
+        if self._client is None:
+            logger.warning("weight transfer engine is not initialized")
+            return
+        if self._update_active:
+            logger.warning("weight update is already active")
+            return
+        self._update_active = True
+        self._staged = None
+
+    def receive_weights(
+        self, update_info: ModelExpressWeightTransferUpdateInfo
+    ) -> None:
+        if not self._update_active:
+            logger.warning("weight update has not been started")
+            return
+        if self._staged is not None:
+            logger.warning("weight update already received a version")
+            return
+
+        client = self._client
+        if client is None:
+            logger.warning("weight transfer engine is not initialized")
+            self._update_active = False
+            return
+
+        staged: StagedWeightHandle | None = None
+        try:
+            staged = client.stage_weight(
+                version=WeightVersionRef(update_info.version_id)
+            )
+            client.apply_weight(staged)
+            self._staged = staged
+        except BaseException as error:
+            if staged is not None:
+                try:
+                    staged.release()
+                except BaseException:
+                    logger.warning(
+                        "failed to release version %s while handling %s",
+                        staged.version_id,
+                        type(error).__name__,
+                        exc_info=True,
+                    )
+            self._update_active = False
+            self._staged = None
+            raise
+
+    def finish_weight_update(self) -> None:
+        if not self._update_active:
+            logger.warning("weight update has not been started")
+            return
+        if self._staged is None:
+            logger.warning("weight update has not received a version")
+            self._update_active = False
+            return
+        staged = self._staged
+        try:
+            staged.release()
+        finally:
+            self._staged = None
+            self._update_active = False
+
+    def shutdown(self) -> None:
+        if self._closed:
+            return
+        try:
+            if self._staged is not None:
+                self._staged.release()
+        finally:
+            self._staged = None
+            self._update_active = False
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+            self._closed = True
+
+
+__all__ = [
+    "ModelExpressWeightTransferEngine",
+    "ModelExpressWeightTransferInitInfo",
+    "ModelExpressWeightTransferUpdateInfo",
+]

--- a/modelexpress_client/python/modelexpress_rl/train/client.py
+++ b/modelexpress_client/python/modelexpress_rl/train/client.py
@@ -84,7 +84,7 @@ class ModelExpressTrainerConfig:
 
     # CUDA device used by the rank-local NIXL manager; defaults to LOCAL_RANK.
     device_id: int | None = None
-    # NIXL process identity; generated from the distributed rank when omitted.
+    # NIXL process identity; generated from the rank and a fresh suffix when omitted.
     agent_name: str | None = None
     # Logical model identity; defaults to MODEL_NAME.
     model_name: str | None = None

--- a/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
@@ -33,6 +33,7 @@ from modelexpress.refit.reshard.rendezvous import (
     PublishedTensor,
     wrap_rendezvous_blob,
 )
+from modelexpress.refit.reshard.verify import published_digest
 from modelexpress_rl.train.adapter import NixlMetadataProvider
 
 logger = logging.getLogger("modelexpress_rl.train.engines.fsdp.publisher")
@@ -180,6 +181,7 @@ def build_fsdp_reshard_manifest(
             addr=addr,
             shard_offset=tuple(shard.shard_offset),
             shape=tuple(shard.local_shape),
+            digest=published_digest(served),
         )
         tensor = by_name.get(shard.name)
         if tensor is None:

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/aliases.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/aliases.py
@@ -171,8 +171,8 @@ def _build_gated_aliases(
 def _build_qkv_aliases(
     item: MegatronTensorSpec, agent_name: str
 ) -> list[PublishedTensor]:
-    if len(item.hf_names) != 3 or item.tensor.ndim != 2:
-        raise ValueError(f"{item.name}: QKV aliasing requires 2D q/k/v weights")
+    if len(item.hf_names) != 3 or item.tensor.ndim not in {1, 2}:
+        raise ValueError(f"{item.name}: QKV aliasing requires 1D biases or 2D weights")
     has_global_q = "num_heads" in item.extras
     has_global_kv = "num_kv_heads" in item.extras
     if has_global_q != has_global_kv:
@@ -299,9 +299,9 @@ def _build_global_qkv_aliases(
     band.
     """
     layout = _read_qkv_layout(item)
-    hidden = int(item.tensor.shape[1])
-    if len(item.global_shape) != 2 or int(item.global_shape[1]) != hidden:
-        raise ValueError(f"{item.name}: QKV hidden dimension mismatch")
+    trailing_shape = tuple(int(dim) for dim in item.tensor.shape[1:])
+    if tuple(int(dim) for dim in item.global_shape[1:]) != trailing_shape:
+        raise ValueError(f"{item.name}: QKV trailing dimensions mismatch")
     if int(item.global_shape[0]) != layout.total_rows:
         raise ValueError(f"{item.name}: global QKV rows disagree with head metadata")
 
@@ -319,7 +319,8 @@ def _build_global_qkv_aliases(
                 agent_name=agent_name,
                 device_id=int(tensor.device.index or 0),
                 addr=int(tensor.data_ptr()),
-                shard_offset=(band.destination_start + overlap_lo - band.start, 0),
+                shard_offset=(band.destination_start + overlap_lo - band.start,)
+                + (0,) * len(trailing_shape),
                 shape=tuple(int(dim) for dim in tensor.shape),
                 digest=tensor_digest(tensor),
             )
@@ -340,7 +341,7 @@ def _build_global_qkv_aliases(
             name=name,
             dtype=str(item.tensor.dtype),
             elsize=int(item.tensor.element_size()),
-            full_shape=(rows, hidden),
+            full_shape=(rows,) + trailing_shape,
             shards=projection_shards,
         )
         for name, rows, projection_shards in zip(
@@ -367,7 +368,7 @@ def _build_legacy_qkv_aliases(
     if rows_per_group * kv_heads_local != int(item.tensor.shape[0]):
         raise ValueError(f"{item.name}: QKV rows disagree with head metadata")
     source_rank, source_size = _source_rank_and_size(item, 0)
-    hidden = int(item.tensor.shape[1])
+    trailing_shape = tuple(int(dim) for dim in item.tensor.shape[1:])
     q_heads_per_group = q_heads_local // kv_heads_local
     q_shards = []
     k_shards = []
@@ -389,7 +390,7 @@ def _build_legacy_qkv_aliases(
                     agent_name=agent_name,
                     device_id=int(tensor.device.index or 0),
                     addr=int(tensor.data_ptr()),
-                    shard_offset=(start, 0),
+                    shard_offset=(start,) + (0,) * len(trailing_shape),
                     shape=tuple(int(dim) for dim in tensor.shape),
                     # The narrow, not the fused parent: this is the box a receiver
                     # reads from ``addr``, so it is the box whose bytes must match.
@@ -401,7 +402,7 @@ def _build_legacy_qkv_aliases(
             name=name,
             dtype=str(item.tensor.dtype),
             elsize=int(item.tensor.element_size()),
-            full_shape=(rows, hidden),
+            full_shape=(rows,) + trailing_shape,
             shards=shards,
         )
         for name, rows, shards in (

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/selection.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/selection.py
@@ -24,9 +24,9 @@ def model_express_role_for_mapping(
             f"ModelExpress does not yet support expert mapping {mapping_name}"
         )
     if _inherits(mapping, "QKVMapping"):
-        if tensor_ndim != 2:
+        if tensor_ndim not in {1, 2}:
             raise NotImplementedError(
-                "ModelExpress QKV publication currently supports weights only"
+                "ModelExpress QKV publication supports only weights and biases"
             )
         return "qkv_column"
     if _inherits(mapping, "GatedMLPMapping"):

--- a/modelexpress_client/python/modelexpress_rl/train/resources.py
+++ b/modelexpress_client/python/modelexpress_rl/train/resources.py
@@ -12,8 +12,10 @@ from concurrent import futures
 from typing import Any
 
 import grpc
+
 from modelexpress import envs
 
+from .. import envs as rl_envs
 from .. import refit_pb2_grpc
 from .manifest import WeightVersionShardManifestService
 
@@ -56,12 +58,11 @@ class _TrainerResources:
             "MX_WORKER_HOST",
         )
         os.environ.setdefault("MX_WORKER_HOST", host)
-        rank = os.environ.get("RANK")
-        agent_name = agent_name or (
-            f"modelexpress-trainer-{rank}"
-            if rank is not None
-            else f"modelexpress-trainer-{uuid.uuid4().hex[:8]}"
-        )
+        if agent_name is None:
+            process_id = uuid.uuid4().hex[:8]
+            rank = rl_envs.RANK
+            rank_segment = f"{rank}-" if rank is not None else ""
+            agent_name = f"modelexpress-trainer-{rank_segment}{process_id}"
         manager = NixlTransferManager(
             agent_name=agent_name,
             device_id=device_id,

--- a/modelexpress_client/python/pyproject.toml
+++ b/modelexpress_client/python/pyproject.toml
@@ -72,7 +72,7 @@ Repository = "https://github.com/ai-dynamo/modelexpress.git"
 Documentation = "https://github.com/ai-dynamo/modelexpress/tree/main/docs"
 
 [project.entry-points."vllm.general_plugins"]
-modelexpress = "modelexpress:register_modelexpress_loaders"
+modelexpress = "modelexpress:register_modelexpress"
 
 [tool.pytest.ini_options]
 markers = [

--- a/modelexpress_client/python/tests/conftest.py
+++ b/modelexpress_client/python/tests/conftest.py
@@ -99,6 +99,40 @@ def _maybe_mock_vllm():
             return cls
         return _wrapper
 
+    @dataclass
+    class WeightTransferInitInfo:
+        pass
+
+    @dataclass
+    class WeightTransferUpdateInfo:
+        pass
+
+    class WeightTransferEngine(ABC):
+        def __init__(self, config, vllm_config, device, model):
+            self.config = config
+            self.vllm_config = vllm_config
+            self.parallel_config = vllm_config.parallel_config
+            self.model_config = vllm_config.model_config
+            self.device = device
+            self.model = model
+
+        def update_weights(self, update_info):
+            self.receive_weights(self.update_info_cls(**update_info))
+
+        @staticmethod
+        @abstractmethod
+        def trainer_send_weights(iterator, trainer_args):
+            raise NotImplementedError
+
+    class WeightTransferEngineFactory:
+        _registry = {}
+
+        @classmethod
+        def register_engine(cls, name, module_path_or_cls, class_name=None):
+            if name in cls._registry:
+                raise ValueError(f"Weight transfer engine {name!r} is registered")
+            cls._registry[name] = (module_path_or_cls, class_name)
+
     # Build mock module tree
     vllm_mods = {
         "vllm": MagicMock(),
@@ -113,12 +147,27 @@ def _maybe_mock_vllm():
         "vllm.utils": MagicMock(),
         "vllm.utils.torch_utils": MagicMock(),
         "vllm.distributed": MagicMock(),
+        "vllm.distributed.weight_transfer": MagicMock(),
+        "vllm.distributed.weight_transfer.base": MagicMock(),
+        "vllm.distributed.weight_transfer.factory": MagicMock(),
     }
 
     # Wire up real objects where behavior matters
     vllm_mods["vllm.model_executor.model_loader.base_loader"].BaseModelLoader = BaseModelLoader
     vllm_mods["vllm.model_executor.model_loader"].register_model_loader = register_model_loader
     vllm_mods["vllm.model_executor.model_loader"].BaseModelLoader = BaseModelLoader
+    vllm_mods["vllm.distributed.weight_transfer"].WeightTransferEngine = (
+        WeightTransferEngine
+    )
+    vllm_mods["vllm.distributed.weight_transfer.base"].WeightTransferInitInfo = (
+        WeightTransferInitInfo
+    )
+    vllm_mods["vllm.distributed.weight_transfer.base"].WeightTransferUpdateInfo = (
+        WeightTransferUpdateInfo
+    )
+    vllm_mods["vllm.distributed.weight_transfer.factory"].WeightTransferEngineFactory = (
+        WeightTransferEngineFactory
+    )
 
     # set_default_torch_dtype needs to be a real context manager
     from contextlib import contextmanager

--- a/modelexpress_client/python/tests/test_patches.py
+++ b/modelexpress_client/python/tests/test_patches.py
@@ -66,6 +66,11 @@ def test_vllm_entrypoint_configures_logging_before_patches(monkeypatch):
         "register_plugin_model_loader",
         lambda: calls.append(("loader", None)),
     )
+    monkeypatch.setattr(
+        registration,
+        "register_plugin_weight_transfer_engine",
+        lambda: calls.append(("weight_transfer", None)),
+    )
 
     vllm_integration.register_modelexpress_loaders()
 
@@ -73,6 +78,7 @@ def test_vllm_entrypoint_configures_logging_before_patches(monkeypatch):
         ("logging", None),
         ("patches", vllm_integration.VLLM_PATCHES),
         ("loader", None),
+        ("weight_transfer", None),
     ]
 
 

--- a/modelexpress_client/python/tests/test_refit_fsdp_publisher.py
+++ b/modelexpress_client/python/tests/test_refit_fsdp_publisher.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from modelexpress.refit.reshard.rendezvous import unwrap_rendezvous_blob
+from modelexpress.refit.reshard.verify import tensor_digest
 from modelexpress_rl.train.engines.fsdp.publisher import (
     LocalTensorShard,
     build_fsdp_reshard_manifest,
@@ -73,6 +74,20 @@ def test_build_manifest_describes_the_served_buffer():
     assert pshard.addr == tensor.data_ptr()
     assert tuple(pshard.shard_offset) == (0, 0)
     assert tuple(pshard.shape) == (2, 4)
+
+
+def test_build_manifest_publishes_enabled_verification_digest(monkeypatch):
+    monkeypatch.setenv("MX_RESHARD_PUBLISH_DIGEST", "1")
+    tensor = torch.arange(8, dtype=torch.bfloat16).reshape(2, 4)
+    shard = LocalTensorShard("w", (2, 4), (0, 0), (2, 4), tensor)
+
+    payload = unwrap_rendezvous_blob(
+        build_fsdp_reshard_manifest(
+            manager=_Manager(), shards=[shard], metadata_endpoint="host:1234"
+        )
+    )
+
+    assert payload.tensors[0].shards[0].digest == tensor_digest(tensor)
 
 
 def test_build_manifest_groups_multiple_shards_under_one_tensor():

--- a/modelexpress_client/python/tests/test_refit_megatron_selection.py
+++ b/modelexpress_client/python/tests/test_refit_megatron_selection.py
@@ -95,13 +95,15 @@ def test_explicit_mapping_roles(mapping, expected):
     )
 
 
-def test_qkv_bias_fails_until_alias_format_supports_it():
-    with pytest.raises(NotImplementedError, match="weights only"):
+def test_qkv_bias_uses_the_qkv_column_role():
+    assert (
         model_express_role_for_mapping(
             mapping=QKVMapping(),
             megatron_module=SimpleNamespace(),
             tensor_ndim=1,
         )
+        == "qkv_column"
+    )
 
 
 def test_unknown_mapping_fails_instead_of_assuming_replicated():

--- a/modelexpress_client/python/tests/test_refit_trainer_resources.py
+++ b/modelexpress_client/python/tests/test_refit_trainer_resources.py
@@ -3,20 +3,38 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import modelexpress_rl
 from modelexpress_rl.train.resources import _TrainerResources
 
 
-def test_resources_initialize_transport_and_manifest_service(monkeypatch):
+@pytest.mark.parametrize(
+    ("rank", "agent_name"),
+    [
+        ("7", "modelexpress-trainer-7-01234567"),
+        (None, "modelexpress-trainer-01234567"),
+    ],
+)
+def test_resources_initialize_transport_and_manifest_service(
+    monkeypatch, rank, agent_name
+):
     monkeypatch.setenv("MX_WORKER_HOST", "trainer.test")
     monkeypatch.setenv("MX_METADATA_PORT", "18000")
     monkeypatch.setenv("MX_WORKER_GRPC_PORT", "19000")
-    monkeypatch.setenv("RANK", "7")
+    if rank is None:
+        monkeypatch.delenv("RANK", raising=False)
+    else:
+        monkeypatch.setenv("RANK", rank)
     manager = MagicMock()
     server = MagicMock()
     server.add_insecure_port.return_value = 19002
 
     with (
+        patch(
+            "modelexpress_rl.train.resources.uuid.uuid4",
+            return_value=MagicMock(hex="0123456789abcdef"),
+        ),
         patch(
             "modelexpress.nixl_transfer.NixlTransferManager",
             return_value=manager,
@@ -29,7 +47,7 @@ def test_resources_initialize_transport_and_manifest_service(monkeypatch):
         resources = _TrainerResources.initialize(device_id=2)
 
     manager_type.assert_called_once_with(
-        agent_name="modelexpress-trainer-7",
+        agent_name=agent_name,
         device_id=2,
         listen_port=18002,
     )

--- a/modelexpress_client/python/tests/test_reshard_megatron_gqa.py
+++ b/modelexpress_client/python/tests/test_reshard_megatron_gqa.py
@@ -166,6 +166,44 @@ def test_global_interval_aliases_cover_qkv_without_gaps_or_overlaps(
     )
 
 
+def test_global_qkv_bias_aliases_preserve_interleaved_head_order():
+    q_heads, kv_heads, head_dim = 4, 2, 2
+    fused = torch.arange(16, dtype=torch.float32)
+    aliases = build_hf_aliases(
+        [
+            MegatronTensorSpec(
+                name="linear_qkv.bias",
+                tensor=fused,
+                role="qkv_column",
+                hf_names=("q_proj.bias", "k_proj.bias", "v_proj.bias"),
+                global_shape=tuple(fused.shape),
+                placement_kind="REPLICATE",
+                shard_axis=None,
+                local_shard_range=None,
+                extras=_global_extras(q_heads, kv_heads, head_dim),
+            )
+        ],
+        agent_name="trainer-tp0",
+    )
+
+    actual = []
+    for alias in aliases:
+        destination = torch.empty(alias.full_shape, dtype=fused.dtype)
+        for shard in alias.shards:
+            source_start = (shard.addr - fused.data_ptr()) // fused.element_size()
+            destination_start = shard.shard_offset[0]
+            destination.narrow(0, destination_start, shard.shape[0]).copy_(
+                fused.narrow(0, source_start, shard.shape[0])
+            )
+        actual.append(destination)
+
+    expected = _expected_hf(fused, q_heads, kv_heads, head_dim)
+    assert [alias.full_shape for alias in aliases] == [(8,), (4,), (4,)]
+    assert all(
+        torch.equal(got, want) for got, want in zip(actual, expected, strict=True)
+    )
+
+
 def test_kv_below_tp_only_advertises_kv_on_ranks_that_own_it():
     _, _, published = _publish_all_ranks(64, 2, 8, 128)
     names_by_agent = {f"tp{rank}": set() for rank in range(8)}

--- a/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
+++ b/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from modelexpress_rl.inference.engines.vllm.weight_transfer_engine import (
+    ModelExpressWeightTransferEngine,
+)
+
+
+def _engine(monkeypatch, client=None, *, initialize=True):
+    client = client or MagicMock()
+    monkeypatch.setattr(
+        "modelexpress_rl.inference.engines.vllm.weight_transfer_engine."
+        "ModelExpressGeneratorClient.initialize",
+        lambda config: client,
+    )
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(),
+        model_config=SimpleNamespace(model="test/model"),
+    )
+    engine = ModelExpressWeightTransferEngine(
+        SimpleNamespace(),
+        vllm_config,
+        torch.device("cpu"),
+        torch.nn.Linear(2, 2),
+    )
+    if initialize:
+        engine.init_transfer_engine(engine.init_info_cls())
+    return engine, client
+
+
+def test_weight_transfer_engine_initializes_client_in_init_hook(monkeypatch):
+    client = MagicMock()
+    initialize = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        "modelexpress_rl.inference.engines.vllm.weight_transfer_engine."
+        "ModelExpressGeneratorClient.initialize",
+        initialize,
+    )
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(),
+        model_config=SimpleNamespace(model="test/model"),
+    )
+    model = torch.nn.Linear(2, 2)
+    engine = ModelExpressWeightTransferEngine(
+        SimpleNamespace(), vllm_config, torch.device("cpu"), model
+    )
+
+    initialize.assert_not_called()
+    engine.init_transfer_engine(engine.init_info_cls())
+
+    config = initialize.call_args.args[0]
+    assert config.model_name == "test/model"
+    assert config.engine_context.model is model
+
+
+def test_weight_transfer_engine_applies_one_exact_version(monkeypatch):
+    engine, client = _engine(monkeypatch)
+    staged = client.stage_weight.return_value
+
+    engine.start_weight_update()
+    engine.update_weights({"version_id": "version-a"})
+    engine.finish_weight_update()
+
+    version = client.stage_weight.call_args.kwargs["version"]
+    assert version.version_id == "version-a"
+    client.apply_weight.assert_called_once_with(staged)
+    staged.release.assert_called_once_with()
+
+
+def test_weight_transfer_engine_warns_for_out_of_order_updates(monkeypatch, caplog):
+    engine, _client = _engine(monkeypatch)
+
+    engine.update_weights({"version_id": "version-a"})
+
+    engine.start_weight_update()
+    engine.update_weights({"version_id": "version-a"})
+    engine.update_weights({"version_id": "version-b"})
+
+    assert "weight update has not been started" in caplog.text
+    assert "weight update already received a version" in caplog.text
+
+
+def test_weight_transfer_engine_warns_for_duplicate_lifecycle_calls(
+    monkeypatch, caplog
+):
+    engine, client = _engine(monkeypatch)
+
+    engine.init_transfer_engine(engine.init_info_cls())
+    engine.start_weight_update()
+    engine.start_weight_update()
+    engine.finish_weight_update()
+    engine.finish_weight_update()
+
+    assert client.stage_weight.call_count == 0
+    assert "weight transfer engine is already initialized" in caplog.text
+    assert "weight update is already active" in caplog.text
+    assert "weight update has not received a version" in caplog.text
+    assert "weight update has not been started" in caplog.text
+
+
+def test_weight_transfer_engine_releases_failed_update(monkeypatch):
+    client = MagicMock()
+    client.apply_weight.side_effect = RuntimeError("apply failed")
+    engine, client = _engine(monkeypatch, client)
+    staged = client.stage_weight.return_value
+
+    engine.start_weight_update()
+    with pytest.raises(RuntimeError, match="apply failed"):
+        engine.update_weights({"version_id": "version-a"})
+
+    staged.release.assert_called_once_with()
+    engine.start_weight_update()
+
+
+def test_weight_transfer_engine_preserves_apply_error_when_release_fails(monkeypatch):
+    client = MagicMock()
+    client.apply_weight.side_effect = RuntimeError("apply failed")
+    client.stage_weight.return_value.release.side_effect = RuntimeError(
+        "release failed"
+    )
+    engine, _client = _engine(monkeypatch, client)
+
+    engine.start_weight_update()
+    with pytest.raises(RuntimeError, match="apply failed"):
+        engine.update_weights({"version_id": "version-a"})
+
+    engine.start_weight_update()
+
+
+def test_weight_transfer_engine_shutdown_is_idempotent(monkeypatch):
+    engine, client = _engine(monkeypatch)
+    staged = client.stage_weight.return_value
+    engine.start_weight_update()
+    engine.update_weights({"version_id": "version-a"})
+
+    engine.shutdown()
+    engine.shutdown()
+
+    staged.release.assert_called_once_with()
+    client.close.assert_called_once_with()
+
+
+def test_weight_transfer_engine_shutdown_before_initialization(monkeypatch):
+    engine, client = _engine(monkeypatch, initialize=False)
+
+    engine.shutdown()
+    engine.start_weight_update()
+
+    client.close.assert_not_called()
+
+
+def test_weight_transfer_engine_ignores_vllm_trainer_transport(caplog):
+    ModelExpressWeightTransferEngine.trainer_send_weights(iter(()), {})
+
+    assert "ModelExpressTrainerClient" in caplog.text
+
+
+@pytest.mark.parametrize("version_id", ["", "   ", None, 1])
+def test_weight_transfer_engine_rejects_invalid_version_id(version_id):
+    with pytest.raises(ValueError, match="version_id is required"):
+        ModelExpressWeightTransferEngine.update_info_cls(version_id=version_id)
+
+
+def test_vllm_plugin_registers_weight_transfer_engine(monkeypatch):
+    from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
+
+    from modelexpress.engines.vllm import registration
+
+    calls = []
+    monkeypatch.setattr(WeightTransferEngineFactory, "_registry", {})
+    monkeypatch.setattr(
+        WeightTransferEngineFactory,
+        "register_engine",
+        lambda name, module_path, class_name: calls.append(
+            (name, module_path, class_name)
+        ),
+    )
+
+    registration.register_plugin_weight_transfer_engine()
+
+    assert calls == [
+        (
+            "modelexpress",
+            "modelexpress_rl.inference.engines.vllm.weight_transfer_engine",
+            "ModelExpressWeightTransferEngine",
+        )
+    ]


### PR DESCRIPTION
## Summary

- register ModelExpress as a vLLM general plugin and implement the native `WeightTransferEngine` adapter over `ModelExpressGeneratorClient`
- support the Megatron tensor forms and trainer process identities needed by repeated refit publication
- add a standalone Dynamo DGD + vLLM + ModelExpress refit example under `examples/rl/dynamo_vllm_refit`

## Validation

- `69 passed, 1 skipped` across the focused control, trainer, generator, Megatron, reshard, and vLLM transfer-engine tests
- live DGD loaded `ModelExpressWeightTransferEngine`
- live Qwen2.5-0.5B transfer exercised a 0.99 GB NIXL receive/apply path with 290 mapped copies and zero unsupported source mappings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Kubernetes examples for reinforcement-learning workflows with Dynamo, vLLM, and ModelExpress.
  * Added support for transferring and applying model weight updates through the vLLM integration.
  * Added deployment guidance, validation steps, and lifecycle coordination for refit workflows.
* **Bug Fixes**
  * Improved handling of QKV biases and tensor shapes.
  * Added safer trainer identity generation and cleanup during weight updates.
  * Added optional tensor digests to reshard manifests for verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->