### PR TITLE
feat(refit): add canonical S3 generator integration

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -403,6 +403,9 @@ prepared snapshot without checkpoint I/O.
 Canonical S3 artifacts live under
 `{uri_prefix}/v{version_number}/`, with the
 index and delta shards stored as siblings.
+The index's `compression_format` selects the receiver's decompressor. The
+current implementation supports Zstandard. Unknown compression formats are
+rejected before shard download.
 Canonical S3 versions are retained for rollout fault recovery. Trainer
 processes keep only the current base snapshot; older
 immutable S3 objects are governed by external bucket lifecycle policy.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -885,22 +885,25 @@ Thin orchestration layer that delegates to `LoadStrategyChain.run()`. Builds a `
 
 ### vLLM Refit Installation
 
-`VllmGeneratorAdapter` has two fixed initialization modes. Without an S3
-configuration it preserves the existing full-tensor NIXL transfer, plan reuse,
-and staged-buffer installation path. With an S3 configuration it directly uses
-`CanonicalS3GeneratorAdapter` to reconstruct and verify an exact XOR delta in a
-host-local safetensors checkpoint; no NIXL transfer manager or transfer plan is
-created. The shared private installer reloads that prepared checkpoint through
-vLLM's `DefaultModelLoader` inside the same graph-safe layerwise reload window
-used by the NIXL path.
+`VllmGeneratorAdapter` has two fixed initialization modes. Without an object
+storage configuration it preserves the existing full-tensor NIXL transfer,
+plan reuse, and staged-buffer installation path. With
+`ObjectStorageGeneratorConfig(storage_type=ObjectStorageType.S3, ...)` it
+directly uses `CanonicalS3GeneratorAdapter` to reconstruct and verify an exact
+XOR delta in a host-local safetensors checkpoint; no NIXL transfer manager or
+transfer plan is created. The shared private installer reloads that prepared
+checkpoint through vLLM's `DefaultModelLoader` inside the same graph-safe
+layerwise reload window used by the NIXL path.
 
 The ModelExpress vLLM plugin registers one `modelexpress` native weight-transfer
 backend for both paths. An empty initialization payload preserves the existing
 NIXL path. The payload can override the logical ModelExpress model name when it
-differs from vLLM's model path. Supplying the READY launch-base version ID,
-launch checkpoint, and preparation cache selects canonical S3/XOR; the payload
-can also override the MX server and S3 endpoint settings. Each update carries
-the opaque MX `version_id`.
+differs from vLLM's model path. Supplying `object_storage_type` with the READY
+launch-base version ID, launch checkpoint, and preparation cache selects the
+object-storage path; the initial implementation accepts only `S3`. The payload
+can also override the MX server through `server_url` and the storage connection
+through `object_storage_endpoint_url` and `object_storage_region_name`. Each
+update carries the opaque MX `version_id`.
 `start_weight_update()` opens the update window, `receive_weights()` stages and
 applies the version through `ModelExpressGeneratorClient`, and
 `finish_weight_update()` releases its staged handle. Draft-model updates remain

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -489,8 +489,12 @@ than inheriting from the legacy reshard receiver:
 
 - `nixl_staged_transfer.py` owns exact-manifest decoding, transfer planning,
   reusable registered buffers, NIXL reads, transforms, and digest verification.
+- `inference/receiver.py` owns canonical S3 downloads, safetensors XOR
+  reconstruction, and locked host-local checkpoint state.
 - `inference/engines/vllm/installer.py` owns vLLM load-layout capture and
   graph-safe installation through vLLM's layerwise reload and post-load path.
+- `inference/engines/sglang/adapter.py` reloads a prepared canonical checkpoint
+  through SGLang's native safetensors loader.
 
 This keeps transport and verification independent of vLLM while keeping
 engine-specific parameter and CUDA-graph handling out of the transfer layer.
@@ -524,6 +528,11 @@ trainer shard publications. Applied generators publish their verified canonical
 staging buffers—not engine-specific packed kernel tensors—under that identity.
 An identical-rank peer pulls those buffers directly with NIXL, then uses the
 same graph-safe engine installer as a trainer update.
+
+S3-configured generator clients currently bypass the peer and trainer refit
+strategies. They resolve the version-level S3 URI directly and use the canonical
+S3 receiver; peer-first selection with trainer fallback applies only to the NIXL
+path for now.
 
 `WeightVersion.uid` is MX's opaque identity. `version_number` is the optional
 framework-provided numeric label used for correlation; canonical S3 publication
@@ -830,11 +839,14 @@ RL framework integrations live in the separate `modelexpress_rl` package:
 | `train/engines/megatron/selection.py` | Megatron-Bridge mapping and tensor-selection translation into MX publication specs |
 | `train/engines/megatron/adapter.py` | Stable in-place Megatron tensor registration and manifest construction |
 | `train/engines/fsdp/adapter.py` | FSDP/DTensor source capture with in-place or device-copy staging |
-| `inference/client.py` | Rank-local generator lifecycle, leases, exact-version source discovery, plan validation, staging, and apply |
+| `inference/client.py` | Rank-local generator lifecycle, leases, exact-version source discovery, staging, and apply |
+| `inference/receiver.py` | Canonical S3 index/shard decoding and exact-base checkpoint mutation under a local lock |
 | `inference/nixl_staged_transfer.py` | Private engine-neutral exact-manifest NIXL planning, transfer, reusable buffers, and verification |
+| `inference/engines/sglang/` | SGLang context and native checkpoint reload adapter |
 | `inference/engines/vllm/context.py` | Public typed vLLM objects passed to `ModelExpressGeneratorClient.initialize()` |
-| `inference/engines/vllm/adapter.py` | Generator adapter that composes staged transfer with the private vLLM installer |
-| `inference/engines/vllm/installer.py` | Private vLLM load-layout capture and graph-safe installation |
+| `inference/engines/vllm/adapter.py` | Generator adapter that keeps the existing NIXL full-tensor path and directly uses canonical S3 staging for XOR deltas |
+| `inference/engines/vllm/installer.py` | Private vLLM load-layout capture plus graph-safe tensor or prepared-checkpoint installation |
+| `inference/engines/vllm/weight_transfer_engine.py` | Native vLLM weight-transfer bridge for NIXL full-tensor and canonical S3/XOR refit |
 
 ### MxClient
 
@@ -872,6 +884,32 @@ Thin orchestration layer that delegates to `LoadStrategyChain.run()`. Builds a `
 **MTP two-pass load.** Multi-token-prediction models (Qwen3.5 MTP, DeepSeek MTP) call the loader twice on one worker: the target, then the draft head. `_is_speculative_draft()` detects the second pass via `model_config.runner_type == "draft"` and sets `ctx.p2p_enabled = False`. A P2P draft would collide on the target's NIXL metadata port, and since the merged draft shares the target's `SourceIdentity` it could poison source discovery, so registration, publication, and RDMA stay off for the draft while the target keeps serving. The draft loads through the ModelStreamer/default path. To avoid re-reading the whole checkpoint for a small head, `build_model_streamer_weight_iter` streams only the shards holding the draft's tensors: it reads `model.safetensors.index.json` from the directory of the shards `_prepare_weights` already resolved, which is what makes a Hugging Face model ID work, and falls back to the model URI itself (local directory, then the runai streamer's `pull_files`) for object storage. It keeps shards whose tensor names start with `mtp.`. The draft's embedding and `lm_head` come from the target, so they are not streamed. An index that holds no `mtp.` tensors is expected on a checkpoint without a draft head and streams every shard; an index that cannot be resolved at all logs a warning and also streams every shard.
 
 ### vLLM Refit Installation
+
+`VllmGeneratorAdapter` has two fixed initialization modes. Without an S3
+configuration it preserves the existing full-tensor NIXL transfer, plan reuse,
+and staged-buffer installation path. With an S3 configuration it directly uses
+`CanonicalS3GeneratorAdapter` to reconstruct and verify an exact XOR delta in a
+host-local safetensors checkpoint; no NIXL transfer manager or transfer plan is
+created. The shared private installer reloads that prepared checkpoint through
+vLLM's `DefaultModelLoader` inside the same graph-safe layerwise reload window
+used by the NIXL path.
+
+The ModelExpress vLLM plugin registers one `modelexpress` native weight-transfer
+backend for both paths. An empty initialization payload preserves the existing
+NIXL path. The payload can override the logical ModelExpress model name when it
+differs from vLLM's model path. Supplying the READY launch-base version ID,
+launch checkpoint, and preparation cache selects canonical S3/XOR; the payload
+can also override the MX server and S3 endpoint settings. Each update carries
+the opaque MX `version_id`.
+`start_weight_update()` opens the update window, `receive_weights()` stages and
+applies the version through `ModelExpressGeneratorClient`, and
+`finish_weight_update()` releases its staged handle. Draft-model updates remain
+unsupported, and trainer-pushed bytes are ignored because trainers publish
+WeightVersions through `ModelExpressTrainerClient`. After a successful apply,
+the bridge merges staging
+and installation metrics and logs each numeric `perf/` phase as a separate INFO
+line in deterministic key order. `perf/mx_receive_stage_weight_time` covers the
+complete `ModelExpressGeneratorClient.stage_weight()` wall-clock call.
 
 `engines/vllm/refit/MdlLoader` implements Mapped Direct Load (MDL) for tensors that have already
 been translated into the inference model's naming and numerical format. The

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -132,8 +132,9 @@ training framework. Framework-native bucket settings remain the default.
 The public trainer API accepts
 `ModelExpressTrainerConfig(object_storage=ObjectStorageConfig(...))`; its
 `storage_type` selects the provider. Weight versions use the corresponding
-typed `ObjectStorageSource` envelope. The current trainer and generator clients
-support only `ObjectStorageType.S3`.
+typed `ObjectStorageSource` envelope. Generator clients likewise accept
+`ModelExpressGeneratorConfig(object_storage=ObjectStorageGeneratorConfig(...))`.
+The current trainer and generator clients support only `ObjectStorageType.S3`.
 Integrations may use `MX_REFIT_DELTA_BUCKET_BYTES` as an explicit override, or
 its 512 MiB default when they have no native setting. CPU workers are configured
 by `MX_REFIT_DELTA_WORKERS` (default `min(32, CPU count)`).

--- a/modelexpress_client/python/modelexpress_rl/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/__init__.py
@@ -7,7 +7,7 @@ from .control import ModelExpressControlClient, WeightVersion, WeightVersionStat
 from .inference import (
     ModelExpressGeneratorClient,
     ModelExpressGeneratorConfig,
-    S3GeneratorConfig,
+    ObjectStorageGeneratorConfig,
     SglangGeneratorContext,
     VllmGeneratorContext,
 )
@@ -30,7 +30,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API role, not alphabetically.
     "ModelExpressGeneratorConfig",
     "ModelExpressTrainerConfig",
     "ObjectStorageConfig",
-    "S3GeneratorConfig",
+    "ObjectStorageGeneratorConfig",
     "SglangGeneratorContext",
     "TrainerStagingMode",
     "WeightPayloadFormat",

--- a/modelexpress_client/python/modelexpress_rl/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/__init__.py
@@ -7,6 +7,8 @@ from .control import ModelExpressControlClient, WeightVersion, WeightVersionStat
 from .inference import (
     ModelExpressGeneratorClient,
     ModelExpressGeneratorConfig,
+    S3GeneratorConfig,
+    SglangGeneratorContext,
     VllmGeneratorContext,
 )
 from .train import (
@@ -28,6 +30,8 @@ __all__ = [  # noqa: RUF022 - grouped by public API role, not alphabetically.
     "ModelExpressGeneratorConfig",
     "ModelExpressTrainerConfig",
     "ObjectStorageConfig",
+    "S3GeneratorConfig",
+    "SglangGeneratorContext",
     "TrainerStagingMode",
     "WeightPayloadFormat",
     "VllmGeneratorContext",

--- a/modelexpress_client/python/modelexpress_rl/inference/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/__init__.py
@@ -8,11 +8,15 @@ from .client import (
     ModelExpressGeneratorConfig,
     StagedWeightHandle,
 )
+from .engines.sglang import SglangGeneratorContext
 from .engines.vllm import VllmGeneratorContext
+from .receiver import S3GeneratorConfig
 
 __all__ = [
     "ModelExpressGeneratorClient",
     "ModelExpressGeneratorConfig",
+    "S3GeneratorConfig",
+    "SglangGeneratorContext",
     "StagedWeightHandle",
     "VllmGeneratorContext",
 ]

--- a/modelexpress_client/python/modelexpress_rl/inference/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/__init__.py
@@ -10,12 +10,12 @@ from .client import (
 )
 from .engines.sglang import SglangGeneratorContext
 from .engines.vllm import VllmGeneratorContext
-from .receiver import S3GeneratorConfig
+from .receiver import ObjectStorageGeneratorConfig
 
 __all__ = [
     "ModelExpressGeneratorClient",
     "ModelExpressGeneratorConfig",
-    "S3GeneratorConfig",
+    "ObjectStorageGeneratorConfig",
     "SglangGeneratorContext",
     "StagedWeightHandle",
     "VllmGeneratorContext",

--- a/modelexpress_client/python/modelexpress_rl/inference/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/adapter.py
@@ -19,39 +19,56 @@ class GeneratorEngineContext(ABC):
 
 
 @dataclass(frozen=True)
-class GeneratorSource:
-    """One verified, version-scoped source selected for a logical slot."""
+class NixlGeneratorSource:
+    """Worker-hosted NIXL manifest for one source."""
 
-    source_slot_id: str
-    worker_id: str
     manifest_endpoint: str
-    manifest_digest: str
-    transport: str
     manifest: bytes
 
 
 @dataclass(frozen=True)
+class GeneratorSource:
+    """One version-scoped source selected for a logical slot."""
+
+    source_slot_id: str
+    worker_id: str
+    manifest_digest: str
+    transport: NixlGeneratorSource
+
+    @property
+    def physical_fingerprint(self) -> tuple:
+        """Return the transport identity that controls plan reuse."""
+        return (
+            "NIXL",
+            self.transport.manifest_endpoint,
+            self.manifest_digest,
+        )
+
+
+@dataclass(frozen=True)
 class GeneratorTransferInputs:
-    """Exact-version source metadata used to validate or build a transfer plan."""
+    """Exact-version source metadata passed to one engine adapter."""
 
     version_id: str
+    base_version_id: str | None
     layout_signature: str
     payload_format: WeightPayloadFormat
     sources: tuple[GeneratorSource, ...]
+    s3_uri: str | None = None
 
     @property
     def physical_fingerprint(self) -> tuple:
         """Return the physical assumptions whose drift invalidates a plan."""
         return (
+            self.base_version_id,
             self.layout_signature,
             self.payload_format,
+            self.s3_uri,
             tuple(
                 (
                     source.source_slot_id,
                     source.worker_id,
-                    source.manifest_endpoint,
-                    source.manifest_digest,
-                    source.transport,
+                    source.physical_fingerprint,
                 )
                 for source in self.sources
             ),
@@ -59,22 +76,21 @@ class GeneratorTransferInputs:
 
 
 class GeneratorEngineAdapter(ABC):
-    """Engine-specific transfer planning and installation boundary."""
+    """Engine-specific staging and installation boundary."""
 
     @property
-    @abstractmethod
     def worker_rank(self) -> int:
         """Return the rank used to match an inference P2P source."""
+        raise NotImplementedError
 
-    @abstractmethod
     def build_p2p_identity(self, version_id: str) -> p2p_pb2.SourceIdentity:
         """Build the engine-compatible P2P identity for an exact version."""
+        raise NotImplementedError
 
-    @abstractmethod
     def stage_peer_weight(self, source: p2p_pb2.WorkerMetadata) -> object:
         """Stage an exact version from a compatible inference peer."""
+        raise NotImplementedError
 
-    @abstractmethod
     def publish_weight_version(
         self,
         *,
@@ -84,26 +100,27 @@ class GeneratorEngineAdapter(ABC):
         worker_id: str,
     ) -> None:
         """Publish applied staging buffers as an exact-version P2P source."""
+        raise NotImplementedError
 
     @property
     @abstractmethod
     def supported_payload_formats(self) -> frozenset[WeightPayloadFormat]:
         """Return payload formats implemented by this adapter."""
 
-    @abstractmethod
     def create_transfer_plan(self, inputs: GeneratorTransferInputs) -> Any:
         """Compile a reusable rank-local plan from verified source manifests."""
+        raise NotImplementedError
 
-    @abstractmethod
     def validate_transfer_plan(
         self,
         plan: Any,
         inputs: GeneratorTransferInputs,
     ) -> bool:
         """Return whether engine and transport assumptions still permit reuse."""
+        raise NotImplementedError
 
     @abstractmethod
-    def stage_weight(self, plan: Any) -> Any:
+    def stage_weight(self, inputs: GeneratorTransferInputs) -> Any:
         """Transfer and verify one version without changing live weights."""
 
     @abstractmethod
@@ -124,4 +141,5 @@ __all__ = [
     "GeneratorEngineAdapter",
     "GeneratorSource",
     "GeneratorTransferInputs",
+    "NixlGeneratorSource",
 ]

--- a/modelexpress_client/python/modelexpress_rl/inference/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/adapter.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClientBase
+from modelexpress_rl.object_storage import ObjectStorageSource
 from modelexpress_rl.train import WeightPayloadFormat
 
 
@@ -54,7 +55,7 @@ class GeneratorTransferInputs:
     layout_signature: str
     payload_format: WeightPayloadFormat
     sources: tuple[GeneratorSource, ...]
-    s3_uri: str | None = None
+    object_storage: ObjectStorageSource | None = None
 
     @property
     def physical_fingerprint(self) -> tuple:
@@ -63,7 +64,7 @@ class GeneratorTransferInputs:
             self.base_version_id,
             self.layout_signature,
             self.payload_format,
-            self.s3_uri,
+            self.object_storage,
             tuple(
                 (
                     source.source_slot_id,

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -413,6 +413,8 @@ class ModelExpressGeneratorClient:
             refit_pb2.GetWeightVersionRequest(uid=version_id),
             timeout=self._rpc_timeout_seconds,
         )
+        if not response.HasField("version"):
+            raise RuntimeError("MX GetWeightVersion response is missing version")
         version = _weight_version(response.version)
         if version.state is not WeightVersionState.READY:
             raise RuntimeError(f"initial base {version_id!r} is not READY")

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -194,7 +194,6 @@ class ModelExpressGeneratorClient:
         adapter = _create_generator_adapter(
             engine_context=config.engine_context,
             worker_id=worker_id,
-            model_name=model_name,
             object_storage=config.object_storage,
         )
         client = cls()
@@ -495,6 +494,8 @@ class ModelExpressGeneratorClient:
                     raise RuntimeError(
                         "The version is missing its object storage source"
                     )
+                if version.object_storage.storage_type is not ObjectStorageType.S3:
+                    raise RuntimeError("S3 generator requires S3 object storage")
                 inputs = GeneratorTransferInputs(
                     version_id=version.version_id,
                     base_version_id=version.base_version_id,

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -21,13 +21,14 @@ from modelexpress_rl.version import WeightVersionRef
 
 from .. import refit_pb2, refit_pb2_grpc
 from ..control import WeightVersion, WeightVersionState, _weight_version
+from ..object_storage import ObjectStorageType
 from .adapter import (
     GeneratorEngineAdapter,
     GeneratorEngineContext,
     GeneratorTransferInputs,
 )
 from .engines import _create_generator_adapter
-from .receiver import S3GeneratorConfig
+from .receiver import ObjectStorageGeneratorConfig
 from .refit_strategy import RefitStrategy
 from .refit_strategy.peer import _PeerRefitStrategy
 from .refit_strategy.trainer import _TrainerRefitStrategy
@@ -61,8 +62,8 @@ class ModelExpressGeneratorConfig:
     max_transfer_attempts: int = 3
     # Deadline applied independently to each control-plane or manifest RPC.
     rpc_timeout_seconds: float = 30.0
-    # Canonical S3 checkpoint settings. Omit for the existing NIXL path.
-    s3: S3GeneratorConfig | None = None
+    # Canonical object-storage checkpoint settings. Omit for the NIXL path.
+    object_storage: ObjectStorageGeneratorConfig | None = None
 
     def __post_init__(self) -> None:
         """Validate explicit settings before client initialization."""
@@ -184,12 +185,17 @@ class ModelExpressGeneratorClient:
         registration_ttl_seconds = rl_envs.require_positive_int(
             registration_ttl_seconds, "registration_ttl_seconds"
         )
+        if (
+            config.object_storage is not None
+            and config.object_storage.storage_type is not ObjectStorageType.S3
+        ):
+            raise ValueError("only S3 object storage is currently supported")
 
         adapter = _create_generator_adapter(
             engine_context=config.engine_context,
             worker_id=worker_id,
             model_name=model_name,
-            s3=config.s3,
+            object_storage=config.object_storage,
         )
         client = cls()
         client.model_name = model_name
@@ -200,9 +206,9 @@ class ModelExpressGeneratorClient:
         client._max_transfer_attempts = config.max_transfer_attempts
         client._rpc_timeout_seconds = config.rpc_timeout_seconds
         client._adapter = adapter
-        client._uses_s3 = config.s3 is not None
-        if config.s3 is not None:
-            client._serving_version_id = config.s3.initial_base_version_id
+        client._uses_s3 = config.object_storage is not None
+        if config.object_storage is not None:
+            client._serving_version_id = config.object_storage.initial_base_version_id
         else:
             client._p2p_client = MxClient(server_url=server_url)
             client._refit_strategies = (
@@ -404,12 +410,11 @@ class ModelExpressGeneratorClient:
         return version
 
     def _validate_initial_base(self, version_id: str) -> None:
-        version = _weight_version(
-            self._service.GetWeightVersion(
-                refit_pb2.GetWeightVersionRequest(uid=version_id),
-                timeout=self._rpc_timeout_seconds,
-            )
+        response = self._service.GetWeightVersion(
+            refit_pb2.GetWeightVersionRequest(uid=version_id),
+            timeout=self._rpc_timeout_seconds,
         )
+        version = _weight_version(response.version)
         if version.state is not WeightVersionState.READY:
             raise RuntimeError(f"initial base {version_id!r} is not READY")
         if version.model_name != self.model_name:
@@ -486,15 +491,17 @@ class ModelExpressGeneratorClient:
         lease = self._start_version_lease(version.version_id)
         try:
             if self._uses_s3:
-                if not version.s3_uri:
-                    raise RuntimeError("XOR_DELTA version is missing its S3 transport")
+                if version.object_storage is None:
+                    raise RuntimeError(
+                        "The version is missing its object storage source"
+                    )
                 inputs = GeneratorTransferInputs(
                     version_id=version.version_id,
                     base_version_id=version.base_version_id,
                     layout_signature=version.layout_signature,
                     payload_format=version.payload_format,
                     sources=(),
-                    s3_uri=version.s3_uri,
+                    object_storage=version.object_storage,
                 )
                 last_error: grpc.RpcError | RuntimeError | None = None
                 for _ in range(self._max_transfer_attempts):

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -16,12 +16,18 @@ from modelexpress import auth, envs
 from modelexpress.client import MxClient, _get_server_url
 
 from modelexpress_rl import envs as rl_envs
+from modelexpress_rl.train import WeightPayloadFormat
 from modelexpress_rl.version import WeightVersionRef
 
 from .. import refit_pb2, refit_pb2_grpc
 from ..control import WeightVersion, WeightVersionState, _weight_version
-from .adapter import GeneratorEngineAdapter, GeneratorEngineContext
+from .adapter import (
+    GeneratorEngineAdapter,
+    GeneratorEngineContext,
+    GeneratorTransferInputs,
+)
 from .engines import _create_generator_adapter
+from .receiver import S3GeneratorConfig
 from .refit_strategy import RefitStrategy
 from .refit_strategy.peer import _PeerRefitStrategy
 from .refit_strategy.trainer import _TrainerRefitStrategy
@@ -55,6 +61,8 @@ class ModelExpressGeneratorConfig:
     max_transfer_attempts: int = 3
     # Deadline applied independently to each control-plane or manifest RPC.
     rpc_timeout_seconds: float = 30.0
+    # Canonical S3 checkpoint settings. Omit for the existing NIXL path.
+    s3: S3GeneratorConfig | None = None
 
     def __post_init__(self) -> None:
         """Validate explicit settings before client initialization."""
@@ -63,9 +71,7 @@ class ModelExpressGeneratorConfig:
                 self.registration_ttl_seconds, "registration_ttl_seconds"
             )
         if self.lease_ttl_seconds is not None:
-            rl_envs.require_positive_int(
-                self.lease_ttl_seconds, "lease_ttl_seconds"
-            )
+            rl_envs.require_positive_int(self.lease_ttl_seconds, "lease_ttl_seconds")
         rl_envs.require_positive_int(
             self.max_transfer_attempts, "max_transfer_attempts"
         )
@@ -94,6 +100,16 @@ class StagedWeightHandle:
     def release(self) -> None:
         """Release local staging buffers; repeated calls are idempotent."""
         self._client._release_staged(self)
+
+    @property
+    def metrics(self) -> dict[str, float]:
+        """Return preparation metrics exposed by the selected adapter."""
+        return dict(getattr(self._staged, "metrics", {}))
+
+    @property
+    def applied(self) -> bool:
+        """Return whether engine installation completed."""
+        return self._applied
 
 
 class _VersionLease:
@@ -141,6 +157,7 @@ class ModelExpressGeneratorClient:
         self._adapter: GeneratorEngineAdapter | None = None
         self._p2p_client: MxClient | None = None
         self._refit_strategies: tuple[RefitStrategy, ...] = ()
+        self._uses_s3 = False
         self._closed = False
 
     @classmethod
@@ -171,6 +188,8 @@ class ModelExpressGeneratorClient:
         adapter = _create_generator_adapter(
             engine_context=config.engine_context,
             worker_id=worker_id,
+            model_name=model_name,
+            s3=config.s3,
         )
         client = cls()
         client.model_name = model_name
@@ -178,25 +197,32 @@ class ModelExpressGeneratorClient:
         client.server_url = server_url
         client._registration_ttl_seconds = registration_ttl_seconds
         client._lease_ttl_seconds = lease_ttl_seconds
+        client._max_transfer_attempts = config.max_transfer_attempts
         client._rpc_timeout_seconds = config.rpc_timeout_seconds
         client._adapter = adapter
-        client._p2p_client = MxClient(server_url=server_url)
-        client._refit_strategies = (
-            _PeerRefitStrategy(
-                adapter=adapter,
-                p2p_client=client._p2p_client,
-                worker_id=worker_id,
-                max_transfer_attempts=config.max_transfer_attempts,
-                rpc_timeout_seconds=config.rpc_timeout_seconds,
-            ),
-            _TrainerRefitStrategy(
-                adapter=adapter,
-                service=lambda: client._service,
-                max_transfer_attempts=config.max_transfer_attempts,
-                rpc_timeout_seconds=config.rpc_timeout_seconds,
-            ),
-        )
+        client._uses_s3 = config.s3 is not None
+        if config.s3 is not None:
+            client._serving_version_id = config.s3.initial_base_version_id
+        else:
+            client._p2p_client = MxClient(server_url=server_url)
+            client._refit_strategies = (
+                _PeerRefitStrategy(
+                    adapter=adapter,
+                    p2p_client=client._p2p_client,
+                    worker_id=worker_id,
+                    max_transfer_attempts=config.max_transfer_attempts,
+                    rpc_timeout_seconds=config.rpc_timeout_seconds,
+                ),
+                _TrainerRefitStrategy(
+                    adapter=adapter,
+                    service=lambda: client._service,
+                    max_transfer_attempts=config.max_transfer_attempts,
+                    rpc_timeout_seconds=config.rpc_timeout_seconds,
+                ),
+            )
         try:
+            if client._serving_version_id is not None:
+                client._validate_initial_base(client._serving_version_id)
             client._register_worker()
             client._registration_thread = threading.Thread(
                 target=client._renew_worker_registration,
@@ -246,29 +272,30 @@ class ModelExpressGeneratorClient:
                 staged._apply_result = self._adapter.apply_weight(staged._staged)
                 staged._applied = True
                 self._serving_version_id = staged.version_id
-                for attempt in range(2):
-                    try:
-                        self._adapter.publish_weight_version(
-                            version_id=staged.version_id,
-                            staged=staged._staged,
-                            p2p_client=self._p2p_client,
-                            worker_id=self.worker_id,
-                        )
-                        break
-                    except Exception:
-                        if attempt == 0:
-                            logger.warning(
-                                "failed to publish applied version %s as a P2P "
-                                "source; retrying once",
-                                staged.version_id,
-                                exc_info=True,
+                if self._p2p_client is not None:
+                    for attempt in range(2):
+                        try:
+                            self._adapter.publish_weight_version(
+                                version_id=staged.version_id,
+                                staged=staged._staged,
+                                p2p_client=self._p2p_client,
+                                worker_id=self.worker_id,
                             )
-                        else:
-                            logger.exception(
-                                "failed to publish applied version %s as a P2P "
-                                "source after retry",
-                                staged.version_id,
-                            )
+                            break
+                        except Exception:
+                            if attempt == 0:
+                                logger.warning(
+                                    "failed to publish applied version %s as a P2P "
+                                    "source; retrying once",
+                                    staged.version_id,
+                                    exc_info=True,
+                                )
+                            else:
+                                logger.exception(
+                                    "failed to publish applied version %s as a P2P "
+                                    "source after retry",
+                                    staged.version_id,
+                                )
                 return staged._apply_result
             except BaseException as error:
                 primary_error = error
@@ -361,7 +388,32 @@ class ModelExpressGeneratorClient:
             raise RuntimeError(f"weight version {version_id!r} is not READY")
         if version.model_name != self.model_name:
             raise RuntimeError("weight version model_name does not match the generator")
+        if self._uses_s3:
+            if version.payload_format is not WeightPayloadFormat.XOR_DELTA:
+                raise RuntimeError("S3 generator requires XOR_DELTA weight versions")
+            if version.base_version_id is None:
+                raise RuntimeError("XOR_DELTA version is missing base_version_id")
+            if (
+                version.version_id != self._serving_version_id
+                and version.base_version_id != self._serving_version_id
+            ):
+                raise RuntimeError(
+                    f"weight version base {version.base_version_id!r} does not match "
+                    f"serving version {self._serving_version_id!r}"
+                )
         return version
+
+    def _validate_initial_base(self, version_id: str) -> None:
+        version = _weight_version(
+            self._service.GetWeightVersion(
+                refit_pb2.GetWeightVersionRequest(uid=version_id),
+                timeout=self._rpc_timeout_seconds,
+            )
+        )
+        if version.state is not WeightVersionState.READY:
+            raise RuntimeError(f"initial base {version_id!r} is not READY")
+        if version.model_name != self.model_name:
+            raise RuntimeError("initial base model_name does not match the generator")
 
     def _register_lease(self, version_id: str):
         response = self._service.RegisterVersionLease(
@@ -433,6 +485,26 @@ class ModelExpressGeneratorClient:
     ) -> tuple[object, _VersionLease]:
         lease = self._start_version_lease(version.version_id)
         try:
+            if self._uses_s3:
+                if not version.s3_uri:
+                    raise RuntimeError("XOR_DELTA version is missing its S3 transport")
+                inputs = GeneratorTransferInputs(
+                    version_id=version.version_id,
+                    base_version_id=version.base_version_id,
+                    layout_signature=version.layout_signature,
+                    payload_format=version.payload_format,
+                    sources=(),
+                    s3_uri=version.s3_uri,
+                )
+                last_error: grpc.RpcError | RuntimeError | None = None
+                for _ in range(self._max_transfer_attempts):
+                    try:
+                        return self._adapter.stage_weight(inputs), lease
+                    except (grpc.RpcError, RuntimeError) as error:
+                        last_error = error
+                assert last_error is not None
+                raise last_error
+
             for strategy in self._refit_strategies:
                 staged = strategy.stage(version)
                 if staged is not None:

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from ..adapter import GeneratorEngineAdapter, GeneratorEngineContext
-from ..receiver import S3GeneratorConfig
+from ..receiver import ObjectStorageGeneratorConfig
 from .sglang import SglangGeneratorContext
 from .sglang.adapter import _create_sglang_adapter
 from .vllm import VllmGeneratorContext, _create_vllm_adapter
@@ -17,13 +17,18 @@ def _create_generator_adapter(
     engine_context: GeneratorEngineContext,
     worker_id: str,
     model_name: str,
-    s3: S3GeneratorConfig | None,
+    object_storage: ObjectStorageGeneratorConfig | None,
 ) -> GeneratorEngineAdapter:
     """Construct the adapter selected by the concrete engine context."""
     if isinstance(engine_context, SglangGeneratorContext):
-        return _create_sglang_adapter(engine_context, model_name, s3)
+        return _create_sglang_adapter(engine_context, model_name, object_storage)
     if isinstance(engine_context, VllmGeneratorContext):
-        return _create_vllm_adapter(engine_context, worker_id, model_name, s3)
+        return _create_vllm_adapter(
+            engine_context,
+            worker_id,
+            model_name,
+            object_storage,
+        )
     raise TypeError(f"unsupported generator context {type(engine_context).__name__}")
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/__init__.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 from ..adapter import GeneratorEngineAdapter, GeneratorEngineContext
 from ..receiver import ObjectStorageGeneratorConfig
-from .sglang import SglangGeneratorContext
-from .sglang.adapter import _create_sglang_adapter
+from .sglang import SglangGeneratorContext, _create_sglang_adapter
 from .vllm import VllmGeneratorContext, _create_vllm_adapter
 
 
@@ -16,17 +15,15 @@ def _create_generator_adapter(
     *,
     engine_context: GeneratorEngineContext,
     worker_id: str,
-    model_name: str,
     object_storage: ObjectStorageGeneratorConfig | None,
 ) -> GeneratorEngineAdapter:
     """Construct the adapter selected by the concrete engine context."""
     if isinstance(engine_context, SglangGeneratorContext):
-        return _create_sglang_adapter(engine_context, model_name, object_storage)
+        return _create_sglang_adapter(engine_context, object_storage)
     if isinstance(engine_context, VllmGeneratorContext):
         return _create_vllm_adapter(
             engine_context,
             worker_id,
-            model_name,
             object_storage,
         )
     raise TypeError(f"unsupported generator context {type(engine_context).__name__}")

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/__init__.py
@@ -6,6 +6,9 @@
 from __future__ import annotations
 
 from ..adapter import GeneratorEngineAdapter, GeneratorEngineContext
+from ..receiver import S3GeneratorConfig
+from .sglang import SglangGeneratorContext
+from .sglang.adapter import _create_sglang_adapter
 from .vllm import VllmGeneratorContext, _create_vllm_adapter
 
 
@@ -13,10 +16,14 @@ def _create_generator_adapter(
     *,
     engine_context: GeneratorEngineContext,
     worker_id: str,
+    model_name: str,
+    s3: S3GeneratorConfig | None,
 ) -> GeneratorEngineAdapter:
     """Construct the adapter selected by the concrete engine context."""
+    if isinstance(engine_context, SglangGeneratorContext):
+        return _create_sglang_adapter(engine_context, model_name, s3)
     if isinstance(engine_context, VllmGeneratorContext):
-        return _create_vllm_adapter(engine_context, worker_id)
+        return _create_vllm_adapter(engine_context, worker_id, model_name, s3)
     raise TypeError(f"unsupported generator context {type(engine_context).__name__}")
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/__init__.py
@@ -3,8 +3,25 @@
 
 """SGLang generator integration for ModelExpress RL refit."""
 
+from ...adapter import GeneratorEngineContext
+from ...receiver import ObjectStorageGeneratorConfig
 from .adapter import SGLangGeneratorAdapter
 from .context import SglangGeneratorContext
+
+
+def _create_sglang_adapter(
+    engine_context: GeneratorEngineContext,
+    object_storage: ObjectStorageGeneratorConfig | None,
+) -> SGLangGeneratorAdapter:
+    if not isinstance(engine_context, SglangGeneratorContext):
+        raise TypeError("SGLang requires a SglangGeneratorContext")
+    if object_storage is None:
+        raise ValueError("SGLang requires object storage")
+    return SGLangGeneratorAdapter(
+        context=engine_context,
+        config=object_storage,
+    )
+
 
 __all__ = [
     "SGLangGeneratorAdapter",

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang generator integration for ModelExpress RL refit."""
+
+from .adapter import SGLangGeneratorAdapter
+from .context import SglangGeneratorContext
+
+__all__ = [
+    "SGLangGeneratorAdapter",
+    "SglangGeneratorContext",
+]

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/adapter.py
@@ -26,11 +26,13 @@ class SGLangGeneratorAdapter(CanonicalS3GeneratorAdapter):
         self,
         *,
         context: SglangGeneratorContext,
-        model_name: str,
         config: ObjectStorageGeneratorConfig,
     ) -> None:
         self.model_runner = context.model_runner
-        super().__init__(model_name=model_name, config=config)
+        super().__init__(
+            model_name=self.model_runner.model_config.model_path,
+            config=config,
+        )
 
     def install_prepared_checkpoint(self, prepared: PreparedCheckpoint) -> None:
         try:
@@ -78,18 +80,6 @@ class SGLangGeneratorAdapter(CanonicalS3GeneratorAdapter):
                 device.synchronize()
         except Exception as error:
             raise ReceiverInstallError(str(error)) from error
-
-
-def _create_sglang_adapter(
-    context: SglangGeneratorContext,
-    model_name: str,
-    config: ObjectStorageGeneratorConfig,
-) -> SGLangGeneratorAdapter:
-    return SGLangGeneratorAdapter(
-        context=context,
-        model_name=model_name,
-        config=config,
-    )
 
 
 __all__ = [

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/adapter.py
@@ -11,9 +11,9 @@ import torch
 
 from modelexpress_rl.inference.receiver import (
     CanonicalS3GeneratorAdapter,
+    ObjectStorageGeneratorConfig,
     PreparedCheckpoint,
     ReceiverInstallError,
-    S3GeneratorConfig,
 )
 
 from .context import SglangGeneratorContext
@@ -27,7 +27,7 @@ class SGLangGeneratorAdapter(CanonicalS3GeneratorAdapter):
         *,
         context: SglangGeneratorContext,
         model_name: str,
-        config: S3GeneratorConfig,
+        config: ObjectStorageGeneratorConfig,
     ) -> None:
         self.model_runner = context.model_runner
         super().__init__(model_name=model_name, config=config)
@@ -83,7 +83,7 @@ class SGLangGeneratorAdapter(CanonicalS3GeneratorAdapter):
 def _create_sglang_adapter(
     context: SglangGeneratorContext,
     model_name: str,
-    config: S3GeneratorConfig,
+    config: ObjectStorageGeneratorConfig,
 ) -> SGLangGeneratorAdapter:
     return SGLangGeneratorAdapter(
         context=context,

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/adapter.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang installation adapter for canonical S3 refit."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from modelexpress_rl.inference.receiver import (
+    CanonicalS3GeneratorAdapter,
+    PreparedCheckpoint,
+    ReceiverInstallError,
+    S3GeneratorConfig,
+)
+
+from .context import SglangGeneratorContext
+
+
+class SGLangGeneratorAdapter(CanonicalS3GeneratorAdapter):
+    """Reload a prepared canonical checkpoint into one SGLang model runner."""
+
+    def __init__(
+        self,
+        *,
+        context: SglangGeneratorContext,
+        model_name: str,
+        config: S3GeneratorConfig,
+    ) -> None:
+        self.model_runner = context.model_runner
+        super().__init__(model_name=model_name, config=config)
+
+    def install_prepared_checkpoint(self, prepared: PreparedCheckpoint) -> None:
+        try:
+            from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+            from sglang.srt.model_loader.loader import (
+                DefaultModelLoader,
+                get_model_loader,
+            )
+
+            loader = get_model_loader(
+                LoadConfig(
+                    load_format=LoadFormat.SAFETENSORS,
+                    download_dir=self.model_runner.server_args.download_dir,
+                    model_loader_extra_config=(
+                        self.model_runner.server_args.model_loader_extra_config
+                    ),
+                ),
+                self.model_runner.model_config,
+            )
+            if not isinstance(loader, DefaultModelLoader):
+                raise TypeError("ModelExpress requires DefaultModelLoader")
+            weights = loader._get_weights_iterator(
+                SimpleNamespace(
+                    model_or_path=str(prepared.path),
+                    revision=None,
+                    prefix="",
+                    fall_back_to_pt=False,
+                    model_config=self.model_runner.model_config,
+                )
+            )
+        except Exception as error:
+            raise ReceiverInstallError(str(error)) from error
+
+        try:
+            from sglang.srt.model_loader.utils import set_default_torch_dtype
+
+            with set_default_torch_dtype(self.model_runner.model_config.dtype):
+                loader.load_weights_and_postprocess(
+                    self.model_runner.model,
+                    weights,
+                    torch.device(self.model_runner.device),
+                )
+            device = torch.get_device_module(self.model_runner.device)
+            if hasattr(device, "synchronize"):
+                device.synchronize()
+        except Exception as error:
+            raise ReceiverInstallError(str(error)) from error
+
+
+def _create_sglang_adapter(
+    context: SglangGeneratorContext,
+    model_name: str,
+    config: S3GeneratorConfig,
+) -> SGLangGeneratorAdapter:
+    return SGLangGeneratorAdapter(
+        context=context,
+        model_name=model_name,
+        config=config,
+    )
+
+
+__all__ = [
+    "SGLangGeneratorAdapter",
+]

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/context.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/sglang/context.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public rank-local context required by the SGLang generator adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ...adapter import GeneratorEngineContext
+
+
+@dataclass(frozen=True)
+class SglangGeneratorContext(GeneratorEngineContext):
+    """Live SGLang model runner used to install prepared checkpoints."""
+
+    model_runner: Any
+
+
+__all__ = ["SglangGeneratorContext"]

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/__init__.py
@@ -14,7 +14,6 @@ from .context import VllmGeneratorContext
 def _create_vllm_adapter(
     engine_context: GeneratorEngineContext,
     worker_id: str,
-    model_name: str | None = None,
     object_storage: ObjectStorageGeneratorConfig | None = None,
 ) -> VllmGeneratorAdapter:
     if not isinstance(engine_context, VllmGeneratorContext):
@@ -37,7 +36,6 @@ def _create_vllm_adapter(
         vllm_config=vllm_config,
         model_config=model_config,
         worker_id=worker_id,
-        model_name=model_name,
         object_storage=object_storage,
     )
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from ...adapter import GeneratorEngineContext
-from ...receiver import S3GeneratorConfig
+from ...receiver import ObjectStorageGeneratorConfig
 from .adapter import VllmGeneratorAdapter
 from .context import VllmGeneratorContext
 
@@ -15,7 +15,7 @@ def _create_vllm_adapter(
     engine_context: GeneratorEngineContext,
     worker_id: str,
     model_name: str | None = None,
-    s3: S3GeneratorConfig | None = None,
+    object_storage: ObjectStorageGeneratorConfig | None = None,
 ) -> VllmGeneratorAdapter:
     if not isinstance(engine_context, VllmGeneratorContext):
         raise TypeError("VLLM requires a VllmGeneratorContext")
@@ -38,7 +38,7 @@ def _create_vllm_adapter(
         model_config=model_config,
         worker_id=worker_id,
         model_name=model_name,
-        s3=s3,
+        object_storage=object_storage,
     )
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/__init__.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/__init__.py
@@ -6,12 +6,16 @@
 from __future__ import annotations
 
 from ...adapter import GeneratorEngineContext
+from ...receiver import S3GeneratorConfig
 from .adapter import VllmGeneratorAdapter
 from .context import VllmGeneratorContext
 
 
 def _create_vllm_adapter(
-    engine_context: GeneratorEngineContext, worker_id: str
+    engine_context: GeneratorEngineContext,
+    worker_id: str,
+    model_name: str | None = None,
+    s3: S3GeneratorConfig | None = None,
 ) -> VllmGeneratorAdapter:
     if not isinstance(engine_context, VllmGeneratorContext):
         raise TypeError("VLLM requires a VllmGeneratorContext")
@@ -33,6 +37,8 @@ def _create_vllm_adapter(
         vllm_config=vllm_config,
         model_config=model_config,
         worker_id=worker_id,
+        model_name=model_name,
+        s3=s3,
     )
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
@@ -12,13 +12,18 @@ from modelexpress.client import MxClientBase
 from modelexpress.engines.vllm.adapter import VllmAdapter
 from modelexpress_rl import envs as rl_envs
 from modelexpress_rl.inference.adapter import (
-    GeneratorEngineAdapter,
     GeneratorTransferInputs,
+    NixlGeneratorSource,
 )
 from modelexpress_rl.inference.nixl_staged_transfer import (
     _NixlStagedTransfer,
     _PreparedNixlTransfer,
     _StagedNixlWeights,
+)
+from modelexpress_rl.inference.receiver import (
+    CanonicalS3GeneratorAdapter,
+    PreparedCheckpoint,
+    S3GeneratorConfig,
 )
 from modelexpress_rl.train import WeightPayloadFormat
 
@@ -29,8 +34,8 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
 
 
-class VllmGeneratorAdapter(GeneratorEngineAdapter):
-    """Compose exact-version NIXL staging with graph-safe vLLM installation."""
+class VllmGeneratorAdapter(CanonicalS3GeneratorAdapter):
+    """Install NIXL full tensors or canonical S3 deltas into vLLM."""
 
     def __init__(
         self,
@@ -39,7 +44,13 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
         vllm_config: VllmConfig,
         model_config: ModelConfig,
         worker_id: str,
+        model_name: str | None = None,
+        s3: S3GeneratorConfig | None = None,
     ) -> None:
+        self._uses_s3 = s3 is not None
+        if self._uses_s3 and not model_name:
+            raise ValueError("model_name is required for canonical S3")
+
         engine = VllmAdapter(vllm_config, model_config)
         self._engine = engine
         device_id = engine.get_device_id()
@@ -50,6 +61,10 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
             model_config=model_config,
             device=device,
         )
+        if s3 is not None:
+            super().__init__(model_name=cast(str, model_name), config=s3)
+            return
+
         self._transfer = _NixlStagedTransfer(
             agent_name=f"mx-refit-{worker_id}",
             device_id=device_id,
@@ -69,9 +84,7 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
         identity.revision = version_id
         return identity
 
-    def stage_peer_weight(
-        self, source: p2p_pb2.WorkerMetadata
-    ) -> _StagedNixlWeights:
+    def stage_peer_weight(self, source: p2p_pb2.WorkerMetadata) -> _StagedNixlWeights:
         self._active_plan = None
         self._active_fingerprint = None
         staged = self._transfer.stage_peer(
@@ -103,6 +116,8 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
 
     @property
     def supported_payload_formats(self) -> frozenset[WeightPayloadFormat]:
+        if self._uses_s3:
+            return super().supported_payload_formats
         return frozenset({WeightPayloadFormat.FULL_TENSOR})
 
     def create_transfer_plan(
@@ -117,12 +132,15 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
                 f"VllmGeneratorAdapter does not support "
                 f"{inputs.payload_format.value} payloads"
             )
-        if any(source.transport.upper() != "NIXL" for source in inputs.sources):
+        if any(
+            not isinstance(source.transport, NixlGeneratorSource)
+            for source in inputs.sources
+        ):
             raise ValueError(
                 "VllmGeneratorAdapter currently supports NIXL sources only"
             )
         plan = self._transfer.prepare(
-            manifests=[source.manifest for source in inputs.sources],
+            manifests=[source.transport.manifest for source in inputs.sources],
             capture_layout=self._installer.capture,
         )
         self._active_plan = plan
@@ -139,7 +157,9 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
             and self._active_fingerprint == inputs.physical_fingerprint
         )
 
-    def stage_weight(self, plan: object) -> _StagedNixlWeights:
+    def stage_weight(self, plan: object) -> PreparedCheckpoint | _StagedNixlWeights:
+        if self._uses_s3:
+            return super().stage_weight(cast(GeneratorTransferInputs, plan))
         if plan is not self._active_plan:
             raise RuntimeError("vLLM transfer plan is no longer active")
         self._transfer.unpublish_peer()
@@ -148,13 +168,21 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
         return staged
 
     def apply_weight(self, staged: object) -> dict[str, Any]:
+        if self._uses_s3:
+            return super().apply_weight(staged)
         active_staged = self._active_staged
         if active_staged is None or staged is not active_staged:
             raise RuntimeError("vLLM staged weight is no longer active")
         self._installer.install(active_staged.tensors)
         return active_staged.metrics
 
+    def install_prepared_checkpoint(self, prepared: PreparedCheckpoint) -> None:
+        self._installer.install_checkpoint(prepared.path)
+
     def release_staged_weight(self, staged: object) -> None:
+        if self._uses_s3:
+            super().release_staged_weight(staged)
+            return
         active_staged = self._active_staged
         if active_staged is None or staged is not active_staged:
             raise RuntimeError("vLLM staged weight is no longer active")
@@ -163,7 +191,10 @@ class VllmGeneratorAdapter(GeneratorEngineAdapter):
         self._active_staged = None
 
     def close(self) -> None:
-        """Release the rank-local NIXL agent."""
+        """Release the selected rank-local transport."""
+        if self._uses_s3:
+            super().close()
+            return
         self._active_staged = None
         self._active_plan = None
         self._active_fingerprint = None

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
@@ -44,12 +44,9 @@ class VllmGeneratorAdapter(CanonicalS3GeneratorAdapter):
         vllm_config: VllmConfig,
         model_config: ModelConfig,
         worker_id: str,
-        model_name: str | None = None,
         object_storage: ObjectStorageGeneratorConfig | None = None,
     ) -> None:
         self._uses_s3 = object_storage is not None
-        if self._uses_s3 and not model_name:
-            raise ValueError("model_name is required for canonical S3")
 
         engine = VllmAdapter(vllm_config, model_config)
         self._engine = engine
@@ -63,7 +60,7 @@ class VllmGeneratorAdapter(CanonicalS3GeneratorAdapter):
         )
         if object_storage is not None:
             super().__init__(
-                model_name=cast(str, model_name),
+                model_name=vllm_config.model_config.model,
                 config=object_storage,
             )
             return

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/adapter.py
@@ -22,8 +22,8 @@ from modelexpress_rl.inference.nixl_staged_transfer import (
 )
 from modelexpress_rl.inference.receiver import (
     CanonicalS3GeneratorAdapter,
+    ObjectStorageGeneratorConfig,
     PreparedCheckpoint,
-    S3GeneratorConfig,
 )
 from modelexpress_rl.train import WeightPayloadFormat
 
@@ -45,9 +45,9 @@ class VllmGeneratorAdapter(CanonicalS3GeneratorAdapter):
         model_config: ModelConfig,
         worker_id: str,
         model_name: str | None = None,
-        s3: S3GeneratorConfig | None = None,
+        object_storage: ObjectStorageGeneratorConfig | None = None,
     ) -> None:
-        self._uses_s3 = s3 is not None
+        self._uses_s3 = object_storage is not None
         if self._uses_s3 and not model_name:
             raise ValueError("model_name is required for canonical S3")
 
@@ -61,8 +61,11 @@ class VllmGeneratorAdapter(CanonicalS3GeneratorAdapter):
             model_config=model_config,
             device=device,
         )
-        if s3 is not None:
-            super().__init__(model_name=cast(str, model_name), config=s3)
+        if object_storage is not None:
+            super().__init__(
+                model_name=cast(str, model_name),
+                config=object_storage,
+            )
             return
 
         self._transfer = _NixlStagedTransfer(

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import copy
 import logging
+from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
@@ -144,6 +146,31 @@ class _VllmInstaller:
         _update_mla_absorbed_weights(self._model, quantized=self._is_quantized)
         torch.cuda.synchronize(self._device)
 
+    def install_checkpoint(self, path: str | Path) -> None:
+        """Reload a prepared safetensors checkpoint into the live model."""
+        try:
+            from vllm.model_executor.model_loader.default_loader import (
+                DefaultModelLoader,
+            )
+        except (ImportError, AttributeError) as error:
+            raise RuntimeError(
+                "ModelExpress refit requires vLLM's default model loader"
+            ) from error
+
+        load_config = copy.copy(self._vllm_config.load_config)
+        try:
+            load_config.load_format = "safetensors"
+        except AttributeError:
+            object.__setattr__(load_config, "load_format", "safetensors")
+        model_config = copy.copy(self._model_config)
+        model_config.model = str(path)
+        model_config.revision = None
+        loader = DefaultModelLoader(load_config)
+
+        self._reload(lambda: loader.load_weights(self._model, model_config))
+        _update_mla_absorbed_weights(self._model, quantized=self._is_quantized)
+        torch.cuda.synchronize(self._device)
+
     @torch.no_grad()
     def _process_and_commit(self, tensors: dict[str, torch.Tensor]) -> None:
         """Run vLLM's per-layer post-load processing into graph-bound storage.
@@ -156,40 +183,19 @@ class _VllmInstaller:
         from torch import nn
 
         try:
-            from vllm.config import set_current_vllm_config
             from vllm.model_executor.layers.quantization.base_config import (
                 QuantizeMethodBase,
             )
             from vllm.model_executor.model_loader.reload.layerwise import (
                 LAYERWISE_INFO,
                 _copy_and_restore_kernel_tensors,
-                finalize_layerwise_reload,
-                initialize_layerwise_reload,
             )
         except (ImportError, AttributeError) as error:
             raise RuntimeError(
                 "ModelExpress refit requires vLLM's layerwise reload APIs"
             ) from error
 
-        # vLLM also keeps graph-bound tensors as plain object attributes rather
-        # than registered parameters or buffers. Layerwise reload does not save
-        # these. Snapshot their original storage so Marlin workspaces and MLA
-        # derived tensors are not replaced with addresses absent from the graph.
-        bare_tensors = {
-            module: {
-                name: value
-                for name, value in module.__dict__.items()
-                if isinstance(value, torch.Tensor)
-            }
-            for module in self._model.modules()
-        }
-        bare_tensors = {
-            module: values for module, values in bare_tensors.items() if values
-        }
-
-        with torch.device(self._device), set_current_vllm_config(self._vllm_config):
-            initialize_layerwise_reload(self._model)
-
+        def load() -> None:
             # Quantized models expose kernel-packed parameters before layerwise
             # reload and load-time parameters after it. Resolve the captured
             # names only after vLLM has restored that load-time hierarchy.
@@ -225,6 +231,42 @@ class _VllmInstaller:
                     _copy_and_restore_kernel_tensors(layer, info)
                 if info is not None:
                     info.reset()
+
+        self._reload(load)
+
+    @torch.no_grad()
+    def _reload(self, load: Callable[[], None]) -> None:
+        """Run one weight loader inside vLLM's graph-safe reload window."""
+        try:
+            from vllm.config import set_current_vllm_config
+            from vllm.model_executor.model_loader.reload.layerwise import (
+                finalize_layerwise_reload,
+                initialize_layerwise_reload,
+            )
+        except (ImportError, AttributeError) as error:
+            raise RuntimeError(
+                "ModelExpress refit requires vLLM's layerwise reload APIs"
+            ) from error
+
+        # vLLM also keeps graph-bound tensors as plain object attributes rather
+        # than registered parameters or buffers. Layerwise reload does not save
+        # these. Snapshot their original storage so Marlin workspaces and MLA
+        # derived tensors are not replaced with addresses absent from the graph.
+        bare_tensors = {
+            module: {
+                name: value
+                for name, value in module.__dict__.items()
+                if isinstance(value, torch.Tensor)
+            }
+            for module in self._model.modules()
+        }
+        bare_tensors = {
+            module: values for module, values in bare_tensors.items() if values
+        }
+
+        with torch.device(self._device), set_current_vllm_config(self._vllm_config):
+            initialize_layerwise_reload(self._model)
+            load()
             finalize_layerwise_reload(self._model, self._model_config)
 
             # PWAL may recreate a bare attribute. Copy meaningful derived content

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from time import perf_counter
 from typing import Any
 
 from vllm.distributed.weight_transfer import WeightTransferEngine
@@ -21,6 +22,7 @@ from modelexpress_rl.inference.client import (
     ModelExpressGeneratorConfig,
     StagedWeightHandle,
 )
+from modelexpress_rl.inference.receiver import S3GeneratorConfig
 from modelexpress_rl.version import WeightVersionRef
 
 from .context import VllmGeneratorContext
@@ -30,7 +32,19 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ModelExpressWeightTransferInitInfo(WeightTransferInitInfo):
-    """ModelExpress initializes from the vLLM worker's live model context."""
+    """Optional ModelExpress connection and canonical S3 settings."""
+
+    model_name: str | None = None
+    initial_base_version_id: str | None = None
+    launch_checkpoint: str | None = None
+    preparation_cache_dir: str | None = None
+    server_url: str | None = None
+    s3_endpoint_url: str | None = None
+    s3_region_name: str | None = None
+    registration_ttl_seconds: int | None = None
+    lease_ttl_seconds: int | None = None
+    max_transfer_attempts: int = 3
+    rpc_timeout_seconds: float = 30.0
 
 
 @dataclass
@@ -77,7 +91,7 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
         self._closed = False
 
     def init_transfer_engine(
-        self, _init_info: ModelExpressWeightTransferInitInfo
+        self, init_info: ModelExpressWeightTransferInitInfo
     ) -> None:
         """Initialize ModelExpress from the rank-local vLLM model context."""
         if self._closed:
@@ -86,7 +100,50 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
         if self._client is not None:
             logger.warning("weight transfer engine is already initialized")
             return
-        self._client = ModelExpressGeneratorClient.initialize(self._generator_config)
+
+        s3_values = (
+            init_info.initial_base_version_id,
+            init_info.launch_checkpoint,
+            init_info.preparation_cache_dir,
+            init_info.s3_endpoint_url,
+            init_info.s3_region_name,
+        )
+        s3 = None
+        if any(value is not None for value in s3_values):
+            if (
+                init_info.initial_base_version_id is None
+                or init_info.launch_checkpoint is None
+                or init_info.preparation_cache_dir is None
+            ):
+                raise ValueError(
+                    "canonical S3 requires initial_base_version_id, "
+                    "launch_checkpoint, and preparation_cache_dir"
+                )
+            s3 = S3GeneratorConfig(
+                initial_base_version_id=init_info.initial_base_version_id,
+                launch_checkpoint=init_info.launch_checkpoint,
+                preparation_cache_dir=init_info.preparation_cache_dir,
+                endpoint_url=init_info.s3_endpoint_url,
+                region_name=init_info.s3_region_name,
+            )
+
+        model_name = (
+            init_info.model_name
+            if init_info.model_name is not None
+            else self._generator_config.model_name
+        )
+        self._client = ModelExpressGeneratorClient.initialize(
+            replace(
+                self._generator_config,
+                model_name=model_name,
+                server_url=init_info.server_url,
+                registration_ttl_seconds=init_info.registration_ttl_seconds,
+                lease_ttl_seconds=init_info.lease_ttl_seconds,
+                max_transfer_attempts=init_info.max_transfer_attempts,
+                rpc_timeout_seconds=init_info.rpc_timeout_seconds,
+                s3=s3,
+            )
+        )
 
     def start_weight_update(self) -> None:
         if self._closed:
@@ -119,10 +176,19 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
 
         staged: StagedWeightHandle | None = None
         try:
+            stage_started = perf_counter()
             staged = client.stage_weight(
                 version=WeightVersionRef(update_info.version_id)
             )
-            client.apply_weight(staged)
+            stage_weight_time = perf_counter() - stage_started
+            metrics = staged.metrics
+            apply_metrics = client.apply_weight(staged)
+            if isinstance(apply_metrics, dict):
+                metrics.update(apply_metrics)
+            metrics["perf/mx_receive_stage_weight_time"] = stage_weight_time
+            for key, value in sorted(metrics.items()):
+                if key.startswith("perf/") and isinstance(value, (int, float)):
+                    logger.info("ModelExpress receiver metric %s=%s", key, value)
             self._staged = staged
         except BaseException as error:
             if staged is not None:

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
@@ -22,7 +22,8 @@ from modelexpress_rl.inference.client import (
     ModelExpressGeneratorConfig,
     StagedWeightHandle,
 )
-from modelexpress_rl.inference.receiver import S3GeneratorConfig
+from modelexpress_rl.inference.receiver import ObjectStorageGeneratorConfig
+from modelexpress_rl.object_storage import ObjectStorageType
 from modelexpress_rl.version import WeightVersionRef
 
 from .context import VllmGeneratorContext
@@ -32,15 +33,16 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ModelExpressWeightTransferInitInfo(WeightTransferInitInfo):
-    """Optional ModelExpress connection and canonical S3 settings."""
+    """Optional ModelExpress connection and object-storage settings."""
 
     model_name: str | None = None
     initial_base_version_id: str | None = None
     launch_checkpoint: str | None = None
     preparation_cache_dir: str | None = None
     server_url: str | None = None
-    s3_endpoint_url: str | None = None
-    s3_region_name: str | None = None
+    object_storage_type: str | None = None
+    object_storage_endpoint_url: str | None = None
+    object_storage_region_name: str | None = None
     registration_ttl_seconds: int | None = None
     lease_ttl_seconds: int | None = None
     max_transfer_attempts: int = 3
@@ -101,30 +103,41 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
             logger.warning("weight transfer engine is already initialized")
             return
 
-        s3_values = (
+        object_storage_values = (
+            init_info.object_storage_type,
             init_info.initial_base_version_id,
             init_info.launch_checkpoint,
             init_info.preparation_cache_dir,
-            init_info.s3_endpoint_url,
-            init_info.s3_region_name,
+            init_info.object_storage_endpoint_url,
+            init_info.object_storage_region_name,
         )
-        s3 = None
-        if any(value is not None for value in s3_values):
+        object_storage = None
+        if any(value is not None for value in object_storage_values):
             if (
-                init_info.initial_base_version_id is None
+                init_info.object_storage_type is None
+                or init_info.initial_base_version_id is None
                 or init_info.launch_checkpoint is None
                 or init_info.preparation_cache_dir is None
             ):
                 raise ValueError(
-                    "canonical S3 requires initial_base_version_id, "
-                    "launch_checkpoint, and preparation_cache_dir"
+                    "object storage requires object_storage_type, "
+                    "initial_base_version_id, launch_checkpoint, and "
+                    "preparation_cache_dir"
                 )
-            s3 = S3GeneratorConfig(
+            try:
+                storage_type = ObjectStorageType(init_info.object_storage_type)
+            except ValueError as error:
+                raise ValueError(
+                    f"unsupported object_storage_type="
+                    f"{init_info.object_storage_type!r}"
+                ) from error
+            object_storage = ObjectStorageGeneratorConfig(
+                storage_type=storage_type,
                 initial_base_version_id=init_info.initial_base_version_id,
                 launch_checkpoint=init_info.launch_checkpoint,
                 preparation_cache_dir=init_info.preparation_cache_dir,
-                endpoint_url=init_info.s3_endpoint_url,
-                region_name=init_info.s3_region_name,
+                endpoint_url=init_info.object_storage_endpoint_url,
+                region_name=init_info.object_storage_region_name,
             )
 
         model_name = (
@@ -141,7 +154,7 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
                 lease_ttl_seconds=init_info.lease_ttl_seconds,
                 max_transfer_attempts=init_info.max_transfer_attempts,
                 rpc_timeout_seconds=init_info.rpc_timeout_seconds,
-                s3=s3,
+                object_storage=object_storage,
             )
         )
 

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -22,6 +22,7 @@ import numpy as np
 import zstandard
 
 from modelexpress_rl import envs as rl_envs
+from modelexpress_rl.object_storage import ObjectStorageType
 from modelexpress_rl.s3 import S3Client
 from modelexpress_rl.train import WeightPayloadFormat
 from modelexpress_rl.utils import index_checkpoint_tensors, read_safetensors_header
@@ -33,9 +34,10 @@ from .adapter import (
 
 
 @dataclass(frozen=True)
-class S3GeneratorConfig:
-    """Canonical checkpoint and S3 settings for one generator rank."""
+class ObjectStorageGeneratorConfig:
+    """Object-storage checkpoint settings for one generator rank."""
 
+    storage_type: ObjectStorageType
     initial_base_version_id: str
     launch_checkpoint: str | Path
     preparation_cache_dir: str | Path
@@ -43,6 +45,8 @@ class S3GeneratorConfig:
     region_name: str | None = None
 
     def __post_init__(self) -> None:
+        if not isinstance(self.storage_type, ObjectStorageType):
+            raise TypeError("storage_type must be an ObjectStorageType")
         if not self.initial_base_version_id.strip():
             raise ValueError("initial_base_version_id is required")
         if not str(self.launch_checkpoint).strip():
@@ -110,7 +114,7 @@ class _LocalCheckpoint:
         self,
         *,
         model_name: str,
-        config: S3GeneratorConfig,
+        config: ObjectStorageGeneratorConfig,
         s3: S3Client,
     ) -> None:
         self.initial_version = config.initial_base_version_id
@@ -362,8 +366,10 @@ class CanonicalS3GeneratorAdapter(GeneratorEngineAdapter):
         self,
         *,
         model_name: str,
-        config: S3GeneratorConfig,
+        config: ObjectStorageGeneratorConfig,
     ) -> None:
+        if config.storage_type is not ObjectStorageType.S3:
+            raise ValueError("only S3 object storage is currently supported")
         self._s3 = S3Client(
             endpoint_url=config.endpoint_url,
             region_name=config.region_name,
@@ -387,7 +393,7 @@ class CanonicalS3GeneratorAdapter(GeneratorEngineAdapter):
             raise ValueError("canonical S3 requires XOR_DELTA payloads")
         if not inputs.base_version_id:
             raise ValueError("canonical S3 version is missing base_version_id")
-        if not inputs.s3_uri:
+        if inputs.object_storage is None:
             raise ValueError("canonical S3 requires a version-level URI")
         if self._checkpoint.current_version not in {
             inputs.base_version_id,
@@ -397,7 +403,7 @@ class CanonicalS3GeneratorAdapter(GeneratorEngineAdapter):
         version = _S3Version(
             version_id=inputs.version_id,
             base_version_id=inputs.base_version_id,
-            uri=inputs.s3_uri,
+            uri=inputs.object_storage.uri,
         )
         started = time.perf_counter()
         try:
@@ -434,5 +440,5 @@ __all__ = [
     "CanonicalS3GeneratorAdapter",
     "PreparedCheckpoint",
     "ReceiverInstallError",
-    "S3GeneratorConfig",
+    "ObjectStorageGeneratorConfig",
 ]

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -1,0 +1,438 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical S3 checkpoint preparation for generator refit."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import mmap
+import shutil
+import time
+import zlib
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import numpy as np
+import zstandard
+
+from modelexpress_rl import envs as rl_envs
+from modelexpress_rl.s3 import S3Client
+from modelexpress_rl.train import WeightPayloadFormat
+from modelexpress_rl.utils import index_checkpoint_tensors, read_safetensors_header
+
+from .adapter import (
+    GeneratorEngineAdapter,
+    GeneratorTransferInputs,
+)
+
+
+@dataclass(frozen=True)
+class S3GeneratorConfig:
+    """Canonical checkpoint and S3 settings for one generator rank."""
+
+    initial_base_version_id: str
+    launch_checkpoint: str | Path
+    preparation_cache_dir: str | Path
+    endpoint_url: str | None = None
+    region_name: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.initial_base_version_id.strip():
+            raise ValueError("initial_base_version_id is required")
+        if not str(self.launch_checkpoint).strip():
+            raise ValueError("launch_checkpoint is required")
+        if not str(self.preparation_cache_dir).strip():
+            raise ValueError("preparation_cache_dir is required")
+
+
+class ReceiverInstallError(RuntimeError):
+    """An engine reload failed."""
+
+
+@dataclass(frozen=True)
+class PreparedCheckpoint:
+    """One verified host-local checkpoint ready for engine installation."""
+
+    target_version: str
+    path: Path
+    metrics: dict[str, float]
+
+
+@dataclass(frozen=True)
+class _S3Version:
+    version_id: str
+    base_version_id: str
+    uri: str
+
+
+def _seed_checkpoint(source: Path, target: Path) -> None:
+    shutil.rmtree(target, ignore_errors=True)
+    target.mkdir(parents=True)
+    if source.is_file():
+        shutil.copy2(source, target / "model.safetensors")
+        return
+    if not source.is_dir():
+        raise FileNotFoundError(f"launch checkpoint does not exist: {source}")
+    for entry in source.iterdir():
+        if entry.is_file():
+            shutil.copy2(entry, target / entry.name)
+
+
+def _checkpoint_files_state(
+    locations: dict[str, tuple[Path, int, int]],
+) -> dict[str, list[int]]:
+    return {
+        path.name: [path.stat().st_size, path.stat().st_mtime_ns]
+        for path in sorted({item[0] for item in locations.values()})
+    }
+
+
+def _write_state(path: Path, state: dict) -> None:
+    temporary = path.with_name(f"{path.name}.tmp")
+    temporary.write_text(json.dumps(state, sort_keys=True))
+    temporary.replace(path)
+
+
+def _source_identity(version: _S3Version) -> dict[str, str]:
+    return {"uri": version.uri}
+
+
+class _LocalCheckpoint:
+    """One host-local checkpoint updated under an exact-base lock."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        config: S3GeneratorConfig,
+        s3: S3Client,
+    ) -> None:
+        self.initial_version = config.initial_base_version_id
+        self.launch_checkpoint = Path(config.launch_checkpoint)
+        self.s3 = s3
+        self.cache = Path(config.preparation_cache_dir) / quote(model_name, safe="")
+        self.local_checkpoint = self.cache / "checkpoint"
+        self.state_path = self.cache / "state.json"
+        self.lock_path = self.cache / ".lock"
+        self.locations: dict[str, tuple[Path, int, int]] = {}
+
+    def initialize(self) -> None:
+        self.cache.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            state = self._state()
+            reusable = (
+                state is not None
+                and state.get("version") == self.initial_version
+                and any(self.local_checkpoint.glob("*.safetensors"))
+            )
+            if reusable:
+                self.locations, _ = index_checkpoint_tensors(self.local_checkpoint)
+                reusable = state.get("files") == _checkpoint_files_state(self.locations)
+            if not reusable:
+                _seed_checkpoint(self.launch_checkpoint, self.local_checkpoint)
+                self.locations, _ = index_checkpoint_tensors(self.local_checkpoint)
+                _write_state(
+                    self.state_path,
+                    {
+                        "version": self.initial_version,
+                        "files": _checkpoint_files_state(self.locations),
+                    },
+                )
+
+    def _state(self) -> dict | None:
+        if not self.state_path.is_file():
+            return None
+        try:
+            value = json.loads(self.state_path.read_text())
+        except (OSError, ValueError):
+            return None
+        return value if isinstance(value, dict) else None
+
+    @property
+    def current_version(self) -> str:
+        state = self._state()
+        if state is None:
+            raise RuntimeError("local checkpoint state is missing")
+        return str(state["version"])
+
+    def prepare(self, version: _S3Version) -> PreparedCheckpoint:
+        with self.lock_path.open("a+") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            state = self._state()
+            if state is None:
+                raise RuntimeError("local checkpoint state is missing")
+            if state.get("files") != _checkpoint_files_state(self.locations):
+                raise RuntimeError("local checkpoint files changed outside ModelExpress")
+            if state["version"] == version.version_id:
+                if state.get("source") != _source_identity(version):
+                    raise ValueError(
+                        "prepared checkpoint came from a different canonical root"
+                    )
+                return PreparedCheckpoint(
+                    target_version=version.version_id,
+                    path=self.local_checkpoint,
+                    metrics={
+                        "perf/mx_receive_delta_index_download": 0.0,
+                        "perf/mx_receive_delta_download": 0.0,
+                        "perf/mx_receive_delta_apply": 0.0,
+                    },
+                )
+            if state["version"] != version.base_version_id:
+                raise RuntimeError(
+                    f"local checkpoint version {state['version']!r} does not match "
+                    f"exact base {version.base_version_id!r}"
+                )
+
+            started = time.perf_counter()
+            try:
+                index_data = self.s3.get(version.uri)
+            except Exception as error:
+                raise RuntimeError("canonical root download failed") from error
+
+            index_download_time = time.perf_counter() - started
+            weight_map = json.loads(index_data)["weight_map"]
+
+            download_started = time.perf_counter()
+            shards = self._download_deltas(weight_map, version.uri)
+            download_time = time.perf_counter() - download_started
+
+            apply_started = time.perf_counter()
+            self._apply_shards(shards)
+            _write_state(
+                self.state_path,
+                {
+                    "version": version.version_id,
+                    "source": _source_identity(version),
+                    "files": _checkpoint_files_state(self.locations),
+                },
+            )
+            return PreparedCheckpoint(
+                target_version=version.version_id,
+                path=self.local_checkpoint,
+                metrics={
+                    "perf/mx_receive_delta_index_download": index_download_time,
+                    "perf/mx_receive_delta_download": download_time,
+                    "perf/mx_receive_delta_apply": time.perf_counter() - apply_started,
+                },
+            )
+
+    def _download_deltas(
+        self,
+        weight_map: dict[str, str],
+        root_uri: str,
+    ) -> dict[str, tuple[bytes, list[str]]]:
+        if not weight_map:
+            return {}
+        by_file: dict[str, list[str]] = {}
+        for name, filename in weight_map.items():
+            by_file.setdefault(filename, []).append(name)
+        parent_uri = root_uri.rsplit("/", 1)[0]
+        shards = {}
+        with ThreadPoolExecutor(
+            max_workers=min(rl_envs.MX_S3_DOWNLOAD_WORKERS, len(by_file)),
+            thread_name_prefix="modelexpress-s3-download-file",
+        ) as pool:
+            downloads = {
+                filename: pool.submit(
+                    self.s3.get,
+                    f"{parent_uri}/{filename}",
+                )
+                for filename in by_file
+            }
+            for filename, names in by_file.items():
+                try:
+                    data = downloads[filename].result()
+                except Exception as error:
+                    raise RuntimeError(
+                        f"canonical delta download failed for {filename!r}"
+                    ) from error
+                shards[filename] = (data, names)
+        return shards
+
+    def _apply_shards(
+        self,
+        shards: dict[str, tuple[bytes, list[str]]],
+    ) -> None:
+        if not shards:
+            return
+
+        items = []
+        for filename, (data, names) in shards.items():
+            header, data_start = read_safetensors_header(data, repr(filename))
+            checksums = header["__metadata__"]
+            view = memoryview(data)
+            for name in names:
+                begin, end = header[name]["data_offsets"]
+                items.append(
+                    (
+                        name,
+                        view[data_start + begin : data_start + end],
+                        checksums[name],
+                    )
+                )
+        if not items:
+            return
+
+        maps: dict[Path, tuple[Any, mmap.mmap]] = {}
+        try:
+            for path in {self.locations[name][0] for name, _data, _checksum in items}:
+                file_handle = path.open("r+b")
+                maps[path] = (file_handle, mmap.mmap(file_handle.fileno(), 0))
+
+            def apply_one(item) -> None:
+                name, compressed, expected_checksum = item
+                path, file_offset, size = self.locations[name]
+                target = np.frombuffer(
+                    maps[path][1],
+                    dtype=np.uint8,
+                    count=size,
+                    offset=file_offset,
+                )
+                checksum = 1
+                position = 0
+                extra = b""
+                try:
+                    reader = zstandard.ZstdDecompressor().stream_reader(compressed)
+                    try:
+                        while position < size:
+                            block = reader.read(min(2 << 20, size - position))
+                            if not block:
+                                break
+                            delta = np.frombuffer(block, dtype=np.uint8)
+                            end = position + delta.size
+                            region = target[position:end]
+                            try:
+                                np.bitwise_xor(region, delta, out=region)
+                                checksum = zlib.adler32(region, checksum)
+                            finally:
+                                del region
+                            position = end
+                        if position == size:
+                            extra = reader.read(1)
+                    finally:
+                        reader.close()
+                finally:
+                    del target
+                if position != size or extra:
+                    raise ValueError(
+                        f"canonical delta byte size differs for {name!r}"
+                    )
+                if f"{checksum:08x}" != expected_checksum:
+                    raise ValueError(
+                        f"canonical target checksum differs for {name!r}"
+                    )
+
+            with ThreadPoolExecutor(
+                max_workers=min(rl_envs.MX_REFIT_DELTA_WORKERS, len(items)),
+                thread_name_prefix="modelexpress-delta-apply",
+            ) as pool:
+                list(pool.map(apply_one, items))
+        finally:
+            for file_handle, mapped in maps.values():
+                mapped.close()
+                file_handle.close()
+
+    @contextmanager
+    def installation(self, prepared: PreparedCheckpoint):
+        with self.lock_path.open("a+") as handle:
+            fcntl.flock(handle, fcntl.LOCK_SH)
+            state = self._state()
+            if (
+                state is None
+                or state.get("version") != prepared.target_version
+                or state.get("files") != _checkpoint_files_state(self.locations)
+            ):
+                raise ReceiverInstallError(
+                    "prepared checkpoint changed before installation"
+                )
+            yield
+
+
+class CanonicalS3GeneratorAdapter(GeneratorEngineAdapter):
+    """Prepare one canonical S3 delta, then reload it through an engine hook."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        config: S3GeneratorConfig,
+    ) -> None:
+        self._s3 = S3Client(
+            endpoint_url=config.endpoint_url,
+            region_name=config.region_name,
+        )
+        self._checkpoint = _LocalCheckpoint(
+            model_name=model_name,
+            config=config,
+            s3=self._s3,
+        )
+        self._checkpoint.initialize()
+        self._active_staged: PreparedCheckpoint | None = None
+
+    @property
+    def supported_payload_formats(self) -> frozenset[WeightPayloadFormat]:
+        return frozenset({WeightPayloadFormat.XOR_DELTA})
+
+    def stage_weight(self, inputs: GeneratorTransferInputs) -> PreparedCheckpoint:
+        if self._active_staged is not None:
+            raise RuntimeError("release staged weight before staging another version")
+        if inputs.payload_format is not WeightPayloadFormat.XOR_DELTA:
+            raise ValueError("canonical S3 requires XOR_DELTA payloads")
+        if not inputs.base_version_id:
+            raise ValueError("canonical S3 version is missing base_version_id")
+        if not inputs.s3_uri:
+            raise ValueError("canonical S3 requires a version-level URI")
+        if self._checkpoint.current_version not in {
+            inputs.base_version_id,
+            inputs.version_id,
+        }:
+            raise ValueError("canonical S3 target does not match the exact local base")
+        version = _S3Version(
+            version_id=inputs.version_id,
+            base_version_id=inputs.base_version_id,
+            uri=inputs.s3_uri,
+        )
+        started = time.perf_counter()
+        try:
+            staged = self._checkpoint.prepare(version)
+        except ValueError as error:
+            raise RuntimeError(str(error)) from error
+        staged.metrics["perf/mx_receive_prepare_time"] = time.perf_counter() - started
+        self._active_staged = staged
+        return staged
+
+    def apply_weight(self, staged: object) -> dict[str, float]:
+        if staged is not self._active_staged:
+            raise RuntimeError("canonical S3 staged weight is no longer active")
+        started = time.perf_counter()
+        with self._checkpoint.installation(self._active_staged):
+            self.install_prepared_checkpoint(self._active_staged)
+        return {"perf/mx_receive_install_time": time.perf_counter() - started}
+
+    def install_prepared_checkpoint(self, prepared: PreparedCheckpoint) -> None:
+        """Load ``prepared.path`` into the live engine."""
+        raise NotImplementedError
+
+    def release_staged_weight(self, staged: object) -> None:
+        if staged is not self._active_staged:
+            raise RuntimeError("canonical S3 staged weight is no longer active")
+        self._active_staged = None
+
+    def close(self) -> None:
+        self._active_staged = None
+        self._s3.close()
+
+
+__all__ = [
+    "CanonicalS3GeneratorAdapter",
+    "PreparedCheckpoint",
+    "ReceiverInstallError",
+    "S3GeneratorConfig",
+]

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -11,6 +11,7 @@ import mmap
 import shutil
 import time
 import zlib
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -107,6 +108,31 @@ def _source_identity(version: _S3Version) -> dict[str, str]:
     return {"uri": version.uri}
 
 
+_Decompressor = Callable[[memoryview], Any]
+
+
+_DECOMPRESSORS: dict[str, _Decompressor] = {
+    "zstd": lambda data: zstandard.ZstdDecompressor().stream_reader(data),
+}
+
+
+def _parse_delta_manifest(
+    data: bytes,
+) -> tuple[dict[str, str], _Decompressor]:
+    try:
+        manifest = json.loads(data)
+    except (TypeError, ValueError) as error:
+        raise ValueError("canonical delta manifest is not valid JSON") from error
+    compression_format = manifest["metadata"]["compression_format"]
+    try:
+        decompressor = _DECOMPRESSORS[compression_format]
+    except KeyError as error:
+        raise ValueError(
+            f"unsupported canonical delta compression format {compression_format!r}"
+        ) from error
+    return manifest["weight_map"], decompressor
+
+
 class _LocalCheckpoint:
     """One host-local checkpoint updated under an exact-base lock."""
 
@@ -125,6 +151,7 @@ class _LocalCheckpoint:
         self.state_path = self.cache / "state.json"
         self.lock_path = self.cache / ".lock"
         self.locations: dict[str, tuple[Path, int, int]] = {}
+        self.decompressor: _Decompressor | None = None
 
     def initialize(self) -> None:
         self.cache.mkdir(parents=True, exist_ok=True)
@@ -201,7 +228,7 @@ class _LocalCheckpoint:
                 raise RuntimeError("canonical root download failed") from error
 
             index_download_time = time.perf_counter() - started
-            weight_map = json.loads(index_data)["weight_map"]
+            weight_map, self.decompressor = _parse_delta_manifest(index_data)
 
             download_started = time.perf_counter()
             shards = self._download_deltas(weight_map, version.uri)
@@ -266,6 +293,7 @@ class _LocalCheckpoint:
     ) -> None:
         if not shards:
             return
+        assert self.decompressor is not None
 
         items = []
         for filename, (data, names) in shards.items():
@@ -302,27 +330,25 @@ class _LocalCheckpoint:
                 checksum = 1
                 position = 0
                 extra = b""
+                reader = self.decompressor(compressed)
                 try:
-                    reader = zstandard.ZstdDecompressor().stream_reader(compressed)
-                    try:
-                        while position < size:
-                            block = reader.read(min(2 << 20, size - position))
-                            if not block:
-                                break
-                            delta = np.frombuffer(block, dtype=np.uint8)
-                            end = position + delta.size
-                            region = target[position:end]
-                            try:
-                                np.bitwise_xor(region, delta, out=region)
-                                checksum = zlib.adler32(region, checksum)
-                            finally:
-                                del region
-                            position = end
-                        if position == size:
-                            extra = reader.read(1)
-                    finally:
-                        reader.close()
+                    while position < size:
+                        block = reader.read(min(2 << 20, size - position))
+                        if not block:
+                            break
+                        delta = np.frombuffer(block, dtype=np.uint8)
+                        end = position + delta.size
+                        region = target[position:end]
+                        try:
+                            np.bitwise_xor(region, delta, out=region)
+                            checksum = zlib.adler32(region, checksum)
+                        finally:
+                            del region
+                        position = end
+                    if position == size:
+                        extra = reader.read(1)
                 finally:
+                    reader.close()
                     del target
                 if position != size or extra:
                     raise ValueError(
@@ -395,6 +421,8 @@ class CanonicalS3GeneratorAdapter(GeneratorEngineAdapter):
             raise ValueError("canonical S3 version is missing base_version_id")
         if inputs.object_storage is None:
             raise ValueError("canonical S3 requires a version-level URI")
+        if inputs.object_storage.storage_type is not ObjectStorageType.S3:
+            raise ValueError("canonical S3 requires S3 object storage")
         if self._checkpoint.current_version not in {
             inputs.base_version_id,
             inputs.version_id,

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -298,9 +298,27 @@ class _LocalCheckpoint:
         items = []
         for filename, (data, names) in shards.items():
             header, data_start = read_safetensors_header(data, repr(filename))
-            checksums = header["__metadata__"]
+            checksums = header.get("__metadata__")
+            if not isinstance(checksums, dict):
+                raise ValueError(
+                    f"canonical delta shard {filename!r} is missing checksum metadata"
+                )
             view = memoryview(data)
             for name in names:
+                if name not in header:
+                    raise ValueError(
+                        f"canonical delta shard {filename!r} is missing tensor {name!r}"
+                    )
+                if name not in checksums:
+                    raise ValueError(
+                        f"canonical delta shard {filename!r} is missing checksum "
+                        f"for tensor {name!r}"
+                    )
+                if name not in self.locations:
+                    raise ValueError(
+                        f"canonical delta tensor {name!r} from shard {filename!r} "
+                        "is absent from the local checkpoint"
+                    )
                 begin, end = header[name]["data_offsets"]
                 items.append(
                     (

--- a/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/trainer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/refit_strategy/trainer.py
@@ -11,7 +11,12 @@ import grpc
 
 from ... import refit_pb2, refit_pb2_grpc
 from ...control import WeightVersion
-from ..adapter import GeneratorEngineAdapter, GeneratorSource, GeneratorTransferInputs
+from ..adapter import (
+    GeneratorEngineAdapter,
+    GeneratorSource,
+    GeneratorTransferInputs,
+    NixlGeneratorSource,
+)
 from .base import RefitStrategy
 
 
@@ -53,7 +58,9 @@ class _TrainerRefitStrategy(RefitStrategy):
         assert last_error is not None
         raise last_error
 
-    def _fetch_manifest(self, shard: refit_pb2.WeightVersionShard) -> bytes:
+    def _resolve_source(self, shard: refit_pb2.WeightVersionShard) -> GeneratorSource:
+        if not shard.manifest_endpoint:
+            raise RuntimeError("NIXL source is missing its manifest endpoint")
         with grpc.insecure_channel(shard.manifest_endpoint) as channel:
             response = refit_pb2_grpc.RefitWorkerServiceStub(
                 channel
@@ -72,7 +79,17 @@ class _TrainerRefitStrategy(RefitStrategy):
             raise RuntimeError(
                 f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
             )
-        return response.manifest
+        if not shard.manifest_digest:
+            raise RuntimeError("source is missing its manifest digest")
+        return GeneratorSource(
+            source_slot_id=shard.source_slot_id,
+            worker_id=shard.worker_id,
+            manifest_digest=shard.manifest_digest,
+            transport=NixlGeneratorSource(
+                manifest_endpoint=shard.manifest_endpoint,
+                manifest=response.manifest,
+            ),
+        )
 
     def _discover_sources(
         self,
@@ -99,20 +116,11 @@ class _TrainerRefitStrategy(RefitStrategy):
                 ordered = ordered[offset:] + ordered[:offset]
             for shard in ordered:
                 try:
-                    manifest = self._fetch_manifest(shard)
+                    source = self._resolve_source(shard)
                 except (grpc.RpcError, RuntimeError) as error:
                     failures.append(str(error))
                     continue
-                selected.append(
-                    GeneratorSource(
-                        source_slot_id=source_slot_id,
-                        worker_id=shard.worker_id,
-                        manifest_endpoint=shard.manifest_endpoint,
-                        manifest_digest=shard.manifest_digest,
-                        transport="NIXL",
-                        manifest=manifest,
-                    )
-                )
+                selected.append(source)
                 break
             else:
                 detail = f": {failures[-1]}" if failures else ""
@@ -122,6 +130,7 @@ class _TrainerRefitStrategy(RefitStrategy):
 
         return GeneratorTransferInputs(
             version_id=version.version_id,
+            base_version_id=version.base_version_id,
             layout_signature=version.layout_signature,
             payload_format=version.payload_format,
             sources=tuple(selected),

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -12,7 +12,9 @@ from modelexpress.types import ManifestMismatchError
 from modelexpress_rl import (
     ModelExpressGeneratorClient,
     ModelExpressGeneratorConfig,
-    S3GeneratorConfig,
+    ObjectStorageGeneratorConfig,
+    ObjectStorageSource,
+    ObjectStorageType,
     VllmGeneratorContext,
     WeightPayloadFormat,
     WeightVersion,
@@ -68,7 +70,7 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
 
     def GetWeightVersion(self, request, context):
         if request.uid == self.base.uid:
-            return self.base
+            return refit_pb2.GetWeightVersionResponse(version=self.base)
         if request.uid != self.version.uid:
             context.abort(grpc.StatusCode.NOT_FOUND, "version not found")
         return refit_pb2.GetWeightVersionResponse(version=self.version)
@@ -228,7 +230,7 @@ def _initialize(
     endpoint,
     adapter,
     *,
-    s3=False,
+    object_storage=False,
     max_transfer_attempts=3,
 ):
     monkeypatch.setattr(
@@ -247,13 +249,14 @@ def _initialize(
             server_url=endpoint,
             registration_ttl_seconds=60,
             lease_ttl_seconds=60,
-            s3=(
-                S3GeneratorConfig(
+            object_storage=(
+                ObjectStorageGeneratorConfig(
+                    storage_type=ObjectStorageType.S3,
                     initial_base_version_id="base-a",
                     launch_checkpoint="unused-launch",
                     preparation_cache_dir="unused-cache",
                 )
-                if s3
+                if object_storage
                 else None
             ),
             max_transfer_attempts=max_transfer_attempts,
@@ -282,6 +285,33 @@ def test_generator_config_rejects_invalid_numeric_settings(setting, value, messa
                 vllm_config=object(),
             ),
             **{setting: value},
+        )
+
+
+def test_generator_rejects_unsupported_object_storage_before_adapter_creation(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        generator_client_module,
+        "_create_generator_adapter",
+        lambda **_kwargs: pytest.fail("adapter must not be created"),
+    )
+
+    with pytest.raises(ValueError, match="only S3 object storage"):
+        ModelExpressGeneratorClient.initialize(
+            ModelExpressGeneratorConfig(
+                engine_context=VllmGeneratorContext(
+                    model=object(),
+                    vllm_config=object(),
+                ),
+                model_name="test/model",
+                object_storage=ObjectStorageGeneratorConfig(
+                    storage_type=ObjectStorageType.GCS,
+                    initial_base_version_id="base-a",
+                    launch_checkpoint="unused-launch",
+                    preparation_cache_dir="unused-cache",
+                ),
+            )
         )
 
 
@@ -404,13 +434,18 @@ def test_generator_dispatches_canonical_s3_without_fetching_a_worker_manifest(
     service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
     service.version.base_version_id = "base-a"
     service.version.expected_source_slots[:] = []
-    service.version.s3.uri = "s3://weights/model.safetensors.index.json"
+    service.version.object_storage.CopyFrom(
+        refit_pb2.ObjectStorageSource(
+            storage_type=refit_pb2.OBJECT_STORAGE_TYPE_S3,
+            uri="s3://weights/model.safetensors.index.json",
+        )
+    )
     adapter = _Adapter(service)
     generator = _initialize(
         monkeypatch,
         endpoint,
         adapter,
-        s3=True,
+        object_storage=True,
     )
     assert generator._p2p_client is None
     assert generator._refit_strategies == ()
@@ -418,9 +453,9 @@ def test_generator_dispatches_canonical_s3_without_fetching_a_worker_manifest(
     try:
         staged = generator.stage_weight(version=WeightVersionRef("version-a"))
         assert adapter.stage_calls[0].sources == ()
-        assert (
-            adapter.stage_calls[0].s3_uri
-            == "s3://weights/model.safetensors.index.json"
+        assert adapter.stage_calls[0].object_storage == ObjectStorageSource(
+            storage_type=ObjectStorageType.S3,
+            uri="s3://weights/model.safetensors.index.json",
         )
         assert service.list_calls == 0
         assert generator.apply_weight(staged) == "installed"
@@ -434,7 +469,9 @@ def test_generator_dispatches_canonical_s3_without_fetching_a_worker_manifest(
         server.stop(grace=None).wait()
 
 
-def test_generator_rejects_missing_s3_transport_before_adapter_mutation(monkeypatch):
+def test_generator_rejects_missing_object_storage_before_adapter_mutation(
+    monkeypatch,
+):
     server, endpoint, service = _start_server()
     service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
     service.version.base_version_id = "base-a"
@@ -444,11 +481,43 @@ def test_generator_rejects_missing_s3_transport_before_adapter_mutation(monkeypa
         monkeypatch,
         endpoint,
         adapter,
-        s3=True,
+        object_storage=True,
     )
 
     try:
-        with pytest.raises(RuntimeError, match="missing its S3 transport"):
+        with pytest.raises(RuntimeError, match="missing its object storage source"):
+            generator.stage_weight(version=WeightVersionRef("version-a"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert adapter.stage_calls == []
+    assert service.lease_deletions == 1
+
+
+def test_generator_rejects_non_s3_object_storage_before_adapter_mutation(
+    monkeypatch,
+):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "base-a"
+    service.version.expected_source_slots[:] = []
+    service.version.object_storage.CopyFrom(
+        refit_pb2.ObjectStorageSource(
+            storage_type=refit_pb2.OBJECT_STORAGE_TYPE_GCS,
+            uri="gs://weights/model.safetensors.index.json",
+        )
+    )
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        object_storage=True,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="requires S3 object storage"):
             generator.stage_weight(version=WeightVersionRef("version-a"))
     finally:
         generator.close()
@@ -468,7 +537,7 @@ def test_generator_rejects_wrong_delta_base_before_leasing(monkeypatch):
         monkeypatch,
         endpoint,
         adapter,
-        s3=True,
+        object_storage=True,
     )
 
     try:
@@ -493,7 +562,7 @@ def test_generator_validates_the_initial_s3_base_before_registration(monkeypatch
                 monkeypatch,
                 endpoint,
                 adapter,
-                s3=True,
+                object_storage=True,
             )
     finally:
         server.stop(grace=None).wait()

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -12,6 +12,7 @@ from modelexpress.types import ManifestMismatchError
 from modelexpress_rl import (
     ModelExpressGeneratorClient,
     ModelExpressGeneratorConfig,
+    S3GeneratorConfig,
     VllmGeneratorContext,
     WeightPayloadFormat,
     WeightVersion,
@@ -29,6 +30,7 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
         self.active_leases = set()
         self.lease_registrations = 0
         self.lease_deletions = 0
+        self.list_calls = 0
         self.fail_lease_deletion = False
         self.version = refit_pb2.WeightVersion(
             uid="version-a",
@@ -37,6 +39,12 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
             expected_source_slots=["rank:0", "rank:1"],
             layout_signature="layout-a",
             state=state or refit_pb2.WEIGHT_VERSION_STATE_READY,
+        )
+        self.base = refit_pb2.WeightVersion(
+            uid="base-a",
+            model_name="test/model",
+            payload_format=refit_pb2.WEIGHT_PAYLOAD_FORMAT_FULL_TENSOR,
+            state=refit_pb2.WEIGHT_VERSION_STATE_READY,
         )
         digest = manifest_digest or hashlib.sha256(b"manifest").hexdigest()
         self.shards = [
@@ -59,11 +67,14 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
         return refit_pb2.RegisterWorkerResponse(worker=worker)
 
     def GetWeightVersion(self, request, context):
+        if request.uid == self.base.uid:
+            return self.base
         if request.uid != self.version.uid:
             context.abort(grpc.StatusCode.NOT_FOUND, "version not found")
         return refit_pb2.GetWeightVersionResponse(version=self.version)
 
     def ListWeightVersionShards(self, request, _context):
+        self.list_calls += 1
         return refit_pb2.ListWeightVersionShardsResponse(
             shards=self.shards if request.version_id == self.version.uid else []
         )
@@ -166,19 +177,19 @@ class _Adapter(GeneratorEngineAdapter):
 
     def create_transfer_plan(self, inputs):
         self.create_calls.append(inputs)
-        return {"sources": inputs.sources}
+        return {"inputs": inputs}
 
     def validate_transfer_plan(self, plan, inputs):
         self.validate_calls.append((plan, inputs))
         return True
 
-    def stage_weight(self, plan):
+    def stage_weight(self, inputs):
         assert self.service.active_leases
-        self.stage_calls.append(plan)
+        self.stage_calls.append(inputs)
         if self.stage_failures:
             self.stage_failures -= 1
             raise RuntimeError("transfer failed")
-        return {"plan": plan}
+        return {"inputs": inputs}
 
     def apply_weight(self, staged):
         assert self.service.active_leases
@@ -212,7 +223,14 @@ def _start_server(*, state=None, manifest_digest=None):
     return server, endpoint, service
 
 
-def _initialize(monkeypatch, endpoint, adapter, *, max_transfer_attempts=3):
+def _initialize(
+    monkeypatch,
+    endpoint,
+    adapter,
+    *,
+    s3=False,
+    max_transfer_attempts=3,
+):
     monkeypatch.setattr(
         generator_client_module,
         "_create_generator_adapter",
@@ -229,6 +247,15 @@ def _initialize(monkeypatch, endpoint, adapter, *, max_transfer_attempts=3):
             server_url=endpoint,
             registration_ttl_seconds=60,
             lease_ttl_seconds=60,
+            s3=(
+                S3GeneratorConfig(
+                    initial_base_version_id="base-a",
+                    launch_checkpoint="unused-launch",
+                    preparation_cache_dir="unused-cache",
+                )
+                if s3
+                else None
+            ),
             max_transfer_attempts=max_transfer_attempts,
         )
     )
@@ -367,8 +394,112 @@ def test_generator_releases_lease_when_manifest_is_invalid(monkeypatch):
     assert not service.active_leases
     assert service.lease_registrations == 1
     assert service.lease_deletions == 1
-    assert adapter.create_calls == []
     assert adapter.stage_calls == []
+
+
+def test_generator_dispatches_canonical_s3_without_fetching_a_worker_manifest(
+    monkeypatch,
+):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "base-a"
+    service.version.expected_source_slots[:] = []
+    service.version.s3.uri = "s3://weights/model.safetensors.index.json"
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        s3=True,
+    )
+    assert generator._p2p_client is None
+    assert generator._refit_strategies == ()
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        assert adapter.stage_calls[0].sources == ()
+        assert (
+            adapter.stage_calls[0].s3_uri
+            == "s3://weights/model.safetensors.index.json"
+        )
+        assert service.list_calls == 0
+        assert generator.apply_weight(staged) == "installed"
+        assert adapter.publish_attempts == 0
+        assert service.p2p.requests == []
+        staged.release()
+        repeated = generator.stage_weight(version=WeightVersionRef("version-a"))
+        repeated.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+
+def test_generator_rejects_missing_s3_transport_before_adapter_mutation(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "base-a"
+    service.version.expected_source_slots[:] = []
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        s3=True,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="missing its S3 transport"):
+            generator.stage_weight(version=WeightVersionRef("version-a"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert adapter.stage_calls == []
+    assert service.lease_deletions == 1
+
+
+def test_generator_rejects_wrong_delta_base_before_leasing(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA
+    service.version.base_version_id = "other-base"
+    service.version.expected_source_slots[:] = []
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        s3=True,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="does not match serving version"):
+            generator.stage_weight(version=WeightVersionRef("version-a"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.lease_registrations == 0
+    assert adapter.stage_calls == []
+
+
+def test_generator_validates_the_initial_s3_base_before_registration(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.base.state = refit_pb2.WEIGHT_VERSION_STATE_STAGING
+    adapter = _Adapter(service)
+
+    try:
+        with pytest.raises(RuntimeError, match="initial base.*not READY"):
+            _initialize(
+                monkeypatch,
+                endpoint,
+                adapter,
+                s3=True,
+            )
+    finally:
+        server.stop(grace=None).wait()
+
+    assert service.registrations == {}
+    assert adapter.close_calls == 1
 
 
 def test_generator_retries_complete_staged_transfer_under_one_lease(monkeypatch):
@@ -387,7 +518,6 @@ def test_generator_retries_complete_staged_transfer_under_one_lease(monkeypatch)
     assert service.lease_registrations == 1
     assert service.lease_deletions == 1
     assert len(adapter.stage_calls) == 2
-    assert len(adapter.create_calls) == 2
 
 
 def test_generator_retries_with_redundant_worker_for_same_slot(monkeypatch):
@@ -407,9 +537,10 @@ def test_generator_retries_with_redundant_worker_for_same_slot(monkeypatch):
         generator.close()
         server.stop(grace=None).wait()
 
-    assert [
-        call.sources[0].worker_id for call in adapter.create_calls
-    ] == ["trainer-0", "trainer-replica"]
+    assert [call.sources[0].worker_id for call in adapter.create_calls] == [
+        "trainer-0",
+        "trainer-replica",
+    ]
 
 
 def test_generator_preserves_transfer_error_when_lease_cleanup_also_fails(

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -34,6 +34,7 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
         self.lease_deletions = 0
         self.list_calls = 0
         self.fail_lease_deletion = False
+        self.omit_base_version = False
         self.version = refit_pb2.WeightVersion(
             uid="version-a",
             model_name="test/model",
@@ -70,6 +71,8 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
 
     def GetWeightVersion(self, request, context):
         if request.uid == self.base.uid:
+            if self.omit_base_version:
+                return refit_pb2.GetWeightVersionResponse()
             return refit_pb2.GetWeightVersionResponse(version=self.base)
         if request.uid != self.version.uid:
             context.abort(grpc.StatusCode.NOT_FOUND, "version not found")
@@ -558,6 +561,26 @@ def test_generator_validates_the_initial_s3_base_before_registration(monkeypatch
 
     try:
         with pytest.raises(RuntimeError, match="initial base.*not READY"):
+            _initialize(
+                monkeypatch,
+                endpoint,
+                adapter,
+                object_storage=True,
+            )
+    finally:
+        server.stop(grace=None).wait()
+
+    assert service.registrations == {}
+    assert adapter.close_calls == 1
+
+
+def test_generator_rejects_missing_initial_s3_base_before_registration(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.omit_base_version = True
+    adapter = _Adapter(service)
+
+    try:
+        with pytest.raises(RuntimeError, match="GetWeightVersion response is missing"):
             _initialize(
                 monkeypatch,
                 endpoint,

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -3,6 +3,7 @@
 
 import json
 import threading
+from dataclasses import replace
 
 import pytest
 import safetensors.numpy
@@ -11,7 +12,12 @@ import torch
 import zstandard
 from safetensors.torch import load_file, save_file
 
-from modelexpress_rl import S3GeneratorConfig, WeightPayloadFormat
+from modelexpress_rl import (
+    ObjectStorageGeneratorConfig,
+    ObjectStorageSource,
+    ObjectStorageType,
+    WeightPayloadFormat,
+)
 from modelexpress_rl.inference.adapter import GeneratorTransferInputs
 from modelexpress_rl.inference import receiver as receiver_module
 from modelexpress_rl.inference.receiver import CanonicalS3GeneratorAdapter
@@ -349,7 +355,10 @@ def _inputs(
         layout_signature="",
         payload_format=WeightPayloadFormat.XOR_DELTA,
         sources=(),
-        s3_uri=uri,
+        object_storage=ObjectStorageSource(
+            storage_type=ObjectStorageType.S3,
+            uri=uri,
+        ),
     )
 
 
@@ -361,13 +370,33 @@ def _build(monkeypatch, tmp_path, objects):
     monkeypatch.setattr(receiver_module, "S3Client", lambda **_kwargs: storage)
     adapter = _Adapter(
         model_name="test/model",
-        config=S3GeneratorConfig(
+        config=ObjectStorageGeneratorConfig(
+            storage_type=ObjectStorageType.S3,
             initial_base_version_id="base-a",
             launch_checkpoint=launch,
             preparation_cache_dir=tmp_path / "cache",
         ),
     )
     return adapter, storage
+
+
+def test_canonical_s3_rejects_non_s3_source_before_storage_access(
+    monkeypatch,
+    tmp_path,
+):
+    adapter, storage = _build(monkeypatch, tmp_path, {})
+    inputs = replace(
+        _inputs(None),
+        object_storage=ObjectStorageSource(
+            storage_type=ObjectStorageType.GCS,
+            uri="gs://weights/test/v1/model.safetensors.index.json",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires S3 object storage"):
+        adapter.stage_weight(inputs)
+
+    assert storage.calls == []
 
 
 def test_canonical_s3_prepares_then_installs_one_global_index(monkeypatch, tmp_path):
@@ -487,7 +516,8 @@ def test_canonical_s3_applies_delta_tensors_concurrently(monkeypatch, tmp_path):
     save_file(base, launch / "model.safetensors")
     checkpoint = receiver_module._LocalCheckpoint(
         model_name="test/model",
-        config=S3GeneratorConfig(
+        config=ObjectStorageGeneratorConfig(
+            storage_type=ObjectStorageType.S3,
             initial_base_version_id="base-a",
             launch_checkpoint=launch,
             preparation_cache_dir=tmp_path / "cache",

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -451,22 +451,30 @@ def test_canonical_s3_accepts_an_empty_delta(monkeypatch, tmp_path):
     )
 
 
-def test_canonical_s3_uses_weight_map_without_index_validation(monkeypatch, tmp_path):
+def test_canonical_s3_rejects_unsupported_compression(monkeypatch, tmp_path):
     base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
-    target_tensor = torch.tensor([3.0, 4.0])
-    objects = _artifact(base, target_tensor.view(torch.uint8).numpy())
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
     key = "s3://weights/test/v1/model.safetensors.index.json"
-    root = json.dumps(
-        {"weight_map": {"weight": "model-00000-of-00001.safetensors"}}
-    ).encode()
-    objects[key] = root
-    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+    manifest = json.loads(objects[key])
+    manifest["metadata"]["compression_format"] = "gzip"
+    objects[key] = json.dumps(manifest).encode()
+    adapter, storage = _build(monkeypatch, tmp_path, objects)
 
-    staged = adapter.stage_weight(_inputs(root))
+    with pytest.raises(RuntimeError, match="unsupported.*compression"):
+        adapter.stage_weight(_inputs(objects[key]))
 
-    assert torch.equal(
-        load_file(staged.path / "model.safetensors")["weight"], target_tensor
-    )
+    assert storage.calls == [key]
+
+
+def test_canonical_s3_rejects_invalid_manifest_json(monkeypatch, tmp_path):
+    key = "s3://weights/test/v1/model.safetensors.index.json"
+    adapter, storage = _build(monkeypatch, tmp_path, {key: b"not-json"})
+
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        adapter.stage_weight(_inputs(None))
+
+    assert storage.calls == [key]
 
 
 def test_canonical_s3_downloads_unique_shards_concurrently(monkeypatch, tmp_path):
@@ -573,6 +581,7 @@ def test_canonical_s3_applies_delta_tensors_concurrently(monkeypatch, tmp_path):
         StreamingDecompressor,
     )
 
+    checkpoint.decompressor = receiver_module._DECOMPRESSORS["zstd"]
     checkpoint._apply_shards({"delta.safetensors": (shard, list(target))})
 
     loaded = load_file(checkpoint.local_checkpoint / "model.safetensors")

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -1,0 +1,679 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import threading
+
+import pytest
+import safetensors.numpy
+import s3transfer.manager
+import torch
+import zstandard
+from safetensors.torch import load_file, save_file
+
+from modelexpress_rl import S3GeneratorConfig, WeightPayloadFormat
+from modelexpress_rl.inference.adapter import GeneratorTransferInputs
+from modelexpress_rl.inference import receiver as receiver_module
+from modelexpress_rl.inference.receiver import CanonicalS3GeneratorAdapter
+from modelexpress_rl.s3 import ImmutableS3Conflict, S3Client
+from modelexpress_rl.utils import adler32_checksum, compress_delta, compute_delta
+
+
+class _MemoryS3:
+    def __init__(self, objects):
+        self.objects = objects
+        self.calls = []
+        self.fail_key_once = None
+
+    def get(self, uri):
+        self.calls.append(uri)
+        if uri == self.fail_key_once:
+            self.fail_key_once = None
+            raise RuntimeError("injected shard download failure")
+        return self.objects[uri]
+
+    def close(self):
+        pass
+
+
+class _TransferFuture:
+    def result(self):
+        pass
+
+
+class _TransferManager:
+    def __init__(self, client, config):
+        self.client = client
+        self.config = config
+
+    def download(self, bucket, key, target):
+        response = self.client.get_object(Bucket=bucket, Key=key)
+        body = response["Body"]
+        try:
+            target.write(body.read())
+        finally:
+            body.close()
+        return _TransferFuture()
+
+    def shutdown(self):
+        pass
+
+
+class _Body:
+    def __init__(self, data):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+    def close(self):
+        pass
+
+
+class _S3Error(Exception):
+    def __init__(self, code):
+        self.response = {"Error": {"Code": code}}
+
+
+class _S3Backend:
+    def __init__(
+        self,
+        data=b"",
+        *,
+        put_error=None,
+        complete_error=None,
+        barrier=None,
+    ):
+        self.data = data
+        self.put_error = put_error
+        self.complete_error = complete_error
+        self.barrier = barrier
+        self.parts = {}
+        self.put_request = None
+        self.get_request = None
+        self.get_requests = []
+        self.completed = None
+        self.aborted = False
+
+    def put_object(self, **request):
+        self.put_request = request
+        if self.put_error is not None:
+            raise self.put_error
+
+    def get_object(self, **request):
+        self.get_request = request
+        self.get_requests.append(request)
+        return {"Body": _Body(self.data)}
+
+    def create_multipart_upload(self, **request):
+        assert request == {"Bucket": "weights", "Key": "delta"}
+        return {"UploadId": "upload-1"}
+
+    def upload_part(self, **request):
+        if self.barrier is not None and request["PartNumber"] <= 2:
+            self.barrier.wait(timeout=2)
+        self.parts[request["PartNumber"]] = request["Body"]
+        return {"ETag": f"etag-{request['PartNumber']}"}
+
+    def complete_multipart_upload(self, **request):
+        if self.complete_error is not None:
+            raise self.complete_error
+        self.completed = request
+
+    def abort_multipart_upload(self, **_request):
+        self.aborted = True
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _transfer_manager(monkeypatch):
+    monkeypatch.setattr(s3transfer.manager, "TransferManager", _TransferManager)
+
+
+class _Adapter(CanonicalS3GeneratorAdapter):
+    def __init__(self, **kwargs):
+        self.installed = []
+        super().__init__(**kwargs)
+
+    def install_prepared_checkpoint(self, prepared):
+        self.installed.append(prepared.path)
+
+
+def test_s3_read_parses_uri():
+    data = b"canonical-root"
+    backend = _S3Backend(data)
+    s3 = object.__new__(S3Client)
+    s3._client = backend
+    s3._download_manager = _TransferManager(backend, None)
+    assert s3.get("s3://weights/root.json") == data
+    assert backend.get_request == {
+        "Bucket": "weights",
+        "Key": "root.json",
+    }
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "s3://weights//root.json",
+        "s3://weights/root.json?query",
+        "s3://weights/root.json#fragment",
+    ],
+)
+def test_s3_rejects_noncanonical_uri(uri):
+    s3 = object.__new__(S3Client)
+    with pytest.raises(ValueError, match="invalid S3 URI"):
+        s3.get(uri)
+
+
+def test_s3_write_accepts_only_an_identical_immutable_retry():
+    backend = _S3Backend(b"same", put_error=_S3Error("PreconditionFailed"))
+    s3 = object.__new__(S3Client)
+    s3._client = backend
+    s3._multipart_threshold_bytes = 100
+    s3._download_manager = _TransferManager(backend, None)
+    s3.put(uri="s3://weights/root.json", data=b"same")
+    with pytest.raises(ImmutableS3Conflict):
+        s3.put(uri="s3://weights/root.json", data=b"different")
+    assert backend.put_request["IfNoneMatch"] == "*"
+
+
+def test_s3_client_uses_transfer_connection_and_retry_settings(monkeypatch):
+    import boto3
+
+    captured = {}
+    backend = _S3Backend()
+
+    def client(_service, **kwargs):
+        captured.update(kwargs)
+        return backend
+
+    monkeypatch.setenv("MX_S3_UPLOAD_WORKERS", "2")
+    monkeypatch.setenv("MX_S3_DOWNLOAD_WORKERS", "3")
+    monkeypatch.setenv("MX_S3_DOWNLOAD_RANGE_THRESHOLD_BYTES", "4096")
+    monkeypatch.setenv("MX_S3_DOWNLOAD_RANGE_BYTES", "1024")
+    monkeypatch.setenv("MX_S3_DOWNLOAD_IO_CHUNK_BYTES", "512")
+    monkeypatch.setenv("MX_S3_DOWNLOAD_MAX_IN_MEMORY_CHUNKS", "7")
+    monkeypatch.setenv("MX_S3_MAX_POOL_CONNECTIONS", "17")
+    monkeypatch.setenv("MX_S3_MAX_ATTEMPTS", "6")
+    monkeypatch.setenv("MX_S3_TCP_KEEPALIVE", "false")
+    monkeypatch.setattr(boto3, "client", client)
+
+    s3 = S3Client()
+    try:
+        config = captured["config"]
+        assert config.max_pool_connections == 17
+        assert config.retries == {"total_max_attempts": 6, "mode": "standard"}
+        assert config.tcp_keepalive is False
+        assert s3._upload_pool._max_workers == 2
+        transfer = s3._download_manager.config
+        assert transfer.multipart_threshold == 4096
+        assert transfer.multipart_chunksize == 1024
+        assert transfer.max_request_concurrency == 3
+        assert transfer.io_chunksize == 512
+        assert transfer.max_io_queue_size == 7
+        assert transfer.max_in_memory_download_chunks == 7
+        assert transfer.num_download_attempts == 6
+    finally:
+        s3.close()
+
+
+def test_s3_multipart_uploads_parts_concurrently_and_completes_immutably(
+    monkeypatch,
+):
+    import boto3
+
+    part_bytes = 5 * 1024**2
+    barrier = threading.Barrier(2)
+    backend = _S3Backend(barrier=barrier)
+    monkeypatch.setenv("MX_S3_MULTIPART_THRESHOLD_BYTES", "1")
+    monkeypatch.setenv("MX_S3_UPLOAD_PART_BYTES", str(part_bytes))
+    monkeypatch.setenv("MX_S3_UPLOAD_WORKERS", "2")
+    monkeypatch.setattr(boto3, "client", lambda *_args, **_kwargs: backend)
+    data = b"a" * part_bytes + b"b" * part_bytes + b"c"
+
+    s3 = S3Client()
+    try:
+        s3.put(uri="s3://weights/delta", data=data)
+    finally:
+        s3.close()
+
+    assert backend.parts == {
+        1: data[:part_bytes],
+        2: data[part_bytes : 2 * part_bytes],
+        3: b"c",
+    }
+    assert backend.completed["IfNoneMatch"] == "*"
+    assert backend.completed["MultipartUpload"] == {
+        "Parts": [
+            {"ETag": "etag-1", "PartNumber": 1},
+            {"ETag": "etag-2", "PartNumber": 2},
+            {"ETag": "etag-3", "PartNumber": 3},
+        ]
+    }
+    assert backend.aborted is False
+
+
+def test_s3_multipart_aborts_and_propagates_conditional_conflict(monkeypatch):
+    import boto3
+
+    error = _S3Error("ConditionalRequestConflict")
+    backend = _S3Backend(complete_error=error)
+    monkeypatch.setenv("MX_S3_MULTIPART_THRESHOLD_BYTES", "1")
+    monkeypatch.setenv("MX_S3_UPLOAD_PART_BYTES", str(5 * 1024**2))
+    monkeypatch.setattr(boto3, "client", lambda *_args, **_kwargs: backend)
+
+    s3 = S3Client()
+    try:
+        with pytest.raises(_S3Error) as raised:
+            s3.put(uri="s3://weights/delta", data=b"x" * (5 * 1024**2))
+    finally:
+        s3.close()
+
+    assert raised.value is error
+    assert backend.aborted is True
+
+
+def test_s3_multipart_precondition_failure_accepts_identical_retry(monkeypatch):
+    import boto3
+
+    data = b"x" * (5 * 1024**2)
+    backend = _S3Backend(
+        data,
+        complete_error=_S3Error("PreconditionFailed"),
+    )
+    monkeypatch.setenv("MX_S3_MULTIPART_THRESHOLD_BYTES", "1")
+    monkeypatch.setenv("MX_S3_UPLOAD_PART_BYTES", str(5 * 1024**2))
+    monkeypatch.setattr(boto3, "client", lambda *_args, **_kwargs: backend)
+
+    s3 = S3Client()
+    try:
+        s3.put(uri="s3://weights/delta", data=data)
+    finally:
+        s3.close()
+
+    assert backend.aborted is True
+
+
+def _artifact(
+    base,
+    target,
+    *,
+    checksum=None,
+    version="target-a",
+    version_number=1,
+    base_version="base-a",
+):
+    delta, _ = compute_delta(target, base)
+    assert delta is not None
+    shard = safetensors.numpy.save(
+        {"weight": compress_delta(delta)},
+        metadata={"weight": checksum or adler32_checksum(target)},
+    )
+    root = json.dumps(
+        {
+            "metadata": {
+                "version": version,
+                "base_version": base_version,
+                "delta_encoding": "xor",
+                "compression_format": "zstd",
+                "checksum_format": "adler32",
+            },
+            "weight_map": {"weight": "model-00000-of-00001.safetensors"},
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    prefix = f"s3://weights/test/v{version_number}"
+    return {
+        f"{prefix}/model.safetensors.index.json": root,
+        f"{prefix}/model-00000-of-00001.safetensors": shard,
+    }
+
+
+def _inputs(
+    _root,
+    *,
+    base_version="base-a",
+    version="target-a",
+    version_number=1,
+    uri=None,
+):
+    if uri is None:
+        uri = f"s3://weights/test/v{version_number}/model.safetensors.index.json"
+    return GeneratorTransferInputs(
+        version_id=version,
+        base_version_id=base_version,
+        layout_signature="",
+        payload_format=WeightPayloadFormat.XOR_DELTA,
+        sources=(),
+        s3_uri=uri,
+    )
+
+
+def _build(monkeypatch, tmp_path, objects):
+    launch = tmp_path / "launch"
+    launch.mkdir(exist_ok=True)
+    save_file({"weight": torch.tensor([1.0, 2.0])}, launch / "model.safetensors")
+    storage = _MemoryS3(objects)
+    monkeypatch.setattr(receiver_module, "S3Client", lambda **_kwargs: storage)
+    adapter = _Adapter(
+        model_name="test/model",
+        config=S3GeneratorConfig(
+            initial_base_version_id="base-a",
+            launch_checkpoint=launch,
+            preparation_cache_dir=tmp_path / "cache",
+        ),
+    )
+    return adapter, storage
+
+
+def test_canonical_s3_prepares_then_installs_one_global_index(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target_tensor = torch.tensor([3.0, 4.0])
+    target = target_tensor.view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root = objects["s3://weights/test/v1/model.safetensors.index.json"]
+    adapter, storage = _build(monkeypatch, tmp_path, objects)
+
+    staged = adapter.stage_weight(_inputs(root))
+
+    assert adapter.installed == []
+    assert torch.equal(
+        load_file(staged.path / "model.safetensors")["weight"], target_tensor
+    )
+    assert storage.calls == [
+        "s3://weights/test/v1/model.safetensors.index.json",
+        "s3://weights/test/v1/model-00000-of-00001.safetensors",
+    ]
+    assert staged.metrics["perf/mx_receive_delta_download"] >= 0
+    assert adapter.apply_weight(staged)["perf/mx_receive_install_time"] >= 0
+    assert adapter.installed == [staged.path]
+    adapter.release_staged_weight(staged)
+    adapter.close()
+
+
+def test_canonical_s3_accepts_an_empty_delta(monkeypatch, tmp_path):
+    key = "s3://weights/test/v1/model.safetensors.index.json"
+    root = json.dumps(
+        {
+            "metadata": {
+                "version": "target-a",
+                "base_version": "base-a",
+                "delta_encoding": "xor",
+                "compression_format": "zstd",
+                "checksum_format": "adler32",
+            },
+            "weight_map": {},
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    adapter, storage = _build(monkeypatch, tmp_path, {key: root})
+
+    staged = adapter.stage_weight(_inputs(root))
+
+    assert storage.calls == [key]
+    assert torch.equal(
+        load_file(staged.path / "model.safetensors")["weight"],
+        torch.tensor([1.0, 2.0]),
+    )
+
+
+def test_canonical_s3_uses_weight_map_without_index_validation(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target_tensor = torch.tensor([3.0, 4.0])
+    objects = _artifact(base, target_tensor.view(torch.uint8).numpy())
+    key = "s3://weights/test/v1/model.safetensors.index.json"
+    root = json.dumps(
+        {"weight_map": {"weight": "model-00000-of-00001.safetensors"}}
+    ).encode()
+    objects[key] = root
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+
+    staged = adapter.stage_weight(_inputs(root))
+
+    assert torch.equal(
+        load_file(staged.path / "model.safetensors")["weight"], target_tensor
+    )
+
+
+def test_canonical_s3_downloads_unique_shards_concurrently(monkeypatch, tmp_path):
+    adapter, storage = _build(monkeypatch, tmp_path, {})
+    barrier = threading.Barrier(2)
+
+    def get(uri):
+        barrier.wait(timeout=2)
+        return uri.encode()
+
+    storage.get = get
+    root = "s3://weights/prefix/model.safetensors.index.json"
+
+    shards = adapter._checkpoint._download_deltas(
+        {
+            "weight_a": "model-00000-of-00002.safetensors",
+            "weight_b": "model-00000-of-00002.safetensors",
+            "weight_c": "model-00001-of-00002.safetensors",
+        },
+        root,
+    )
+
+    assert shards == {
+        "model-00000-of-00002.safetensors": (
+            b"s3://weights/prefix/model-00000-of-00002.safetensors",
+            ["weight_a", "weight_b"],
+        ),
+        "model-00001-of-00002.safetensors": (
+            b"s3://weights/prefix/model-00001-of-00002.safetensors",
+            ["weight_c"],
+        ),
+    }
+
+
+def test_canonical_s3_applies_delta_tensors_concurrently(monkeypatch, tmp_path):
+    launch = tmp_path / "launch"
+    launch.mkdir()
+    tensor_size = (2 << 20) + 1
+    base = {
+        "weight_a": torch.zeros(tensor_size, dtype=torch.uint8),
+        "weight_b": torch.ones(tensor_size, dtype=torch.uint8),
+    }
+    target = {
+        "weight_a": torch.full((tensor_size,), 2, dtype=torch.uint8),
+        "weight_b": torch.full((tensor_size,), 3, dtype=torch.uint8),
+    }
+    save_file(base, launch / "model.safetensors")
+    checkpoint = receiver_module._LocalCheckpoint(
+        model_name="test/model",
+        config=S3GeneratorConfig(
+            initial_base_version_id="base-a",
+            launch_checkpoint=launch,
+            preparation_cache_dir=tmp_path / "cache",
+        ),
+        s3=_MemoryS3({}),
+    )
+    checkpoint.initialize()
+
+    encoded = {}
+    checksums = {}
+    for name in target:
+        current = target[name].view(torch.uint8).numpy()
+        delta, _ = compute_delta(current, base[name].view(torch.uint8).numpy())
+        assert delta is not None
+        encoded[name] = compress_delta(delta)
+        checksums[name] = adler32_checksum(current)
+    shard = safetensors.numpy.save(encoded, metadata=checksums)
+
+    barrier = threading.Barrier(2)
+    decompressor = zstandard.ZstdDecompressor
+    read_counts = {}
+    read_sizes = []
+    read_lock = threading.Lock()
+
+    class TrackingReader:
+        def __init__(self, reader):
+            self.reader = reader
+
+        def read(self, size):
+            block = self.reader.read(size)
+            with read_lock:
+                read_sizes.append(size)
+                if block:
+                    thread_id = threading.get_ident()
+                    read_counts[thread_id] = read_counts.get(thread_id, 0) + 1
+            return block
+
+        def close(self):
+            self.reader.close()
+
+    class StreamingDecompressor:
+        def stream_reader(self, compressed):
+            barrier.wait(timeout=2)
+            return TrackingReader(decompressor().stream_reader(compressed))
+
+        def decompress(self, *_args, **_kwargs):
+            raise AssertionError("full-tensor decompression should not be used")
+
+    monkeypatch.setenv("MX_REFIT_DELTA_WORKERS", "2")
+    monkeypatch.setattr(
+        receiver_module.zstandard,
+        "ZstdDecompressor",
+        StreamingDecompressor,
+    )
+
+    checkpoint._apply_shards({"delta.safetensors": (shard, list(target))})
+
+    loaded = load_file(checkpoint.local_checkpoint / "model.safetensors")
+    assert all(torch.equal(loaded[name], value) for name, value in target.items())
+    assert sorted(read_counts.values()) == [2, 2]
+    assert max(read_sizes) == 2 << 20
+    assert all(0 < size <= 2 << 20 for size in read_sizes)
+
+
+def test_reconstructed_checksum_failure_propagates(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target, checksum="00000000")
+    root = objects["s3://weights/test/v1/model.safetensors.index.json"]
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+    with pytest.raises(RuntimeError, match="target checksum differs"):
+        adapter.stage_weight(_inputs(root))
+
+    recovered, _ = _build(monkeypatch, tmp_path, objects)
+    state = json.loads(recovered._checkpoint.state_path.read_text())
+    assert state["version"] == "base-a"
+    assert torch.equal(
+        load_file(recovered._checkpoint.local_checkpoint / "model.safetensors")[
+            "weight"
+        ],
+        torch.tensor([1.0, 2.0]),
+    )
+
+
+def test_wrong_base_fails_before_s3_download(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root = objects["s3://weights/test/v1/model.safetensors.index.json"]
+    adapter, storage = _build(monkeypatch, tmp_path, objects)
+
+    with pytest.raises(ValueError, match="exact local base"):
+        adapter.stage_weight(_inputs(root, base_version="other-base"))
+
+    assert storage.calls == []
+
+
+def test_child_download_failure_is_retryable(
+    monkeypatch,
+    tmp_path,
+):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root_key = "s3://weights/test/v1/model.safetensors.index.json"
+    shard_key = "s3://weights/test/v1/model-00000-of-00001.safetensors"
+    adapter, storage = _build(monkeypatch, tmp_path, objects)
+    storage.fail_key_once = shard_key
+
+    with pytest.raises(RuntimeError, match="canonical delta download failed"):
+        adapter.stage_weight(_inputs(objects[root_key]))
+
+    state = json.loads(adapter._checkpoint.state_path.read_text())
+    assert state["version"] == "base-a"
+    assert adapter.stage_weight(_inputs(objects[root_key])).target_version == "target-a"
+
+
+def test_corrupt_zstd_fails_before_checkpoint_mutation(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root_key = "s3://weights/test/v1/model.safetensors.index.json"
+    shard_key = "s3://weights/test/v1/model-00000-of-00001.safetensors"
+    shard = bytearray(objects[shard_key])
+    header_size = int.from_bytes(shard[:8], "little")
+    data_start = 8 + header_size
+    shard[data_start:] = b"\x28\xb5\x2f\xfd" + bytes(len(shard) - data_start - 4)
+    objects[shard_key] = bytes(shard)
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+
+    with pytest.raises(RuntimeError, match="delta byte size differs"):
+        adapter.stage_weight(_inputs(objects[root_key]))
+
+    state = json.loads(adapter._checkpoint.state_path.read_text())
+    assert state["version"] == "base-a"
+
+
+def test_cached_target_requires_the_same_canonical_root(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root_key = "s3://weights/test/v1/model.safetensors.index.json"
+    alternate_key = "s3://weights/test/alternate/v1/model.safetensors.index.json"
+    objects[alternate_key] = objects[root_key]
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+    staged = adapter.stage_weight(_inputs(objects[root_key]))
+    adapter.apply_weight(staged)
+    adapter.release_staged_weight(staged)
+
+    with pytest.raises(RuntimeError, match="different canonical root"):
+        adapter.stage_weight(_inputs(objects[alternate_key], uri=alternate_key))
+
+
+def test_installed_target_becomes_the_next_exact_base(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    first_tensor = torch.tensor([3.0, 4.0])
+    first = first_tensor.view(torch.uint8).numpy()
+    second_tensor = torch.tensor([5.0, 6.0])
+    second = second_tensor.view(torch.uint8).numpy()
+    objects = _artifact(base, first)
+    objects.update(
+        _artifact(
+            first,
+            second,
+            version="target-b",
+            version_number=2,
+            base_version="target-a",
+        )
+    )
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+    first_root = objects["s3://weights/test/v1/model.safetensors.index.json"]
+    staged = adapter.stage_weight(_inputs(first_root))
+    adapter.apply_weight(staged)
+    adapter.release_staged_weight(staged)
+
+    second_root = objects["s3://weights/test/v2/model.safetensors.index.json"]
+    staged = adapter.stage_weight(
+        _inputs(
+            second_root,
+            version="target-b",
+            version_number=2,
+            base_version="target-a",
+        )
+    )
+
+    assert torch.equal(
+        load_file(staged.path / "model.safetensors")["weight"],
+        second_tensor,
+    )

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -611,6 +611,59 @@ def test_reconstructed_checksum_failure_propagates(monkeypatch, tmp_path):
     )
 
 
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("missing_metadata", "missing checksum metadata"),
+        ("missing_tensor", "missing tensor 'weight'"),
+        ("missing_checksum", "missing checksum for tensor 'weight'"),
+        ("missing_local_tensor", "tensor 'other'.*absent from the local checkpoint"),
+    ],
+)
+def test_malformed_delta_shard_reports_context(
+    monkeypatch,
+    tmp_path,
+    case,
+    message,
+):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root_key = "s3://weights/test/v1/model.safetensors.index.json"
+    filename = "model-00000-of-00001.safetensors"
+    shard_key = f"s3://weights/test/v1/{filename}"
+    delta, _ = compute_delta(target, base)
+    assert delta is not None
+    encoded = compress_delta(delta)
+    checksum = adler32_checksum(target)
+
+    if case == "missing_metadata":
+        objects[shard_key] = safetensors.numpy.save({"weight": encoded})
+    elif case == "missing_tensor":
+        objects[shard_key] = safetensors.numpy.save(
+            {"other": encoded}, metadata={"other": checksum}
+        )
+    elif case == "missing_checksum":
+        objects[shard_key] = safetensors.numpy.save(
+            {"weight": encoded}, metadata={"other": checksum}
+        )
+    else:
+        manifest = json.loads(objects[root_key])
+        manifest["weight_map"] = {"other": filename}
+        objects[root_key] = json.dumps(manifest).encode()
+        objects[shard_key] = safetensors.numpy.save(
+            {"other": encoded}, metadata={"other": checksum}
+        )
+
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+    with pytest.raises(RuntimeError, match=message) as raised:
+        adapter.stage_weight(_inputs(objects[root_key]))
+
+    assert filename in str(raised.value)
+    state = json.loads(adapter._checkpoint.state_path.read_text())
+    assert state["version"] == "base-a"
+
+
 def test_wrong_base_fails_before_s3_download(monkeypatch, tmp_path):
     base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
     target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()

--- a/modelexpress_client/python/tests/test_refit_sglang_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_sglang_adapter.py
@@ -10,8 +10,17 @@ from unittest.mock import Mock
 import pytest
 import torch
 
-from modelexpress_rl.inference.engines.sglang import SGLangGeneratorAdapter
-from modelexpress_rl.inference.receiver import PreparedCheckpoint, ReceiverInstallError
+from modelexpress_rl import ObjectStorageGeneratorConfig, ObjectStorageType
+from modelexpress_rl.inference.engines.sglang import (
+    SGLangGeneratorAdapter,
+    SglangGeneratorContext,
+    _create_sglang_adapter,
+)
+from modelexpress_rl.inference.receiver import (
+    CanonicalS3GeneratorAdapter,
+    PreparedCheckpoint,
+    ReceiverInstallError,
+)
 
 
 def _runner(tmp_path):
@@ -76,6 +85,29 @@ def _install_sglang_modules(monkeypatch, loader=None, setup_error=None):
     for name, module in modules.items():
         monkeypatch.setitem(sys.modules, name, module)
     return loader
+
+
+def test_sglang_factory_uses_model_path_from_context(tmp_path, monkeypatch):
+    runner = _runner(tmp_path)
+    config = ObjectStorageGeneratorConfig(
+        storage_type=ObjectStorageType.S3,
+        initial_base_version_id="base-a",
+        launch_checkpoint=tmp_path / "launch",
+        preparation_cache_dir=tmp_path / "cache",
+    )
+    initialized = []
+
+    def initialize(self, **kwargs):
+        initialized.append(kwargs)
+
+    monkeypatch.setattr(CanonicalS3GeneratorAdapter, "__init__", initialize)
+
+    adapter = _create_sglang_adapter(SglangGeneratorContext(runner), config)
+
+    assert isinstance(adapter, SGLangGeneratorAdapter)
+    assert initialized == [
+        {"model_name": runner.model_config.model_path, "config": config}
+    ]
 
 
 def test_sglang_install_uses_the_prepared_checkpoint(tmp_path, monkeypatch):

--- a/modelexpress_client/python/tests/test_refit_sglang_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_sglang_adapter.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from modelexpress_rl.inference.engines.sglang import SGLangGeneratorAdapter
+from modelexpress_rl.inference.receiver import PreparedCheckpoint, ReceiverInstallError
+
+
+def _runner(tmp_path):
+    checkpoint = tmp_path / "launch"
+    return SimpleNamespace(
+        model=object(),
+        device="cpu",
+        loader=SimpleNamespace(
+            _prepare_weights=Mock(return_value=(checkpoint, None, None))
+        ),
+        model_config=SimpleNamespace(
+            model_path=str(checkpoint),
+            revision=None,
+            dtype=torch.float32,
+        ),
+        server_args=SimpleNamespace(
+            download_dir=None,
+            model_loader_extra_config=None,
+        ),
+    )
+
+
+def _install_sglang_modules(monkeypatch, loader=None, setup_error=None):
+    class DefaultModelLoader:
+        pass
+
+    if loader is None:
+        loader = DefaultModelLoader()
+        loader._get_weights_iterator = Mock(return_value=iter([]))
+        loader.load_weights_and_postprocess = Mock()
+    else:
+        DefaultModelLoader = type(loader)
+
+    modules = {
+        name: ModuleType(name)
+        for name in (
+            "sglang",
+            "sglang.srt",
+            "sglang.srt.configs",
+            "sglang.srt.configs.load_config",
+            "sglang.srt.model_loader",
+            "sglang.srt.model_loader.loader",
+            "sglang.srt.model_loader.utils",
+        )
+    }
+    modules["sglang.srt.configs.load_config"].LoadConfig = lambda **values: (
+        SimpleNamespace(**values)
+    )
+    modules["sglang.srt.configs.load_config"].LoadFormat = SimpleNamespace(
+        SAFETENSORS="safetensors"
+    )
+    loader_module = modules["sglang.srt.model_loader.loader"]
+    loader_module.DefaultModelLoader = DefaultModelLoader
+    loader_module.get_model_loader = (
+        Mock(side_effect=setup_error)
+        if setup_error is not None
+        else lambda *_args: loader
+    )
+    modules["sglang.srt.model_loader.utils"].set_default_torch_dtype = lambda _dtype: (
+        nullcontext()
+    )
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    return loader
+
+
+def test_sglang_install_uses_the_prepared_checkpoint(tmp_path, monkeypatch):
+    runner = _runner(tmp_path)
+    adapter = object.__new__(SGLangGeneratorAdapter)
+    adapter.model_runner = runner
+    loader = _install_sglang_modules(monkeypatch)
+    prepared = PreparedCheckpoint("target-a", tmp_path / "prepared", {})
+
+    adapter.install_prepared_checkpoint(prepared)
+
+    source = loader._get_weights_iterator.call_args.args[0]
+    assert Path(source.model_or_path) == prepared.path
+    loader.load_weights_and_postprocess.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("setup_error", "load_error", "message"),
+    [
+        (RuntimeError("setup failed"), None, "setup failed"),
+        (None, RuntimeError("load failed"), "load failed"),
+    ],
+)
+def test_sglang_install_wraps_errors(
+    tmp_path,
+    monkeypatch,
+    setup_error,
+    load_error,
+    message,
+):
+    runner = _runner(tmp_path)
+    adapter = object.__new__(SGLangGeneratorAdapter)
+    adapter.model_runner = runner
+
+    class Loader:
+        def _get_weights_iterator(self, _source):
+            return iter([])
+
+        def load_weights_and_postprocess(self, *_args):
+            if load_error is not None:
+                raise load_error
+
+    _install_sglang_modules(monkeypatch, Loader(), setup_error)
+
+    with pytest.raises(ReceiverInstallError, match=message):
+        adapter.install_prepared_checkpoint(
+            PreparedCheckpoint("target-a", tmp_path / "prepared", {})
+        )

--- a/modelexpress_client/python/tests/test_refit_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_adapter.py
@@ -8,7 +8,7 @@ import modelexpress_rl.inference.engines.vllm.adapter as vllm_adapter_module
 import pytest
 import torch
 from modelexpress import p2p_pb2
-from modelexpress_rl import WeightPayloadFormat
+from modelexpress_rl import ObjectStorageType, WeightPayloadFormat
 from modelexpress_rl.inference.adapter import (
     GeneratorSource,
     GeneratorTransferInputs,
@@ -17,8 +17,8 @@ from modelexpress_rl.inference.adapter import (
 from modelexpress_rl.inference.engines.vllm import VllmGeneratorAdapter
 from modelexpress_rl.inference.receiver import (
     CanonicalS3GeneratorAdapter,
+    ObjectStorageGeneratorConfig,
     PreparedCheckpoint,
-    S3GeneratorConfig,
 )
 
 
@@ -295,7 +295,8 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
     )
     monkeypatch.setattr(CanonicalS3GeneratorAdapter, "close", close_s3)
 
-    s3 = S3GeneratorConfig(
+    object_storage = ObjectStorageGeneratorConfig(
+        storage_type=ObjectStorageType.S3,
         initial_base_version_id="base-a",
         launch_checkpoint=tmp_path / "launch",
         preparation_cache_dir=tmp_path / "cache",
@@ -306,7 +307,7 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
         model_config="model-config",
         worker_id="generator-0",
         model_name="test/model",
-        s3=s3,
+        object_storage=object_storage,
     )
     inputs = object()
 
@@ -328,7 +329,10 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
                 "device": torch.device("cuda:2"),
             },
         ),
-        ("s3_init", {"model_name": "test/model", "config": s3}),
+        (
+            "s3_init",
+            {"model_name": "test/model", "config": object_storage},
+        ),
         ("s3_stage", inputs),
         ("s3_apply", prepared),
         ("install_checkpoint", prepared.path),
@@ -344,7 +348,8 @@ def test_vllm_s3_requires_model_name():
             vllm_config="vllm-config",
             model_config="model-config",
             worker_id="generator-0",
-            s3=S3GeneratorConfig(
+            object_storage=ObjectStorageGeneratorConfig(
+                storage_type=ObjectStorageType.S3,
                 initial_base_version_id="base-a",
                 launch_checkpoint="launch",
                 preparation_cache_dir="cache",

--- a/modelexpress_client/python/tests/test_refit_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_adapter.py
@@ -238,6 +238,8 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
 ):
     events = []
     prepared = PreparedCheckpoint("target-a", tmp_path / "prepared", {})
+    model_config = SimpleNamespace(model="config/model")
+    vllm_config = SimpleNamespace(model_config=model_config)
 
     class _Installer:
         def __init__(self, **kwargs):
@@ -251,9 +253,9 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
             pytest.fail("S3 mode must not create a NIXL transfer")
 
     class _Engine:
-        def __init__(self, vllm_config, model_config):
-            assert vllm_config == "vllm-config"
-            assert model_config == "model-config"
+        def __init__(self, received_vllm_config, received_model_config):
+            assert received_vllm_config is vllm_config
+            assert received_model_config is model_config
 
         def get_device_id(self):
             return 2
@@ -303,10 +305,9 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
     )
     adapter = VllmGeneratorAdapter(
         model="model",
-        vllm_config="vllm-config",
-        model_config="model-config",
+        vllm_config=vllm_config,
+        model_config=model_config,
         worker_id="generator-0",
-        model_name="test/model",
         object_storage=object_storage,
     )
     inputs = object()
@@ -324,14 +325,14 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
             "installer_init",
             {
                 "model": "model",
-                "vllm_config": "vllm-config",
-                "model_config": "model-config",
+                "vllm_config": vllm_config,
+                "model_config": model_config,
                 "device": torch.device("cuda:2"),
             },
         ),
         (
             "s3_init",
-            {"model_name": "test/model", "config": object_storage},
+            {"model_name": "config/model", "config": object_storage},
         ),
         ("s3_stage", inputs),
         ("s3_apply", prepared),
@@ -339,19 +340,3 @@ def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
         ("s3_release", prepared),
         ("s3_close",),
     ]
-
-
-def test_vllm_s3_requires_model_name():
-    with pytest.raises(ValueError, match="model_name is required"):
-        VllmGeneratorAdapter(
-            model="model",
-            vllm_config="vllm-config",
-            model_config="model-config",
-            worker_id="generator-0",
-            object_storage=ObjectStorageGeneratorConfig(
-                storage_type=ObjectStorageType.S3,
-                initial_base_version_id="base-a",
-                launch_checkpoint="launch",
-                preparation_cache_dir="cache",
-            ),
-        )

--- a/modelexpress_client/python/tests/test_refit_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_adapter.py
@@ -9,8 +9,17 @@ import pytest
 import torch
 from modelexpress import p2p_pb2
 from modelexpress_rl import WeightPayloadFormat
-from modelexpress_rl.inference.adapter import GeneratorSource, GeneratorTransferInputs
+from modelexpress_rl.inference.adapter import (
+    GeneratorSource,
+    GeneratorTransferInputs,
+    NixlGeneratorSource,
+)
 from modelexpress_rl.inference.engines.vllm import VllmGeneratorAdapter
+from modelexpress_rl.inference.receiver import (
+    CanonicalS3GeneratorAdapter,
+    PreparedCheckpoint,
+    S3GeneratorConfig,
+)
 
 
 def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
@@ -106,16 +115,18 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
     )
     inputs = GeneratorTransferInputs(
         version_id="version-a",
+        base_version_id=None,
         layout_signature="layout-a",
         payload_format=WeightPayloadFormat.FULL_TENSOR,
         sources=(
             GeneratorSource(
                 source_slot_id="rank:0",
                 worker_id="trainer-0",
-                manifest_endpoint="trainer-0:9000",
                 manifest_digest="digest",
-                transport="NIXL",
-                manifest=b"manifest",
+                transport=NixlGeneratorSource(
+                    manifest_endpoint="trainer-0:9000",
+                    manifest=b"manifest",
+                ),
             ),
         ),
     )
@@ -219,3 +230,123 @@ def test_vllm_adapter_composes_transfer_and_installer_lifecycles(
         ("install", peer_staged.tensors),
         ("close",),
     ]
+
+
+def test_vllm_adapter_uses_canonical_s3_without_creating_nixl(
+    monkeypatch,
+    tmp_path,
+):
+    events = []
+    prepared = PreparedCheckpoint("target-a", tmp_path / "prepared", {})
+
+    class _Installer:
+        def __init__(self, **kwargs):
+            events.append(("installer_init", kwargs))
+
+        def install_checkpoint(self, path):
+            events.append(("install_checkpoint", path))
+
+    class _Transfer:
+        def __init__(self, **_kwargs):
+            pytest.fail("S3 mode must not create a NIXL transfer")
+
+    class _Engine:
+        def __init__(self, vllm_config, model_config):
+            assert vllm_config == "vllm-config"
+            assert model_config == "model-config"
+
+        def get_device_id(self):
+            return 2
+
+        def get_target_device(self):
+            return torch.device("cuda:2")
+
+    def initialize_s3(self, **kwargs):
+        events.append(("s3_init", kwargs))
+        self._active_staged = None
+
+    def stage_s3(self, inputs):
+        events.append(("s3_stage", inputs))
+        self._active_staged = prepared
+        return prepared
+
+    def apply_s3(self, staged):
+        events.append(("s3_apply", staged))
+        self.install_prepared_checkpoint(staged)
+        return {"installed": 1.0}
+
+    def release_s3(self, staged):
+        events.append(("s3_release", staged))
+        self._active_staged = None
+
+    def close_s3(self):
+        events.append(("s3_close",))
+
+    monkeypatch.setattr(vllm_adapter_module, "VllmAdapter", _Engine)
+    monkeypatch.setattr(vllm_adapter_module, "_VllmInstaller", _Installer)
+    monkeypatch.setattr(vllm_adapter_module, "_NixlStagedTransfer", _Transfer)
+    monkeypatch.setattr(CanonicalS3GeneratorAdapter, "__init__", initialize_s3)
+    monkeypatch.setattr(CanonicalS3GeneratorAdapter, "stage_weight", stage_s3)
+    monkeypatch.setattr(CanonicalS3GeneratorAdapter, "apply_weight", apply_s3)
+    monkeypatch.setattr(
+        CanonicalS3GeneratorAdapter,
+        "release_staged_weight",
+        release_s3,
+    )
+    monkeypatch.setattr(CanonicalS3GeneratorAdapter, "close", close_s3)
+
+    s3 = S3GeneratorConfig(
+        initial_base_version_id="base-a",
+        launch_checkpoint=tmp_path / "launch",
+        preparation_cache_dir=tmp_path / "cache",
+    )
+    adapter = VllmGeneratorAdapter(
+        model="model",
+        vllm_config="vllm-config",
+        model_config="model-config",
+        worker_id="generator-0",
+        model_name="test/model",
+        s3=s3,
+    )
+    inputs = object()
+
+    assert adapter.supported_payload_formats == frozenset(
+        {WeightPayloadFormat.XOR_DELTA}
+    )
+    assert adapter.stage_weight(inputs) is prepared
+    assert adapter.apply_weight(prepared) == {"installed": 1.0}
+    adapter.release_staged_weight(prepared)
+    adapter.close()
+
+    assert events == [
+        (
+            "installer_init",
+            {
+                "model": "model",
+                "vllm_config": "vllm-config",
+                "model_config": "model-config",
+                "device": torch.device("cuda:2"),
+            },
+        ),
+        ("s3_init", {"model_name": "test/model", "config": s3}),
+        ("s3_stage", inputs),
+        ("s3_apply", prepared),
+        ("install_checkpoint", prepared.path),
+        ("s3_release", prepared),
+        ("s3_close",),
+    ]
+
+
+def test_vllm_s3_requires_model_name():
+    with pytest.raises(ValueError, match="model_name is required"):
+        VllmGeneratorAdapter(
+            model="model",
+            vllm_config="vllm-config",
+            model_config="model-config",
+            worker_id="generator-0",
+            s3=S3GeneratorConfig(
+                initial_base_version_id="base-a",
+                launch_checkpoint="launch",
+                preparation_cache_dir="cache",
+            ),
+        )

--- a/modelexpress_client/python/tests/test_refit_vllm_installer.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_installer.py
@@ -3,7 +3,7 @@
 
 import sys
 from contextlib import contextmanager
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -37,6 +37,9 @@ def _install_fake_vllm(monkeypatch, initialize):
         ),
         "vllm.model_executor.model_loader": ModuleType(
             "vllm.model_executor.model_loader"
+        ),
+        "vllm.model_executor.model_loader.default_loader": ModuleType(
+            "vllm.model_executor.model_loader.default_loader"
         ),
         "vllm.model_executor.model_loader.reload": ModuleType(
             "vllm.model_executor.model_loader.reload"
@@ -96,6 +99,78 @@ def test_installer_rejects_parameters_left_on_meta(monkeypatch):
 
     with pytest.raises(IncompleteRefit, match="left parameters on the meta device"):
         installer._process_and_commit({"weight": torch.tensor([7.0])})
+
+
+def test_installer_loads_prepared_checkpoint_inside_vllm_config(monkeypatch, tmp_path):
+    active_config = [None]
+    events = []
+
+    @contextmanager
+    def current_config(config):
+        active_config[0] = config
+        try:
+            yield
+        finally:
+            active_config[0] = None
+
+    def initialize(_model):
+        events.append(("initialize", active_config[0]))
+
+    _install_fake_vllm(monkeypatch, initialize)
+    sys.modules["vllm.config"].set_current_vllm_config = current_config
+    layerwise = sys.modules["vllm.model_executor.model_loader.reload.layerwise"]
+    layerwise.finalize_layerwise_reload = lambda _model, _config: events.append(
+        ("finalize", active_config[0])
+    )
+
+    class DefaultModelLoader:
+        def __init__(self, load_config):
+            events.append(("loader", load_config.load_format))
+
+        def load_weights(self, model, model_config):
+            events.append(
+                (
+                    "load",
+                    active_config[0],
+                    model_config.model,
+                    model_config.revision,
+                )
+            )
+            model.weight.data.fill_(7.0)
+
+    sys.modules[
+        "vllm.model_executor.model_loader.default_loader"
+    ].DefaultModelLoader = DefaultModelLoader
+    synchronized = []
+    monkeypatch.setattr(torch.cuda, "synchronize", synchronized.append)
+
+    model = nn.Linear(1, 1, bias=False)
+    model_config = SimpleNamespace(model="/launch", revision="main")
+    vllm_config = SimpleNamespace(
+        load_config=SimpleNamespace(load_format="modelexpress"),
+        quant_config=None,
+    )
+    installer = _VllmInstaller(
+        model=model,
+        vllm_config=vllm_config,
+        model_config=model_config,
+        device=torch.device("cpu"),
+    )
+    prepared = tmp_path / "prepared"
+
+    installer.install_checkpoint(prepared)
+
+    assert events == [
+        ("loader", "safetensors"),
+        ("initialize", vllm_config),
+        ("load", vllm_config, str(prepared), None),
+        ("finalize", vllm_config),
+    ]
+    assert model.weight.item() == 7.0
+    assert model_config.model == "/launch"
+    assert model_config.revision == "main"
+    assert vllm_config.load_config.load_format == "modelexpress"
+    assert synchronized == [torch.device("cpu")]
 
 
 def test_installer_caches_parameter_layout():

--- a/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
+++ b/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
+from modelexpress_rl import ObjectStorageType
 from modelexpress_rl.inference.engines.vllm import weight_transfer_engine
 from modelexpress_rl.inference.engines.vllm.weight_transfer_engine import (
     ModelExpressWeightTransferEngine,
@@ -59,10 +60,10 @@ def test_weight_transfer_engine_initializes_client_in_init_hook(monkeypatch):
     config = initialize.call_args.args[0]
     assert config.model_name == "test/model"
     assert config.engine_context.model is model
-    assert config.s3 is None
+    assert config.object_storage is None
 
 
-def test_weight_transfer_engine_parses_vime_s3_init_info(monkeypatch):
+def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch):
     client = MagicMock()
     initialize = MagicMock(return_value=client)
     monkeypatch.setattr(
@@ -85,8 +86,9 @@ def test_weight_transfer_engine_parses_vime_s3_init_info(monkeypatch):
         "launch_checkpoint": "/models/launch",
         "preparation_cache_dir": "/cache/modelexpress",
         "server_url": "mx:8001",
-        "s3_endpoint_url": "http://minio:9000",
-        "s3_region_name": "us-west-2",
+        "object_storage_type": "S3",
+        "object_storage_endpoint_url": "http://minio:9000",
+        "object_storage_region_name": "us-west-2",
         "registration_ttl_seconds": 90,
         "lease_ttl_seconds": 60,
         "max_transfer_attempts": 4,
@@ -102,28 +104,47 @@ def test_weight_transfer_engine_parses_vime_s3_init_info(monkeypatch):
     assert config.lease_ttl_seconds == 60
     assert config.max_transfer_attempts == 4
     assert config.rpc_timeout_seconds == 12.5
-    assert config.s3.initial_base_version_id == "base-a"
-    assert config.s3.launch_checkpoint == "/models/launch"
-    assert config.s3.preparation_cache_dir == "/cache/modelexpress"
-    assert config.s3.endpoint_url == "http://minio:9000"
-    assert config.s3.region_name == "us-west-2"
+    assert config.object_storage.storage_type is ObjectStorageType.S3
+    assert config.object_storage.initial_base_version_id == "base-a"
+    assert config.object_storage.launch_checkpoint == "/models/launch"
+    assert config.object_storage.preparation_cache_dir == "/cache/modelexpress"
+    assert config.object_storage.endpoint_url == "http://minio:9000"
+    assert config.object_storage.region_name == "us-west-2"
 
 
 @pytest.mark.parametrize(
     "kwargs",
     [
+        {"object_storage_type": "S3"},
         {"initial_base_version_id": "base-a"},
         {"launch_checkpoint": "/models/launch"},
         {"preparation_cache_dir": "/cache/modelexpress"},
-        {"s3_endpoint_url": "http://minio:9000"},
-        {"s3_region_name": "us-west-2"},
+        {"object_storage_endpoint_url": "http://minio:9000"},
+        {"object_storage_region_name": "us-west-2"},
     ],
 )
-def test_weight_transfer_engine_requires_complete_s3_init(monkeypatch, kwargs):
+def test_weight_transfer_engine_requires_complete_object_storage_init(
+    monkeypatch,
+    kwargs,
+):
     engine, _client = _engine(monkeypatch, initialize=False)
 
-    with pytest.raises(ValueError, match="canonical S3 requires"):
+    with pytest.raises(ValueError, match="object storage requires"):
         engine.init_transfer_engine(engine.init_info_cls(**kwargs))
+
+
+def test_weight_transfer_engine_rejects_unknown_object_storage_type(monkeypatch):
+    engine, _client = _engine(monkeypatch, initialize=False)
+
+    with pytest.raises(ValueError, match="unsupported object_storage_type"):
+        engine.init_transfer_engine(
+            engine.init_info_cls(
+                object_storage_type="UNKNOWN",
+                initial_base_version_id="base-a",
+                launch_checkpoint="/models/launch",
+                preparation_cache_dir="/cache/modelexpress",
+            )
+        )
 
 
 def test_weight_transfer_engine_applies_one_exact_version(monkeypatch):

--- a/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
+++ b/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 
+from modelexpress_rl.inference.engines.vllm import weight_transfer_engine
 from modelexpress_rl.inference.engines.vllm.weight_transfer_engine import (
     ModelExpressWeightTransferEngine,
 )
@@ -57,6 +59,71 @@ def test_weight_transfer_engine_initializes_client_in_init_hook(monkeypatch):
     config = initialize.call_args.args[0]
     assert config.model_name == "test/model"
     assert config.engine_context.model is model
+    assert config.s3 is None
+
+
+def test_weight_transfer_engine_parses_vime_s3_init_info(monkeypatch):
+    client = MagicMock()
+    initialize = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        weight_transfer_engine.ModelExpressGeneratorClient,
+        "initialize",
+        initialize,
+    )
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(),
+        model_config=SimpleNamespace(model="test/model"),
+    )
+    model = torch.nn.Linear(2, 2)
+    engine = ModelExpressWeightTransferEngine(
+        SimpleNamespace(), vllm_config, torch.device("cpu"), model
+    )
+
+    init_info = {
+        "model_name": "policy",
+        "initial_base_version_id": "base-a",
+        "launch_checkpoint": "/models/launch",
+        "preparation_cache_dir": "/cache/modelexpress",
+        "server_url": "mx:8001",
+        "s3_endpoint_url": "http://minio:9000",
+        "s3_region_name": "us-west-2",
+        "registration_ttl_seconds": 90,
+        "lease_ttl_seconds": 60,
+        "max_transfer_attempts": 4,
+        "rpc_timeout_seconds": 12.5,
+    }
+    engine.init_transfer_engine(engine.init_info_cls(**init_info))
+
+    config = initialize.call_args.args[0]
+    assert config.model_name == "policy"
+    assert config.engine_context.model is model
+    assert config.server_url == "mx:8001"
+    assert config.registration_ttl_seconds == 90
+    assert config.lease_ttl_seconds == 60
+    assert config.max_transfer_attempts == 4
+    assert config.rpc_timeout_seconds == 12.5
+    assert config.s3.initial_base_version_id == "base-a"
+    assert config.s3.launch_checkpoint == "/models/launch"
+    assert config.s3.preparation_cache_dir == "/cache/modelexpress"
+    assert config.s3.endpoint_url == "http://minio:9000"
+    assert config.s3.region_name == "us-west-2"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"initial_base_version_id": "base-a"},
+        {"launch_checkpoint": "/models/launch"},
+        {"preparation_cache_dir": "/cache/modelexpress"},
+        {"s3_endpoint_url": "http://minio:9000"},
+        {"s3_region_name": "us-west-2"},
+    ],
+)
+def test_weight_transfer_engine_requires_complete_s3_init(monkeypatch, kwargs):
+    engine, _client = _engine(monkeypatch, initialize=False)
+
+    with pytest.raises(ValueError, match="canonical S3 requires"):
+        engine.init_transfer_engine(engine.init_info_cls(**kwargs))
 
 
 def test_weight_transfer_engine_applies_one_exact_version(monkeypatch):
@@ -70,6 +137,43 @@ def test_weight_transfer_engine_applies_one_exact_version(monkeypatch):
     version = client.stage_weight.call_args.kwargs["version"]
     assert version.version_id == "version-a"
     client.apply_weight.assert_called_once_with(staged)
+    staged.release.assert_called_once_with()
+
+
+def test_weight_transfer_engine_logs_receiver_metrics(monkeypatch, caplog):
+    engine, client = _engine(monkeypatch)
+    staged = SimpleNamespace(
+        metrics={
+            "perf/mx_receive_prepare_time": 2.0,
+            "perf/not_numeric": "ignored",
+            "receiver/detail": 7.0,
+        },
+        release=MagicMock(),
+    )
+    client.stage_weight.return_value = staged
+    client.apply_weight.return_value = {
+        "perf/mx_receive_install_time": 3.0,
+        "receiver/attempts": 1,
+    }
+    clock = iter([10.0, 14.5])
+    monkeypatch.setattr(weight_transfer_engine, "perf_counter", lambda: next(clock))
+
+    with caplog.at_level(logging.INFO, logger=weight_transfer_engine.__name__):
+        engine.start_weight_update()
+        engine.update_weights({"version_id": "version-a"})
+
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("ModelExpress receiver metric")
+    ] == [
+        "ModelExpress receiver metric perf/mx_receive_install_time=3.0",
+        "ModelExpress receiver metric perf/mx_receive_prepare_time=2.0",
+        "ModelExpress receiver metric perf/mx_receive_stage_weight_time=4.5",
+    ]
+    staged.release.assert_not_called()
+
+    engine.finish_weight_update()
     staged.release.assert_called_once_with()
 
 


### PR DESCRIPTION
  ## Stack

  This PR is stacked on https://github.com/ai-dynamo/modelexpress/pull/685. It contains one generator-side commit and
  should be reviewed and merged after the trainer/control-plane PR.

  ## Summary

  Add canonical S3/XOR delta receiving and installation for SGLang and vLLM generators.

  - Download canonical indexes and delta shards from the version-owned S3 URI.
  - Maintain a locked host-local checkpoint with exact-base validation.
  - Reconstruct and verify updated tensors before engine installation.
  - Add an SGLang adapter using its native safetensors loader.
  - Add a native vLLM weight-transfer backend for ModelExpress S3 updates.
  - Report preparation, download, delta application, installation, and total staging metrics.
  - Register the vLLM backend through the existing ModelExpress plugin.
  - Add generator, receiver, SGLang, vLLM, and plugin tests and documentation.

  ## Behavior

  When S3 configuration is present, the generator resolves the canonical URI from WeightVersion and
  uses the S3 receiver directly.

  The existing non-S3 peer/trainer refit strategies and NIXL transfer path remain unchanged. Peer-
  first S3 loading and trainer fallback are intentionally out of scope.

  ## Validation

  ### Automated

  - 194 focused Python refit and vLLM tests passed.
  - Ruff passed for all changed Python files.
  - Repository pre-commit checks passed.
  - The final tree matches the previously validated PR-ready implementation exactly.

  ### End-to-end

  Validated over 100 weight-update steps using:

  - Model: Qwen3-30B-A3B
  - Hardware: NVIDIA B200
  - Trainer: 4 GPUs, TP2 / PP2 / EP2
  - Inference: 4 GPUs, TP4
  - Delta storage: AWS S3 in us-west-2

```
   Workflow          Average total update time    Average delta size
  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━
   Slime + SGLang                      40.23 s            393.77 MiB
  ────────────────  ───────────────────────────  ────────────────────
   Vime + vLLM                         53.77 s            398.69 MiB
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3-backed checkpoint updates for generator clients, including cached preparation, delta application, validation, retries, and cleanup.
  * Added SGLang support for loading prepared checkpoints.
  * Extended vLLM support with native checkpoint installation alongside existing transfer workflows.
  * Exposed generator object-storage configuration and checkpoint status metrics.
* **Documentation**
  * Updated architecture and Python usage documentation with S3 configuration, lifecycle, metrics, and supported behaviors.
* **Tests**
  * Added coverage for S3, SGLang, vLLM, validation, retries, integrity checks, and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->