### PR TITLE
docs(helm): document CRD updates for existing clusters

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -111,9 +111,13 @@ reachable.
 | `REDIS_URL` | e.g. `redis://host:6379` | when Redis | Redis connection (or set `MX_REDIS_HOST` / `MX_REDIS_PORT`) |
 | `POD_NAMESPACE` / `MX_METADATA_NAMESPACE` | e.g. `default` | when Kubernetes | Namespace for the `ModelMetadata` and `ModelCacheEntry` CRDs |
 
-To use the Kubernetes backend, apply `examples/crds.yaml` at cluster install time
-(installs both the `ModelMetadata` P2P CRD and the `ModelCacheEntry` registry CRD),
-then either enable `serviceAccount.rbac.enabled=true` on the Helm chart or apply
+To use the Kubernetes backend in a standalone deployment, apply
+`examples/crds.yaml` before the first deployment and reapply it when upgrading
+ModelExpress (it installs or updates both the `ModelMetadata` P2P CRD and the
+`ModelCacheEntry` registry CRD). When using the Helm chart, follow the CRD
+installation and upgrade instructions in [`helm/README.md`](../helm/README.md);
+Helm does not update an existing CRD from the chart's `crds/` directory. Then
+either enable `serviceAccount.rbac.enabled=true` on the Helm chart or apply
 `examples/p2p_transfer_k8s/server/kubernetes_backend/rbac-modelmetadata.yaml`.
 The chart creates a `ClusterRole` and `ClusterRoleBinding`, allowing the server
 to run in a dedicated namespace while accessing metadata resources in another

--- a/helm/README.md
+++ b/helm/README.md
@@ -21,7 +21,33 @@ helm repo add modelexpress https://your-repo-url
 helm repo update
 ```
 
-### 2. Install the chart
+### 2. Install or update CRDs for the Kubernetes backend
+
+The chart ships the `ModelMetadata` and `ModelCacheEntry` CRDs in its `crds/`
+directory. Helm installs CRDs that are missing during `helm install`, but it does
+not update CRDs that already exist during either `helm install` or
+`helm upgrade`. Because CRDs are cluster-scoped, an older definition can remain
+even when installing a new release in a different namespace.
+
+Before upgrading the chart, or installing it on a cluster that already has
+ModelExpress CRDs, apply the definitions from the chart with cluster-admin
+credentials:
+
+```bash
+kubectl apply -f helm/crds/modelexpress-crds.yaml
+```
+
+When using a packaged or remote chart rather than a source checkout, extract and
+apply the CRDs from the same chart version you are about to install:
+
+```bash
+helm show crds CHART_REFERENCE --version CHART_VERSION | kubectl apply -f -
+```
+
+This step is required to deliver schema changes to existing clusters. Helm does
+not remove these CRDs when the application release is uninstalled.
+
+### 3. Install the chart
 
 To view the available tags for the official ModelExpress image, see the
 [ModelExpress Server tags](https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/containers/modelexpress-server/-/tags)
@@ -200,6 +226,9 @@ env:
 ## Upgrading
 
 ```bash
+# Helm does not upgrade existing CRDs, so update them first.
+kubectl apply -f helm/crds/modelexpress-crds.yaml
+
 helm upgrade my-modelexpress ./helm
 ```
 

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -11,6 +11,18 @@ or override env.REDIS_URL to point at your own instance.
 {{- end }}
 {{- if eq .Values.env.MX_METADATA_BACKEND "kubernetes" }}
 
+IMPORTANT: Helm installs missing CRDs from this chart, but does not update CRDs
+that already exist. Before upgrading, or when installing on a cluster with an
+older ModelExpress installation, apply the CRDs shipped with this chart:
+
+From a source checkout:
+
+  kubectl apply -f helm/crds/modelexpress-crds.yaml
+
+For a packaged or remote chart, extract the CRDs from the same chart version:
+
+  helm show crds CHART_REFERENCE --version {{ .Chart.Version }} | kubectl apply -f -
+
 Set serviceAccount.rbac.enabled=true so the server can manage ModelMetadata and
 ModelCacheEntry resources with the Kubernetes backend.
 {{- end }}


### PR DESCRIPTION
## Summary

Backport of #696 to `release/0.6.0`.

- document that Helm installs missing CRDs but does not update existing CRDs
- tell operators to apply the chart's CRDs before upgrades or installs on clusters carrying older ModelExpress CRDs
- provide source-checkout and packaged-chart commands in the Helm README and release NOTES
- clarify CRD reapplication for standalone Kubernetes upgrades

## Testing

- `helm lint helm` with Helm v3.16.4
- `cmp examples/crds.yaml helm/crds/modelexpress-crds.yaml`
- `git diff --check origin/release/0.6.0...HEAD`

Cherry-picked with `-x`; the original DCO sign-off is preserved.
