### PR TITLE
fix(crds): accept S3 in the ModelCacheEntry provider enum

### DIFF
--- a/ci/k8s/server/crd-modelmetadata.yaml
+++ b/ci/k8s/server/crd-modelmetadata.yaml
@@ -217,6 +217,7 @@ spec:
                     - HuggingFace
                     - Ngc
                     - Gcs
+                    - S3
             status:
               type: object
               properties:

--- a/examples/crds.yaml
+++ b/examples/crds.yaml
@@ -218,6 +218,7 @@ spec:
                     - HuggingFace
                     - Ngc
                     - Gcs
+                    - S3
             status:
               type: object
               properties:

--- a/helm/crds/modelexpress-crds.yaml
+++ b/helm/crds/modelexpress-crds.yaml
@@ -218,6 +218,7 @@ spec:
                     - HuggingFace
                     - Ngc
                     - Gcs
+                    - S3
             status:
               type: object
               properties:

--- a/modelexpress_server/src/registry/k8s_types.rs
+++ b/modelexpress_server/src/registry/k8s_types.rs
@@ -30,7 +30,7 @@ pub struct ModelCacheEntrySpec {
     #[serde(rename = "modelName")]
     pub model_name: String,
 
-    /// Provider string — `"HuggingFace"`, `"Ngc"`, or `"Gcs"`.
+    /// Provider string — `"HuggingFace"`, `"Ngc"`, `"Gcs"`, or `"S3"`.
     pub provider: String,
 }
 


### PR DESCRIPTION
The server can emit S3 as a model provider. ModelProvider carries the
variant, the Kubernetes registry backend's ALL_PROVIDERS lists it, and
provider_str serializes it as the literal "S3" into
ModelCacheEntry.spec.provider. The CRD the chart ships declares a
spec.provider enum of only HuggingFace, Ngc and Gcs, so the API server
rejects the object outright.

That costs more than a registry entry. The claim is taken before any bytes
are fetched, so the rejected ModelCacheEntry aborts the download itself:
the client gets "Model download failed: Registry error occurred" and
nothing is fetched. On the Kubernetes registry backend the S3 provider is
unusable end to end. The Redis backend does not go through CRD schema
validation and is unaffected, which is why the provider implementation
itself is fine.

Adds S3 to the enum in all three shipped copies. examples/crds.yaml and
helm/crds/modelexpress-crds.yaml are held identical by CI, and
ci/k8s/server/crd-modelmetadata.yaml needs its own edit. Also corrects the
provider doc string in registry/k8s_types.rs, which listed the same three.

This is the second time the shipped enum has lagged the ModelProvider
variants, after Gcs. Asserting at CI time that every variant appears in all
three copies would stop the next provider repeating it; that is left as a
follow-up rather than folded into a release fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `S3` as a provider for model cache entries.
  - Updated Kubernetes resource definitions and provider documentation to reflect the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->