### PR TITLE
refactor(refit): rename checkpoint path settings and add a S3 delta refit doc

### DIFF
--- a/docs/S3_DELTA_WEIGHT_REFIT.md
+++ b/docs/S3_DELTA_WEIGHT_REFIT.md
@@ -1,0 +1,395 @@
+# S3 Delta Weight Refit
+
+This guide shows how to publish XOR-delta weight updates to S3 and install them
+in a running vLLM model with ModelExpress. The trainer and generator start from
+the same local checkpoint; only the delta artifacts are transferred through S3.
+ModelExpress coordinates each version's lineage and readiness.
+
+## Components
+
+| Component | Responsibility |
+|---|---|
+| `ModelExpressControlClient` | Create and transition immutable weight-version records in the ModelExpress catalog. |
+| `ModelExpressTrainerClient` | Capture the seed-checkpoint base, compute XOR deltas from trainer tensors, and publish delta shards plus the global index to S3. |
+| `ModelExpressGeneratorClient` | Validate READY versions, download and apply S3 deltas to its prepared checkpoint, and reload the live model. |
+
+## Requirements
+
+- A Redis-backed ModelExpress Refit service.
+- A ModelExpress build containing the canonical S3 delta and vLLM integrations.
+- The `modelexpress` Python package installed in both the trainer environment
+  and the environment used to launch vLLM.
+- vLLM 0.27.1.
+- Trainer ranks with S3 read/write access and vLLM hosts with read access.
+- The corresponding base checkpoint in safetensors format on every trainer and
+  vLLM host.
+
+Minimal ModelExpress server configuration:
+
+```bash
+export MX_METADATA_BACKEND=redis
+export REDIS_URL=redis://redis:6379
+```
+
+Environment variables used by the clients and vLLM engine:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MX_SERVER_ADDRESS` | `localhost:8001` | ModelExpress server address. |
+| `MX_AUTH_TOKEN_PATH` | unset | Optional ModelExpress bearer-token file. |
+| `MX_AUTH_TOKEN_TTL_SECONDS` | `60` | Token-file reread interval in seconds. |
+| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | unset | S3 credentials when an IAM role or workload identity is unavailable. |
+| `AWS_SESSION_TOKEN` | unset | Session token when using temporary AWS credentials. |
+| `AWS_DEFAULT_REGION` | unset | S3 region when `region_name` is not supplied in client configuration. |
+| `MX_REFIT_DELTA_BUCKET_BYTES` | `536870912` (512 MiB) | Optional tensor-bucket size override for framework integrations. |
+| `MX_REFIT_DELTA_WORKERS` | `min(32, CPU count)` | CPU workers used to compute and apply XOR deltas. |
+| `MX_S3_UPLOAD_WORKERS` | `8` | Maximum concurrent multipart uploads per trainer rank. |
+| `MX_S3_DOWNLOAD_WORKERS` | `16` | Generator download concurrency. |
+| `MX_S3_MAX_POOL_CONNECTIONS` | `32` | Botocore HTTP connection-pool size. |
+| `MX_S3_MAX_ATTEMPTS` | `5` | Total S3 request attempts. |
+| `VLLM_SERVER_DEV_MODE` | unset | Set to `1` to enable vLLM's weight-update HTTP routes. Network-isolate these routes. |
+| `VLLM_PLUGINS` | unset | Set to `modelexpress` to load the ModelExpress vLLM plugin. |
+
+Optional S3 tuning variables and defaults are documented in
+[`modelexpress_client/python/README.md`](../modelexpress_client/python/README.md#canonical-s3-transfer-tuning).
+
+## Initialization
+
+### 1. Create the base version
+
+Create a READY initial WeightVersion before initializing trainer or generator
+clients. The current API requires a syntactically valid object-storage URI, but
+this local seed-checkpoint flow does not upload or read an object at that URI.
+
+```python
+from modelexpress_rl import (
+    ModelExpressControlClient,
+    ModelExpressTrainerClient,
+    ModelExpressTrainerConfig,
+    ObjectStorageConfig,
+    ObjectStorageSource,
+    ObjectStorageType,
+    TrainerStagingMode,
+    WeightPayloadFormat,
+    WeightVersionState,
+)
+
+S3_URI_PREFIX = "s3://my-bucket/weights"
+
+with ModelExpressControlClient.connect(
+    server_url="modelexpress:8001",
+) as control:
+    base = control.create_weight_version(
+        uid="v0",
+        model_name="Qwen/Qwen3-30B-A3B",
+        idempotency_key="initialize-v0",
+        payload_format=WeightPayloadFormat.FULL_TENSOR,
+        object_storage=ObjectStorageSource(  # Catalog-only; no object is uploaded.
+            storage_type=ObjectStorageType.S3,
+            uri=f"{S3_URI_PREFIX}/v0/model.safetensors.index.json",
+        ),
+        state=WeightVersionState.READY,
+    )
+```
+
+Trainer and generator initialization use `base.version_id` as their initial base
+ID. They read the real weights from `seed_checkpoint_path`; the base version URI
+is not downloaded.
+
+See [`refit.proto`](../modelexpress_common/proto/refit.proto) for the complete
+control-plane request and response schemas.
+
+### 2. Initialize the trainer client
+
+Initialize one trainer client on every distributed trainer rank and keep it for
+the full training run. `hf_tensor_buckets()` below represents a framework-owned
+function that returns a fresh iterable of Hugging Face tensor buckets.
+
+```python
+import torch.distributed as dist
+
+trainer = ModelExpressTrainerClient.initialize(
+    ModelExpressTrainerConfig(
+        model_name="Qwen/Qwen3-30B-A3B",
+        staging_mode=TrainerStagingMode.WRITE_TO_STORAGE,
+        payload_format=WeightPayloadFormat.XOR_DELTA,
+        server_url="modelexpress:8001",
+        process_group=...,  # Gloo process group for control plane
+        object_storage=ObjectStorageConfig(
+            storage_type=ObjectStorageType.S3,
+            uri_prefix=S3_URI_PREFIX,
+            initial_base_version_id="v0",
+            seed_checkpoint_path="/models/Qwen3-30B-A3B",
+            region_name="us-west-2",
+        ),
+    )
+)
+
+# Call once before the first optimizer update.
+trainer.prepare_delta_base(hf_tensor_iter=hf_tensor_buckets())
+```
+
+The bucket names must match tensors in the seed checkpoint. Keep the trainer
+client alive because each successful publication advances its retained base
+from `v0` to `v1`, then `v2`, and so on.
+
+Use a dedicated Gloo process group containing every participating trainer rank.
+ModelExpress uses it for CPU object collectives that coordinate shard and index
+publication; do not reuse the model-training NCCL group for this example.
+
+### 3. Initialize the generator
+
+Install the `modelexpress` Python package in the same environment used to run
+`vllm serve`. The package provides the vLLM plugin entry point:
+
+```toml
+[project.entry-points."vllm.general_plugins"]
+modelexpress = "modelexpress:register_modelexpress"
+```
+
+`VLLM_PLUGINS=modelexpress` selects that installed plugin. Then start vLLM:
+
+```bash
+export VLLM_SERVER_DEV_MODE=1
+export VLLM_PLUGINS=modelexpress
+export MX_SERVER_ADDRESS=modelexpress:8001
+
+vllm serve /models/Qwen3-30B-A3B \
+  --tensor-parallel-size 4 \
+  --weight-transfer-config '{"backend":"modelexpress"}'
+```
+
+After vLLM is ready, initialize each server once:
+
+```python
+import requests
+
+VLLM_URL = "http://vllm-generator:8000"
+
+response = requests.post(
+    f"{VLLM_URL}/init_weight_transfer_engine",
+    json={
+        "init_info": {
+            "model_name": "Qwen/Qwen3-30B-A3B",
+            "server_url": "modelexpress:8001",
+            "object_storage_type": "S3",
+            "initial_base_version_id": "v0",
+            "seed_checkpoint_path": "/models/Qwen3-30B-A3B",
+            "refit_checkpoint_dir": "/var/cache/modelexpress",
+            "object_storage_region_name": "us-west-2",
+            "max_transfer_attempts": 3,
+            "rpc_timeout_seconds": 30,
+        }
+    },
+    timeout=900,
+)
+response.raise_for_status()
+```
+
+#### `seed_checkpoint_path`
+
+This must be a complete local safetensors checkpoint for
+`initial_base_version_id`, readable by every inference engine worker. It may be
+either:
+
+- one unsharded `.safetensors` file containing the full model; or
+- a directory containing all `.safetensors` shards. If
+  `model.safetensors.index.json` is present, every shard referenced by its
+  `weight_map` must also be present.
+
+For typical sharded models such as Qwen3-30B-A3B, use the full Hugging Face
+snapshot directory.
+
+#### `refit_checkpoint_dir`
+
+This is the root of ModelExpress's mutable working checkpoint. During
+initialization, ModelExpress creates a model-specific subdirectory containing
+`checkpoint/`, `state.json`, and `.lock`.
+
+The `checkpoint/` directory starts as a full copy of `seed_checkpoint_path` and
+is updated in place as sequential deltas are applied. `state.json` records its
+current version. The file lock prevents co-located ranks from seeding or
+updating the same checkpoint concurrently. With an HF snapshot seed checkpoint,
+the resulting layout is:
+
+```text
+<refit_checkpoint_dir>/<URL-quoted-vLLM-model-path-or-ID>/
+  .lock
+  state.json
+  checkpoint/
+    *.safetensors
+    config.json
+    ...
+```
+
+All ranks sharing one host filesystem can share the same cache. Each host without
+a shared filesystem needs its own cache.
+
+A Kubernetes example:
+
+```yaml
+spec:
+  containers:
+    - name: vllm
+      image: your-vllm-image
+      env:
+        - name: HF_HOME
+          value: /root/.cache/huggingface
+      volumeMounts:
+        # Immutable seed checkpoint in the default HF cache.
+        - name: hf-cache
+          mountPath: /root/.cache/huggingface
+          readOnly: true
+
+        # Mutable, host-local refit checkpoint directory.
+        - name: mx-refit-checkpoint
+          mountPath: /var/cache/modelexpress
+
+  volumes:
+    - name: hf-cache
+      persistentVolumeClaim:
+        claimName: huggingface-cache
+
+    # To retain the prepared checkpoint across Pod recreation on the same node.
+    # emptyDir is also a valid choice.
+    - name: mx-refit-checkpoint
+      hostPath:
+        path: /var/lib/modelexpress/refit
+        type: DirectoryOrCreate
+```
+
+The corresponding generator configuration would use:
+
+```json
+{
+  "seed_checkpoint_path": "/root/.cache/huggingface/hub/models--ORG--MODEL/snapshots/SNAPSHOT_ID",
+  "refit_checkpoint_dir": "/var/cache/modelexpress"
+}
+```
+
+Ensure the host directory has space for at least one complete checkpoint copy.
+ModelExpress creates the model-specific subdirectory automatically. On
+initialization, it reuses the cache only when its recorded version is
+`initial_base_version_id` and its files match. A cache advanced to a later
+version is reseeded from `seed_checkpoint_path`.
+
+#### Initialization behavior
+
+`POST /init_weight_transfer_engine` fans out to every vLLM worker. Each worker:
+
+1. initializes or reuses its refit checkpoint;
+2. fetches `initial_base_version_id` from the ModelExpress server;
+3. verifies that the base is READY and has the configured model name; and
+4. registers itself as a ModelExpress generator worker.
+
+Initialization fails before serving updates if any worker cannot read the
+seed checkpoint, write the cache, or validate the base version.
+
+## Weight Update
+
+### 1. Publish `v1`
+
+Create `v1` as STAGING, upload the delta shards and index, and then mark it
+READY. The S3 URI is the exact index URI, not a directory prefix.
+
+```python
+import torch.distributed as dist
+
+from modelexpress_rl import (
+    ModelExpressControlClient,
+    ObjectStorageSource,
+    ObjectStorageType,
+    WeightPayloadFormat,
+    WeightVersionRef,
+    WeightVersionState,
+)
+
+# The coordinator creates the target version.
+if dist.get_rank(group=refit_process_group) == 0:
+    with ModelExpressControlClient.connect(
+        server_url="modelexpress:8001",
+    ) as control:
+        control.create_weight_version(
+            uid="v1",
+            model_name="Qwen/Qwen3-30B-A3B",
+            idempotency_key="publish-v1",
+            payload_format=WeightPayloadFormat.XOR_DELTA,
+            base_version_id="v0",
+            object_storage=ObjectStorageSource(
+                storage_type=ObjectStorageType.S3,
+                uri=f"{S3_URI_PREFIX}/v1/model.safetensors.index.json",
+            ),
+            state=WeightVersionState.STAGING,
+        )
+dist.barrier(group=refit_process_group)
+
+# Every trainer rank computes and publishes its contribution. This writes the
+# global index after all rank-local delta shards are durable.
+staged = trainer.stage_shard(
+    version=WeightVersionRef("v1"),
+    hf_tensor_iter=hf_tensor_buckets(),
+)
+staged.publish()
+dist.barrier(group=refit_process_group)
+
+# The coordinator exposes the completed version to generators.
+if dist.get_rank(group=refit_process_group) == 0:
+    with ModelExpressControlClient.connect(
+        server_url="modelexpress:8001",
+    ) as control:
+        control.update_weight_version_state(
+            "v1",
+            WeightVersionState.READY,
+        )
+```
+
+The index has this shape; shard names are resolved relative to its parent URI:
+
+```json
+{
+  "metadata": {
+    "version": "v1",
+    "base_version": "v0",
+    "delta_encoding": "xor",
+    "compression_format": "zstd",
+    "checksum_format": "adler32"
+  },
+  "weight_map": {
+    "model.layers.0.example.weight": "model-00000-of-00004.safetensors"
+  }
+}
+```
+
+### 2. Apply `v1` in vLLM
+
+Run the update while generation is paused. `mode=abort` clears active requests
+and vLLM caches before the weight update.
+
+```python
+import requests
+
+VLLM_URL = "http://vllm-generator:8000"
+
+
+def post(path, *, body=None, params=None):
+    response = requests.post(
+        f"{VLLM_URL}/{path}",
+        json=body or {},
+        params=params,
+        timeout=900,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+post("pause", body={}, params={"mode": "abort"})
+try:
+    post("start_weight_update", body={})
+    post("update_weights", body={"update_info": {"version_id": "v1"}})
+    post("finish_weight_update", body={"weight_version": "v1"})
+finally:
+    post("resume", body={})
+```
+
+The next update must be `v2` with `base_version_id="v1"`. The current receiver
+supports only sequential S3 XOR deltas with `compression_format="zstd"`.

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
@@ -37,8 +37,8 @@ class ModelExpressWeightTransferInitInfo(WeightTransferInitInfo):
 
     model_name: str | None = None
     initial_base_version_id: str | None = None
-    launch_checkpoint: str | None = None
-    preparation_cache_dir: str | None = None
+    seed_checkpoint_path: str | None = None
+    refit_checkpoint_dir: str | None = None
     server_url: str | None = None
     object_storage_type: str | None = None
     object_storage_endpoint_url: str | None = None
@@ -107,8 +107,8 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
         object_storage_values = (
             init_info.object_storage_type,
             init_info.initial_base_version_id,
-            init_info.launch_checkpoint,
-            init_info.preparation_cache_dir,
+            init_info.seed_checkpoint_path,
+            init_info.refit_checkpoint_dir,
             init_info.object_storage_endpoint_url,
             init_info.object_storage_region_name,
         )
@@ -117,13 +117,13 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
             if (
                 init_info.object_storage_type is None
                 or init_info.initial_base_version_id is None
-                or init_info.launch_checkpoint is None
-                or init_info.preparation_cache_dir is None
+                or init_info.seed_checkpoint_path is None
+                or init_info.refit_checkpoint_dir is None
             ):
                 raise ValueError(
                     "object storage requires object_storage_type, "
-                    "initial_base_version_id, launch_checkpoint, and "
-                    "preparation_cache_dir"
+                    "initial_base_version_id, seed_checkpoint_path, and "
+                    "refit_checkpoint_dir"
                 )
             try:
                 storage_type = ObjectStorageType(init_info.object_storage_type)
@@ -135,8 +135,8 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
             object_storage = ObjectStorageGeneratorConfig(
                 storage_type=storage_type,
                 initial_base_version_id=init_info.initial_base_version_id,
-                launch_checkpoint=init_info.launch_checkpoint,
-                preparation_cache_dir=init_info.preparation_cache_dir,
+                seed_checkpoint_path=init_info.seed_checkpoint_path,
+                refit_checkpoint_dir=init_info.refit_checkpoint_dir,
                 endpoint_url=init_info.object_storage_endpoint_url,
                 region_name=init_info.object_storage_region_name,
             )

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -34,8 +34,8 @@ class ObjectStorageGeneratorConfig:
 
     storage_type: ObjectStorageType
     initial_base_version_id: str
-    launch_checkpoint: str | Path
-    preparation_cache_dir: str | Path
+    seed_checkpoint_path: str | Path
+    refit_checkpoint_dir: str | Path
     endpoint_url: str | None = None
     region_name: str | None = None
 
@@ -44,10 +44,10 @@ class ObjectStorageGeneratorConfig:
             raise TypeError("storage_type must be an ObjectStorageType")
         if not self.initial_base_version_id.strip():
             raise ValueError("initial_base_version_id is required")
-        if not str(self.launch_checkpoint).strip():
-            raise ValueError("launch_checkpoint is required")
-        if not str(self.preparation_cache_dir).strip():
-            raise ValueError("preparation_cache_dir is required")
+        if not str(self.seed_checkpoint_path).strip():
+            raise ValueError("seed_checkpoint_path is required")
+        if not str(self.refit_checkpoint_dir).strip():
+            raise ValueError("refit_checkpoint_dir is required")
 
 
 class ReceiverInstallError(RuntimeError):
@@ -77,7 +77,7 @@ def _seed_checkpoint(source: Path, target: Path) -> None:
         shutil.copy2(source, target / "model.safetensors")
         return
     if not source.is_dir():
-        raise FileNotFoundError(f"launch checkpoint does not exist: {source}")
+        raise FileNotFoundError(f"seed checkpoint does not exist: {source}")
     for entry in source.iterdir():
         if entry.is_file():
             shutil.copy2(entry, target / entry.name)
@@ -144,9 +144,9 @@ class _LocalCheckpoint:
         s3: S3Client,
     ) -> None:
         self.initial_version = config.initial_base_version_id
-        self.launch_checkpoint = Path(config.launch_checkpoint)
+        self.seed_checkpoint_path = Path(config.seed_checkpoint_path)
         self.s3 = s3
-        self.cache = Path(config.preparation_cache_dir) / quote(model_name, safe="")
+        self.cache = Path(config.refit_checkpoint_dir) / quote(model_name, safe="")
         self.local_checkpoint = self.cache / "checkpoint"
         self.state_path = self.cache / "state.json"
         self.lock_path = self.cache / ".lock"
@@ -167,7 +167,7 @@ class _LocalCheckpoint:
                 self.locations, _ = index_checkpoint_tensors(self.local_checkpoint)
                 reusable = state.get("files") == _checkpoint_files_state(self.locations)
             if not reusable:
-                _seed_checkpoint(self.launch_checkpoint, self.local_checkpoint)
+                _seed_checkpoint(self.seed_checkpoint_path, self.local_checkpoint)
                 self.locations, _ = index_checkpoint_tensors(self.local_checkpoint)
                 _write_state(
                     self.state_path,

--- a/modelexpress_client/python/modelexpress_rl/train/client.py
+++ b/modelexpress_client/python/modelexpress_rl/train/client.py
@@ -55,12 +55,12 @@ def _payload_format(value: WeightPayloadFormat | None) -> WeightPayloadFormat:
 
 @dataclass(frozen=True)
 class ObjectStorageConfig:
-    """Object-storage and launch-base settings for canonical XOR publication."""
+    """Object-storage and seed-base settings for canonical XOR publication."""
 
     storage_type: ObjectStorageType
     uri_prefix: str
     initial_base_version_id: str
-    launch_checkpoint: str | Path
+    seed_checkpoint_path: str | Path
     endpoint_url: str | None = None
     region_name: str | None = None
 
@@ -72,8 +72,8 @@ class ObjectStorageConfig:
             self.initial_base_version_id,
             "object_storage.initial_base_version_id",
         )
-        if not str(self.launch_checkpoint).strip():
-            raise ValueError("object_storage.launch_checkpoint is required")
+        if not str(self.seed_checkpoint_path).strip():
+            raise ValueError("object_storage.seed_checkpoint_path is required")
 
 @dataclass(frozen=True)
 class ModelExpressTrainerConfig:

--- a/modelexpress_client/python/modelexpress_rl/train/methods/canonical_delta.py
+++ b/modelexpress_client/python/modelexpress_rl/train/methods/canonical_delta.py
@@ -54,7 +54,7 @@ class CanonicalDeltaPublicationMethod:
         service: Callable[[], refit_pb2_grpc.RefitServiceStub],
         rpc_timeout_seconds: float,
         process_group: Any,
-        read_launch_tensor: Callable[[str], np.ndarray],
+        read_seed_tensor: Callable[[str], np.ndarray],
         s3: S3Client,
         clock: Callable[[], float] = perf_counter,
     ) -> None:
@@ -65,7 +65,7 @@ class CanonicalDeltaPublicationMethod:
         self._process_group = process_group
         self._rank = dist.get_rank(process_group)
         self._world_size = dist.get_world_size(process_group)
-        self._read_launch_tensor = read_launch_tensor
+        self._read_seed_tensor = read_seed_tensor
         self._s3 = s3
         self._clock = clock
         self.current_base_version_id = config.initial_base_version_id
@@ -83,7 +83,7 @@ class CanonicalDeltaPublicationMethod:
             bucket: list[tuple[str, torch.Tensor]],
         ) -> dict[str, np.ndarray]:
             return {
-                name: np.asarray(self._read_launch_tensor(name), dtype=np.uint8)
+                name: np.asarray(self._read_seed_tensor(name), dtype=np.uint8)
                 for name, _ in bucket
             }
 

--- a/modelexpress_client/python/modelexpress_rl/train/runtime.py
+++ b/modelexpress_client/python/modelexpress_rl/train/runtime.py
@@ -78,8 +78,8 @@ class TrainerRuntime:
         rpc_timeout_seconds: float,
     ) -> TrainerRuntime:
         if object_storage is not None:
-            read_launch_tensor, _ = make_tensor_reader(
-                object_storage.launch_checkpoint
+            read_seed_tensor, _ = make_tensor_reader(
+                object_storage.seed_checkpoint_path
             )
             s3 = S3Client(
                 endpoint_url=object_storage.endpoint_url,
@@ -92,7 +92,7 @@ class TrainerRuntime:
                     service=service,
                     rpc_timeout_seconds=rpc_timeout_seconds,
                     process_group=process_group,
-                    read_launch_tensor=read_launch_tensor,
+                    read_seed_tensor=read_seed_tensor,
                     s3=s3,
                     clock=lambda: perf_counter(),
                 )

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -429,8 +429,8 @@ def _initialize(
                 ObjectStorageGeneratorConfig(
                     storage_type=ObjectStorageType.S3,
                     initial_base_version_id="base-a",
-                    launch_checkpoint="unused-launch",
-                    preparation_cache_dir="unused-cache",
+                    seed_checkpoint_path="unused-launch",
+                    refit_checkpoint_dir="unused-cache",
                 )
                 if object_storage
                 else None
@@ -485,8 +485,8 @@ def test_generator_config_rejects_invalid_source_order():
             object_storage=ObjectStorageGeneratorConfig(
                 storage_type=ObjectStorageType.S3,
                 initial_base_version_id="base-a",
-                launch_checkpoint="unused-launch",
-                preparation_cache_dir="unused-cache",
+                seed_checkpoint_path="unused-launch",
+                refit_checkpoint_dir="unused-cache",
             ),
             source_order=(WeightSource.TRAINER,),
         )
@@ -496,8 +496,8 @@ def test_generator_config_rejects_invalid_source_order():
             object_storage=ObjectStorageGeneratorConfig(
                 storage_type=ObjectStorageType.S3,
                 initial_base_version_id="base-a",
-                launch_checkpoint="unused-launch",
-                preparation_cache_dir="unused-cache",
+                seed_checkpoint_path="unused-launch",
+                refit_checkpoint_dir="unused-cache",
             ),
             source_order=(
                 WeightSource.GENERATOR,
@@ -528,8 +528,8 @@ def test_generator_rejects_unsupported_object_storage_before_adapter_creation(
                 object_storage=ObjectStorageGeneratorConfig(
                     storage_type=ObjectStorageType.GCS,
                     initial_base_version_id="base-a",
-                    launch_checkpoint="unused-launch",
-                    preparation_cache_dir="unused-cache",
+                    seed_checkpoint_path="unused-launch",
+                    refit_checkpoint_dir="unused-cache",
                 ),
             )
         )

--- a/modelexpress_client/python/tests/test_refit_generator_runtime.py
+++ b/modelexpress_client/python/tests/test_refit_generator_runtime.py
@@ -115,8 +115,8 @@ def test_object_storage_runtime_skips_full_tensor_transport(
     storage = ObjectStorageGeneratorConfig(
         storage_type=ObjectStorageType.S3,
         initial_base_version_id="base-a",
-        launch_checkpoint=Path(tmp_path / "launch"),
-        preparation_cache_dir=Path(tmp_path / "cache"),
+        seed_checkpoint_path=Path(tmp_path / "launch"),
+        refit_checkpoint_dir=Path(tmp_path / "cache"),
     )
 
     runtime = GeneratorRuntime.initialize(

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -413,8 +413,8 @@ def _build(monkeypatch, tmp_path, objects):
         config=ObjectStorageGeneratorConfig(
             storage_type=ObjectStorageType.S3,
             initial_base_version_id="base-a",
-            launch_checkpoint=launch,
-            preparation_cache_dir=tmp_path / "cache",
+            seed_checkpoint_path=launch,
+            refit_checkpoint_dir=tmp_path / "cache",
         ),
     )
     return adapter, storage
@@ -567,8 +567,8 @@ def test_canonical_s3_applies_delta_tensors_concurrently(monkeypatch, tmp_path):
         config=ObjectStorageGeneratorConfig(
             storage_type=ObjectStorageType.S3,
             initial_base_version_id="base-a",
-            launch_checkpoint=launch,
-            preparation_cache_dir=tmp_path / "cache",
+            seed_checkpoint_path=launch,
+            refit_checkpoint_dir=tmp_path / "cache",
         ),
         s3=_MemoryS3({}),
     )

--- a/modelexpress_client/python/tests/test_refit_trainer_s3.py
+++ b/modelexpress_client/python/tests/test_refit_trainer_s3.py
@@ -149,13 +149,13 @@ def _trainer(
     monkeypatch,
     tmp_path,
     server_url,
-    launch_tensors=None,
+    seed_tensors=None,
     process_group=None,
     prepare_base=True,
 ):
     launch = tmp_path / "model.safetensors"
-    launch_tensors = launch_tensors or {"weight": torch.tensor([1.0, 2.0])}
-    _write_safetensors(launch, launch_tensors)
+    seed_tensors = seed_tensors or {"weight": torch.tensor([1.0, 2.0])}
+    _write_safetensors(launch, seed_tensors)
     storage = _MemoryS3()
     monkeypatch.setattr(trainer_runtime_module, "S3Client", lambda **_kwargs: storage)
     monkeypatch.setattr(torch.distributed, "get_rank", lambda _group=None: 0)
@@ -190,13 +190,13 @@ def _trainer(
                 storage_type=ObjectStorageType.S3,
                 uri_prefix="s3://weights/tests",
                 initial_base_version_id="base-a",
-                launch_checkpoint=launch,
+                seed_checkpoint_path=launch,
             ),
         )
     )
     if prepare_base:
         trainer.prepare_delta_base(
-            hf_tensor_iter=iter([list(launch_tensors.items())]),
+            hf_tensor_iter=iter([list(seed_tensors.items())]),
         )
     return trainer, storage
 
@@ -230,11 +230,11 @@ def test_s3_multipart_abort_failure_preserves_upload_outcome(code, caplog):
     assert "Failed to abort multipart upload" in caplog.text
 
 
-def test_s3_prepare_delta_base_uses_owned_launch_tensors(
+def test_s3_prepare_delta_base_uses_owned_seed_tensors(
     monkeypatch, tmp_path, refit_server, caplog
 ):
     _service, server_url = refit_server
-    launch_tensors = {
+    seed_tensors = {
         "a": torch.tensor([1.0]),
         "b": torch.tensor([2.0]),
     }
@@ -242,7 +242,7 @@ def test_s3_prepare_delta_base_uses_owned_launch_tensors(
         monkeypatch,
         tmp_path,
         server_url,
-        launch_tensors,
+        seed_tensors,
         prepare_base=False,
     )
     try:
@@ -254,7 +254,7 @@ def test_s3_prepare_delta_base_uses_owned_launch_tensors(
         assert set(trainer._runtime.method.snapshot) == {"a"}
         assert np.array_equal(
             trainer._runtime.method.snapshot["a"],
-            launch_tensors["a"].view(torch.uint8).numpy(),
+            seed_tensors["a"].view(torch.uint8).numpy(),
         )
         assert (
             "ModelExpress prepare_delta_base: rank=0 tensors=1 duration=" in caplog.text
@@ -278,7 +278,7 @@ def test_s3_prepare_delta_base_reads_framework_buckets_concurrently(
         },
         prepare_base=False,
     )
-    reader = trainer._runtime.method._read_launch_tensor
+    reader = trainer._runtime.method._read_seed_tensor
     assert reader is not None
     barrier = threading.Barrier(2)
     threads = set()
@@ -288,7 +288,7 @@ def test_s3_prepare_delta_base_reads_framework_buckets_concurrently(
         barrier.wait(timeout=2)
         return reader(name)
 
-    trainer._runtime.method._read_launch_tensor = read
+    trainer._runtime.method._read_seed_tensor = read
     try:
         trainer.prepare_delta_base(
             hf_tensor_iter=iter(
@@ -539,7 +539,7 @@ def test_s3_client_closes_when_publication_method_initialization_fails(
         storage_type=ObjectStorageType.S3,
         uri_prefix="s3://weights/tests",
         initial_base_version_id="base-a",
-        launch_checkpoint=tmp_path / "launch",
+        seed_checkpoint_path=tmp_path / "launch",
     )
     monkeypatch.setattr(
         trainer_runtime_module,
@@ -873,7 +873,7 @@ def test_object_storage_config_requires_storage_delta_pair(tmp_path):
         storage_type=ObjectStorageType.S3,
         uri_prefix="s3://weights/tests",
         initial_base_version_id="base-a",
-        launch_checkpoint=launch,
+        seed_checkpoint_path=launch,
     )
     with pytest.raises(ValueError, match="WRITE_TO_STORAGE and XOR_DELTA"):
         ModelExpressTrainerClient.initialize(
@@ -900,7 +900,7 @@ def test_object_storage_config_rejects_unsupported_provider(tmp_path):
                     storage_type=ObjectStorageType.GCS,
                     uri_prefix="gs://weights/tests",
                     initial_base_version_id="base-a",
-                    launch_checkpoint=launch,
+                    seed_checkpoint_path=launch,
                 ),
             )
         )

--- a/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
+++ b/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
@@ -83,8 +83,8 @@ def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch
     init_info = {
         "model_name": "policy",
         "initial_base_version_id": "base-a",
-        "launch_checkpoint": "/models/launch",
-        "preparation_cache_dir": "/cache/modelexpress",
+        "seed_checkpoint_path": "/models/launch",
+        "refit_checkpoint_dir": "/cache/modelexpress",
         "server_url": "mx:8001",
         "object_storage_type": "S3",
         "object_storage_endpoint_url": "http://minio:9000",
@@ -106,8 +106,8 @@ def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch
     assert config.rpc_timeout_seconds == 12.5
     assert config.object_storage.storage_type is ObjectStorageType.S3
     assert config.object_storage.initial_base_version_id == "base-a"
-    assert config.object_storage.launch_checkpoint == "/models/launch"
-    assert config.object_storage.preparation_cache_dir == "/cache/modelexpress"
+    assert config.object_storage.seed_checkpoint_path == "/models/launch"
+    assert config.object_storage.refit_checkpoint_dir == "/cache/modelexpress"
     assert config.object_storage.endpoint_url == "http://minio:9000"
     assert config.object_storage.region_name == "us-west-2"
 
@@ -117,8 +117,8 @@ def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch
     [
         {"object_storage_type": "S3"},
         {"initial_base_version_id": "base-a"},
-        {"launch_checkpoint": "/models/launch"},
-        {"preparation_cache_dir": "/cache/modelexpress"},
+        {"seed_checkpoint_path": "/models/launch"},
+        {"refit_checkpoint_dir": "/cache/modelexpress"},
         {"object_storage_endpoint_url": "http://minio:9000"},
         {"object_storage_region_name": "us-west-2"},
     ],
@@ -141,8 +141,8 @@ def test_weight_transfer_engine_rejects_unknown_object_storage_type(monkeypatch)
             engine.init_info_cls(
                 object_storage_type="UNKNOWN",
                 initial_base_version_id="base-a",
-                launch_checkpoint="/models/launch",
-                preparation_cache_dir="/cache/modelexpress",
+                seed_checkpoint_path="/models/launch",
+                refit_checkpoint_dir="/cache/modelexpress",
             )
         )
 


### PR DESCRIPTION
 ## Summary

  - Rename launch_checkpoint to seed_checkpoint_path.
  - Rename preparation_cache_dir to refit_checkpoint_dir.
  - Update trainer, generator, vLLM weight-transfer integration, tests, and the S3 delta refit guide.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive guidance for publishing and applying sequential object-storage model weight updates.
  * Documented setup, checkpoint management, staged publication, readiness validation, and vLLM update workflows.

* **Breaking Changes**
  * Renamed checkpoint configuration fields to clarify seed checkpoint and refit cache usage.
  * Updated seed tensor terminology across training and inference configuration interfaces.

* **Bug Fixes**
  * Improved validation and error messages for missing checkpoint and storage configuration values.

* **Tests**
  * Updated coverage for the renamed configuration fields and seed-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->