### PR TITLE
fix(refit): support trainer-only MoE weight updates

### DIFF
--- a/modelexpress_client/python/modelexpress/envs.py
+++ b/modelexpress_client/python/modelexpress/envs.py
@@ -114,6 +114,8 @@ if TYPE_CHECKING:
     MX_ARTIFACT_TRANSFER_CHUNK_SIZE: Optional[str]
     # Trainer weight sync
     MX_REDIS_URL: str
+    # Generator weight sync
+    MX_GENERATOR_SOURCE_ORDER: Optional[str]
     # P2P source selection
     MX_P2P_SOURCE_SELECTOR: Optional[str]
     # Weight of the NIC-utilization penalty in the load_aware selector.
@@ -384,6 +386,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_ARTIFACT_TRANSFER_CHUNK_SIZE": lambda: os.environ.get("MX_ARTIFACT_TRANSFER_CHUNK_SIZE"),
     # ── Trainer pull (live weight sync from a running trainer) ─────────────
     "MX_REDIS_URL": lambda: os.environ.get("MX_REDIS_URL", "redis://localhost:6379"),
+    # ── Generator weight sync ──────────────────────────────────────────────
+    "MX_GENERATOR_SOURCE_ORDER": lambda: os.environ.get("MX_GENERATOR_SOURCE_ORDER"),
     # ── P2P source selection ───────────────────────────────────────────────
     # Raw (None when unset); source_selection applies its DEFAULT_SELECTOR fallback.
     "MX_P2P_SOURCE_SELECTOR": lambda: os.environ.get("MX_P2P_SOURCE_SELECTOR"),

--- a/modelexpress_client/python/modelexpress/nixl_transfer.py
+++ b/modelexpress_client/python/modelexpress/nixl_transfer.py
@@ -371,12 +371,18 @@ class NixlTransferManager:
             raise RuntimeError("NIXL agent not initialized")
 
         tensor_descriptors = self._build_tensor_descriptors(tensors)
+        registrable_descriptors = [
+            descriptor for descriptor in tensor_descriptors if descriptor.size > 0
+        ]
+        registrable_tensors = [
+            tensor for tensor in tensors.values() if tensor.numel() > 0
+        ]
 
         # Phase 1: Discover CUDA allocation boundaries (if pool reg enabled)
         alloc_discovery_start = time.perf_counter()
         if _pool_reg_enabled() and not force_per_tensor:
             if self._accelerator_backend.supports_pool_reg():
-                allocations = self._find_cuda_allocations(tensor_descriptors)
+                allocations = self._find_cuda_allocations(registrable_descriptors)
             else:
                 allocations = None
                 logger.warning(
@@ -405,12 +411,15 @@ class NixlTransferManager:
                 )
             )
             reg_count = len(allocations)
-        else:
-            tensor_list = list(tensors.values())
+        elif registrable_tensors:
             self._registered_memory.append(
-                self._agent.register_memory(tensor_list, backends=self._backends)
+                self._agent.register_memory(
+                    registrable_tensors, backends=self._backends
+                )
             )
-            reg_count = len(tensor_list)
+            reg_count = len(registrable_tensors)
+        else:
+            reg_count = 0
         nixl_reg_time = time.perf_counter() - nixl_reg_start
 
         # Phase 3: Get agent metadata blob

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -43,6 +43,19 @@ def _required(value: str, name: str) -> str:
     return value
 
 
+def _source_order_from_env(value: str) -> tuple[WeightSource, ...]:
+    names = tuple(item.strip().upper() for item in value.split(","))
+    if not names or any(not name for name in names):
+        raise ValueError("MX_GENERATOR_SOURCE_ORDER must be a comma-separated list")
+    try:
+        return tuple(WeightSource(name) for name in names)
+    except ValueError as exc:
+        choices = ", ".join(source.value for source in WeightSource)
+        raise ValueError(
+            f"MX_GENERATOR_SOURCE_ORDER entries must be one of: {choices}"
+        ) from exc
+
+
 @dataclass(frozen=True)
 class ModelExpressGeneratorConfig:
     """Immutable configuration for one rank-local generator client."""
@@ -81,6 +94,13 @@ class ModelExpressGeneratorConfig:
             and not self.initial_serving_version_id.strip()
         ):
             raise ValueError("initial_serving_version_id must not be empty")
+        source_order_env = envs.MX_GENERATOR_SOURCE_ORDER
+        if self.source_order is None and source_order_env is not None:
+            object.__setattr__(
+                self,
+                "source_order",
+                _source_order_from_env(source_order_env),
+            )
         if self.registration_ttl_seconds is not None:
             rl_envs.require_positive_int(
                 self.registration_ttl_seconds, "registration_ttl_seconds"

--- a/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
@@ -43,6 +43,7 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
         worker_id: str,
         accelerator: str,
         p2p_client: MxClientBase,
+        enable_peer_publication: bool,
     ) -> None:
         self._transfer = transfer
         self._capture_layout = capture_layout
@@ -52,6 +53,7 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
         self._worker_id = worker_id
         self._accelerator = accelerator
         self._p2p_client = p2p_client
+        self._enable_peer_publication = enable_peer_publication
         self._active_plan: _PreparedNixlTransfer | None = None
         self._active_fingerprint: tuple | None = None
         self._active_staged: _StagedNixlWeights | None = None
@@ -116,6 +118,8 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
             raise TypeError("full-tensor method requires staged engine tensors")
         if prepared.staged is not self._active_staged:
             raise RuntimeError("full-tensor staged weight is no longer active")
+        if not self._enable_peer_publication:
+            return
         self._transfer.publish_peer(
             staged=self._active_staged,
             identity=self._build_identity(version_id),

--- a/modelexpress_client/python/modelexpress_rl/inference/runtime.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/runtime.py
@@ -149,6 +149,8 @@ class GeneratorRuntime:
                     device=full_tensor.device,
                     listen_port=(
                         rl_envs.MX_REFIT_METADATA_PORT + full_tensor.device_id
+                        if WeightSource.GENERATOR in source_order
+                        else None
                     ),
                 )
                 methods.append(
@@ -161,6 +163,9 @@ class GeneratorRuntime:
                         worker_id=worker_id,
                         accelerator=full_tensor.accelerator,
                         p2p_client=p2p_client,
+                        enable_peer_publication=(
+                            WeightSource.GENERATOR in source_order
+                        ),
                     )
                 )
 

--- a/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
@@ -18,6 +18,8 @@ from ..plan import ResolvedSource, SourceResolver, TrainerUpdateSource, WeightSo
 
 logger = logging.getLogger("modelexpress_rl.inference.source.trainer")
 
+_MAX_MANIFEST_MESSAGE_SIZE_BYTES = 100 * 1024 * 1024
+
 
 class TrainerSourceResolver(SourceResolver):
     """Resolve trainer shard manifests without compiling a transfer plan."""
@@ -109,7 +111,15 @@ class TrainerSourceResolver(SourceResolver):
     def _resolve_source(self, shard: refit_pb2.WeightVersionShard) -> GeneratorSource:
         if not shard.manifest_endpoint:
             raise RuntimeError("NIXL source is missing its manifest endpoint")
-        with grpc.insecure_channel(shard.manifest_endpoint) as channel:
+        with grpc.insecure_channel(
+            shard.manifest_endpoint,
+            options=[
+                (
+                    "grpc.max_receive_message_length",
+                    _MAX_MANIFEST_MESSAGE_SIZE_BYTES,
+                )
+            ],
+        ) as channel:
             response = refit_pb2_grpc.RefitWorkerServiceStub(
                 channel
             ).GetWeightVersionShardManifest(

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/selection.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/selection.py
@@ -156,7 +156,7 @@ def build_megatron_tensor_specs(
             shard_axis = None
 
         if role == "replicated":
-            if tensor_parallel_rank != 0:
+            if parallel_rank != 0:
                 continue
             global_shape = tuple(int(dim) for dim in tensor.shape)
             shard_range = None

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/selection.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/selection.py
@@ -19,22 +19,25 @@ def model_express_role_for_mapping(
 ) -> str:
     """Return the MX role for one supported Megatron-Bridge mapping."""
     mapping_name = type(mapping).__name__
-    if getattr(mapping, "is_expert", False):
-        raise NotImplementedError(
-            f"ModelExpress does not yet support expert mapping {mapping_name}"
-        )
+    is_expert = bool(getattr(mapping, "is_expert", False))
     if _inherits(mapping, "QKVMapping"):
+        if is_expert:
+            raise NotImplementedError(
+                "ModelExpress does not support expert QKV mapping"
+            )
         if tensor_ndim not in {1, 2}:
             raise NotImplementedError(
                 "ModelExpress QKV publication supports only weights and biases"
             )
         return "qkv_column"
     if _inherits(mapping, "GatedMLPMapping"):
-        return "gated_mlp_column"
+        return "expert_column" if is_expert else "gated_mlp_column"
     if _inherits(mapping, "ColumnParallelMapping"):
-        return "column"
+        return "expert_column" if is_expert else "column"
     if _inherits(mapping, "RowParallelMapping"):
-        return "row" if tensor_ndim > 1 else "replicated"
+        if tensor_ndim <= 1:
+            return "replicated"
+        return "expert_row" if is_expert else "row"
     if _inherits(mapping, "ReplicatedMapping") or _inherits(mapping, "DirectMapping"):
         return "replicated"
     if mapping_name == "AutoMapping":
@@ -45,9 +48,11 @@ def model_express_role_for_mapping(
             )
         detected = mapping._detect_parallelism_type(megatron_module)
         if detected == "column":
-            return "column"
+            return "expert_column" if is_expert else "column"
         if detected == "row":
-            return "row" if tensor_ndim > 1 else "replicated"
+            if tensor_ndim <= 1:
+                return "replicated"
+            return "expert_row" if is_expert else "row"
         if detected == "replicated":
             return "replicated"
         raise ValueError(f"AutoMapping returned unsupported parallelism {detected!r}")
@@ -97,8 +102,16 @@ def build_megatron_tensor_specs(
     transformer_config: Any,
     tensor_parallel_size: int,
     tensor_parallel_rank: int,
+    expert_tensor_parallel_size: int,
+    expert_tensor_parallel_rank: int,
 ) -> list[MegatronTensorSpec]:
     """Translate local Megatron-Bridge conversion tasks into MX tensor specs."""
+    for name, size, rank in (
+        ("tensor", tensor_parallel_size, tensor_parallel_rank),
+        ("expert tensor", expert_tensor_parallel_size, expert_tensor_parallel_rank),
+    ):
+        if size < 1 or not 0 <= rank < size:
+            raise ValueError(f"invalid {name} parallel rank {rank} for size {size}")
     specs = []
     for task in conversion_tasks:
         tensor = task.param_weight
@@ -110,6 +123,13 @@ def build_megatron_tensor_specs(
             tensor_ndim=tensor.ndim,
         )
         hf_param = task.mapping.hf_param
+        is_expert = bool(getattr(task.mapping, "is_expert", False))
+        parallel_size = (
+            expert_tensor_parallel_size if is_expert else tensor_parallel_size
+        )
+        parallel_rank = (
+            expert_tensor_parallel_rank if is_expert else tensor_parallel_rank
+        )
         extras: dict[str, str] = {}
         if role == "qkv_column":
             hf_names = tuple(hf_param[key] for key in ("q", "k", "v"))
@@ -119,14 +139,16 @@ def build_megatron_tensor_specs(
                 global_rows=int(tensor.shape[0]) * tensor_parallel_size,
             )
             shard_axis = 0
-        elif role == "gated_mlp_column":
+        elif role in {"gated_mlp_column", "expert_column"} and _inherits(
+            task.mapping, "GatedMLPMapping"
+        ):
             hf_names = (hf_param["gate"], hf_param["up"])
             extras = {"gated_mlp_order": "gate_then_up"}
             shard_axis = 0
-        elif role == "column":
+        elif role in {"column", "expert_column"}:
             hf_names = (str(hf_param),)
             shard_axis = 0
-        elif role == "row":
+        elif role in {"row", "expert_row"}:
             hf_names = (str(hf_param),)
             shard_axis = 1
         else:
@@ -143,11 +165,11 @@ def build_megatron_tensor_specs(
             assert shard_axis is not None
             local_extent = int(tensor.shape[shard_axis])
             global_shape_list = [int(dim) for dim in tensor.shape]
-            global_shape_list[shard_axis] *= tensor_parallel_size
+            global_shape_list[shard_axis] *= parallel_size
             global_shape = tuple(global_shape_list)
             shard_range = (
-                tensor_parallel_rank * local_extent,
-                (tensor_parallel_rank + 1) * local_extent,
+                parallel_rank * local_extent,
+                (parallel_rank + 1) * local_extent,
             )
             placement = "SHARD"
 

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -234,6 +234,27 @@ class TestAcceleratorCapabilityGates:
             backends=["UCX"],
         )
 
+    def test_tensor_registration_skips_zero_sized_regions(
+        self,
+        monkeypatch,
+        mock_accelerator_backend_cls,
+    ):
+        monkeypatch.delenv("MX_POOL_REG", raising=False)
+        mgr = self._make_manager(mock_accelerator_backend_cls())
+        tensor = torch.zeros(4, dtype=torch.float32)
+        empty = torch.empty(0, dtype=torch.float32)
+
+        assert mgr.register_tensors({"w": tensor, "empty": empty}) == b"metadata"
+
+        mgr._agent.register_memory.assert_called_once_with(
+            [tensor],
+            backends=["UCX"],
+        )
+        assert [descriptor.name for descriptor in mgr.tensor_descriptors] == [
+            "w",
+            "empty",
+        ]
+
     def test_vmm_arena_unsupported_falls_back_to_tensor_registration(
         self,
         mock_accelerator_backend_cls,

--- a/modelexpress_client/python/tests/test_envs.py
+++ b/modelexpress_client/python/tests/test_envs.py
@@ -13,6 +13,7 @@ def test_defaults_when_unset(monkeypatch):
         "MX_NIXL_BACKEND",
         "MX_METADATA_PORT",
         "MX_WORKER_GRPC_PORT",
+        "MX_GENERATOR_SOURCE_ORDER",
         "MX_POOL_REG",
         "MX_VMM_ARENA",
         "MX_MS_DISTRIBUTED",
@@ -37,6 +38,7 @@ def test_defaults_when_unset(monkeypatch):
     assert envs.MX_NIXL_BACKEND == "UCX"
     assert envs.MX_METADATA_PORT == 5555
     assert envs.MX_WORKER_GRPC_PORT == 6555
+    assert envs.MX_GENERATOR_SOURCE_ORDER is None
     assert envs.MX_POOL_REG is False
     assert envs.MX_VMM_ARENA is False
     assert envs.MX_MS_DISTRIBUTED is True
@@ -64,6 +66,11 @@ def test_int_and_float_parsing(monkeypatch):
     assert envs.MX_METADATA_PORT == 1234
     assert envs.MX_GDS_TIMEOUT == pytest.approx(1.5)
     assert envs.MX_SOURCE_QUERY_TIMEOUT == 42
+
+
+def test_generator_source_order_is_read_raw(monkeypatch):
+    monkeypatch.setenv("MX_GENERATOR_SOURCE_ORDER", "TRAINER,GENERATOR")
+    assert envs.MX_GENERATOR_SOURCE_ORDER == "TRAINER,GENERATOR"
 
 
 def test_invalid_int_falls_back_to_default(monkeypatch):

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -137,10 +137,13 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
 
 
 class _WorkerService(refit_pb2_grpc.RefitWorkerServiceServicer):
+    def __init__(self, manifest=b"manifest"):
+        self.manifest = manifest
+
     def GetWeightVersionShardManifest(self, _request, _context):
         return refit_pb2.GetWeightVersionShardManifestResponse(
-            manifest=b"manifest",
-            manifest_digest=hashlib.sha256(b"manifest").hexdigest(),
+            manifest=self.manifest,
+            manifest_digest=hashlib.sha256(self.manifest).hexdigest(),
         )
 
 
@@ -406,17 +409,19 @@ def _runtime(
     )
 
 
-def _start_server(*, state=None, manifest_digest=None):
+def _start_server(*, state=None, manifest=b"manifest", manifest_digest=None):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
     port = server.add_insecure_port("127.0.0.1:0")
     endpoint = f"127.0.0.1:{port}"
     service = _RefitService(
         endpoint=endpoint,
         state=state,
-        manifest_digest=manifest_digest,
+        manifest_digest=manifest_digest or hashlib.sha256(manifest).hexdigest(),
     )
     refit_pb2_grpc.add_RefitServiceServicer_to_server(service, server)
-    refit_pb2_grpc.add_RefitWorkerServiceServicer_to_server(_WorkerService(), server)
+    refit_pb2_grpc.add_RefitWorkerServiceServicer_to_server(
+        _WorkerService(manifest), server
+    )
     p2p_service = _P2pService()
     p2p_pb2_grpc.add_P2pServiceServicer_to_server(p2p_service, server)
     service.p2p = p2p_service
@@ -754,6 +759,30 @@ def test_generator_releases_lease_when_manifest_is_invalid(monkeypatch):
     assert service.lease_registrations == 1
     assert service.lease_deletions == 1
     assert adapter.stage_calls == []
+
+
+def test_generator_fetches_trainer_manifest_larger_than_grpc_default(monkeypatch):
+    manifest = b"x" * (4 * 1024 * 1024 + 1)
+    server, endpoint, service = _start_server(manifest=manifest)
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        source_order=(WeightSource.TRAINER,),
+    )
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert all(
+        source.transport.manifest == manifest
+        for source in adapter.stage_calls[0].sources
+    )
 
 
 def test_generator_reports_missing_trainer_manifest_digest(monkeypatch, caplog):

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -540,6 +540,37 @@ def test_generator_config_rejects_invalid_source_order():
         )
 
 
+def test_generator_config_reads_source_order_from_env(monkeypatch):
+    monkeypatch.setenv("MX_GENERATOR_SOURCE_ORDER", "trainer")
+
+    config = ModelExpressGeneratorConfig(
+        engine_context=VllmGeneratorContext(model=object(), vllm_config=object())
+    )
+
+    assert config.source_order == (WeightSource.TRAINER,)
+
+
+def test_generator_config_explicit_source_order_overrides_env(monkeypatch):
+    monkeypatch.setenv("MX_GENERATOR_SOURCE_ORDER", "invalid")
+
+    config = ModelExpressGeneratorConfig(
+        engine_context=VllmGeneratorContext(model=object(), vllm_config=object()),
+        source_order=(WeightSource.TRAINER,),
+    )
+
+    assert config.source_order == (WeightSource.TRAINER,)
+
+
+@pytest.mark.parametrize("value", ["", "TRAINER,", "unknown"])
+def test_generator_config_rejects_invalid_source_order_env(monkeypatch, value):
+    monkeypatch.setenv("MX_GENERATOR_SOURCE_ORDER", value)
+
+    with pytest.raises(ValueError, match="MX_GENERATOR_SOURCE_ORDER"):
+        ModelExpressGeneratorConfig(
+            engine_context=VllmGeneratorContext(model=object(), vllm_config=object())
+        )
+
+
 def test_generator_rejects_unsupported_object_storage_before_adapter_creation(
     monkeypatch,
 ):
@@ -593,6 +624,19 @@ def test_generator_uses_configured_source_order(monkeypatch):
         adapter,
         source_order=(WeightSource.TRAINER,),
     )
+    try:
+        resolvers = generator._runtime.session._planner._resolvers
+        assert [resolver.kind for resolver in resolvers] == [WeightSource.TRAINER]
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+
+def test_generator_uses_source_order_from_env(monkeypatch):
+    monkeypatch.setenv("MX_GENERATOR_SOURCE_ORDER", "TRAINER")
+    server, endpoint, service = _start_server()
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
     try:
         resolvers = generator._runtime.session._planner._resolvers
         assert [resolver.kind for resolver in resolvers] == [WeightSource.TRAINER]

--- a/modelexpress_client/python/tests/test_refit_generator_runtime.py
+++ b/modelexpress_client/python/tests/test_refit_generator_runtime.py
@@ -143,6 +143,50 @@ def test_object_storage_runtime_skips_full_tensor_transport(
     assert not p2p.closed
 
 
+def test_trainer_only_runtime_does_not_open_generator_listener(monkeypatch):
+    context = GeneratorEngineContext()
+    monkeypatch.setattr(
+        engines_module, "_create_engine_runtime", lambda received: _full_tensor_engine()
+    )
+    p2p = _P2P(server_url="mx:8000")
+    monkeypatch.setattr(runtime_module, "MxClient", lambda **_kwargs: p2p)
+    transfer_kwargs = {}
+
+    def create_transfer(**kwargs):
+        transfer_kwargs.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(runtime_module, "_NixlStagedTransfer", create_transfer)
+    full_tensor = _Method({WeightSource.GENERATOR, WeightSource.TRAINER})
+    method_kwargs = {}
+
+    def create_method(**kwargs):
+        method_kwargs.update(kwargs)
+        return full_tensor
+
+    monkeypatch.setattr(
+        runtime_module,
+        "FullTensorNixlUpdateMethod",
+        create_method,
+    )
+
+    runtime = GeneratorRuntime.initialize(
+        engine_context=context,
+        worker_id="generator-3",
+        server_url="mx:8000",
+        object_storage=None,
+        source_order=(WeightSource.TRAINER,),
+        max_transfer_attempts=3,
+        rpc_timeout_seconds=30,
+        service=lambda: object(),
+        start_lease=lambda _version_id: object(),
+    )
+
+    assert transfer_kwargs["listen_port"] is None
+    assert method_kwargs["enable_peer_publication"] is False
+    runtime.close()
+
+
 def test_generator_runtime_closes_resources_when_resolver_creation_fails(
     monkeypatch,
 ):

--- a/modelexpress_client/python/tests/test_refit_megatron_selection.py
+++ b/modelexpress_client/python/tests/test_refit_megatron_selection.py
@@ -179,6 +179,30 @@ def test_expert_row_specs_use_expert_tensor_parallel_geometry():
     assert specs[0].local_shard_range == (4, 8)
 
 
+def test_replicated_expert_specs_use_expert_tensor_parallel_rank():
+    mapping = AutoMapping("row", is_expert=True)
+    mapping.hf_param = "model.layers.0.mlp.experts.4.down_proj.bias"
+    task = SimpleNamespace(
+        mapping=mapping,
+        megatron_module=SimpleNamespace(),
+        param_weight=torch.zeros(3),
+        global_param_name="decoder.layers.0.mlp.experts.linear_fc2.bias4",
+    )
+
+    specs = build_megatron_tensor_specs(
+        conversion_tasks=[task],
+        transformer_config=SimpleNamespace(),
+        tensor_parallel_size=4,
+        tensor_parallel_rank=3,
+        expert_tensor_parallel_size=2,
+        expert_tensor_parallel_rank=0,
+    )
+
+    assert len(specs) == 1
+    assert specs[0].role == "replicated"
+    assert specs[0].placement_kind == "REPLICATE"
+
+
 def test_qkv_bias_uses_the_qkv_column_role():
     assert (
         model_express_role_for_mapping(

--- a/modelexpress_client/python/tests/test_refit_megatron_selection.py
+++ b/modelexpress_client/python/tests/test_refit_megatron_selection.py
@@ -4,9 +4,11 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from modelexpress_rl.train.engines.megatron.selection import (
     _qkv_descriptor_extras,
+    build_megatron_tensor_specs,
     model_express_role_for_mapping,
 )
 
@@ -15,8 +17,9 @@ class AutoMapping:
     is_expert = False
     permute_dims = None
 
-    def __init__(self, detected: str):
+    def __init__(self, detected: str, *, is_expert: bool = False):
         self.detected = detected
+        self.is_expert = is_expert
 
     def _detect_parallelism_type(self, _module):
         return self.detected
@@ -40,6 +43,16 @@ class QKVMapping:
 
 class GatedMLPMapping:
     is_expert = False
+
+
+class ExpertGatedMLPMapping(GatedMLPMapping):
+    is_expert = True
+
+    def __init__(self):
+        self.hf_param = {
+            "gate": "model.layers.0.mlp.experts.4.gate_proj.weight",
+            "up": "model.layers.0.mlp.experts.4.up_proj.weight",
+        }
 
 
 @pytest.mark.parametrize(
@@ -93,6 +106,77 @@ def test_explicit_mapping_roles(mapping, expected):
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("mapping", "expected"),
+    [
+        (ExpertGatedMLPMapping(), "expert_column"),
+        (AutoMapping("row", is_expert=True), "expert_row"),
+    ],
+)
+def test_expert_mapping_roles(mapping, expected):
+    assert (
+        model_express_role_for_mapping(
+            mapping=mapping,
+            megatron_module=SimpleNamespace(),
+            tensor_ndim=2,
+        )
+        == expected
+    )
+
+
+def test_expert_specs_use_expert_tensor_parallel_geometry():
+    gated = ExpertGatedMLPMapping()
+    task = SimpleNamespace(
+        mapping=gated,
+        megatron_module=SimpleNamespace(),
+        param_weight=torch.zeros(8, 3),
+        global_param_name="decoder.layers.0.mlp.experts.linear_fc1.weight4",
+    )
+
+    specs = build_megatron_tensor_specs(
+        conversion_tasks=[task],
+        transformer_config=SimpleNamespace(),
+        tensor_parallel_size=4,
+        tensor_parallel_rank=3,
+        expert_tensor_parallel_size=2,
+        expert_tensor_parallel_rank=1,
+    )
+
+    assert len(specs) == 1
+    assert specs[0].role == "expert_column"
+    assert specs[0].global_shape == (16, 3)
+    assert specs[0].local_shard_range == (8, 16)
+    assert specs[0].hf_names == (
+        "model.layers.0.mlp.experts.4.gate_proj.weight",
+        "model.layers.0.mlp.experts.4.up_proj.weight",
+    )
+
+
+def test_expert_row_specs_use_expert_tensor_parallel_geometry():
+    mapping = AutoMapping("row", is_expert=True)
+    mapping.hf_param = "model.layers.0.mlp.experts.4.down_proj.weight"
+    task = SimpleNamespace(
+        mapping=mapping,
+        megatron_module=SimpleNamespace(),
+        param_weight=torch.zeros(3, 4),
+        global_param_name="decoder.layers.0.mlp.experts.linear_fc2.weight4",
+    )
+
+    specs = build_megatron_tensor_specs(
+        conversion_tasks=[task],
+        transformer_config=SimpleNamespace(),
+        tensor_parallel_size=4,
+        tensor_parallel_rank=3,
+        expert_tensor_parallel_size=2,
+        expert_tensor_parallel_rank=1,
+    )
+
+    assert len(specs) == 1
+    assert specs[0].role == "expert_row"
+    assert specs[0].global_shape == (3, 8)
+    assert specs[0].local_shard_range == (4, 8)
 
 
 def test_qkv_bias_uses_the_qkv_column_role():


### PR DESCRIPTION
## Summary

- support Megatron expert-tensor-parallel geometry when publishing MoE tensors
- allow generator source order to be selected through `MX_GENERATOR_SOURCE_ORDER`
- avoid opening a generator peer listener or publishing generator metadata for trainer-only updates
- skip zero-sized tensors when registering NIXL memory while preserving their manifest descriptors

This keeps ModelExpress-specific source and listener configuration inside ModelExpress rather than adding MX transport settings to NeMo-RL.

## Validation

- current ModelExpress head: `79ddd877`
- focused ModelExpress suite: **90 passed**
- Python compilation checks passed for all changed source and test files
- `git diff --check` passed

### Qwen3-30B MoE functional E2E

- model: `Qwen/Qwen3-30B-A3B`
- topology: four Megatron trainer ranks using TP1/EP4 and two vLLM generator ranks using TP2 on six B200 GPUs
- the exact version was published, staged over NIXL, digest-verified, installed, and used for generation
- reward calculation, log-prob calculation, backward, and the optimizer step completed; the run reached `NEMO_E2E_COMPLETE`

The GPU run used the equivalent working changes on an earlier MX base and predates the final trainer-only peer-publication gate. The final gate is covered by focused tests but has not received a repeat current-head GPU run.

This is functional lifecycle evidence, not parameter-equality, generation-parity, repeated multi-step stability, or performance qualification. A UCX abort remains during post-training process teardown after the training result completes; that cleanup issue is not addressed by this PR.

## NeMo-RL integration

Follow-up for NVIDIA-NeMo/RL#3704 and the RL refit composition merged in #690.
