### PR TITLE
fix(helm): keep apiVersion out of the SPDX comment in ingress.yaml

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if and .Values.ingress .Values.ingress.enabled -}}
+{{- if and .Values.ingress .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
## Summary

`helm/values.yaml` ships an `ingress` block and the chart carries `templates/ingress.yaml`, so `--set ingress.enabled=true` is an advertised chart option. Enabling it rendered an Ingress whose `apiVersion` line was absorbed into the preceding SPDX comment, so the document had no `apiVersion` key and Kubernetes rejected it:

```
error: error validating "STDIN": error validating data: apiVersion not set
```

Every other object in the chart applied normally — only the Ingress was refused, which made `ingress.enabled` non-functional on any cluster.

Fixes nvbugs 6701459.

## Root cause

`templates/ingress.yaml:4` was the only template in the chart combining a leading comment block with an opening action trimmed on **both** sides:

```gotemplate
{{- if and .Values.ingress .Values.ingress.enabled -}}
```

The trailing `-}}` consumed the newline that would have separated the directive from `apiVersion:`, so the rendered output became:

```yaml
# SPDX-License-Identifier: Apache-2.0apiVersion: networking.k8s.io/v1
kind: Ingress
```

Line 3 is a YAML comment, so `apiVersion` was parsed as comment text. `kind` alone is not enough — kubectl needs `apiVersion` to resolve the resource, so the document was rejected before reaching any admission stage.

## Change

Drop the trailing `-`, one character:

```diff
-{{- if and .Values.ingress .Values.ingress.enabled -}}
+{{- if and .Values.ingress .Values.ingress.enabled }}
```

This matches how every other conditional template in the chart is written.

## Not a 0.6.0 regression

Pre-existing. `templates/ingress.yaml` lines 1-6 are byte-identical in 0.5.1 and 0.6.0, and both render an Ingress that parses to `apiVersion = None`.

## Verification

```
helm template probe ./helm --set ingress.enabled=true
```

Before — `apiVersion` glued to the comment:
```
# SPDX-License-Identifier: Apache-2.0apiVersion: networking.k8s.io/v1
kind: Ingress
```

After — all six rendered documents parse with both `apiVersion` and `kind`:
```
ok  v1                      ServiceAccount          probe-modelexpress
ok  v1                      PersistentVolumeClaim   probe-modelexpress-pvc
ok  v1                      Service                 probe-modelexpress
ok  apps/v1                 Deployment              probe-modelexpress
ok  networking.k8s.io/v1    Ingress                 probe-modelexpress
ok  v1                      Pod                     probe-modelexpress-test-connection
```

Default path (ingress disabled) still renders no Ingress document. `helm lint` passes before and after — it does not parse rendered documents for required fields, which is why it never surfaced this.

## Follow-up (not in this PR)

The bug also suggests a CI guard that renders the chart with each optional feature enabled and asserts every document has `apiVersion` and `kind`. Deliberately left out to keep this backportable to `release/0.6.0` as a minimal change — worth doing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ingress template formatting while preserving conditional ingress generation based on the ingress-enabled setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->