### PR TITLE
fix(helm): keep apiVersion out of the SPDX comment in ingress.yaml (cherry-pick #707)

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if and .Values.ingress .Values.ingress.enabled -}}
+{{- if and .Values.ingress .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
Cherry-pick of #707 onto `release/0.6.0`. Clean pick, no conflicts — one character.

## Why this branch needs it

The bug was filed against chart **0.6.0**, which is what this branch carries. `templates/ingress.yaml` is byte-identical here and on `main`, and both rendered an Ingress with no `apiVersion` key:

```
error: error validating "STDIN": error validating data: apiVersion not set
```

Only the Ingress was rejected; every other object in the chart applied normally. That made the advertised `ingress.enabled=true` option non-functional on any cluster.

Fixes nvbugs 6701459.

## Change

```diff
-{{- if and .Values.ingress .Values.ingress.enabled -}}
+{{- if and .Values.ingress .Values.ingress.enabled }}
```

The trailing `-}}` consumed the newline separating the directive from `apiVersion:`, gluing it onto the end of the `# SPDX-License-Identifier: Apache-2.0` comment where YAML swallowed it as comment text.

## Verification on this branch

`helm template probe ./helm --set ingress.enabled=true` against chart 0.6.0 — all six documents parse with both `apiVersion` and `kind`:

```
ok  v1                      ServiceAccount
ok  v1                      PersistentVolumeClaim
ok  v1                      Service
ok  apps/v1                 Deployment
ok  networking.k8s.io/v1    Ingress
ok  v1                      Pod
```

Default path (ingress disabled) still renders no Ingress document.

See #707 for the full root-cause analysis.