### PR TITLE
feat(refit): add target-version delta replay

### DIFF
--- a/docs/S3_DELTA_WEIGHT_REFIT.md
+++ b/docs/S3_DELTA_WEIGHT_REFIT.md
@@ -181,6 +181,7 @@ response = requests.post(
             "refit_checkpoint_max_size_gb": 500,
             "object_storage_region_name": "us-west-2",
             "max_transfer_attempts": 3,
+            "max_replay_chain_length": 64,
             "rpc_timeout_seconds": 30,
         }
     },
@@ -259,6 +260,17 @@ activation.
       config.json
       ...
 ```
+
+The generator may request a target several revisions ahead of its active
+version. ModelExpress first resolves the complete READY chain, rejecting cycles,
+missing or incompatible revisions, and chains longer than
+`max_replay_chain_length` (64 by default). It then prepares the ordered chain as
+one immutable target checkpoint and installs only that final target. If engine
+installation starts and fails, the checkpoint remains `READY`, `active.json`
+continues to identify the last successfully installed version, and the local
+engine is marked uncertain. The next request may reinstall that active version
+or install any target reconstructed from it; either successful installation
+clears the uncertain state.
 
 All ranks sharing one host filesystem can share the same cache. Each host without
 a shared filesystem needs its own cache.

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -9,6 +9,7 @@ import logging
 import threading
 import uuid
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 import grpc
@@ -29,6 +30,11 @@ from .runtime import GeneratorRuntime
 from .session import SessionUpdate
 
 logger = logging.getLogger("modelexpress_rl.inference.client")
+
+
+class _EngineState(str, Enum):
+    READY = "READY"
+    UNCERTAIN = "UNCERTAIN"
 
 
 def _required(value: str, name: str) -> str:
@@ -55,6 +61,8 @@ class ModelExpressGeneratorConfig:
     lease_ttl_seconds: int | None = None
     # Maximum source-discovery and transfer attempts for one staged update.
     max_transfer_attempts: int = 3
+    # Maximum number of payload revisions applied by one target replay.
+    max_replay_chain_length: int = 64
     # Deadline applied independently to each control-plane or manifest RPC.
     rpc_timeout_seconds: float = 30.0
     # Canonical object-storage checkpoint settings.
@@ -74,6 +82,9 @@ class ModelExpressGeneratorConfig:
             rl_envs.require_positive_int(self.lease_ttl_seconds, "lease_ttl_seconds")
         rl_envs.require_positive_int(
             self.max_transfer_attempts, "max_transfer_attempts"
+        )
+        rl_envs.require_positive_int(
+            self.max_replay_chain_length, "max_replay_chain_length"
         )
         rl_envs.require_positive_float(self.rpc_timeout_seconds, "rpc_timeout_seconds")
         if self.source_order is not None:
@@ -116,11 +127,12 @@ class StagedWeightHandle:
         *,
         client: ModelExpressGeneratorClient,
         version_id: str,
-        update: SessionUpdate,
+        update: SessionUpdate | None,
     ) -> None:
         self._client = client
         self.version_id = version_id
         self._update = update
+        self._no_op_released = False
 
     def release(self) -> None:
         """Release local staging buffers; repeated calls are idempotent."""
@@ -129,11 +141,15 @@ class StagedWeightHandle:
     @property
     def metrics(self) -> dict[str, float]:
         """Return preparation metrics exposed by the selected adapter."""
+        if self._update is None:
+            return {}
         return self._update.prepared.metrics
 
     @property
     def applied(self) -> bool:
         """Return whether engine installation completed."""
+        if self._update is None:
+            return True
         return self._update.applied
 
 
@@ -179,6 +195,7 @@ class ModelExpressGeneratorClient:
         self._operation_lock = threading.RLock()
         self._active_handle: StagedWeightHandle | None = None
         self._serving_version_id: str | None = None
+        self._engine_state = _EngineState.READY
         self._runtime: GeneratorRuntime | None = None
         self._closed = False
 
@@ -219,6 +236,7 @@ class ModelExpressGeneratorClient:
         client._registration_ttl_seconds = registration_ttl_seconds
         client._lease_ttl_seconds = lease_ttl_seconds
         client._rpc_timeout_seconds = config.rpc_timeout_seconds
+        client._max_replay_chain_length = config.max_replay_chain_length
         try:
             runtime = GeneratorRuntime.initialize(
                 engine_context=config.engine_context,
@@ -260,9 +278,32 @@ class ModelExpressGeneratorClient:
                 if self._active_handle.version_id == version.version_id:
                     return self._active_handle
                 raise RuntimeError("another generator update is still active")
-            ready = self._get_ready_version(version.version_id)
             assert self._runtime is not None
-            update = self._runtime.session.stage(ready)
+            if (
+                self._runtime.initial_version_id is not None
+                and version.version_id == self._serving_version_id
+                and self._engine_state is _EngineState.READY
+            ):
+                self._fetch_ready_version(
+                    version.version_id,
+                    target_version_id=version.version_id,
+                )
+                self._active_handle = StagedWeightHandle(
+                    client=self,
+                    version_id=version.version_id,
+                    update=None,
+                )
+                return self._active_handle
+            if self._runtime.initial_version_id is not None:
+                chain = self._resolve_replay_chain(version.version_id)
+                update = (
+                    self._runtime.session.stage(chain[0])
+                    if len(chain) == 1
+                    else self._runtime.session.stage_chain(chain)
+                )
+            else:
+                ready = self._get_ready_version(version.version_id)
+                update = self._runtime.session.stage(ready)
             self._active_handle = StagedWeightHandle(
                 client=self,
                 version_id=version.version_id,
@@ -275,11 +316,21 @@ class ModelExpressGeneratorClient:
         if not isinstance(staged, StagedWeightHandle) or staged._client is not self:
             raise ValueError("staged handle does not belong to this client")
         with self._operation_lock:
+            if staged._update is None:
+                if staged._no_op_released:
+                    raise RuntimeError("staged weight has already been released")
+                return None
             if staged._update.released:
                 raise RuntimeError("staged weight has already been released")
             assert self._runtime is not None
-            result = self._runtime.session.apply(staged._update)
+            try:
+                result = self._runtime.session.apply(staged._update)
+            except BaseException:
+                if staged._update.installation_started and not staged._update.applied:
+                    self._engine_state = _EngineState.UNCERTAIN
+                raise
             self._serving_version_id = staged.version_id
+            self._engine_state = _EngineState.READY
             return result
 
     def close(self) -> None:
@@ -342,42 +393,132 @@ class ModelExpressGeneratorClient:
                 continue
 
     def _get_ready_version(self, version_id: str) -> WeightVersion:
-        response = self._service.GetWeightVersion(
-            refit_pb2.GetWeightVersionRequest(uid=version_id),
-            timeout=self._rpc_timeout_seconds,
+        version = self._fetch_ready_version(
+            version_id,
+            target_version_id=version_id,
         )
-        if not response.HasField("version"):
-            raise RuntimeError("MX GetWeightVersion response is missing version")
-        version = _weight_version(response.version)
-        if version.state is not WeightVersionState.READY:
-            raise RuntimeError(f"weight version {version_id!r} is not READY")
-        if version.model_name != self.model_name:
-            raise RuntimeError("weight version model_name does not match the generator")
         assert self._runtime is not None
-        if self._runtime.initial_version_id is not None:
-            if version.payload_format is WeightPayloadFormat.XOR_DELTA:
-                if version.base_version_id is None:
-                    raise RuntimeError("XOR_DELTA version is missing base_version_id")
-                if (
-                    version.version_id != self._serving_version_id
-                    and version.base_version_id != self._serving_version_id
-                ):
-                    raise RuntimeError(
-                        f"weight version base {version.base_version_id!r} does not "
-                        f"match serving version {self._serving_version_id!r}"
-                    )
-            elif version.payload_format is WeightPayloadFormat.FULL_HF_CHECKPOINT:
-                if version.base_version_id is not None:
-                    raise RuntimeError(
-                        "FULL_HF_CHECKPOINT version must not have base_version_id"
-                    )
-            else:
-                raise RuntimeError(
-                    "object-storage generator requires XOR_DELTA or "
-                    "FULL_HF_CHECKPOINT weight versions"
-                )
         self._runtime.session.validate(version)
         return version
+
+    def _fetch_ready_version(
+        self,
+        version_id: str,
+        *,
+        target_version_id: str,
+    ) -> WeightVersion:
+        try:
+            response = self._service.GetWeightVersion(
+                refit_pb2.GetWeightVersionRequest(uid=version_id),
+                timeout=self._rpc_timeout_seconds,
+            )
+        except grpc.RpcError as error:
+            raise RuntimeError(
+                f"target {target_version_id!r}: failed to resolve revision "
+                f"{version_id!r}: {error.details()}"
+            ) from error
+        if not response.HasField("version"):
+            raise RuntimeError(
+                f"target {target_version_id!r}: MX GetWeightVersion response is "
+                f"missing revision {version_id!r}"
+            )
+        version = _weight_version(response.version)
+        if version.version_id != version_id:
+            raise RuntimeError(
+                f"target {target_version_id!r}: requested revision {version_id!r} "
+                f"but MX returned {version.version_id!r}"
+            )
+        if version.state is not WeightVersionState.READY:
+            raise RuntimeError(
+                f"target {target_version_id!r}: revision {version_id!r} is not READY"
+            )
+        if version.model_name != self.model_name:
+            raise RuntimeError(
+                f"target {target_version_id!r}: revision {version_id!r} model_name "
+                "does not match the generator"
+            )
+        return version
+
+    def _resolve_replay_chain(
+        self,
+        target_version_id: str,
+    ) -> tuple[WeightVersion, ...]:
+        """Resolve a canonical chain completely before payload preparation."""
+        serving_version_id = self._serving_version_id
+        if serving_version_id is None:
+            raise RuntimeError("canonical replay requires a known serving version")
+
+        reverse_chain: list[WeightVersion] = []
+        seen: set[str] = set()
+        revision_id = target_version_id
+        layout_signature: str | None = None
+        while True:
+            if reverse_chain and revision_id == serving_version_id:
+                break
+            if revision_id in seen:
+                raise RuntimeError(
+                    f"target {target_version_id!r}: cycle detected at revision "
+                    f"{revision_id!r}"
+                )
+            if len(reverse_chain) >= self._max_replay_chain_length:
+                raise RuntimeError(
+                    f"target {target_version_id!r}: replay exceeds maximum chain "
+                    f"length {self._max_replay_chain_length} before revision "
+                    f"{revision_id!r}"
+                )
+            seen.add(revision_id)
+            try:
+                version = self._fetch_ready_version(
+                    revision_id,
+                    target_version_id=target_version_id,
+                )
+            except RuntimeError as error:
+                if revision_id != target_version_id:
+                    raise RuntimeError(
+                        f"target {target_version_id!r}: chain does not match serving "
+                        f"version {serving_version_id!r}; {error}"
+                    ) from error
+                raise
+            if version.layout_signature:
+                if layout_signature is None:
+                    layout_signature = version.layout_signature
+                elif version.layout_signature != layout_signature:
+                    raise RuntimeError(
+                        f"target {target_version_id!r}: layout format mismatch at "
+                        f"revision {revision_id!r}"
+                    )
+            if version.object_storage is None:
+                raise RuntimeError(
+                    f"target {target_version_id!r}: no legal source for revision "
+                    f"{revision_id!r}; object-storage source is missing"
+                )
+            reverse_chain.append(version)
+            if version.version_id == serving_version_id:
+                break
+            if version.payload_format is WeightPayloadFormat.FULL_HF_CHECKPOINT:
+                if version.base_version_id is not None:
+                    raise RuntimeError(
+                        f"target {target_version_id!r}: FULL_HF_CHECKPOINT revision "
+                        f"{revision_id!r} must not have base_version_id"
+                    )
+                break
+            if version.payload_format is not WeightPayloadFormat.XOR_DELTA:
+                raise RuntimeError(
+                    f"target {target_version_id!r}: revision {revision_id!r} has "
+                    f"unsupported replay format {version.payload_format.value}"
+                )
+            if version.base_version_id is None:
+                raise RuntimeError(
+                    f"target {target_version_id!r}: XOR_DELTA revision "
+                    f"{revision_id!r} is missing base_version_id"
+                )
+            revision_id = version.base_version_id
+
+        chain = tuple(reversed(reverse_chain))
+        assert self._runtime is not None
+        for version in chain:
+            self._runtime.session.validate(version)
+        return chain
 
     def _validate_initial_base(self, version_id: str) -> None:
         response = self._service.GetWeightVersion(
@@ -461,6 +602,13 @@ class ModelExpressGeneratorClient:
         if staged._client is not self:
             raise ValueError("staged handle does not belong to this client")
         with self._operation_lock:
+            if staged._update is None:
+                if staged._no_op_released:
+                    return
+                staged._no_op_released = True
+                if self._active_handle is staged:
+                    self._active_handle = None
+                return
             if staged._update.released:
                 return
             assert self._runtime is not None

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
@@ -50,6 +50,7 @@ class ModelExpressWeightTransferInitInfo(WeightTransferInitInfo):
     registration_ttl_seconds: int | None = None
     lease_ttl_seconds: int | None = None
     max_transfer_attempts: int = 3
+    max_replay_chain_length: int = 64
     rpc_timeout_seconds: float = 30.0
 
 
@@ -161,6 +162,7 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
                 registration_ttl_seconds=init_info.registration_ttl_seconds,
                 lease_ttl_seconds=init_info.lease_ttl_seconds,
                 max_transfer_attempts=init_info.max_transfer_attempts,
+                max_replay_chain_length=init_info.max_replay_chain_length,
                 rpc_timeout_seconds=init_info.rpc_timeout_seconds,
                 object_storage=object_storage,
             )

--- a/modelexpress_client/python/modelexpress_rl/inference/methods/canonical_delta.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/methods/canonical_delta.py
@@ -71,8 +71,24 @@ class CanonicalDeltaUpdateMethod(UpdateMethod):
         version: WeightVersion,
         source: ResolvedSource,
     ) -> PreparedArtifact:
+        return self.prepare_chain(((version, source),))
+
+    def prepare_chain(
+        self,
+        chain: tuple[tuple[WeightVersion, ResolvedSource], ...],
+    ) -> PreparedArtifact:
         if self._active is not None:
             raise RuntimeError("release staged weight before staging another version")
+        versions = [self._version(version, source) for version, source in chain]
+        try:
+            checkpoint = self._checkpoint.prepare_chain(tuple(versions))
+        except ValueError as error:
+            raise RuntimeError(str(error)) from error
+        self._active = PreparedCheckpointArtifact(checkpoint=checkpoint)
+        return self._active
+
+    @staticmethod
+    def _version(version: WeightVersion, source: ResolvedSource) -> _S3Version:
         if not isinstance(source, ObjectStorageUpdateSource):
             raise TypeError("canonical checkpoint requires an object-storage source")
         storage = source.storage
@@ -86,19 +102,12 @@ class CanonicalDeltaUpdateMethod(UpdateMethod):
                 raise ValueError("FULL_HF_CHECKPOINT must not have base_version_id")
         else:
             raise ValueError("unsupported canonical S3 payload format")
-        try:
-            checkpoint = self._checkpoint.prepare(
-                _S3Version(
-                    version_id=version.version_id,
-                    base_version_id=version.base_version_id,
-                    payload_format=version.payload_format,
-                    uri=storage.uri,
-                )
-            )
-        except ValueError as error:
-            raise RuntimeError(str(error)) from error
-        self._active = PreparedCheckpointArtifact(checkpoint=checkpoint)
-        return self._active
+        return _S3Version(
+            version_id=version.version_id,
+            base_version_id=version.base_version_id,
+            payload_format=version.payload_format,
+            uri=storage.uri,
+        )
 
     def installation_context(self, prepared: PreparedArtifact):
         if prepared is not self._active:

--- a/modelexpress_client/python/modelexpress_rl/inference/plan.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/plan.py
@@ -175,6 +175,21 @@ class UpdateMethod(ABC):
         del prepared
         return nullcontext()
 
+    def prepare_chain(
+        self,
+        chain: tuple[tuple[WeightVersion, ResolvedSource], ...],
+    ) -> PreparedArtifact:
+        """Prepare an ordered version chain as one installable artifact."""
+        if len(chain) != 1:
+            raise RuntimeError(
+                f"{type(self).__name__} does not support version-chain replay"
+            )
+        version, source = chain[0]
+        return self.prepare(version=version, source=source)
+
+    def installation_failed(self, prepared: PreparedArtifact) -> None:
+        """Fence method-owned state after an engine installation failure."""
+
     def publish_applied(self, *, version_id: str, prepared: PreparedArtifact) -> None:
         """Optionally advertise an installed update as a generator source."""
 
@@ -298,9 +313,9 @@ __all__ = [
     "ResolvedSource",
     "StagedEngineTensors",
     "TrainerUpdateSource",
+    "UpdateMethod",
     "WeightSource",
     "SourceResolver",
-    "UpdateMethod",
     "WeightUpdatePlan",
     "WeightUpdatePlanner",
 ]

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -119,26 +119,47 @@ def _is_safe_shard_basename(value: object) -> bool:
 
 def _parse_delta_manifest(
     data: bytes,
+    version: _S3Version,
 ) -> tuple[dict[str, str], _Decompressor]:
     try:
         manifest = json.loads(data)
     except (TypeError, ValueError) as error:
         raise ValueError("canonical delta manifest is not valid JSON") from error
-    compression_format = manifest["metadata"]["compression_format"]
-    weight_map = manifest["weight_map"]
-    if not isinstance(weight_map, dict):
-        raise ValueError("canonical delta weight_map must be an object")
-    for name, filename in weight_map.items():
-        if not isinstance(name, str) or not _is_safe_shard_basename(filename):
+    try:
+        metadata = manifest["metadata"]
+        weight_map = manifest["weight_map"]
+    except (KeyError, TypeError) as error:
+        raise ValueError(
+            "canonical delta manifest is missing required fields"
+        ) from error
+    if not isinstance(metadata, dict):
+        raise TypeError("canonical delta manifest metadata is invalid")
+    expected_metadata = {
+        "version": version.version_id,
+        "base_version": version.base_version_id,
+        "delta_encoding": "xor",
+        "checksum_format": "adler32",
+    }
+    for name, expected in expected_metadata.items():
+        if metadata.get(name) != expected:
             raise ValueError(
-                f"invalid canonical delta shard filename {filename!r}"
+                f"canonical delta manifest {name} does not match revision "
+                f"{version.version_id!r}"
             )
+    compression_format = metadata.get("compression_format")
     try:
         decompressor = _DECOMPRESSORS[compression_format]
     except KeyError as error:
         raise ValueError(
             f"unsupported canonical delta compression format {compression_format!r}"
         ) from error
+    if not isinstance(weight_map, dict):
+        raise TypeError("canonical delta manifest weight_map is invalid")
+    for name, filename in weight_map.items():
+        if not isinstance(name, str) or not isinstance(filename, str):
+            raise TypeError("canonical delta manifest weight_map must contain strings")
+        if not _is_safe_shard_basename(filename):
+            raise ValueError(f"invalid canonical delta shard filename {filename!r}")
     return weight_map, decompressor
 
 
@@ -285,10 +306,21 @@ class _LocalCheckpoint:
         )
 
     def prepare(self, version: _S3Version) -> PreparedCheckpoint:
+        return self.prepare_chain((version,))
+
+    def prepare_chain(
+        self,
+        versions: tuple[_S3Version, ...],
+    ) -> PreparedCheckpoint:
+        """Prepare an ordered chain into one immutable target checkpoint."""
+        if not versions:
+            raise ValueError("canonical replay chain is empty")
         with self.store.installation_locked(), self.store.locked():
             state = self.store.state()
             if state is None:
                 raise RuntimeError("local checkpoint state is missing")
+            active_version = self.store.active_version()
+            target = versions[-1]
             if state.get("status") != CheckpointState.READY:
                 raise RuntimeError("local checkpoint update is incomplete")
             state_checkpoint = self.store.checkpoint_path(state["version"])
@@ -299,19 +331,17 @@ class _LocalCheckpoint:
                     "local checkpoint files changed outside ModelExpress"
                 )
 
-            active_version = self.store.active_version()
-
             # The requested immutable artifact was already prepared.
-            if state["version"] == version.version_id:
+            if state["version"] == target.version_id:
                 self.store.enforce_capacity(
-                    protected_versions={active_version, version.version_id},
+                    protected_versions={active_version, target.version_id},
                 )
                 self.store.verify_artifact_source(
-                    self._artifact_path(version),
-                    _source_identity(version),
+                    self._artifact_path(target),
+                    _source_identity(target),
                 )
                 return PreparedCheckpoint(
-                    target_version=version.version_id,
+                    target_version=target.version_id,
                     path=self.local_checkpoint,
                     metrics={
                         "perf/mx_receive_delta_index_download": 0.0,
@@ -319,21 +349,47 @@ class _LocalCheckpoint:
                         "perf/mx_receive_delta_apply": 0.0,
                     },
                 )
-            if (
-                version.payload_format is WeightPayloadFormat.XOR_DELTA
-                and active_version != version.base_version_id
-            ):
-                raise RuntimeError(
-                    f"active checkpoint version {active_version!r} does not match "
-                    f"exact base {version.base_version_id!r}"
-                )
-
-            started = time.perf_counter()
-            try:
-                index_data = self.s3.get(version.uri)
-            except Exception as error:
-                raise RuntimeError("canonical root download failed") from error
-            index_download_time = time.perf_counter() - started
+            expected_base = active_version
+            manifests: list[
+                tuple[_S3Version, bytes, dict[str, str], _Decompressor | None]
+            ] = []
+            index_download_time = 0.0
+            for position, version in enumerate(versions):
+                if (
+                    position > 0
+                    and version.payload_format is WeightPayloadFormat.FULL_HF_CHECKPOINT
+                ):
+                    raise RuntimeError(
+                        f"full checkpoint revision {version.version_id!r} must be "
+                        "the first replay revision"
+                    )
+                if (
+                    version.payload_format is WeightPayloadFormat.XOR_DELTA
+                    and expected_base != version.base_version_id
+                ):
+                    raise RuntimeError(
+                        f"active checkpoint version {expected_base!r} does not match "
+                        f"exact base {version.base_version_id!r} for revision "
+                        f"{version.version_id!r}"
+                    )
+                expected_base = version.version_id
+                started = time.perf_counter()
+                try:
+                    index_data = self.s3.get(version.uri)
+                    if version.payload_format is WeightPayloadFormat.XOR_DELTA:
+                        weight_map, decompressor = _parse_delta_manifest(
+                            index_data, version
+                        )
+                    else:
+                        weight_map = _parse_full_checkpoint_manifest(index_data)
+                        decompressor = None
+                except Exception as error:
+                    raise RuntimeError(
+                        f"target {target.version_id!r}: replay validation failed "
+                        f"at revision {version.version_id!r}: {error}"
+                    ) from error
+                index_download_time += time.perf_counter() - started
+                manifests.append((version, index_data, weight_map, decompressor))
 
             self.store.write_state(
                 status=CheckpointState.UPDATING,
@@ -342,14 +398,23 @@ class _LocalCheckpoint:
             )
 
             try:
-                if version.payload_format is WeightPayloadFormat.XOR_DELTA:
-                    download_time, apply_time = self._prepare_delta(
-                        version, index_data
-                    )
-                else:
-                    download_time, apply_time = self._prepare_full(
-                        version, index_data
-                    )
+                download_time = 0.0
+                apply_time = 0.0
+                for version, index_data, weight_map, decompressor in manifests:
+                    if version.payload_format is WeightPayloadFormat.XOR_DELTA:
+                        assert decompressor is not None
+                        downloaded, applied = self._prepare_delta(
+                            version,
+                            index_data,
+                            weight_map,
+                            decompressor,
+                        )
+                    else:
+                        downloaded, applied = self._prepare_full(
+                            version, index_data, weight_map
+                        )
+                    download_time += downloaded
+                    apply_time += applied
             except CheckpointCacheCapacityError:
                 self._set_local_checkpoint(
                     self.store.checkpoint_path(active_version)
@@ -360,15 +425,20 @@ class _LocalCheckpoint:
                     checkpoint_paths=self.checkpoint_paths,
                 )
                 raise
+            except Exception as error:
+                raise RuntimeError(
+                    f"target {target.version_id!r}: replay failed at revision "
+                    f"{version.version_id!r}: {error}"
+                ) from error
 
             self.store.write_state(
                 status=CheckpointState.READY,
-                version=version.version_id,
+                version=target.version_id,
                 checkpoint_paths=self.checkpoint_paths,
-                source=_source_identity(version),
+                source=_source_identity(target),
             )
             return PreparedCheckpoint(
-                target_version=version.version_id,
+                target_version=target.version_id,
                 path=self.local_checkpoint,
                 metrics={
                     "perf/mx_receive_delta_index_download": index_download_time,
@@ -409,9 +479,11 @@ class _LocalCheckpoint:
         )
 
     def _prepare_full(
-        self, version: _S3Version, index_data: bytes
+        self,
+        version: _S3Version,
+        index_data: bytes,
+        weight_map: dict[str, str],
     ) -> tuple[float, float]:
-        weight_map = _parse_full_checkpoint_manifest(index_data)
         target = self.store.full_path(version.version_id)
         if target.exists():
             self.store.enforce_capacity(
@@ -470,9 +542,12 @@ class _LocalCheckpoint:
         return download_time, validation_time
 
     def _prepare_delta(
-        self, version: _S3Version, index_data: bytes
+        self,
+        version: _S3Version,
+        index_data: bytes,
+        weight_map: dict[str, str],
+        decompressor: _Decompressor,
     ) -> tuple[float, float]:
-        weight_map, self.decompressor = _parse_delta_manifest(index_data)
         assert version.base_version_id is not None
         base_chain = self.store.chain(version.base_version_id)
         if base_chain is None:
@@ -491,6 +566,7 @@ class _LocalCheckpoint:
         else:
             protected_versions = {
                 self.store.active_version(),
+                version.base_version_id,
                 version.version_id,
             }
             shards = self._download_deltas(weight_map, version.uri)
@@ -524,6 +600,7 @@ class _LocalCheckpoint:
             0 if reuse_materialized else self.store.path_size_bytes(base_checkpoint),
             protected_versions={
                 self.store.active_version(),
+                version.base_version_id,
                 version.version_id,
             },
         )
@@ -533,7 +610,7 @@ class _LocalCheckpoint:
             shutil.rmtree(target, ignore_errors=True)
             base_checkpoint.replace(target)
             self._set_local_checkpoint(target)
-            self._apply_delta_artifact(artifact, version.version_id)
+            self._apply_delta_artifact(artifact, weight_map, decompressor)
         else:
             # The first delta after a full checkpoint copies once so applying
             # it cannot modify the canonical full artifact.
@@ -542,26 +619,26 @@ class _LocalCheckpoint:
                 copy_from=base_checkpoint,
             ) as temporary:
                 self._set_local_checkpoint(temporary)
-                self._apply_delta_artifact(artifact, version.version_id)
+                self._apply_delta_artifact(artifact, weight_map, decompressor)
 
         self._set_local_checkpoint(target)
         self.store.write_chain(version.version_id, chain)
         return download_time, time.perf_counter() - apply_started
 
-    def _apply_delta_artifact(self, artifact: Path, version: str) -> None:
+    def _apply_delta_artifact(
+        self,
+        artifact: Path,
+        weight_map: dict[str, str],
+        decompressor: _Decompressor,
+    ) -> None:
         self.store.verify_artifact(artifact)
-        manifests = list(artifact.glob("*.safetensors.index.json"))
-        if len(manifests) != 1:
-            raise RuntimeError(f"cached delta {version!r} has no unique index")
-        delta_map, self.decompressor = _parse_delta_manifest(
-            manifests[0].read_bytes()
-        )
+        self.decompressor = decompressor
         shards = {
             filename: (
                 (artifact / filename).read_bytes(),
                 names,
             )
-            for filename, names in _group_tensors_by_shard(delta_map).items()
+            for filename, names in _group_tensors_by_shard(weight_map).items()
         }
         self._apply_shards(shards)
 

--- a/modelexpress_client/python/modelexpress_rl/inference/session.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/session.py
@@ -29,6 +29,25 @@ class SessionUpdate:
     applied: bool = False
     apply_result: Any = None
     released: bool = False
+    installation_started: bool = False
+
+
+class _LeaseGroup:
+    """Close all revision leases held by one replay operation."""
+
+    def __init__(self, leases: list[Any]) -> None:
+        self._leases = leases
+
+    def close(self) -> None:
+        first_error: BaseException | None = None
+        for lease in reversed(self._leases):
+            try:
+                lease.close()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
 
 class WeightUpdateSession:
@@ -124,6 +143,50 @@ class WeightUpdateSession:
             self._close_lease(lease, version.version_id, primary_error)
             raise
 
+    def stage_chain(self, versions: tuple[WeightVersion, ...]) -> SessionUpdate:
+        """Prepare an already-resolved base-to-target chain atomically."""
+        if not versions:
+            raise ValueError("version chain is empty")
+        leases = []
+        try:
+            for version in versions:
+                leases.append(self._start_lease(version.version_id))
+        except BaseException as primary_error:
+            self._close_lease(
+                _LeaseGroup(leases), versions[-1].version_id, primary_error
+            )
+            raise
+        lease_group = _LeaseGroup(leases)
+        try:
+            plans = []
+            for version in versions:
+                try:
+                    plan = next(self._planner.plans(version))
+                except StopIteration as error:
+                    raise RuntimeError(
+                        f"no usable refit source for replay revision "
+                        f"{version.version_id!r}"
+                    ) from error
+                plans.append(plan)
+            target_plan = plans[-1]
+            if any(
+                plan.method is not target_plan.method
+                or plan.installer is not target_plan.installer
+                for plan in plans
+            ):
+                raise RuntimeError("version replay chain requires one update method")
+            prepared = target_plan.method.prepare_chain(
+                tuple((plan.version, plan.source) for plan in plans)
+            )
+            return SessionUpdate(
+                plan=target_plan,
+                prepared=prepared,
+                lease=lease_group,
+            )
+        except BaseException as primary_error:
+            self._close_lease(lease_group, versions[-1].version_id, primary_error)
+            raise
+
     def apply(self, update: SessionUpdate) -> Any:
         if update.released:
             raise RuntimeError("staged weight has already been released")
@@ -140,6 +203,7 @@ class WeightUpdateSession:
                 type(update.plan.installer).__name__,
             )
             with update.plan.method.installation_context(update.prepared):
+                update.installation_started = True
                 update.apply_result = update.plan.installer.install(update.prepared)
             update.applied = True
             try:
@@ -163,6 +227,14 @@ class WeightUpdateSession:
             return update.apply_result
         except BaseException as error:
             primary_error = error
+            if update.installation_started:
+                try:
+                    update.plan.method.installation_failed(update.prepared)
+                except Exception:
+                    logger.exception(
+                        "failed to fence state after installation failure for %s",
+                        update.plan.version.version_id,
+                    )
             raise
         finally:
             self._close_lease(

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -4,6 +4,7 @@
 import hashlib
 import logging
 from concurrent import futures
+from contextlib import contextmanager
 
 import grpc
 import pytest
@@ -30,7 +31,6 @@ from modelexpress_rl.inference.plan import (
     GeneratorPeerUpdateSource,
     MethodCapabilities,
     ObjectStorageUpdateSource,
-    PreparedArtifact,
     PreparedEngineTensors,
     ResolvedSource,
     TrainerUpdateSource,
@@ -55,6 +55,7 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
         self.list_calls = 0
         self.fail_lease_deletion = False
         self.omit_base_version = False
+        self.additional_versions = {}
         self.version = refit_pb2.WeightVersion(
             uid="version-a",
             model_name="test/model",
@@ -90,6 +91,10 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
         return refit_pb2.RegisterWorkerResponse(worker=worker)
 
     def GetWeightVersion(self, request, context):
+        if request.uid in self.additional_versions:
+            return refit_pb2.GetWeightVersionResponse(
+                version=self.additional_versions[request.uid]
+            )
         if request.uid == self.base.uid:
             if self.omit_base_version:
                 return refit_pb2.GetWeightVersionResponse()
@@ -172,6 +177,8 @@ class _Adapter:
         self.publish_failures = 0
         self.stage_failures = 0
         self.apply_failure = False
+        self.installation_context_failure = False
+        self.installation_failure_calls = []
 
     @property
     def worker_rank(self):
@@ -256,13 +263,6 @@ class _TestMethod(UpdateMethod):
             staged = self._adapter.stage_peer_weight(source.worker)
         else:
             if isinstance(source, ObjectStorageUpdateSource):
-                if (
-                    version.payload_format is WeightPayloadFormat.XOR_DELTA
-                    and version.base_version_id != self._adapter.service.base.uid
-                ):
-                    raise ValueError(
-                        "canonical delta target does not match the exact local base"
-                    )
                 inputs = GeneratorTransferInputs(
                     version_id=version.version_id,
                     base_version_id=version.base_version_id,
@@ -286,8 +286,25 @@ class _TestMethod(UpdateMethod):
             staged = self._adapter.stage_weight(inputs)
         return PreparedEngineTensors(staged=staged)
 
+    def prepare_chain(self, chain):
+        prepared = None
+        for version, source in chain:
+            prepared = self.prepare(version=version, source=source)
+        assert prepared is not None
+        return prepared
+
     def release(self, prepared):
         self._adapter.release_staged_weight(prepared.staged)
+
+    @contextmanager
+    def installation_context(self, prepared):
+        del prepared
+        if self._adapter.installation_context_failure:
+            raise RuntimeError("installation context failed")
+        yield
+
+    def installation_failed(self, prepared):
+        self._adapter.installation_failure_calls.append(prepared)
 
     def publish_applied(self, *, version_id, prepared):
         if not self._publish_peer or self._active_source is WeightSource.OBJECT_STORAGE:
@@ -414,6 +431,7 @@ def _initialize(
     *,
     object_storage=False,
     max_transfer_attempts=3,
+    max_replay_chain_length=64,
     source_order=None,
 ):
     monkeypatch.setattr(
@@ -443,6 +461,7 @@ def _initialize(
                 else None
             ),
             max_transfer_attempts=max_transfer_attempts,
+            max_replay_chain_length=max_replay_chain_length,
             source_order=source_order,
         )
     )
@@ -454,6 +473,11 @@ def _initialize(
         ("registration_ttl_seconds", 0, "registration_ttl_seconds must be positive"),
         ("lease_ttl_seconds", -1, "lease_ttl_seconds must be positive"),
         ("max_transfer_attempts", 0, "max_transfer_attempts must be positive"),
+        (
+            "max_replay_chain_length",
+            0,
+            "max_replay_chain_length must be positive",
+        ),
         (
             "rpc_timeout_seconds",
             float("inf"),
@@ -741,10 +765,17 @@ def test_generator_dispatches_canonical_s3_without_fetching_a_worker_manifest(
         assert service.p2p.requests == []
         staged.release()
         repeated = generator.stage_weight(version=WeightVersionRef("version-a"))
+        assert repeated.applied is True
+        assert repeated.metrics == {}
+        assert generator.apply_weight(repeated) is None
         repeated.release()
     finally:
         generator.close()
         server.stop(grace=None).wait()
+
+    assert len(adapter.stage_calls) == 1
+    assert len(adapter.apply_calls) == 1
+    assert service.lease_registrations == 1
 
 
 def test_generator_retries_canonical_s3_under_one_lease(monkeypatch):
@@ -777,6 +808,115 @@ def test_generator_retries_canonical_s3_under_one_lease(monkeypatch):
     assert len(adapter.stage_calls) == 2
     assert service.lease_registrations == 1
     assert service.lease_deletions == 1
+
+
+def test_generator_treats_installed_initial_base_as_successful_no_op(monkeypatch):
+    server, endpoint, service = _start_server()
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter, object_storage=True)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("base-a"))
+        assert staged.applied is True
+        assert generator.apply_weight(staged) is None
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.lease_registrations == 0
+    assert adapter.stage_calls == []
+    assert adapter.apply_calls == []
+
+
+def _canonical_version(uid, base_version_id):
+    return refit_pb2.WeightVersion(
+        uid=uid,
+        model_name="test/model",
+        payload_format=refit_pb2.WEIGHT_PAYLOAD_FORMAT_XOR_DELTA,
+        base_version_id=base_version_id,
+        layout_signature="layout-a",
+        state=refit_pb2.WEIGHT_VERSION_STATE_READY,
+        object_storage=refit_pb2.ObjectStorageSource(
+            storage_type=refit_pb2.OBJECT_STORAGE_TYPE_S3,
+            uri=f"s3://weights/{uid}/model.safetensors.index.json",
+        ),
+    )
+
+
+def test_generator_resolves_and_stages_target_replay_chain(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.CopyFrom(_canonical_version("version-c", "version-b"))
+    service.additional_versions = {
+        "version-a": _canonical_version("version-a", "base-a"),
+        "version-b": _canonical_version("version-b", "version-a"),
+    }
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter, object_storage=True)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-c"))
+        assert [call.version_id for call in adapter.stage_calls] == [
+            "version-a",
+            "version-b",
+            "version-c",
+        ]
+        assert adapter.apply_calls == []
+        assert generator.apply_weight(staged) == "installed"
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert len(adapter.apply_calls) == 1
+    assert service.lease_registrations == 3
+    assert service.lease_deletions == 3
+
+
+def test_generator_rejects_replay_cycle_before_leasing(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.CopyFrom(_canonical_version("version-b", "version-a"))
+    service.additional_versions = {
+        "version-a": _canonical_version("version-a", "version-b"),
+    }
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter, object_storage=True)
+
+    try:
+        with pytest.raises(RuntimeError, match=r"cycle detected.*version-b"):
+            generator.stage_weight(version=WeightVersionRef("version-b"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.lease_registrations == 0
+    assert adapter.stage_calls == []
+
+
+def test_generator_rejects_excessive_replay_chain_before_leasing(monkeypatch):
+    server, endpoint, service = _start_server()
+    service.version.CopyFrom(_canonical_version("version-b", "version-a"))
+    service.additional_versions = {
+        "version-a": _canonical_version("version-a", "base-a"),
+    }
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        object_storage=True,
+        max_replay_chain_length=1,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match=r"maximum chain length 1.*version-a"):
+            generator.stage_weight(version=WeightVersionRef("version-b"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert service.lease_registrations == 0
+    assert adapter.stage_calls == []
 
 
 def test_generator_dispatches_full_hf_checkpoint_without_an_exact_base(
@@ -1063,6 +1203,64 @@ def test_generator_preserves_apply_error_when_lease_cleanup_also_fails(monkeypat
         service.fail_lease_deletion = False
         generator.close()
         server.stop(grace=None).wait()
+
+
+@pytest.mark.parametrize("recovery_version", ["base-a", "version-b"])
+def test_generator_recovers_uncertain_engine_with_active_or_new_version(
+    monkeypatch, recovery_version
+):
+    server, endpoint, service = _start_server()
+    service.version.CopyFrom(_canonical_version("version-a", "base-a"))
+    service.base.payload_format = refit_pb2.WEIGHT_PAYLOAD_FORMAT_FULL_HF_CHECKPOINT
+    service.base.object_storage.CopyFrom(
+        refit_pb2.ObjectStorageSource(
+            storage_type=refit_pb2.OBJECT_STORAGE_TYPE_S3,
+            uri="s3://weights/base-a/model.safetensors.index.json",
+        )
+    )
+    service.additional_versions["version-b"] = _canonical_version(
+        "version-b", "base-a"
+    )
+    adapter = _Adapter(service)
+    adapter.apply_failure = True
+    generator = _initialize(monkeypatch, endpoint, adapter, object_storage=True)
+
+    try:
+        failed = generator.stage_weight(version=WeightVersionRef("version-a"))
+        with pytest.raises(RuntimeError, match="apply failed"):
+            generator.apply_weight(failed)
+        assert len(adapter.installation_failure_calls) == 1
+        failed.release()
+
+        adapter.apply_failure = False
+        recovery = generator.stage_weight(version=WeightVersionRef(recovery_version))
+        assert recovery.applied is False
+        assert generator.apply_weight(recovery) == "installed"
+        recovery.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert len(adapter.apply_calls) == 2
+
+
+def test_generator_does_not_fence_when_installation_context_entry_fails(monkeypatch):
+    server, endpoint, service = _start_server()
+    adapter = _Adapter(service)
+    adapter.installation_context_failure = True
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        with pytest.raises(RuntimeError, match="installation context failed"):
+            generator.apply_weight(staged)
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert adapter.installation_failure_calls == []
+    assert adapter.apply_calls == []
 
 
 def test_generator_rejects_non_ready_version_before_leasing(monkeypatch):

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -184,6 +184,32 @@ class _Adapter:
         )
         return self._active.checkpoint
 
+    def stage_chain(self, inputs):
+        chain = []
+        for item in inputs:
+            version = WeightVersion(
+                version_id=item.version_id,
+                model_name="test/model",
+                payload_format=item.payload_format,
+                base_version_id=item.base_version_id,
+                object_storage=item.object_storage,
+                expected_source_slots=(),
+                layout_signature=item.layout_signature,
+                state=WeightVersionState.READY,
+                created_at_unix_ms=0,
+            )
+            chain.append(
+                (
+                    version,
+                    ObjectStorageUpdateSource(
+                        storage=item.object_storage,
+                        payload_format=item.payload_format,
+                    ),
+                )
+            )
+        self._active = self._method.prepare_chain(tuple(chain))
+        return self._active.checkpoint
+
     def apply_weight(self, staged):
         assert self._active is not None and self._active.checkpoint is staged
         with self._method.installation_context(self._active):
@@ -702,6 +728,224 @@ def test_canonical_s3_prepares_then_installs_one_global_index(monkeypatch, tmp_p
     assert adapter.apply_weight(staged)["perf/mx_receive_install_time"] >= 0
     assert adapter.installed == [staged.path]
     adapter.release_staged_weight(staged)
+    adapter.close()
+
+
+def test_canonical_s3_replays_multiple_deltas_before_one_install(monkeypatch, tmp_path):
+    base = torch.tensor([1.0, 2.0])
+    first = torch.tensor([3.0, 4.0])
+    target = torch.tensor([5.0, 6.0])
+    objects = _artifact(base.view(torch.uint8).numpy(), first.view(torch.uint8).numpy())
+    objects.update(
+        _artifact(
+            first.view(torch.uint8).numpy(),
+            target.view(torch.uint8).numpy(),
+            version="target-b",
+            version_label=2,
+            base_version="target-a",
+        )
+    )
+    parse_calls = []
+    parse_delta_manifest = receiver_module._parse_delta_manifest
+
+    def track_parse(data, version):
+        parse_calls.append(version.version_id)
+        return parse_delta_manifest(data, version)
+
+    monkeypatch.setattr(receiver_module, "_parse_delta_manifest", track_parse)
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+
+    staged = adapter.stage_chain(
+        (
+            _inputs(None),
+            _inputs(
+                None,
+                version="target-b",
+                version_label=2,
+                base_version="target-a",
+            ),
+        )
+    )
+
+    assert torch.equal(load_file(staged.path / "model.safetensors")["weight"], target)
+    assert json.loads(adapter._checkpoint.store.state_path.read_text())["version"] == (
+        "target-b"
+    )
+    assert parse_calls == ["target-a", "target-b"]
+    assert adapter.installed == []
+    adapter.apply_weight(staged)
+    assert adapter.installed == [staged.path]
+    adapter.release_staged_weight(staged)
+    adapter.close()
+
+
+def test_canonical_s3_validates_all_replay_manifests_before_mutation(
+    monkeypatch, tmp_path
+):
+    base_tensor = torch.tensor([1.0, 2.0])
+    first = torch.tensor([3.0, 4.0])
+    target = torch.tensor([5.0, 6.0])
+    objects = _artifact(
+        base_tensor.view(torch.uint8).numpy(), first.view(torch.uint8).numpy()
+    )
+    objects.update(
+        _artifact(
+            first.view(torch.uint8).numpy(),
+            target.view(torch.uint8).numpy(),
+            version="target-b",
+            version_label=2,
+            base_version="target-a",
+        )
+    )
+    second_root = "s3://weights/test/v2/model.safetensors.index.json"
+    manifest = json.loads(objects[second_root])
+    manifest["metadata"]["base_version"] = "wrong-base"
+    objects[second_root] = json.dumps(manifest).encode()
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+
+    with pytest.raises(RuntimeError, match=r"base_version.*target-b"):
+        adapter.stage_chain(
+            (
+                _inputs(None),
+                _inputs(
+                    None,
+                    version="target-b",
+                    version_label=2,
+                    base_version="target-a",
+                ),
+            )
+        )
+
+    state = json.loads(adapter._checkpoint.store.state_path.read_text())
+    state.pop("files")
+    assert state == {"status": "READY", "version": "base-a"}
+    assert torch.equal(
+        load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")["weight"],
+        base_tensor,
+    )
+
+
+def test_canonical_s3_keeps_checkpoint_ready_after_install_failure(
+    monkeypatch, tmp_path
+):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    adapter, _ = _build(monkeypatch, tmp_path, objects)
+    staged = adapter.stage_weight(_inputs(None))
+
+    with pytest.raises(RuntimeError, match="injected install failure"):
+        with adapter._method.installation_context(adapter._active):
+            raise RuntimeError("injected install failure")
+    adapter._method.installation_failed(adapter._active)
+
+    state = json.loads(adapter._checkpoint.store.state_path.read_text())
+    assert state["status"] == "READY"
+    assert state["version"] == "target-a"
+    assert adapter._checkpoint.store.active_version() == "base-a"
+    adapter.release_staged_weight(staged)
+    cached = adapter.stage_weight(_inputs(None))
+    assert cached.path == staged.path
+    adapter.release_staged_weight(cached)
+    adapter.close()
+
+
+@pytest.mark.parametrize("target_version", ["v3", "v4", "v5"])
+def test_canonical_s3_recovers_from_failed_v2_install_with_disjoint_target(
+    monkeypatch, tmp_path, target_version
+):
+    # The configured base-a checkpoint represents v1 in this lineage.
+    tensors = {
+        "v1": torch.tensor([1.0, 2.0]),
+        "v2": torch.tensor([3.0, 4.0]),
+        "v3": torch.tensor([5.0, 6.0]),
+        "v4": torch.tensor([7.0, 8.0]),
+        "v5": torch.tensor([9.0, 10.0]),
+    }
+    objects = {}
+    for version, base in (("v2", "v1"), ("v3", "v2"), ("v5", "v4")):
+        objects.update(
+            _artifact(
+                tensors[base].view(torch.uint8).numpy(),
+                tensors[version].view(torch.uint8).numpy(),
+                version=version,
+                version_label=int(version[1:]),
+                base_version="base-a" if base == "v1" else base,
+            )
+        )
+    objects.update(_full_artifact(tensors["v4"], version_label=4))
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+
+    def delta(version, base):
+        return _inputs(
+            None,
+            version=version,
+            version_label=int(version[1:]),
+            base_version="base-a" if base == "v1" else base,
+        )
+
+    failed = adapter.stage_weight(delta("v2", "v1"))
+    with pytest.raises(RuntimeError, match="injected install failure"):
+        with adapter._method.installation_context(adapter._active):
+            raise RuntimeError("injected install failure")
+    adapter._method.installation_failed(adapter._active)
+    adapter.release_staged_weight(failed)
+    assert adapter._checkpoint.store.state()["version"] == "v2"
+    assert adapter._checkpoint.store.active_version() == "base-a"
+
+    replays = {
+        "v3": (delta("v2", "v1"), delta("v3", "v2")),
+        "v4": (_full_inputs(version="v4", version_label=4),),
+        "v5": (
+            _full_inputs(version="v4", version_label=4),
+            delta("v5", "v4"),
+        ),
+    }
+    replay = replays[target_version]
+    recovered = (
+        adapter.stage_weight(replay[0])
+        if len(replay) == 1
+        else adapter.stage_chain(replay)
+    )
+    shard = recovered.path / "model.safetensors"
+    if not shard.exists():
+        shard = recovered.path / "model-00001-of-00001.safetensors"
+    assert torch.equal(
+        load_file(shard)["weight"],
+        tensors[target_version],
+    )
+    adapter.apply_weight(recovered)
+    assert adapter._checkpoint.store.active_version() == target_version
+    adapter.release_staged_weight(recovered)
+    adapter.close()
+
+
+def test_canonical_s3_reinstalls_active_checkpoint_after_install_failure(
+    monkeypatch, tmp_path
+):
+    objects = _full_artifact(torch.tensor([7.0, 8.0]))
+    objects.update(
+        _full_artifact(
+            torch.tensor([9.0, 10.0]),
+            version_label=3,
+        )
+    )
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+
+    active = adapter.stage_weight(_full_inputs())
+    adapter.apply_weight(active)
+    adapter.release_staged_weight(active)
+
+    failed = adapter.stage_weight(_full_inputs(version="full-b", version_label=3))
+    adapter._method.installation_failed(adapter._active)
+    adapter.release_staged_weight(failed)
+
+    recovery = adapter.stage_weight(_full_inputs())
+    assert recovery.path == adapter._checkpoint.store.full_path("full-a")
+    adapter.apply_weight(recovery)
+    adapter.release_staged_weight(recovery)
+    assert adapter._checkpoint.store.state()["status"] == "READY"
+    assert adapter._checkpoint.store.active_version() == "full-a"
     adapter.close()
 
 
@@ -1875,7 +2119,7 @@ def test_child_download_failure_leaves_checkpoint_updating(
     adapter, storage = _build(monkeypatch, tmp_path, objects)
     storage.fail_key_once = shard_key
 
-    with pytest.raises(OSError, match="injected shard download failure"):
+    with pytest.raises(RuntimeError, match="injected shard download failure"):
         adapter.stage_weight(_inputs(objects[root_key]))
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())

--- a/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
+++ b/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
@@ -92,6 +92,7 @@ def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch
         "registration_ttl_seconds": 90,
         "lease_ttl_seconds": 60,
         "max_transfer_attempts": 4,
+        "max_replay_chain_length": 17,
         "rpc_timeout_seconds": 12.5,
     }
     engine.init_transfer_engine(engine.init_info_cls(**init_info))
@@ -103,6 +104,7 @@ def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch
     assert config.registration_ttl_seconds == 90
     assert config.lease_ttl_seconds == 60
     assert config.max_transfer_attempts == 4
+    assert config.max_replay_chain_length == 17
     assert config.rpc_timeout_seconds == 12.5
     assert config.object_storage.storage_type is ObjectStorageType.S3
     assert config.object_storage.initial_base_version_id == "base-a"


### PR DESCRIPTION
## Summary

Adds target-version replay for canonical refit checkpoints by resolving and validating the complete delta chain before mutation, then installing only the final target. Replay is bounded, lease-protected, safe across shared ranks, and fences workers after potentially partial installation failures.

Closes #703.

## Verification

Validated end-to-end on B200 GPUs with images built:

- Packaged versions: ModelExpress 0.5.1, Dynamo 1.3.0, and vLLM 0.27.1
- Required vLLM weight-transfer imports passed before launching the engine.
- On one B200, a non-adjacent `v0 -> v2` request replayed the `v1` and `v2` XOR deltas and performed exactly one final v2 installation.
- The replayed v2 checkpoint matched the independently prepared full v2 checkpoint: 311 tensors, 1,503,264,768 bytes, aggregate SHA-256 `d85667c10f8122a1d62f6a2a40cba2e9bf94e9574ad3fa5eb363d079e70ae95a`.
- Deterministic inference after replay matched a clean engine loaded directly from full v2, including content, finish reason, and token usage.
- A missing target failed with a clear diagnostic without corrupting the serving engine; inference remained unchanged and the next valid update succeeded.
- Re-requesting the current v2 target completed as a no-op without another installation.
- TP=2 passed on two B200 GPUs after mounting a 1 GiB memory-backed `/dev/shm`. Both ranks installed v2; only rank 0 downloaded and replayed the shared chain, while rank 1 reported zero download/apply time. The TP=2 materialized checkpoint matched the same full-v2 hash and served inference successfully.

## Summary by CodeRabbit

* **New Features**
  * Added support for replaying multiple weight revisions in sequence.
  * Added configurable limits for replay-chain length, defaulting to 64 revisions.
  * Reapplying an already-serving version now completes as a no-op without unnecessary transfer.
  * Added comprehensive validation for revision chains and delta metadata.

* **Bug Fixes**
  * Failed installations now mark checkpoints as unsafe and block further updates until recovery.
  * Updates apply the complete chain atomically and install only the requested final version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
