### PR TITLE
fix(vllm): refresh host attention scales after RDMA (cherry-pick #711)

### DIFF
--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -41,6 +41,12 @@ _VLLM_POST_RDMA_FINALIZER_NAMES = (
     "finalize_mhc_broadcast_weights",
 )
 
+# vLLM keeps accelerator-backed attention scales together with host mirrors
+# consumed by backends such as FlashInfer and AITER. Only the accelerator
+# tensors are part of the ModelExpress manifest, so an RDMA target must refresh
+# the mirrors after the received values overwrite its dummy-loaded tensors.
+_VLLM_ATTENTION_SCALE_NAMES: tuple[str, ...] = ("q", "k", "v")
+
 # MTP draft weights live under an "mtp." prefix in the shared checkpoint. The
 # draft's embedding and lm_head come from the target, so these are all it needs.
 _DRAFT_WEIGHT_PREFIXES: tuple[str, ...] = ("mtp.",)
@@ -231,9 +237,10 @@ class VllmAdapter(EngineAdapter):
 
     def after_rdma_receive(self, result: LoadResult) -> LoadResult:
         """Build target-local tensors derived from the received weights."""
-        return self._finalize_model_specific_weights(
+        result = self._finalize_model_specific_weights(
             result, _VLLM_POST_RDMA_FINALIZER_NAMES
         )
+        return self._refresh_host_quantization_state(result)
 
     def apply_weight_iter(
         self,
@@ -387,6 +394,84 @@ class VllmAdapter(EngineAdapter):
                 result.model,
                 self.model_config,
                 self.target_device,
+            )
+        return result
+
+    @torch.no_grad()
+    def _refresh_host_quantization_state(self, result: LoadResult) -> LoadResult:
+        """Refresh vLLM host mirrors after RDMA overwrites device scales.
+
+        vLLM's attention PWAL copies ``_q/_k/_v_scale`` into Python floats and
+        CPU tensors for backends whose launch APIs require host scalars. RDMA
+        receives only the registered accelerator tensors, leaving those mirrors
+        at values derived from the target's dummy load. Re-running PWAL is not a
+        safe repair because the incoming model is already in its processed
+        runtime representation; update only the non-transferable mirrors.
+
+        Compressed-tensors may use per-head scales. Match vLLM's own conversion
+        by using their maximum for the scalar host mirror.
+        """
+        if result.model is None:
+            raise RuntimeError("vLLM RDMA post-load processing requires result.model")
+
+        refreshed_values = 0
+        stale_values = 0
+        refreshed_modules = 0
+
+        for module_name, module in result.model.named_modules():
+            module_refreshed = False
+            for scale_name in _VLLM_ATTENTION_SCALE_NAMES:
+                tensor_name = f"_{scale_name}_scale"
+                float_name = f"{tensor_name}_float"
+                scale = getattr(module, tensor_name, None)
+                if not isinstance(scale, torch.Tensor) or not hasattr(
+                    module, float_name
+                ):
+                    continue
+                if not self.accelerator_backend.is_accel_tensor(scale):
+                    continue
+                if scale.numel() == 0:
+                    continue
+
+                value = float(scale.detach().float().max().item())
+                previous = getattr(module, float_name)
+                if previous != value:
+                    stale_values += 1
+                    logger.debug(
+                        "Refreshing vLLM host scale %s.%s: %r -> %r",
+                        module_name or type(module).__name__,
+                        float_name,
+                        previous,
+                        value,
+                    )
+                setattr(module, float_name, value)
+
+                cpu_mirror = getattr(module, f"_{scale_name}_scale_cpu", None)
+                if isinstance(cpu_mirror, torch.Tensor):
+                    cpu_mirror.fill_(value)
+
+                refreshed_values += 1
+                module_refreshed = True
+
+            if not module_refreshed:
+                continue
+
+            refreshed_modules += 1
+            # FlashInfer lazily derives these from the host scale mirrors. They
+            # should still be None during cold loading, but invalidate them to
+            # keep this hook correct if initialization order changes upstream.
+            impl = getattr(module, "impl", None)
+            for cache_name in ("bmm1_scale", "bmm2_scale"):
+                if impl is not None and hasattr(impl, cache_name):
+                    setattr(impl, cache_name, None)
+
+        if refreshed_values:
+            logger.info(
+                "Refreshed %d vLLM host attention scales across %d modules "
+                "after RDMA receive (%d stale dummy values replaced)",
+                refreshed_values,
+                refreshed_modules,
+                stale_values,
             )
         return result
 

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -401,12 +401,13 @@ class VllmAdapter(EngineAdapter):
     def _refresh_host_quantization_state(self, result: LoadResult) -> LoadResult:
         """Refresh vLLM host mirrors after RDMA overwrites device scales.
 
-        vLLM's attention PWAL copies ``_q/_k/_v_scale`` into Python floats and
-        CPU tensors for backends whose launch APIs require host scalars. RDMA
-        receives only the registered accelerator tensors, leaving those mirrors
-        at values derived from the target's dummy load. Re-running PWAL is not a
-        safe repair because the incoming model is already in its processed
-        runtime representation; update only the non-transferable mirrors.
+        vLLM's attention PWAL copies ``_q/_k/_v_scale`` into Python floats and,
+        for some backends, CPU tensors whose launch APIs require host scalars.
+        RDMA receives only the registered accelerator tensors, leaving those
+        mirrors at values derived from the target's dummy load. Re-running PWAL
+        is not a safe repair because the incoming model is already in its
+        processed runtime representation; update only the non-transferable
+        mirrors that the selected backend exposes.
 
         Compressed-tensors may use per-head scales. Match vLLM's own conversion
         by using their maximum for the scalar host mirror.
@@ -422,7 +423,7 @@ class VllmAdapter(EngineAdapter):
         device_names = tuple(
             f"_{scale_name}_scale" for scale_name in _VLLM_ATTENTION_SCALE_NAMES
         )
-        required_names = device_names + float_names + cpu_names + ("_o_scale_float",)
+        required_names = device_names + float_names + ("_o_scale_float",)
         flashinfer_cache_names = ("bmm1_scale", "bmm2_scale", "o_sf_scale")
 
         cache_config = getattr(self.vllm_config, "cache_config", None)
@@ -465,6 +466,8 @@ class VllmAdapter(EngineAdapter):
                     )
 
             for cpu_name in cpu_names:
+                if not hasattr(module, cpu_name):
+                    continue
                 cpu_mirror = getattr(module, cpu_name)
                 if (
                     not isinstance(cpu_mirror, torch.Tensor)

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -431,10 +431,13 @@ class VllmAdapter(EngineAdapter):
             configured_cache_dtype.startswith("fp8")
         )
 
-        # Validate every module before mutating any host state. This is a shim
-        # over vLLM private attributes, so an upstream contract change must fail
-        # the RDMA strategy instead of silently serving with stale scales.
-        updates: list[tuple[str, torch.nn.Module, dict[str, float]]] = []
+        # This is a shim over vLLM private attributes, so an upstream scale
+        # contract change must fail the RDMA strategy instead of silently
+        # serving with stale values. Any failure after mutation is recovered by
+        # the outer strategy reinitializing the whole model before fallback.
+        refreshed_values = 0
+        stale_values = 0
+        refreshed_modules = 0
         for module_name, module in result.model.named_modules():
             module_label = module_name or type(module).__name__
             kv_cache_dtype = getattr(module, "kv_cache_dtype", None)
@@ -475,31 +478,14 @@ class VllmAdapter(EngineAdapter):
                     )
 
             impl = getattr(module, "impl", None)
-            cache_presence = [
-                hasattr(impl, cache_name) for cache_name in flashinfer_cache_names
-            ]
-            if any(cache_presence) and not all(cache_presence):
-                missing_cache_names = [
-                    cache_name
-                    for cache_name, present in zip(
-                        flashinfer_cache_names, cache_presence, strict=True
-                    )
-                    if not present
-                ]
-                raise RuntimeError(
-                    "Incomplete vLLM FlashInfer scale cache contract on "
-                    f"{module_label}: missing {', '.join(missing_cache_names)}"
-                )
-
             initialized_cache_names = []
             if module._o_scale_float is not None:
                 initialized_cache_names.append("_o_scale_float")
-            if all(cache_presence):
-                initialized_cache_names.extend(
-                    cache_name
-                    for cache_name in flashinfer_cache_names
-                    if getattr(impl, cache_name) is not None
-                )
+            initialized_cache_names.extend(
+                cache_name
+                for cache_name in flashinfer_cache_names
+                if hasattr(impl, cache_name) and getattr(impl, cache_name) is not None
+            )
             if initialized_cache_names:
                 raise RuntimeError(
                     "vLLM attention host-scale refresh requires a cold-load "
@@ -507,7 +493,6 @@ class VllmAdapter(EngineAdapter):
                     f"{', '.join(initialized_cache_names)}"
                 )
 
-            values: dict[str, float] = {}
             for scale_name, tensor_name in zip(
                 _VLLM_ATTENTION_SCALE_NAMES, device_names, strict=True
             ):
@@ -533,20 +518,7 @@ class VllmAdapter(EngineAdapter):
                         f"{module_label}: {tensor_name} must contain only finite, "
                         "positive values"
                     )
-                values[scale_name] = float(scale_float.max().item())
-
-            updates.append((module_label, module, values))
-
-        if fp8_expected and not updates:
-            raise RuntimeError(
-                "FP8 KV cache requires recognizable vLLM q/k/v host scale state, "
-                "but no attention module was refreshed"
-            )
-
-        refreshed_values = 0
-        stale_values = 0
-        for module_label, module, values in updates:
-            for scale_name, value in values.items():
+                value = float(scale_float.max().item())
                 float_name = f"_{scale_name}_scale_float"
                 previous = getattr(module, float_name)
                 if previous != value:
@@ -565,13 +537,20 @@ class VllmAdapter(EngineAdapter):
                     cpu_mirror.fill_(value)
 
                 refreshed_values += 1
+            refreshed_modules += 1
+
+        if fp8_expected and not refreshed_modules:
+            raise RuntimeError(
+                "FP8 KV cache requires recognizable vLLM q/k/v host scale state, "
+                "but no attention module was refreshed"
+            )
 
         if refreshed_values:
             logger.info(
                 "Refreshed %d vLLM host attention scales across %d modules "
                 "after RDMA receive (%d stale dummy values replaced)",
                 refreshed_values,
-                len(updates),
+                refreshed_modules,
                 stale_values,
             )
         return result

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -414,32 +414,146 @@ class VllmAdapter(EngineAdapter):
         if result.model is None:
             raise RuntimeError("vLLM RDMA post-load processing requires result.model")
 
+        float_names = tuple(
+            f"_{scale_name}_scale_float"
+            for scale_name in _VLLM_ATTENTION_SCALE_NAMES
+        )
+        cpu_names = ("_k_scale_cpu", "_v_scale_cpu")
+        device_names = tuple(
+            f"_{scale_name}_scale" for scale_name in _VLLM_ATTENTION_SCALE_NAMES
+        )
+        required_names = device_names + float_names + cpu_names + ("_o_scale_float",)
+        flashinfer_cache_names = ("bmm1_scale", "bmm2_scale", "o_sf_scale")
+
+        cache_config = getattr(self.vllm_config, "cache_config", None)
+        configured_cache_dtype = getattr(cache_config, "cache_dtype", None)
+        fp8_expected = isinstance(configured_cache_dtype, str) and (
+            configured_cache_dtype.startswith("fp8")
+        )
+
+        # Validate every module before mutating any host state. This is a shim
+        # over vLLM private attributes, so an upstream contract change must fail
+        # the RDMA strategy instead of silently serving with stale scales.
+        updates: list[tuple[str, torch.nn.Module, dict[str, float]]] = []
+        for module_name, module in result.model.named_modules():
+            module_label = module_name or type(module).__name__
+            kv_cache_dtype = getattr(module, "kv_cache_dtype", None)
+            if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("fp8"):
+                fp8_expected = True
+
+            host_names = float_names + cpu_names
+            if not any(hasattr(module, name) for name in host_names):
+                continue
+
+            missing_names = [
+                name for name in required_names if not hasattr(module, name)
+            ]
+            if missing_names:
+                raise RuntimeError(
+                    "Incomplete vLLM attention scale contract on "
+                    f"{module_label}: missing {', '.join(missing_names)}"
+                )
+
+            for float_name in float_names:
+                if not isinstance(getattr(module, float_name), float):
+                    raise RuntimeError(
+                        "Invalid vLLM attention host scalar on "
+                        f"{module_label}: {float_name} must be a float"
+                    )
+
+            for cpu_name in cpu_names:
+                cpu_mirror = getattr(module, cpu_name)
+                if (
+                    not isinstance(cpu_mirror, torch.Tensor)
+                    or cpu_mirror.numel() != 1
+                    or not torch.is_floating_point(cpu_mirror)
+                ):
+                    raise RuntimeError(
+                        "Invalid vLLM attention CPU scale on "
+                        f"{module_label}: {cpu_name} must be a floating-point "
+                        "singleton tensor"
+                    )
+
+            impl = getattr(module, "impl", None)
+            cache_presence = [
+                hasattr(impl, cache_name) for cache_name in flashinfer_cache_names
+            ]
+            if any(cache_presence) and not all(cache_presence):
+                missing_cache_names = [
+                    cache_name
+                    for cache_name, present in zip(
+                        flashinfer_cache_names, cache_presence, strict=True
+                    )
+                    if not present
+                ]
+                raise RuntimeError(
+                    "Incomplete vLLM FlashInfer scale cache contract on "
+                    f"{module_label}: missing {', '.join(missing_cache_names)}"
+                )
+
+            initialized_cache_names = []
+            if module._o_scale_float is not None:
+                initialized_cache_names.append("_o_scale_float")
+            if all(cache_presence):
+                initialized_cache_names.extend(
+                    cache_name
+                    for cache_name in flashinfer_cache_names
+                    if getattr(impl, cache_name) is not None
+                )
+            if initialized_cache_names:
+                raise RuntimeError(
+                    "vLLM attention host-scale refresh requires a cold-load "
+                    f"state on {module_label}; already initialized: "
+                    f"{', '.join(initialized_cache_names)}"
+                )
+
+            values: dict[str, float] = {}
+            for scale_name, tensor_name in zip(
+                _VLLM_ATTENTION_SCALE_NAMES, device_names, strict=True
+            ):
+                scale = getattr(module, tensor_name)
+                if (
+                    not isinstance(scale, torch.Tensor)
+                    or not self.accelerator_backend.is_accel_tensor(scale)
+                    or scale.numel() == 0
+                    or not torch.is_floating_point(scale)
+                ):
+                    raise RuntimeError(
+                        "Invalid vLLM accelerator attention scale on "
+                        f"{module_label}: {tensor_name} must be a nonempty "
+                        "floating-point accelerator tensor"
+                    )
+
+                scale_float = scale.detach().float()
+                if not bool(torch.isfinite(scale_float).all().item()) or not bool(
+                    (scale_float > 0).all().item()
+                ):
+                    raise RuntimeError(
+                        "Invalid vLLM accelerator attention scale on "
+                        f"{module_label}: {tensor_name} must contain only finite, "
+                        "positive values"
+                    )
+                values[scale_name] = float(scale_float.max().item())
+
+            updates.append((module_label, module, values))
+
+        if fp8_expected and not updates:
+            raise RuntimeError(
+                "FP8 KV cache requires recognizable vLLM q/k/v host scale state, "
+                "but no attention module was refreshed"
+            )
+
         refreshed_values = 0
         stale_values = 0
-        refreshed_modules = 0
-
-        for module_name, module in result.model.named_modules():
-            module_refreshed = False
-            for scale_name in _VLLM_ATTENTION_SCALE_NAMES:
-                tensor_name = f"_{scale_name}_scale"
-                float_name = f"{tensor_name}_float"
-                scale = getattr(module, tensor_name, None)
-                if not isinstance(scale, torch.Tensor) or not hasattr(
-                    module, float_name
-                ):
-                    continue
-                if not self.accelerator_backend.is_accel_tensor(scale):
-                    continue
-                if scale.numel() == 0:
-                    continue
-
-                value = float(scale.detach().float().max().item())
+        for module_label, module, values in updates:
+            for scale_name, value in values.items():
+                float_name = f"_{scale_name}_scale_float"
                 previous = getattr(module, float_name)
                 if previous != value:
                     stale_values += 1
                     logger.debug(
                         "Refreshing vLLM host scale %s.%s: %r -> %r",
-                        module_name or type(module).__name__,
+                        module_label,
                         float_name,
                         previous,
                         value,
@@ -451,26 +565,13 @@ class VllmAdapter(EngineAdapter):
                     cpu_mirror.fill_(value)
 
                 refreshed_values += 1
-                module_refreshed = True
-
-            if not module_refreshed:
-                continue
-
-            refreshed_modules += 1
-            # FlashInfer lazily derives these from the host scale mirrors. They
-            # should still be None during cold loading, but invalidate them to
-            # keep this hook correct if initialization order changes upstream.
-            impl = getattr(module, "impl", None)
-            for cache_name in ("bmm1_scale", "bmm2_scale"):
-                if impl is not None and hasattr(impl, cache_name):
-                    setattr(impl, cache_name, None)
 
         if refreshed_values:
             logger.info(
                 "Refreshed %d vLLM host attention scales across %d modules "
                 "after RDMA receive (%d stale dummy values replaced)",
                 refreshed_values,
-                refreshed_modules,
+                len(updates),
                 stale_values,
             )
         return result

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -268,20 +268,17 @@ def test_after_rdma_receive_fails_when_fp8_scales_are_unrecognized(
 def test_after_rdma_receive_fails_on_incomplete_scale_contract(
     mock_accelerator_backend_cls,
 ):
-    """A partial private contract fails before any valid module is updated."""
+    """A partial private q/k/v scale contract fails closed."""
     adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
     adapter.accelerator_backend = mock_accelerator_backend_cls(
         torch_device_type="cpu"
     )
     model = nn.Module()
-    model.first = _AttentionWithStaleHostScales()
-    model.second = _AttentionWithStaleHostScales()
-    del model.second._v_scale_float
+    model.attn = _AttentionWithStaleHostScales()
+    del model.attn._v_scale_float
 
     with pytest.raises(RuntimeError, match="Incomplete.*_v_scale_float"):
         adapter.after_rdma_receive(LoadResult(value=model, model=model))
-
-    assert model.first._q_scale_float == pytest.approx(1.0)
 
 
 def test_after_rdma_receive_rejects_invalid_python_host_scalar(
@@ -316,10 +313,10 @@ def test_after_rdma_receive_rejects_invalid_cpu_scale(
         adapter.after_rdma_receive(LoadResult(value=model, model=model))
 
 
-def test_after_rdma_receive_rejects_incomplete_flashinfer_cache_contract(
+def test_after_rdma_receive_allows_mla_flashinfer_cache_contract(
     mock_accelerator_backend_cls,
 ):
-    """A partial FlashInfer cache family indicates an upstream contract change."""
+    """FlashInfer MLA legitimately has bmm caches without an output cache."""
     adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
     adapter.accelerator_backend = mock_accelerator_backend_cls(
         torch_device_type="cpu"
@@ -328,8 +325,11 @@ def test_after_rdma_receive_rejects_incomplete_flashinfer_cache_contract(
     model.attn = _AttentionWithStaleHostScales()
     del model.attn.impl.o_sf_scale
 
-    with pytest.raises(RuntimeError, match="Incomplete.*o_sf_scale"):
-        adapter.after_rdma_receive(LoadResult(value=model, model=model))
+    adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+    assert model.attn._q_scale_float == pytest.approx(0.25)
+    assert model.attn._k_scale_float == pytest.approx(0.5)
+    assert model.attn._v_scale_float == pytest.approx(0.75)
 
 
 @pytest.mark.parametrize(

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -313,6 +313,26 @@ def test_after_rdma_receive_rejects_invalid_cpu_scale(
         adapter.after_rdma_receive(LoadResult(value=model, model=model))
 
 
+def test_after_rdma_receive_allows_missing_backend_specific_cpu_scales(
+    mock_accelerator_backend_cls,
+):
+    """Backends without CPU scale mirrors still refresh Python host state."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.attn = _AttentionWithStaleHostScales()
+    del model.attn._k_scale_cpu
+    del model.attn._v_scale_cpu
+
+    adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+    assert model.attn._q_scale_float == pytest.approx(0.25)
+    assert model.attn._k_scale_float == pytest.approx(0.5)
+    assert model.attn._v_scale_float == pytest.approx(0.75)
+
+
 def test_after_rdma_receive_allows_mla_flashinfer_cache_contract(
     mock_accelerator_backend_cls,
 ):

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -200,6 +200,7 @@ def test_after_rdma_receive_runs_derived_weight_finalizers(monkeypatch):
 def test_after_rdma_receive_refreshes_host_attention_scale_mirrors(
     mock_accelerator_backend_cls,
 ):
+    """RDMA accelerator scales replace every stale host mirror in place."""
     adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
     adapter.accelerator_backend = mock_accelerator_backend_cls(
         torch_device_type="cpu"
@@ -224,10 +225,165 @@ def test_after_rdma_receive_refreshes_host_attention_scale_mirrors(
     assert model.attn._v_scale_cpu.item() == pytest.approx(0.75)
     assert model.attn.impl.bmm1_scale is None
     assert model.attn.impl.bmm2_scale is None
+    assert model.attn.impl.o_sf_scale is None
     assert {
         name: tensor.data_ptr()
         for name, tensor in model.attn.named_buffers(recurse=False)
     } == pointers
+
+
+def test_after_rdma_receive_refreshes_scales_after_model_finalizer(
+    mock_accelerator_backend_cls,
+):
+    """The mirror refresh observes scale changes made by the finalizer."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = _AttentionScaleFinalizerModel()
+
+    adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+    assert model.finalized is True
+    assert model.attn._q_scale.item() == pytest.approx(0.625)
+    assert model.attn._q_scale_float == pytest.approx(0.625)
+
+
+def test_after_rdma_receive_fails_when_fp8_scales_are_unrecognized(
+    mock_accelerator_backend_cls,
+):
+    """An FP8 target cannot silently complete without refreshing any scales."""
+    config = _context_config(load_device="cpu")
+    config.cache_config.cache_dtype = "fp8"
+    adapter = VllmAdapter(config, _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+
+    with pytest.raises(RuntimeError, match="no attention module was refreshed"):
+        adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+
+def test_after_rdma_receive_fails_on_incomplete_scale_contract(
+    mock_accelerator_backend_cls,
+):
+    """A partial private contract fails before any valid module is updated."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.first = _AttentionWithStaleHostScales()
+    model.second = _AttentionWithStaleHostScales()
+    del model.second._v_scale_float
+
+    with pytest.raises(RuntimeError, match="Incomplete.*_v_scale_float"):
+        adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+    assert model.first._q_scale_float == pytest.approx(1.0)
+
+
+def test_after_rdma_receive_rejects_invalid_python_host_scalar(
+    mock_accelerator_backend_cls,
+):
+    """A renamed or type-changed Python scale fails the private contract."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.attn = _AttentionWithStaleHostScales()
+    model.attn._q_scale_float = torch.tensor(1.0)
+
+    with pytest.raises(RuntimeError, match="_q_scale_float must be a float"):
+        adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+
+def test_after_rdma_receive_rejects_invalid_cpu_scale(
+    mock_accelerator_backend_cls,
+):
+    """Host tensor mirrors must preserve vLLM's singleton CPU contract."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.attn = _AttentionWithStaleHostScales()
+    model.attn._k_scale_cpu = torch.ones(2)
+
+    with pytest.raises(RuntimeError, match="_k_scale_cpu must be"):
+        adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+
+def test_after_rdma_receive_rejects_incomplete_flashinfer_cache_contract(
+    mock_accelerator_backend_cls,
+):
+    """A partial FlashInfer cache family indicates an upstream contract change."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.attn = _AttentionWithStaleHostScales()
+    del model.attn.impl.o_sf_scale
+
+    with pytest.raises(RuntimeError, match="Incomplete.*o_sf_scale"):
+        adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+
+@pytest.mark.parametrize(
+    ("scale_name", "invalid_value"),
+    (
+        ("_q_scale", torch.tensor([])),
+        ("_k_scale", torch.tensor([float("nan")])),
+        ("_v_scale", torch.tensor(0.0)),
+    ),
+)
+def test_after_rdma_receive_rejects_invalid_accelerator_scales(
+    mock_accelerator_backend_cls,
+    scale_name,
+    invalid_value,
+):
+    """Accelerator scales must be nonempty, finite, and positive."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.attn = _AttentionWithStaleHostScales()
+    setattr(model.attn, scale_name, invalid_value)
+
+    with pytest.raises(RuntimeError, match="Invalid vLLM accelerator attention scale"):
+        adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+
+@pytest.mark.parametrize(
+    ("owner_name", "cache_name"),
+    (
+        ("module", "_o_scale_float"),
+        ("impl", "bmm1_scale"),
+        ("impl", "bmm2_scale"),
+        ("impl", "o_sf_scale"),
+    ),
+)
+def test_after_rdma_receive_rejects_prewarmed_attention_scale_cache(
+    mock_accelerator_backend_cls,
+    owner_name,
+    cache_name,
+):
+    """The compatibility shim only supports vLLM's cold-load lifecycle."""
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.attn = _AttentionWithStaleHostScales()
+    owner = model.attn if owner_name == "module" else model.attn.impl
+    setattr(owner, cache_name, 99.0)
+
+    with pytest.raises(RuntimeError, match="requires a cold-load state"):
+        adapter.after_rdma_receive(LoadResult(value=model, model=model))
 
 
 def test_rdma_lifecycle_discovers_prepared_tensors_and_finalizes_received_weights(
@@ -327,6 +483,7 @@ def _context_config(*, load_device):
     return SimpleNamespace(
         device_config=SimpleNamespace(device="cuda"),
         load_config=SimpleNamespace(device=load_device),
+        cache_config=SimpleNamespace(cache_dtype="auto"),
         parallel_config=SimpleNamespace(
             rank=0,
             tensor_parallel_size=2,
@@ -414,7 +571,24 @@ class _AttentionWithStaleHostScales(torch.nn.Module):
         self._prob_scale_float = 1.0
         self._k_scale_cpu = torch.tensor(1.0)
         self._v_scale_cpu = torch.tensor(1.0)
-        self.impl = SimpleNamespace(bmm1_scale=99.0, bmm2_scale=88.0)
+        self._o_scale_float = None
+        self.kv_cache_dtype = "fp8"
+        self.impl = SimpleNamespace(
+            bmm1_scale=None,
+            bmm2_scale=None,
+            o_sf_scale=None,
+        )
+
+
+class _AttentionScaleFinalizerModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.finalized = False
+        self.attn = _AttentionWithStaleHostScales()
+
+    def finalize_mhc_broadcast_weights(self) -> None:
+        self.attn._q_scale.fill_(0.625)
+        self.finalized = True
 
 
 class _StandaloneFinalizer(torch.nn.Module):

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -197,6 +197,39 @@ def test_after_rdma_receive_runs_derived_weight_finalizers(monkeypatch):
     ]
 
 
+def test_after_rdma_receive_refreshes_host_attention_scale_mirrors(
+    mock_accelerator_backend_cls,
+):
+    adapter = VllmAdapter(_context_config(load_device="cpu"), _model_config())
+    adapter.accelerator_backend = mock_accelerator_backend_cls(
+        torch_device_type="cpu"
+    )
+    model = nn.Module()
+    model.attn = _AttentionWithStaleHostScales()
+    pointers = {
+        name: tensor.data_ptr()
+        for name, tensor in model.attn.named_buffers(recurse=False)
+    }
+
+    result = adapter.after_rdma_receive(LoadResult(value=model, model=model))
+
+    assert result.model is model
+    assert model.attn._q_scale_float == pytest.approx(0.25)
+    # Match compressed-tensors' host conversion for per-head scales.
+    assert model.attn._k_scale_float == pytest.approx(0.5)
+    assert model.attn._v_scale_float == pytest.approx(0.75)
+    # vLLM does not derive a host mirror from _prob_scale.
+    assert model.attn._prob_scale_float == pytest.approx(1.0)
+    assert model.attn._k_scale_cpu.item() == pytest.approx(0.5)
+    assert model.attn._v_scale_cpu.item() == pytest.approx(0.75)
+    assert model.attn.impl.bmm1_scale is None
+    assert model.attn.impl.bmm2_scale is None
+    assert {
+        name: tensor.data_ptr()
+        for name, tensor in model.attn.named_buffers(recurse=False)
+    } == pointers
+
+
 def test_rdma_lifecycle_discovers_prepared_tensors_and_finalizes_received_weights(
     monkeypatch,
     mock_accelerator_backend_cls,
@@ -366,6 +399,22 @@ class _RdmaLifecycleModel(torch.nn.Module):
                 int(self.hc_attn_fn.item()),
             )
         )
+
+
+class _AttentionWithStaleHostScales(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("_q_scale", torch.tensor(0.25))
+        self.register_buffer("_k_scale", torch.tensor([0.1, 0.5]))
+        self.register_buffer("_v_scale", torch.tensor(0.75))
+        self.register_buffer("_prob_scale", torch.tensor(0.125))
+        self._q_scale_float = 1.0
+        self._k_scale_float = 1.0
+        self._v_scale_float = 1.0
+        self._prob_scale_float = 1.0
+        self._k_scale_cpu = torch.tensor(1.0)
+        self._v_scale_cpu = torch.tensor(1.0)
+        self.impl = SimpleNamespace(bmm1_scale=99.0, bmm2_scale=88.0)
 
 
 class _StandaloneFinalizer(torch.nn.Module):


### PR DESCRIPTION
## Backport

Cherry-pick of #711 onto `release/0.6.0`.

- source commit on `main` PR: `7b1b8cc279da019865c79fea127f4083eb0138f2`
- backport commit: `0b0d2a8881ca903ee9e485d4957142c61cee4dc8`

## Summary

- refresh vLLM q/k/v host scale mirrors after RDMA overwrites the registered accelerator tensors
- synchronize the CPU mirrors used by host-scalar attention backends
- fail closed unless the complete q/k/v host-scale contract is valid and FlashInfer caches are still cold
- avoid re-running all of `process_weights_after_loading()`, because the received tensors already use the source's processed runtime representation

Tracking bug: [NVBug 6702877](https://nvbugspro.nvidia.com/bug/6702877)

## Root cause

vLLM stores each FP8 attention scale in more than one representation:

- registered accelerator buffers: `_q_scale`, `_k_scale`, `_v_scale`
- Python host scalars: `_q_scale_float`, `_k_scale_float`, `_v_scale_float`
- CPU mirrors for applicable backends: `_k_scale_cpu`, `_v_scale_cpu`

The source runs post-load processing after loading the real checkpoint, so these values agree. An RDMA target first runs post-load processing on dummy weights to expose the final runtime tensor layout. RDMA then overwrites the registered accelerator buffers, but Python floats and CPU tensors are not part of the transferred tensor manifest and retain dummy-derived values (usually `1.0`).

On Blackwell, vLLM's FlashInfer TRTLLM-Gen path passes the Python values as host scalars. The target therefore executes with real device scales but stale launch scalars, producing deterministic degenerate output despite a complete byte transfer.

## Relevant vLLM 0.26.0 source

These links are pinned to the vLLM `v0.26.0` commit (`568afb3a13806beb53bb2e6bd518269357b237c0`):

- vLLM creates both accelerator buffers and host mirrors: [`attention.py#L124-L145`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/model_executor/layers/attention/attention.py#L124-L145)
- post-load processing copies checkpoint scales into the accelerator buffers, Python floats, and CPU mirrors: [`kv_cache.py#L128-L149`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/model_executor/layers/quantization/kv_cache.py#L128-L149) and [`kv_cache.py#L182-L186`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/model_executor/layers/quantization/kv_cache.py#L182-L186)
- architecture split: SM90/H200 supports XQA decode only, while SM100/SM103 enables TRTLLM attention for prefill and decode: [`utils/flashinfer.py#L374-L394`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/utils/flashinfer.py#L374-L394)
- SM100 specifically enables pre-quantized FP8 query input, while the comment documents the different SM90 behavior: [`flashinfer.py#L1587-L1603`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/v1/attention/backends/flashinfer.py#L1587-L1603)
- FlashInfer derives cached BMM launch scales from the Python host mirrors: [`flashinfer.py#L1708-L1716`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/v1/attention/backends/flashinfer.py#L1708-L1716)
- the TRTLLM prefill API receives q/k/v Python host scalars directly: [`flashinfer.py#L1925-L1933`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/v1/attention/backends/flashinfer.py#L1925-L1933)
- decode passes the derived host scalars to the TRTLLM kernel: [`flashinfer.py#L2193-L2224`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/v1/attention/backends/flashinfer.py#L2193-L2224)
- Blackwell also selects a FlashInfer FP8 linear kernel that explicitly requires compute capability 100+: [`scaled_mm/flashinfer.py#L39-L53`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py#L39-L53)

The architecture-specific code does not corrupt RDMA bytes. It exposes the stale host state because the Blackwell execution path consumes those non-transferred Python values differently from the H200 path observed in the same test.

## Verification

### Unit tests

```text
python -m pytest modelexpress_client/python/tests/test_vllm_adapter.py -q
36 passed in 0.09s
```

All pre-commit hooks passed on the release branch.

### B200 end-to-end

Configuration:

- `nvidia/Llama-3.1-405B-Instruct-FP8`
- two B200 nodes, TP=4 on each node
- vLLM 0.26.0, FP8 KV cache, `arch=sm100`, `decode_backend=trtllm-gen`
- source loads locally; target receives over RDMA

All four target ranks transferred 2272 tensors / 102.55 GB. Each rank then logged:

```text
Refreshed 378 vLLM host attention scales across 126 modules after RDMA receive (245 stale dummy values replaced)
```

Before the fix, the target produced repeated/garbled text from the first token. With this change it produces coherent English and matches the source for the first 27 generated tokens in the captured 32-token request.

There is still a normal-English continuation difference after token 27, so the existing strict 32-token byte-equality assertion is not satisfied by this run. This backport fixes the catastrophic stale-scale corruption; it does not claim cross-node Blackwell inference is bit-exact.

