### PR TITLE
fix(refit): support optional full checkpoint checksums

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -414,8 +414,8 @@ or full-checkpoint safetensors objects are stored as siblings. A delta index's
 `compression_format` selects the receiver's decompressor. The current
 implementation supports Zstandard. Unknown compression formats are rejected
 before shard download. Full versions use a standard safetensors index, carry
-per-tensor Adler-32 checksums in shard metadata, and reset the exact base for
-later deltas.
+optional per-tensor Adler-32 checksums under `mx.adler32:<tensor-name>` keys in
+shard metadata, and reset the exact base for later deltas.
 Canonical S3 versions are retained for rollout fault recovery. Trainer
 processes keep only the current base snapshot; older
 immutable S3 objects are governed by external bucket lifecycle policy.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -414,8 +414,9 @@ or full-checkpoint safetensors objects are stored as siblings. A delta index's
 `compression_format` selects the receiver's decompressor. The current
 implementation supports Zstandard. Unknown compression formats are rejected
 before shard download. Full versions use a standard safetensors index, carry
-optional per-tensor Adler-32 checksums under `mx.adler32:<tensor-name>` keys in
-shard metadata, and reset the exact base for later deltas.
+optional per-tensor Adler-32 checksums under tensor-name keys in shard metadata
+when the index declares `checksum_format="adler32"`, and reset the exact base
+for later deltas.
 Canonical S3 versions are retained for rollout fault recovery. Trainer
 processes keep only the current base snapshot; older
 immutable S3 objects are governed by external bucket lifecycle policy.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -959,11 +959,12 @@ Full checkpoints are grouped into concurrently uploaded safetensors objects of
 up to `MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES` tensor bytes (4 GiB by default).
 A single tensor larger than the configured size is uploaded on its own.
 Generators download those objects concurrently through the ModelExpress S3
-client. Each download worker validates one batch and overwrites the matching
-regions in the existing local checkpoint mmaps.
-The receiver marks its local checkpoint `UPDATING` before mutation and `READY`
-only after success. An interrupted update remains unavailable until a fresh
-initialization reseeds it from `seed_checkpoint_path`.
+client. Each download worker validates one batch and writes it into a temporary,
+version-scoped full checkpoint. The target is promoted only after every batch
+succeeds. Preparation uses `UPDATING` as a transaction marker and writes
+`READY(target)` only after verification. Any preparation failure discards its
+temporary target and restores `READY(active)` for immediate retry; the active
+checkpoint is never overwritten.
 
 S3 versions normally use `XOR_DELTA`. Integrations may opt into a
 framework-selected cadence of `FULL_HF_CHECKPOINT` versions; these publish

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -959,12 +959,11 @@ Full checkpoints are grouped into concurrently uploaded safetensors objects of
 up to `MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES` tensor bytes (4 GiB by default).
 A single tensor larger than the configured size is uploaded on its own.
 Generators download those objects concurrently through the ModelExpress S3
-client. Each download worker validates one batch and writes it into a temporary,
-version-scoped full checkpoint. The target is promoted only after every batch
-succeeds. Preparation uses `UPDATING` as a transaction marker and writes
-`READY(target)` only after verification. Any preparation failure discards its
-temporary target and restores `READY(active)` for immediate retry; the active
-checkpoint is never overwritten.
+client. Each download worker validates one batch and overwrites the matching
+regions in the existing local checkpoint mmaps.
+The receiver marks its local checkpoint `UPDATING` before mutation and `READY`
+only after success. An interrupted update remains unavailable until a fresh
+initialization reseeds it from `seed_checkpoint_path`.
 
 S3 versions normally use `XOR_DELTA`. Integrations may opt into a
 framework-selected cadence of `FULL_HF_CHECKPOINT` versions; these publish

--- a/docs/S3_DELTA_WEIGHT_REFIT.md
+++ b/docs/S3_DELTA_WEIGHT_REFIT.md
@@ -44,6 +44,7 @@ Environment variables used by the clients and vLLM engine:
 | `AWS_DEFAULT_REGION` | unset | S3 region when `region_name` is not supplied in client configuration. |
 | `MX_REFIT_DELTA_BUCKET_BYTES` | `536870912` (512 MiB) | Optional tensor-bucket size override for framework integrations. |
 | `MX_REFIT_DELTA_WORKERS` | `min(32, CPU count)` | CPU workers used to compute and apply XOR deltas. |
+| `MX_REFIT_CHECKSUM_FORMAT` | `adler32` | Checksum algorithm written by canonical S3 trainers. |
 | `MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES` | `4294967296` (4 GiB) | Maximum tensor bytes grouped into one full-checkpoint safetensors object. |
 | `MX_S3_UPLOAD_WORKERS` | `8` | Maximum concurrent multipart uploads per trainer rank. |
 | `MX_S3_DOWNLOAD_WORKERS` | `16` | Generator download concurrency. |
@@ -396,7 +397,8 @@ Full checkpoints use a standard Hugging Face safetensors index:
 ```json
 {
   "metadata": {
-    "total_size": 8
+    "total_size": 8,
+    "checksum_format": "adler32"
   },
   "weight_map": {
     "model.layers.0.example.weight": "model-00001-of-00004.safetensors"
@@ -405,17 +407,19 @@ Full checkpoints use a standard Hugging Face safetensors index:
 ```
 
 The generator requires a non-empty `weight_map` covering exactly the local
-checkpoint tensors. The index `metadata` field is optional and ignored.
+checkpoint tensors. The index `metadata` field is optional. When it contains
+`checksum_format`, the only supported value is `adler32`.
 
 Each referenced shard contains native HF tensors. Safetensors `__metadata__`
-is optional and may contain arbitrary string-to-string entries. A namespaced
-entry adds optional integrity checking for one tensor:
+may contain arbitrary string-to-string entries. When the index declares
+`checksum_format="adler32"`, it must also contain a checksum keyed by tensor
+name for every referenced tensor in the shard:
 
 ```json
 {
   "__metadata__": {
     "format": "pt",
-    "mx.adler32:model.layers.0.example.weight": "12ab34cd"
+    "model.layers.0.example.weight": "12ab34cd"
   },
   "model.layers.0.example.weight": {
     "dtype": "F32",
@@ -425,10 +429,10 @@ entry adds optional integrity checking for one tensor:
 }
 ```
 
-When `mx.adler32:<tensor-name>` is present, the generator verifies it against
-the downloaded tensor bytes. When it is absent, checksum verification is
-skipped. Tensor names, dtypes, shapes, and byte sizes are always checked before
-the immutable full artifact is promoted.
+When the index omits `checksum_format`, checksum verification is skipped and
+shard metadata is not interpreted as checksums. Tensor names, dtypes, shapes,
+and byte sizes are always checked before the immutable full artifact is
+promoted.
 
 ### 1. Publish `v1`
 
@@ -520,8 +524,8 @@ finally:
 The next delta must be `v2` with `base_version_id="v1"`. An integration may
 instead create a `FULL_HF_CHECKPOINT` version without `base_version_id`; that
 version becomes the exact base for the following delta. Full checkpoint batches
-may carry optional per-tensor checksums under `mx.adler32:<tensor-name>` keys and
-are retained as an immutable full artifact. XOR deltas require the complete
-index metadata contract above and are replayed in order in the canonical
-lineage; each preparation applies only the incoming delta to its exact active
-base.
+may declare `checksum_format="adler32"` in the index and carry per-tensor
+checksums under tensor-name keys in shard metadata. They are retained as an
+immutable full artifact. XOR deltas require the complete index metadata contract
+above and are replayed in order in the canonical lineage; each preparation
+applies only the incoming delta to its exact active base.

--- a/docs/S3_DELTA_WEIGHT_REFIT.md
+++ b/docs/S3_DELTA_WEIGHT_REFIT.md
@@ -345,6 +345,91 @@ seed checkpoint, write the cache, or validate the base version.
 
 ## Weight Update
 
+### Generator-side S3 artifact contract
+
+The weight version's `object_storage.uri` points to a global JSON index. Shard
+filenames in `weight_map` are resolved relative to that index.
+
+#### `XOR_DELTA`
+
+```json
+{
+  "metadata": {
+    "version": "v1",
+    "base_version": "v0",
+    "delta_encoding": "xor",
+    "compression_format": "zstd",
+    "checksum_format": "adler32"
+  },
+  "weight_map": {
+    "model.layers.0.example.weight": "model-00000-of-00004.safetensors"
+  }
+}
+```
+
+The generator requires all five metadata fields and `weight_map`. It uses
+`compression_format` to select the decompressor; the other metadata values
+describe the artifact. ModelExpress currently publishes `xor`, `zstd`, and
+`adler32` for the encoding, compression, and checksum fields.
+
+Each delta shard contains compressed `U8` XOR bytes. Its safetensors
+`__metadata__` must contain the Adler-32 checksum of every reconstructed full
+tensor:
+
+```json
+{
+  "__metadata__": {
+    "model.layers.0.example.weight": "12ab34cd"
+  },
+  "model.layers.0.example.weight": {
+    "dtype": "U8",
+    "shape": [1234],
+    "data_offsets": [0, 1234]
+  }
+}
+```
+
+#### `FULL_HF_CHECKPOINT`
+
+Full checkpoints use a standard Hugging Face safetensors index:
+
+```json
+{
+  "metadata": {
+    "total_size": 8
+  },
+  "weight_map": {
+    "model.layers.0.example.weight": "model-00001-of-00004.safetensors"
+  }
+}
+```
+
+The generator requires a non-empty `weight_map` covering exactly the local
+checkpoint tensors. The index `metadata` field is optional and ignored.
+
+Each referenced shard contains native HF tensors. Safetensors `__metadata__`
+is optional and may contain arbitrary string-to-string entries. A namespaced
+entry adds optional integrity checking for one tensor:
+
+```json
+{
+  "__metadata__": {
+    "format": "pt",
+    "mx.adler32:model.layers.0.example.weight": "12ab34cd"
+  },
+  "model.layers.0.example.weight": {
+    "dtype": "F32",
+    "shape": [2],
+    "data_offsets": [0, 8]
+  }
+}
+```
+
+When `mx.adler32:<tensor-name>` is present, the generator verifies it against
+the downloaded tensor bytes. When it is absent, checksum verification is
+skipped. Tensor names, dtypes, shapes, and byte sizes are always checked before
+the immutable full artifact is promoted.
+
 ### 1. Publish `v1`
 
 Create `v1` as STAGING, upload the delta shards and index, and then mark it
@@ -401,23 +486,6 @@ if dist.get_rank(group=refit_process_group) == 0:
         )
 ```
 
-The index has this shape; shard names are resolved relative to its parent URI:
-
-```json
-{
-  "metadata": {
-    "version": "v1",
-    "base_version": "v0",
-    "delta_encoding": "xor",
-    "compression_format": "zstd",
-    "checksum_format": "adler32"
-  },
-  "weight_map": {
-    "model.layers.0.example.weight": "model-00000-of-00004.safetensors"
-  }
-}
-```
-
 ### 2. Apply `v1` in vLLM
 
 Run the update while generation is paused. `mode=abort` clears active requests
@@ -452,7 +520,8 @@ finally:
 The next delta must be `v2` with `base_version_id="v1"`. An integration may
 instead create a `FULL_HF_CHECKPOINT` version without `base_version_id`; that
 version becomes the exact base for the following delta. Full checkpoint batches
-carry per-tensor Adler-32 checksums and are retained as an immutable full
-artifact. XOR deltas require `compression_format="zstd"` and are replayed in
-order in the canonical lineage; each preparation applies only the incoming
-delta to its exact active base.
+may carry optional per-tensor checksums under `mx.adler32:<tensor-name>` keys and
+are retained as an immutable full artifact. XOR deltas require the complete
+index metadata contract above and are replayed in order in the canonical
+lineage; each preparation applies only the incoming delta to its exact active
+base.

--- a/docs/S3_DELTA_WEIGHT_REFIT.md
+++ b/docs/S3_DELTA_WEIGHT_REFIT.md
@@ -367,10 +367,10 @@ filenames in `weight_map` are resolved relative to that index.
 }
 ```
 
-The generator requires all five metadata fields and `weight_map`. It uses
-`compression_format` to select the decompressor; the other metadata values
-describe the artifact. ModelExpress currently publishes `xor`, `zstd`, and
-`adler32` for the encoding, compression, and checksum fields.
+The generator requires all five metadata fields and `weight_map`. It requires
+`delta_encoding="xor"` and `checksum_format="adler32"`, and uses
+`compression_format` to select the decompressor. `version` and `base_version`
+describe the artifact.
 
 Each delta shard contains compressed `U8` XOR bytes. Its safetensors
 `__metadata__` must contain the Adler-32 checksum of every reconstructed full

--- a/modelexpress_client/python/README.md
+++ b/modelexpress_client/python/README.md
@@ -147,6 +147,8 @@ Integrations may use `MX_REFIT_DELTA_BUCKET_BYTES` as an explicit override, or
 its 512 MiB default when they have no native setting. CPU workers are configured
 by `MX_REFIT_DELTA_WORKERS` (default `min(32, CPU count)`), while
 `MX_S3_UPLOAD_WORKERS` controls concurrent full-checkpoint batch uploads.
+`MX_REFIT_CHECKSUM_FORMAT` selects the checksum algorithm and defaults to
+`adler32`.
 The framework integration reads the bucket-size setting while constructing the
 stream; ModelExpress processes each supplied bucket without splitting or merging
 it.

--- a/modelexpress_client/python/modelexpress_rl/envs.py
+++ b/modelexpress_client/python/modelexpress_rl/envs.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    MX_REFIT_CHECKSUM_FORMAT: str
     MX_REFIT_DELTA_BUCKET_BYTES: int
     MX_REFIT_DELTA_WORKERS: int
     MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES: int
@@ -50,6 +51,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "MX_WEIGHT_PAYLOAD_FORMAT": lambda: (
         os.environ.get("MX_WEIGHT_PAYLOAD_FORMAT", "FULL_TENSOR").strip().upper()
+    ),
+    "MX_REFIT_CHECKSUM_FORMAT": lambda: (
+        os.environ.get("MX_REFIT_CHECKSUM_FORMAT", "adler32").strip().lower()
     ),
     # Framework integrations read this while constructing ``hf_tensor_iter``;
     # ModelExpress preserves the supplied framework bucket boundaries.

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -9,7 +9,6 @@ import json
 import mmap
 import shutil
 import time
-import zlib
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -30,8 +29,7 @@ from modelexpress_rl.object_storage import ObjectStorageType
 from modelexpress_rl.s3 import S3Client
 from modelexpress_rl.train import WeightPayloadFormat
 from modelexpress_rl.utils import (
-    ADLER32_METADATA_PREFIX,
-    adler32_checksum,
+    checksum_factory,
     index_checkpoint_tensors,
     read_safetensors_header,
     threadpool_map,
@@ -118,66 +116,51 @@ def _is_safe_shard_basename(value: object) -> bool:
     )
 
 
-def _parse_delta_manifest(
+def _parse_index_manifest(
     data: bytes,
-    version: _S3Version,
-) -> tuple[dict[str, str], _Decompressor]:
+    *,
+    is_delta: bool,
+    version: _S3Version | None = None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Parse and validate an index manifest."""
     try:
-        manifest = json.loads(data)
+        index = json.loads(data)
     except (TypeError, ValueError) as error:
-        raise ValueError("canonical delta manifest is not valid JSON") from error
-    try:
-        metadata = manifest["metadata"]
-        weight_map = manifest["weight_map"]
-    except (KeyError, TypeError) as error:
-        raise ValueError(
-            "canonical delta manifest is missing required fields"
-        ) from error
-    if not isinstance(metadata, dict):
-        raise TypeError("canonical delta manifest metadata is invalid")
-    expected_metadata = {
-        "version": version.version_id,
-        "base_version": version.base_version_id,
-        "delta_encoding": "xor",
-        "checksum_format": "adler32",
-    }
-    for name, expected in expected_metadata.items():
-        if metadata.get(name) != expected:
-            raise ValueError(
-                f"canonical delta manifest {name} does not match revision "
-                f"{version.version_id!r}"
-            )
-    compression_format = metadata.get("compression_format")
-    try:
-        decompressor = _DECOMPRESSORS[compression_format]
-    except KeyError as error:
-        raise ValueError(
-            f"unsupported canonical delta compression format {compression_format!r}"
-        ) from error
+        raise ValueError("The index manifest is not valid JSON") from error
+
+    weight_map = index.get("weight_map")
+    if weight_map is None:
+        raise ValueError("The index manifest has no weight_map")
     if not isinstance(weight_map, dict):
-        raise TypeError("canonical delta manifest weight_map is invalid")
+        raise ValueError("The index manifest has invalid weight_map")
+    if not is_delta and not weight_map:
+        raise ValueError("The index manifest has no tensors")
     for name, filename in weight_map.items():
-        if not isinstance(name, str) or not isinstance(filename, str):
-            raise TypeError("canonical delta manifest weight_map must contain strings")
-        if not _is_safe_shard_basename(filename):
-            raise ValueError(f"invalid canonical delta shard filename {filename!r}")
-    return weight_map, decompressor
+        if (
+            not isinstance(name, str)
+            or not _is_safe_shard_basename(filename)
+            or not filename.endswith(".safetensors")
+        ):
+            raise ValueError("The index manifest has invalid weight_map")
 
-
-def _parse_full_checkpoint_manifest(data: bytes) -> dict[str, str]:
-    try:
-        manifest = json.loads(data)
-        weight_map = manifest["weight_map"]
-    except (KeyError, TypeError, ValueError) as error:
-        raise ValueError("full HF checkpoint index is not valid JSON") from error
-    if not isinstance(weight_map, dict) or not weight_map:
-        raise ValueError("full HF checkpoint index has no tensors")
-    for name, filename in weight_map.items():
-        if not isinstance(name, str) or not isinstance(filename, str):
-            raise ValueError("full HF checkpoint weight_map must contain strings")
-        if not _is_safe_shard_basename(filename):
-            raise ValueError(f"invalid full HF checkpoint shard filename {filename!r}")
-    return weight_map
+    metadata = index.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise ValueError("The index manifest has invalid metadata")
+    if is_delta:
+        assert version is not None
+        expected_metadata = {
+            "version": version.version_id,
+            "base_version": version.base_version_id,
+            "delta_encoding": "xor",
+            "checksum_format": "adler32",
+        }
+        for name, expected in expected_metadata.items():
+            if metadata.get(name) != expected:
+                raise ValueError(
+                    f"The index manifest {name} does not match revision "
+                    f"{version.version_id!r}"
+                )
+    return metadata, weight_map
 
 
 def _group_tensors_by_shard(
@@ -215,7 +198,6 @@ class _LocalCheckpoint:
         self.checkpoint_paths: list[Path] = []
         self.locations: dict[str, tuple[Path, int, int]] = {}
         self.tensor_metadata: dict[str, dict] = {}
-        self.decompressor: _Decompressor | None = None
 
     def initialize(self) -> None:
         self.store.initialize()
@@ -351,9 +333,7 @@ class _LocalCheckpoint:
                     },
                 )
             expected_base = active_version
-            manifests: list[
-                tuple[_S3Version, bytes, dict[str, str], _Decompressor | None]
-            ] = []
+            manifests = []
             index_download_time = 0.0
             for position, version in enumerate(versions):
                 if (
@@ -377,20 +357,21 @@ class _LocalCheckpoint:
                 started = time.perf_counter()
                 try:
                     index_data = self.s3.get(version.uri)
-                    if version.payload_format is WeightPayloadFormat.XOR_DELTA:
-                        weight_map, decompressor = _parse_delta_manifest(
-                            index_data, version
-                        )
-                    else:
-                        weight_map = _parse_full_checkpoint_manifest(index_data)
-                        decompressor = None
+                    is_delta = (
+                        version.payload_format is WeightPayloadFormat.XOR_DELTA
+                    )
+                    metadata, weight_map = _parse_index_manifest(
+                        index_data,
+                        is_delta=is_delta,
+                        version=version if is_delta else None,
+                    )
                 except Exception as error:
                     raise RuntimeError(
                         f"target {target.version_id!r}: replay validation failed "
                         f"at revision {version.version_id!r}: {error}"
                     ) from error
                 index_download_time += time.perf_counter() - started
-                manifests.append((version, index_data, weight_map, decompressor))
+                manifests.append((version, index_data, metadata, weight_map))
 
             self.store.write_state(
                 status=CheckpointState.UPDATING,
@@ -401,18 +382,20 @@ class _LocalCheckpoint:
             try:
                 download_time = 0.0
                 apply_time = 0.0
-                for version, index_data, weight_map, decompressor in manifests:
+                for version, index_data, metadata, weight_map in manifests:
                     if version.payload_format is WeightPayloadFormat.XOR_DELTA:
-                        assert decompressor is not None
                         downloaded, applied = self._prepare_delta(
                             version,
                             index_data,
+                            metadata,
                             weight_map,
-                            decompressor,
                         )
                     else:
                         downloaded, applied = self._prepare_full(
-                            version, index_data, weight_map
+                            version,
+                            index_data,
+                            metadata,
+                            weight_map,
                         )
                     download_time += downloaded
                     apply_time += applied
@@ -483,6 +466,7 @@ class _LocalCheckpoint:
         self,
         version: _S3Version,
         index_data: bytes,
+        metadata: dict[str, Any],
         weight_map: dict[str, str],
     ) -> tuple[float, float]:
         target = self.store.full_path(version.version_id)
@@ -522,6 +506,7 @@ class _LocalCheckpoint:
             (temporary / index_name).write_bytes(index_data)
             download_time, validation_time = self._download_full_checkpoint(
                 target=temporary,
+                index_metadata=metadata,
                 weight_map=weight_map,
                 root_uri=version.uri,
                 protected_versions=protected_versions,
@@ -546,8 +531,8 @@ class _LocalCheckpoint:
         self,
         version: _S3Version,
         index_data: bytes,
+        metadata: dict[str, Any],
         weight_map: dict[str, str],
-        decompressor: _Decompressor,
     ) -> tuple[float, float]:
         assert version.base_version_id is not None
         base_chain = self.store.chain(version.base_version_id)
@@ -611,7 +596,7 @@ class _LocalCheckpoint:
             shutil.rmtree(target, ignore_errors=True)
             base_checkpoint.replace(target)
             self._set_local_checkpoint(target)
-            self._apply_delta_artifact(artifact, weight_map, decompressor)
+            self._apply_delta_artifact(artifact, metadata, weight_map)
         else:
             # The first delta after a full checkpoint copies once so applying
             # it cannot modify the canonical full artifact.
@@ -620,7 +605,7 @@ class _LocalCheckpoint:
                 copy_from=base_checkpoint,
             ) as temporary:
                 self._set_local_checkpoint(temporary)
-                self._apply_delta_artifact(artifact, weight_map, decompressor)
+                self._apply_delta_artifact(artifact, metadata, weight_map)
 
         self._set_local_checkpoint(target)
         self.store.write_chain(version.version_id, chain)
@@ -629,11 +614,10 @@ class _LocalCheckpoint:
     def _apply_delta_artifact(
         self,
         artifact: Path,
+        index_metadata: dict[str, Any],
         weight_map: dict[str, str],
-        decompressor: _Decompressor,
     ) -> None:
         self.store.verify_artifact(artifact)
-        self.decompressor = decompressor
         shards = {
             filename: (
                 (artifact / filename).read_bytes(),
@@ -641,7 +625,7 @@ class _LocalCheckpoint:
             )
             for filename, names in _group_tensors_by_shard(weight_map).items()
         }
-        self._apply_shards(shards)
+        self._apply_shards(shards, index_metadata=index_metadata)
 
     def _download_deltas(
         self,
@@ -675,10 +659,12 @@ class _LocalCheckpoint:
         self,
         *,
         target: Path,
+        index_metadata: dict[str, Any],
         weight_map: dict[str, str],
         root_uri: str,
         protected_versions: set[str],
     ) -> tuple[float, float]:
+        checksum_format = index_metadata.get("checksum_format")
         if set(weight_map) != set(self.locations):
             raise ValueError(
                 "full HF checkpoint tensor set differs from local checkpoint"
@@ -745,11 +731,19 @@ class _LocalCheckpoint:
                     count=end - begin,
                     offset=data_start + begin,
                 )
-                checksum = metadata.get(f"{ADLER32_METADATA_PREFIX}{name}")
-                if checksum is not None and adler32_checksum(source) != checksum:
-                    raise ValueError(
-                        f"full HF checkpoint checksum differs for {name!r}"
-                    )
+                if checksum_format is not None:
+                    expected_checksum = metadata.get(name)
+                    if expected_checksum is None:
+                        raise ValueError(
+                            f"full HF checkpoint shard {filename!r} is missing "
+                            f"checksum for tensor {name!r}"
+                        )
+                    checksum = checksum_factory(checksum_format)
+                    checksum.update(source)
+                    if checksum.hexdigest() != expected_checksum:
+                        raise ValueError(
+                            f"full HF checkpoint checksum differs for {name!r}"
+                        )
             (target / filename).write_bytes(data)
             return download_time, time.perf_counter() - validation_started
 
@@ -770,10 +764,11 @@ class _LocalCheckpoint:
     def _apply_shards(
         self,
         shards: dict[str, tuple[bytes, list[str]]],
+        *,
+        index_metadata: dict[str, Any],
     ) -> None:
         if not shards:
             return
-        assert self.decompressor is not None
 
         items = []
         for filename, (data, names) in shards.items():
@@ -825,10 +820,12 @@ class _LocalCheckpoint:
                     count=size,
                     offset=file_offset,
                 )
-                checksum = 1
+                checksum = checksum_factory(index_metadata["checksum_format"])
+                reader = _DECOMPRESSORS[index_metadata["compression_format"]](
+                    compressed
+                )
                 position = 0
                 extra = b""
-                reader = self.decompressor(compressed)
                 try:
                     while position < size:
                         block = reader.read(min(2 << 20, size - position))
@@ -839,7 +836,7 @@ class _LocalCheckpoint:
                         region = target[position:end]
                         try:
                             np.bitwise_xor(region, delta, out=region)
-                            checksum = zlib.adler32(region, checksum)
+                            checksum.update(region)
                         finally:
                             del region
                         position = end
@@ -850,7 +847,7 @@ class _LocalCheckpoint:
                     del target
                 if position != size or extra:
                     raise ValueError(f"canonical delta byte size differs for {name!r}")
-                if f"{checksum:08x}" != expected_checksum:
+                if checksum.hexdigest() != expected_checksum:
                     raise ValueError(f"canonical target checksum differs for {name!r}")
 
             list(

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -30,6 +30,7 @@ from modelexpress_rl.object_storage import ObjectStorageType
 from modelexpress_rl.s3 import S3Client
 from modelexpress_rl.train import WeightPayloadFormat
 from modelexpress_rl.utils import (
+    ADLER32_METADATA_PREFIX,
     adler32_checksum,
     index_checkpoint_tensors,
     read_safetensors_header,
@@ -714,10 +715,10 @@ class _LocalCheckpoint:
             validation_started = time.perf_counter()
             header, data_start = read_safetensors_header(data, repr(filename))
             tensor_names = shard_to_tensors[filename]
-            checksums = header.get("__metadata__")
-            if not isinstance(checksums, dict) or set(checksums) != set(tensor_names):
+            metadata = header.get("__metadata__", {})
+            if not isinstance(metadata, dict):
                 raise ValueError(
-                    f"full HF checkpoint shard {filename!r} has invalid checksums"
+                    f"full HF checkpoint shard {filename!r} has invalid metadata"
                 )
 
             view = memoryview(data)
@@ -744,7 +745,8 @@ class _LocalCheckpoint:
                     count=end - begin,
                     offset=data_start + begin,
                 )
-                if adler32_checksum(source) != checksums[name]:
+                checksum = metadata.get(f"{ADLER32_METADATA_PREFIX}{name}")
+                if checksum is not None and adler32_checksum(source) != checksum:
                     raise ValueError(
                         f"full HF checkpoint checksum differs for {name!r}"
                     )

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -160,6 +160,13 @@ def _parse_index_manifest(
                     f"The index manifest {name} does not match revision "
                     f"{version.version_id!r}"
                 )
+        compression_format = metadata.get("compression_format")
+        if compression_format not in _DECOMPRESSORS:
+            raise ValueError(
+                f"unsupported compression format {compression_format!r}"
+            )
+    elif "checksum_format" in metadata:
+        checksum_factory(metadata["checksum_format"])
     return metadata, weight_map
 
 

--- a/modelexpress_client/python/modelexpress_rl/train/methods/canonical_delta.py
+++ b/modelexpress_client/python/modelexpress_rl/train/methods/canonical_delta.py
@@ -22,8 +22,7 @@ from ... import envs as rl_envs
 from ... import refit_pb2, refit_pb2_grpc
 from ...s3 import S3Client
 from ...utils import (
-    ADLER32_METADATA_PREFIX,
-    adler32_checksum,
+    checksum_factory,
     compress_delta,
     compute_delta,
     threadpool_map,
@@ -103,6 +102,8 @@ class CanonicalDeltaPublicationMethod:
         self._read_seed_tensor = read_seed_tensor
         self._s3 = s3
         self._clock = clock
+        self._checksum_format = rl_envs.MX_REFIT_CHECKSUM_FORMAT
+        checksum_factory(self._checksum_format)
         self.current_base_version_id = config.initial_base_version_id
         self.snapshot: dict[str, np.ndarray | torch.Tensor] = {}
         self._staged: StagedCanonicalDelta | StagedFullCheckpoint | None = None
@@ -171,7 +172,9 @@ class CanonicalDeltaPublicationMethod:
             total_bytes += int(current.nbytes)
             if delta is not None:
                 encoded[name] = compress_delta(delta)
-                checksums[name] = adler32_checksum(current)
+                checksum = checksum_factory(self._checksum_format)
+                checksum.update(current)
+                checksums[name] = checksum.hexdigest()
         return candidate, encoded, checksums, changed_bytes, total_bytes
 
     def stage(
@@ -337,12 +340,11 @@ class CanonicalDeltaPublicationMethod:
             item: tuple[str, dict[str, torch.Tensor]],
         ) -> tuple[dict[str, str], int]:
             filename, tensors = item
-            checksums = {
-                f"{ADLER32_METADATA_PREFIX}{name}": adler32_checksum(
-                    tensor.reshape(-1).view(torch.uint8).numpy()
-                )
-                for name, tensor in tensors.items()
-            }
+            checksums = {}
+            for name, tensor in tensors.items():
+                checksum = checksum_factory(self._checksum_format)
+                checksum.update(tensor.reshape(-1).view(torch.uint8).numpy())
+                checksums[name] = checksum.hexdigest()
             data = safetensors.torch.save(tensors, metadata=checksums)
             self._s3.put(uri=f"{parent_uri}/{filename}", data=data)
             return dict.fromkeys(tensors, filename), len(data)
@@ -380,7 +382,10 @@ class CanonicalDeltaPublicationMethod:
                 weight_map[name] = shard_name
         index = json.dumps(
             {
-                "metadata": {"total_size": total_size},
+                "metadata": {
+                    "total_size": total_size,
+                    "checksum_format": self._checksum_format,
+                },
                 "weight_map": weight_map,
             },
             sort_keys=True,
@@ -459,7 +464,7 @@ class CanonicalDeltaPublicationMethod:
                         "base_version": staged.base_version_id,
                         "delta_encoding": "xor",
                         "compression_format": "zstd",
-                        "checksum_format": "adler32",
+                        "checksum_format": self._checksum_format,
                     },
                     "weight_map": weight_map,
                 },

--- a/modelexpress_client/python/modelexpress_rl/train/methods/canonical_delta.py
+++ b/modelexpress_client/python/modelexpress_rl/train/methods/canonical_delta.py
@@ -21,7 +21,13 @@ import torch.distributed as dist
 from ... import envs as rl_envs
 from ... import refit_pb2, refit_pb2_grpc
 from ...s3 import S3Client
-from ...utils import adler32_checksum, compress_delta, compute_delta, threadpool_map
+from ...utils import (
+    ADLER32_METADATA_PREFIX,
+    adler32_checksum,
+    compress_delta,
+    compute_delta,
+    threadpool_map,
+)
 from ...version import WeightVersionRef
 
 logger = logging.getLogger("modelexpress_rl.train.client")
@@ -332,7 +338,7 @@ class CanonicalDeltaPublicationMethod:
         ) -> tuple[dict[str, str], int]:
             filename, tensors = item
             checksums = {
-                name: adler32_checksum(
+                f"{ADLER32_METADATA_PREFIX}{name}": adler32_checksum(
                     tensor.reshape(-1).view(torch.uint8).numpy()
                 )
                 for name, tensor in tensors.items()

--- a/modelexpress_client/python/modelexpress_rl/utils.py
+++ b/modelexpress_client/python/modelexpress_rl/utils.py
@@ -17,6 +17,8 @@ from typing import TypeVar
 import numpy as np
 
 
+ADLER32_METADATA_PREFIX = "mx.adler32:"
+
 _WorkItem = TypeVar("_WorkItem")
 _WorkResult = TypeVar("_WorkResult")
 
@@ -182,6 +184,7 @@ def index_checkpoint_tensors(
 
 
 __all__ = [
+    "ADLER32_METADATA_PREFIX",
     "adler32_checksum",
     "compress_delta",
     "compute_delta",

--- a/modelexpress_client/python/modelexpress_rl/utils.py
+++ b/modelexpress_client/python/modelexpress_rl/utils.py
@@ -12,15 +12,30 @@ from collections import deque
 from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 
 
-ADLER32_METADATA_PREFIX = "mx.adler32:"
-
 _WorkItem = TypeVar("_WorkItem")
 _WorkResult = TypeVar("_WorkResult")
+
+
+class Adler32Checksum:
+    def __init__(self) -> None:
+        self._value = 1
+
+    def update(self, data: Any) -> None:
+        self._value = zlib.adler32(data, self._value)
+
+    def hexdigest(self) -> str:
+        return f"{self._value:08x}"
+
+
+def checksum_factory(checksum_format: str) -> Adler32Checksum:
+    if checksum_format == "adler32":
+        return Adler32Checksum()
+    raise ValueError(f"unsupported checksum format {checksum_format!r}")
 
 
 def threadpool_map(
@@ -63,11 +78,6 @@ def compress_delta(delta: np.ndarray) -> np.ndarray:
         zstandard.ZstdCompressor(level=1).compress(delta),
         dtype=np.uint8,
     )
-
-
-def adler32_checksum(value: np.ndarray) -> str:
-    """Return the Adler-32 checksum of the given tensor bytes."""
-    return f"{zlib.adler32(value):08x}"
 
 
 def _tied_names(root: Path) -> set[str]:
@@ -184,8 +194,8 @@ def index_checkpoint_tensors(
 
 
 __all__ = [
-    "ADLER32_METADATA_PREFIX",
-    "adler32_checksum",
+    "Adler32Checksum",
+    "checksum_factory",
     "compress_delta",
     "compute_delta",
     "index_checkpoint_tensors",

--- a/modelexpress_client/python/tests/test_refit_envs.py
+++ b/modelexpress_client/python/tests/test_refit_envs.py
@@ -17,6 +17,7 @@ def test_defaults_when_unset(monkeypatch):
     assert envs.MX_REFIT_METADATA_PORT == 7555
     assert envs.MX_TRAINER_STAGING_MODE == "IN_PLACE"
     assert envs.MX_WEIGHT_PAYLOAD_FORMAT == "FULL_TENSOR"
+    assert envs.MX_REFIT_CHECKSUM_FORMAT == "adler32"
     assert envs.MX_REFIT_DELTA_BUCKET_BYTES == 512 * 1024**2
     assert envs.MX_REFIT_DELTA_WORKERS == min(32, os.cpu_count() or 8)
     assert envs.MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES == 4 * 1024**3
@@ -37,6 +38,7 @@ def test_values_are_normalized_and_read_live(monkeypatch):
     monkeypatch.setenv("MX_REFIT_METADATA_PORT", "8000")
     monkeypatch.setenv("MX_TRAINER_STAGING_MODE", " copy_to_device ")
     monkeypatch.setenv("MX_WEIGHT_PAYLOAD_FORMAT", " xor_delta ")
+    monkeypatch.setenv("MX_REFIT_CHECKSUM_FORMAT", " ADLER32 ")
     monkeypatch.setenv("MX_REFIT_DELTA_BUCKET_BYTES", "1024")
     monkeypatch.setenv("MX_REFIT_DELTA_WORKERS", "3")
     monkeypatch.setenv("MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES", "8192")
@@ -55,6 +57,7 @@ def test_values_are_normalized_and_read_live(monkeypatch):
     assert envs.MX_REFIT_METADATA_PORT == 8000
     assert envs.MX_TRAINER_STAGING_MODE == "COPY_TO_DEVICE"
     assert envs.MX_WEIGHT_PAYLOAD_FORMAT == "XOR_DELTA"
+    assert envs.MX_REFIT_CHECKSUM_FORMAT == "adler32"
     assert envs.MX_REFIT_DELTA_BUCKET_BYTES == 1024
     assert envs.MX_REFIT_DELTA_WORKERS == 3
     assert envs.MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES == 8192

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -949,6 +949,36 @@ def test_canonical_s3_reinstalls_active_checkpoint_after_install_failure(
     adapter.close()
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("delta_encoding", "replace"), ("checksum_format", "crc32")],
+)
+def test_canonical_s3_rejects_unsupported_delta_formats(
+    monkeypatch,
+    tmp_path,
+    field,
+    value,
+):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root_uri = "s3://weights/test/v1/model.safetensors.index.json"
+    manifest = json.loads(objects[root_uri])
+    manifest["metadata"][field] = value
+    objects[root_uri] = json.dumps(manifest).encode()
+    adapter, storage = _build(monkeypatch, tmp_path, objects)
+
+    with pytest.raises(RuntimeError, match="unsupported"):
+        adapter.stage_weight(_inputs(objects[root_uri]))
+
+    assert storage.calls == [root_uri]
+    state = adapter._checkpoint.store.state()
+    assert state is not None
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
+    adapter.close()
+
+
 def test_canonical_s3_full_checkpoint_resets_base_for_next_delta(monkeypatch, tmp_path):
     full_tensor = torch.tensor([7.0, 8.0])
     objects = _full_artifact(full_tensor)

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -454,7 +454,7 @@ def _inputs(
 
 def _save_full_tensors(tensors):
     checksums = {
-        name: adler32_checksum(
+        f"mx.adler32:{name}": adler32_checksum(
             tensor.detach()
             .cpu()
             .contiguous()
@@ -1510,23 +1510,80 @@ def test_canonical_s3_streams_scalar_full_tensor(monkeypatch, tmp_path):
     adapter.close()
 
 
-def test_canonical_s3_rejects_corrupt_full_tensor_bytes(monkeypatch, tmp_path):
-    objects = _full_artifact(torch.tensor([7.0, 8.0]))
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        {"format": "pt"},
+        {"format": "pt", "creator": "test", "weight": "trained-v2"},
+    ],
+    ids=["absent", "unrelated", "multiple-with-tensor-name-collision"],
+)
+def test_canonical_s3_accepts_full_checkpoint_without_checksums(
+    monkeypatch,
+    tmp_path,
+    metadata,
+):
+    target = torch.tensor([7.0, 8.0])
+    objects = _full_artifact(target)
     shard_uri = "s3://weights/test/v2/model-00001-of-00001.safetensors"
+    objects[shard_uri] = safetensors.torch.save(
+        {"weight": target},
+        metadata=metadata,
+    )
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+
+    staged = adapter.stage_weight(_full_inputs())
+
+    assert torch.equal(
+        load_file(staged.path / "model-00001-of-00001.safetensors")["weight"],
+        target,
+    )
+    adapter.release_staged_weight(staged)
+    adapter.close()
+
+
+def test_canonical_s3_rejects_corrupt_full_tensor_bytes(monkeypatch, tmp_path):
+    first_tensor = torch.tensor([3.0, 4.0])
+    objects = _full_artifact(first_tensor)
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+    first = adapter.stage_weight(_full_inputs())
+    adapter.apply_weight(first)
+    adapter.release_staged_weight(first)
+
+    target = torch.tensor([7.0, 8.0])
+    objects.update(_full_artifact(target, version_label=3))
+    shard_uri = "s3://weights/test/v3/model-00001-of-00001.safetensors"
+    valid_shard = objects[shard_uri]
     shard = bytearray(objects[shard_uri])
     shard[-1] ^= 1
     objects[shard_uri] = bytes(shard)
-    adapter, _storage = _build(monkeypatch, tmp_path, objects)
 
     with pytest.raises(RuntimeError, match="checksum differs"):
-        adapter.stage_weight(_full_inputs())
+        adapter.stage_weight(_full_inputs(version="full-b", version_label=3))
 
     assert torch.equal(
-        load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")[
-            "weight"
-        ],
-        torch.tensor([1.0, 2.0]),
+        load_file(
+            adapter._checkpoint.local_checkpoint
+            / "model-00001-of-00001.safetensors"
+        )["weight"],
+        first_tensor,
     )
+    state = adapter._checkpoint.store.state()
+    assert state is not None
+    assert state["status"] == "READY"
+    assert state["version"] == "full-a"
+    assert adapter._checkpoint.store.active_version() == "full-a"
+
+    objects[shard_uri] = valid_shard
+    staged = adapter.stage_weight(
+        _full_inputs(version="full-b", version_label=3)
+    )
+    assert torch.equal(
+        load_file(staged.path / "model-00001-of-00001.safetensors")["weight"],
+        target,
+    )
+    adapter.release_staged_weight(staged)
     adapter.close()
 
 
@@ -1579,7 +1636,8 @@ def test_canonical_s3_requires_exact_full_checkpoint_tensor_set(
         for name, tensor in launch_tensors.items()
     )
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "UPDATING"
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
     adapter.close()
 
 
@@ -1621,7 +1679,8 @@ def test_canonical_s3_rejects_incompatible_full_checkpoint_tensor_metadata(
         local_tensor,
     )
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "UPDATING"
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
     adapter.close()
 
 
@@ -1656,10 +1715,14 @@ def test_canonical_s3_rejects_incompatible_full_checkpoint_byte_size(
         ],
         local_tensor,
     )
+    state = adapter._checkpoint.store.state()
+    assert state is not None
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
     adapter.close()
 
 
-def test_canonical_s3_full_download_failure_leaves_checkpoint_updating(
+def test_canonical_s3_full_download_failure_preserves_ready_checkpoint(
     monkeypatch, tmp_path
 ):
     objects = _full_artifact(torch.tensor([7.0, 8.0]))
@@ -1671,7 +1734,7 @@ def test_canonical_s3_full_download_failure_leaves_checkpoint_updating(
         adapter.stage_weight(_full_inputs())
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "UPDATING"
+    assert state["status"] == "READY"
     assert state["version"] == "base-a"
     assert torch.equal(
         load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")["weight"],
@@ -1679,12 +1742,16 @@ def test_canonical_s3_full_download_failure_leaves_checkpoint_updating(
     )
     assert not (adapter._checkpoint.store.full_cache / "full-a.tmp").exists()
 
-    with pytest.raises(RuntimeError, match="update is incomplete"):
-        adapter.stage_weight(_full_inputs())
+    staged = adapter.stage_weight(_full_inputs())
+    assert torch.equal(
+        load_file(staged.path / "model-00001-of-00001.safetensors")["weight"],
+        torch.tensor([7.0, 8.0]),
+    )
+    adapter.release_staged_weight(staged)
     adapter.close()
 
 
-def test_canonical_s3_midstream_failure_leaves_cache_failed_closed(
+def test_canonical_s3_midstream_failure_preserves_active_checkpoint(
     monkeypatch, tmp_path
 ):
     target = {
@@ -1730,14 +1797,15 @@ def test_canonical_s3_midstream_failure_leaves_cache_failed_closed(
         adapter.stage_weight(_full_inputs())
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "UPDATING"
+    assert state["status"] == "READY"
     assert state["version"] == "base-a"
     checkpoint = load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")
     assert torch.equal(checkpoint["a"], torch.tensor([1.0]))
     assert torch.equal(checkpoint["b"], torch.tensor([2.0]))
     assert not (adapter._checkpoint.store.full_cache / "full-a").exists()
-    with pytest.raises(RuntimeError, match="update is incomplete"):
-        adapter.stage_weight(_full_inputs())
+    storage.get = get
+    staged = adapter.stage_weight(_full_inputs())
+    adapter.release_staged_weight(staged)
     adapter.close()
 
 
@@ -1885,10 +1953,14 @@ def test_canonical_s3_rejects_unsupported_compression(monkeypatch, tmp_path):
     objects[key] = json.dumps(manifest).encode()
     adapter, storage = _build(monkeypatch, tmp_path, objects)
 
-    with pytest.raises(RuntimeError, match="unsupported.*compression"):
+    with pytest.raises(KeyError, match="gzip"):
         adapter.stage_weight(_inputs(objects[key]))
 
     assert storage.calls == [key]
+    state = adapter._checkpoint.store.state()
+    assert state is not None
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
 
 
 def test_canonical_s3_rejects_invalid_manifest_json(monkeypatch, tmp_path):
@@ -1899,6 +1971,10 @@ def test_canonical_s3_rejects_invalid_manifest_json(monkeypatch, tmp_path):
         adapter.stage_weight(_inputs(None))
 
     assert storage.calls == [key]
+    state = adapter._checkpoint.store.state()
+    assert state is not None
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
 
 
 def test_canonical_s3_downloads_unique_shards_concurrently(monkeypatch, tmp_path):
@@ -2025,19 +2101,34 @@ def test_reconstructed_checksum_failure_propagates(monkeypatch, tmp_path):
         adapter.stage_weight(_inputs(root))
 
     failed_state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert failed_state["status"] == "UPDATING"
+    assert failed_state["status"] == "READY"
     assert failed_state["version"] == "base-a"
-
-    recovered, _ = _build(monkeypatch, tmp_path, objects)
-    state = json.loads(recovered._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
-    assert state["version"] == "base-a"
     assert torch.equal(
-        load_file(recovered._checkpoint.local_checkpoint / "model.safetensors")[
+        load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")[
             "weight"
         ],
         torch.tensor([1.0, 2.0]),
     )
+
+    objects.update(
+        _artifact(
+            base,
+            target,
+            version="target-b",
+            version_label=2,
+            base_version="base-a",
+        )
+    )
+    staged = adapter.stage_weight(
+        _inputs(
+            None,
+            version="target-b",
+            version_label=2,
+            base_version="base-a",
+        )
+    )
+    adapter.release_staged_weight(staged)
+    adapter.close()
 
 
 @pytest.mark.parametrize(
@@ -2090,7 +2181,7 @@ def test_malformed_delta_shard_reports_context(
 
     assert filename in str(raised.value)
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "UPDATING"
+    assert state["status"] == "READY"
     assert state["version"] == "base-a"
 
 
@@ -2107,7 +2198,7 @@ def test_wrong_base_fails_before_s3_download(monkeypatch, tmp_path):
     assert storage.calls == []
 
 
-def test_child_download_failure_leaves_checkpoint_updating(
+def test_child_download_failure_preserves_ready_checkpoint(
     monkeypatch,
     tmp_path,
 ):
@@ -2123,10 +2214,10 @@ def test_child_download_failure_leaves_checkpoint_updating(
         adapter.stage_weight(_inputs(objects[root_key]))
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "UPDATING"
+    assert state["status"] == "READY"
     assert state["version"] == "base-a"
-    with pytest.raises(RuntimeError, match="update is incomplete"):
-        adapter.stage_weight(_inputs(objects[root_key]))
+    staged = adapter.stage_weight(_inputs(objects[root_key]))
+    adapter.release_staged_weight(staged)
 
 
 def test_corrupt_zstd_fails_before_checkpoint_mutation(monkeypatch, tmp_path):
@@ -2146,7 +2237,7 @@ def test_corrupt_zstd_fails_before_checkpoint_mutation(monkeypatch, tmp_path):
         adapter.stage_weight(_inputs(objects[root_key]))
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "UPDATING"
+    assert state["status"] == "READY"
     assert state["version"] == "base-a"
 
 

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -1278,7 +1278,7 @@ def test_canonical_s3_in_place_delta_failure_requires_recovery(
         )
     )
 
-    def fail_apply(_shards):
+    def fail_apply(_shards, *, index_metadata):
         raise RuntimeError("injected delta failure")
 
     monkeypatch.setattr(adapter._checkpoint, "_apply_shards", fail_apply)

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -32,7 +32,13 @@ from modelexpress_rl.inference.plan import (
     ObjectStorageUpdateSource,
 )
 from modelexpress_rl.s3 import ImmutableS3Conflict, S3Client
-from modelexpress_rl.utils import adler32_checksum, compress_delta, compute_delta
+from modelexpress_rl.utils import checksum_factory, compress_delta, compute_delta
+
+
+def _checksum(value):
+    checksum = checksum_factory("adler32")
+    checksum.update(value)
+    return checksum.hexdigest()
 
 
 class _MemoryS3:
@@ -406,7 +412,7 @@ def _artifact(
     assert delta is not None
     shard = safetensors.numpy.save(
         {"weight": compress_delta(delta)},
-        metadata={"weight": checksum or adler32_checksum(target)},
+        metadata={"weight": checksum or _checksum(target)},
     )
     root = json.dumps(
         {
@@ -454,7 +460,7 @@ def _inputs(
 
 def _save_full_tensors(tensors):
     checksums = {
-        f"mx.adler32:{name}": adler32_checksum(
+        name: _checksum(
             tensor.detach()
             .cpu()
             .contiguous()
@@ -472,7 +478,10 @@ def _full_artifact(tensor, *, version_label=2):
     shard = _save_full_tensors({"weight": tensor})
     root = json.dumps(
         {
-            "metadata": {"total_size": tensor.numel() * tensor.element_size()},
+            "metadata": {
+                "total_size": tensor.numel() * tensor.element_size(),
+                "checksum_format": "adler32",
+            },
             "weight_map": {"weight": shard_name},
         },
         sort_keys=True,
@@ -514,7 +523,7 @@ def test_canonical_s3_rejects_unsafe_delta_shard_filenames(
     objects[root_uri] = json.dumps(manifest).encode()
     adapter, storage = _build(monkeypatch, tmp_path, objects)
 
-    with pytest.raises(RuntimeError, match="invalid canonical delta shard filename"):
+    with pytest.raises(RuntimeError, match="The index manifest has invalid"):
         adapter.stage_weight(_inputs(objects[root_uri]))
 
     assert storage.calls == [root_uri]
@@ -746,13 +755,14 @@ def test_canonical_s3_replays_multiple_deltas_before_one_install(monkeypatch, tm
         )
     )
     parse_calls = []
-    parse_delta_manifest = receiver_module._parse_delta_manifest
+    parse_index_manifest = receiver_module._parse_index_manifest
 
-    def track_parse(data, version):
-        parse_calls.append(version.version_id)
-        return parse_delta_manifest(data, version)
+    def track_parse(data, *, is_delta, version=None):
+        if is_delta:
+            parse_calls.append(version.version_id)
+        return parse_index_manifest(data, is_delta=is_delta, version=version)
 
-    monkeypatch.setattr(receiver_module, "_parse_delta_manifest", track_parse)
+    monkeypatch.setattr(receiver_module, "_parse_index_manifest", track_parse)
     adapter, _ = _build(monkeypatch, tmp_path, objects)
 
     staged = adapter.stage_chain(
@@ -950,10 +960,46 @@ def test_canonical_s3_reinstalls_active_checkpoint_after_install_failure(
 
 
 @pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("version", "version does not match revision"),
+        ("base_version", "base_version does not match revision"),
+        ("delta_encoding", "delta_encoding does not match revision"),
+        ("compression_format", "unsupported compression format"),
+        ("checksum_format", "checksum_format does not match revision"),
+    ],
+)
+def test_canonical_s3_requires_delta_index_metadata_fields(
+    monkeypatch,
+    tmp_path,
+    field,
+    message,
+):
+    base = torch.tensor([1.0, 2.0]).view(torch.uint8).numpy()
+    target = torch.tensor([3.0, 4.0]).view(torch.uint8).numpy()
+    objects = _artifact(base, target)
+    root_uri = "s3://weights/test/v1/model.safetensors.index.json"
+    manifest = json.loads(objects[root_uri])
+    del manifest["metadata"][field]
+    objects[root_uri] = json.dumps(manifest).encode()
+    adapter, storage = _build(monkeypatch, tmp_path, objects)
+
+    with pytest.raises(RuntimeError, match=message):
+        adapter.stage_weight(_inputs(objects[root_uri]))
+
+    assert storage.calls == [root_uri]
+    state = adapter._checkpoint.store.state()
+    assert state is not None
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
+    adapter.close()
+
+
+@pytest.mark.parametrize(
     ("field", "value"),
     [("delta_encoding", "replace"), ("checksum_format", "crc32")],
 )
-def test_canonical_s3_rejects_unsupported_delta_formats(
+def test_canonical_s3_rejects_mismatched_delta_formats(
     monkeypatch,
     tmp_path,
     field,
@@ -968,7 +1014,7 @@ def test_canonical_s3_rejects_unsupported_delta_formats(
     objects[root_uri] = json.dumps(manifest).encode()
     adapter, storage = _build(monkeypatch, tmp_path, objects)
 
-    with pytest.raises(RuntimeError, match="unsupported"):
+    with pytest.raises(RuntimeError, match=rf"{field} does not match revision"):
         adapter.stage_weight(_inputs(objects[root_uri]))
 
     assert storage.calls == [root_uri]
@@ -1144,10 +1190,10 @@ def test_canonical_s3_applies_one_delta_to_the_active_checkpoint(
     apply_calls = 0
     checkpoint_copy_calls = 0
 
-    def track_apply(shards):
+    def track_apply(shards, *, index_metadata):
         nonlocal apply_calls
         apply_calls += 1
-        apply_shards(shards)
+        apply_shards(shards, index_metadata=index_metadata)
 
     @contextmanager
     def track_replace(target, *, copy_from=None):
@@ -1556,6 +1602,10 @@ def test_canonical_s3_accepts_full_checkpoint_without_checksums(
 ):
     target = torch.tensor([7.0, 8.0])
     objects = _full_artifact(target)
+    root_uri = "s3://weights/test/v2/model.safetensors.index.json"
+    index = json.loads(objects[root_uri])
+    del index["metadata"]["checksum_format"]
+    objects[root_uri] = json.dumps(index).encode()
     shard_uri = "s3://weights/test/v2/model-00001-of-00001.safetensors"
     objects[shard_uri] = safetensors.torch.save(
         {"weight": target},
@@ -1573,47 +1623,62 @@ def test_canonical_s3_accepts_full_checkpoint_without_checksums(
     adapter.close()
 
 
-def test_canonical_s3_rejects_corrupt_full_tensor_bytes(monkeypatch, tmp_path):
-    first_tensor = torch.tensor([3.0, 4.0])
-    objects = _full_artifact(first_tensor)
-    adapter, _storage = _build(monkeypatch, tmp_path, objects)
-    first = adapter.stage_weight(_full_inputs())
-    adapter.apply_weight(first)
-    adapter.release_staged_weight(first)
-
+def test_canonical_s3_requires_declared_full_checkpoint_checksums(
+    monkeypatch,
+    tmp_path,
+):
     target = torch.tensor([7.0, 8.0])
-    objects.update(_full_artifact(target, version_label=3))
-    shard_uri = "s3://weights/test/v3/model-00001-of-00001.safetensors"
-    valid_shard = objects[shard_uri]
+    objects = _full_artifact(target)
+    shard_uri = "s3://weights/test/v2/model-00001-of-00001.safetensors"
+    objects[shard_uri] = safetensors.torch.save(
+        {"weight": target},
+        metadata={"format": "pt"},
+    )
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+
+    with pytest.raises(RuntimeError, match="missing checksum for tensor 'weight'"):
+        adapter.stage_weight(_full_inputs())
+
+    adapter.close()
+
+
+@pytest.mark.parametrize("checksum_format", [None, "crc32"])
+def test_canonical_s3_rejects_unsupported_full_checkpoint_checksum_format(
+    monkeypatch,
+    tmp_path,
+    checksum_format,
+):
+    objects = _full_artifact(torch.tensor([7.0, 8.0]))
+    root_uri = "s3://weights/test/v2/model.safetensors.index.json"
+    index = json.loads(objects[root_uri])
+    index["metadata"]["checksum_format"] = checksum_format
+    objects[root_uri] = json.dumps(index).encode()
+    adapter, storage = _build(monkeypatch, tmp_path, objects)
+
+    with pytest.raises(RuntimeError, match="unsupported checksum format"):
+        adapter.stage_weight(_full_inputs())
+
+    assert storage.calls == [root_uri]
+    adapter.close()
+
+
+def test_canonical_s3_rejects_corrupt_full_tensor_bytes(monkeypatch, tmp_path):
+    objects = _full_artifact(torch.tensor([7.0, 8.0]))
+    shard_uri = "s3://weights/test/v2/model-00001-of-00001.safetensors"
     shard = bytearray(objects[shard_uri])
     shard[-1] ^= 1
     objects[shard_uri] = bytes(shard)
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
 
     with pytest.raises(RuntimeError, match="checksum differs"):
-        adapter.stage_weight(_full_inputs(version="full-b", version_label=3))
+        adapter.stage_weight(_full_inputs())
 
     assert torch.equal(
-        load_file(
-            adapter._checkpoint.local_checkpoint
-            / "model-00001-of-00001.safetensors"
-        )["weight"],
-        first_tensor,
+        load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")[
+            "weight"
+        ],
+        torch.tensor([1.0, 2.0]),
     )
-    state = adapter._checkpoint.store.state()
-    assert state is not None
-    assert state["status"] == "READY"
-    assert state["version"] == "full-a"
-    assert adapter._checkpoint.store.active_version() == "full-a"
-
-    objects[shard_uri] = valid_shard
-    staged = adapter.stage_weight(
-        _full_inputs(version="full-b", version_label=3)
-    )
-    assert torch.equal(
-        load_file(staged.path / "model-00001-of-00001.safetensors")["weight"],
-        target,
-    )
-    adapter.release_staged_weight(staged)
     adapter.close()
 
 
@@ -1666,8 +1731,7 @@ def test_canonical_s3_requires_exact_full_checkpoint_tensor_set(
         for name, tensor in launch_tensors.items()
     )
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
-    assert state["version"] == "base-a"
+    assert state["status"] == "UPDATING"
     adapter.close()
 
 
@@ -1709,8 +1773,7 @@ def test_canonical_s3_rejects_incompatible_full_checkpoint_tensor_metadata(
         local_tensor,
     )
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
-    assert state["version"] == "base-a"
+    assert state["status"] == "UPDATING"
     adapter.close()
 
 
@@ -1745,14 +1808,10 @@ def test_canonical_s3_rejects_incompatible_full_checkpoint_byte_size(
         ],
         local_tensor,
     )
-    state = adapter._checkpoint.store.state()
-    assert state is not None
-    assert state["status"] == "READY"
-    assert state["version"] == "base-a"
     adapter.close()
 
 
-def test_canonical_s3_full_download_failure_preserves_ready_checkpoint(
+def test_canonical_s3_full_download_failure_leaves_checkpoint_updating(
     monkeypatch, tmp_path
 ):
     objects = _full_artifact(torch.tensor([7.0, 8.0]))
@@ -1764,7 +1823,7 @@ def test_canonical_s3_full_download_failure_preserves_ready_checkpoint(
         adapter.stage_weight(_full_inputs())
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
+    assert state["status"] == "UPDATING"
     assert state["version"] == "base-a"
     assert torch.equal(
         load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")["weight"],
@@ -1772,16 +1831,12 @@ def test_canonical_s3_full_download_failure_preserves_ready_checkpoint(
     )
     assert not (adapter._checkpoint.store.full_cache / "full-a.tmp").exists()
 
-    staged = adapter.stage_weight(_full_inputs())
-    assert torch.equal(
-        load_file(staged.path / "model-00001-of-00001.safetensors")["weight"],
-        torch.tensor([7.0, 8.0]),
-    )
-    adapter.release_staged_weight(staged)
+    with pytest.raises(RuntimeError, match="update is incomplete"):
+        adapter.stage_weight(_full_inputs())
     adapter.close()
 
 
-def test_canonical_s3_midstream_failure_preserves_active_checkpoint(
+def test_canonical_s3_midstream_failure_leaves_cache_failed_closed(
     monkeypatch, tmp_path
 ):
     target = {
@@ -1827,15 +1882,14 @@ def test_canonical_s3_midstream_failure_preserves_active_checkpoint(
         adapter.stage_weight(_full_inputs())
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
+    assert state["status"] == "UPDATING"
     assert state["version"] == "base-a"
     checkpoint = load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")
     assert torch.equal(checkpoint["a"], torch.tensor([1.0]))
     assert torch.equal(checkpoint["b"], torch.tensor([2.0]))
     assert not (adapter._checkpoint.store.full_cache / "full-a").exists()
-    storage.get = get
-    staged = adapter.stage_weight(_full_inputs())
-    adapter.release_staged_weight(staged)
+    with pytest.raises(RuntimeError, match="update is incomplete"):
+        adapter.stage_weight(_full_inputs())
     adapter.close()
 
 
@@ -1983,7 +2037,7 @@ def test_canonical_s3_rejects_unsupported_compression(monkeypatch, tmp_path):
     objects[key] = json.dumps(manifest).encode()
     adapter, storage = _build(monkeypatch, tmp_path, objects)
 
-    with pytest.raises(KeyError, match="gzip"):
+    with pytest.raises(RuntimeError, match="unsupported compression format 'gzip'"):
         adapter.stage_weight(_inputs(objects[key]))
 
     assert storage.calls == [key]
@@ -2071,7 +2125,7 @@ def test_canonical_s3_applies_delta_tensors_concurrently(monkeypatch, tmp_path):
         delta, _ = compute_delta(current, base[name].view(torch.uint8).numpy())
         assert delta is not None
         encoded[name] = compress_delta(delta)
-        checksums[name] = adler32_checksum(current)
+        checksums[name] = _checksum(current)
     shard = safetensors.numpy.save(encoded, metadata=checksums)
 
     barrier = threading.Barrier(2)
@@ -2111,8 +2165,13 @@ def test_canonical_s3_applies_delta_tensors_concurrently(monkeypatch, tmp_path):
         StreamingDecompressor,
     )
 
-    checkpoint.decompressor = receiver_module._DECOMPRESSORS["zstd"]
-    checkpoint._apply_shards({"delta.safetensors": (shard, list(target))})
+    checkpoint._apply_shards(
+        index_metadata={
+            "compression_format": "zstd",
+            "checksum_format": "adler32",
+        },
+        shards={"delta.safetensors": (shard, list(target))},
+    )
 
     loaded = load_file(checkpoint.local_checkpoint / "model.safetensors")
     assert all(torch.equal(loaded[name], value) for name, value in target.items())
@@ -2131,34 +2190,19 @@ def test_reconstructed_checksum_failure_propagates(monkeypatch, tmp_path):
         adapter.stage_weight(_inputs(root))
 
     failed_state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert failed_state["status"] == "READY"
+    assert failed_state["status"] == "UPDATING"
     assert failed_state["version"] == "base-a"
+
+    recovered, _ = _build(monkeypatch, tmp_path, objects)
+    state = json.loads(recovered._checkpoint.store.state_path.read_text())
+    assert state["status"] == "READY"
+    assert state["version"] == "base-a"
     assert torch.equal(
-        load_file(adapter._checkpoint.local_checkpoint / "model.safetensors")[
+        load_file(recovered._checkpoint.local_checkpoint / "model.safetensors")[
             "weight"
         ],
         torch.tensor([1.0, 2.0]),
     )
-
-    objects.update(
-        _artifact(
-            base,
-            target,
-            version="target-b",
-            version_label=2,
-            base_version="base-a",
-        )
-    )
-    staged = adapter.stage_weight(
-        _inputs(
-            None,
-            version="target-b",
-            version_label=2,
-            base_version="base-a",
-        )
-    )
-    adapter.release_staged_weight(staged)
-    adapter.close()
 
 
 @pytest.mark.parametrize(
@@ -2185,7 +2229,7 @@ def test_malformed_delta_shard_reports_context(
     delta, _ = compute_delta(target, base)
     assert delta is not None
     encoded = compress_delta(delta)
-    checksum = adler32_checksum(target)
+    checksum = _checksum(target)
 
     if case == "missing_metadata":
         objects[shard_key] = safetensors.numpy.save({"weight": encoded})
@@ -2211,7 +2255,7 @@ def test_malformed_delta_shard_reports_context(
 
     assert filename in str(raised.value)
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
+    assert state["status"] == "UPDATING"
     assert state["version"] == "base-a"
 
 
@@ -2228,7 +2272,7 @@ def test_wrong_base_fails_before_s3_download(monkeypatch, tmp_path):
     assert storage.calls == []
 
 
-def test_child_download_failure_preserves_ready_checkpoint(
+def test_child_download_failure_leaves_checkpoint_updating(
     monkeypatch,
     tmp_path,
 ):
@@ -2244,10 +2288,10 @@ def test_child_download_failure_preserves_ready_checkpoint(
         adapter.stage_weight(_inputs(objects[root_key]))
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
+    assert state["status"] == "UPDATING"
     assert state["version"] == "base-a"
-    staged = adapter.stage_weight(_inputs(objects[root_key]))
-    adapter.release_staged_weight(staged)
+    with pytest.raises(RuntimeError, match="update is incomplete"):
+        adapter.stage_weight(_inputs(objects[root_key]))
 
 
 def test_corrupt_zstd_fails_before_checkpoint_mutation(monkeypatch, tmp_path):
@@ -2267,7 +2311,7 @@ def test_corrupt_zstd_fails_before_checkpoint_mutation(monkeypatch, tmp_path):
         adapter.stage_weight(_inputs(objects[root_key]))
 
     state = json.loads(adapter._checkpoint.store.state_path.read_text())
-    assert state["status"] == "READY"
+    assert state["status"] == "UPDATING"
     assert state["version"] == "base-a"
 
 

--- a/modelexpress_client/python/tests/test_refit_trainer_s3.py
+++ b/modelexpress_client/python/tests/test_refit_trainer_s3.py
@@ -439,9 +439,11 @@ def test_s3_full_hf_checkpoint_publishes_native_tensors_and_rebases(
         assert torch.equal(loaded["weight"], expected)
         (header_size,) = struct.unpack("<Q", shard[:8])
         header = json.loads(shard[8 : 8 + header_size])
-        assert header["__metadata__"]["weight"] == (
-            f"{zlib.adler32(expected.view(torch.uint8).numpy()):08x}"
-        )
+        assert header["__metadata__"] == {
+            "mx.adler32:weight": (
+                f"{zlib.adler32(expected.view(torch.uint8).numpy()):08x}"
+            )
+        }
         assert method.current_base_version_id == "target-a"
         assert np.array_equal(
             method.snapshot["weight"],

--- a/modelexpress_client/python/tests/test_refit_trainer_s3.py
+++ b/modelexpress_client/python/tests/test_refit_trainer_s3.py
@@ -203,6 +203,18 @@ def _trainer(
     return trainer, storage
 
 
+def test_s3_rejects_unsupported_checksum_format(
+    monkeypatch,
+    tmp_path,
+    refit_server,
+):
+    _service, server_url = refit_server
+    monkeypatch.setenv("MX_REFIT_CHECKSUM_FORMAT", "crc32")
+
+    with pytest.raises(ValueError, match="unsupported checksum format 'crc32'"):
+        _trainer(monkeypatch, tmp_path, server_url)
+
+
 @pytest.mark.parametrize("code", ["InternalError", "PreconditionFailed"])
 def test_s3_multipart_abort_failure_preserves_upload_outcome(code, caplog):
     data = b"delta"
@@ -429,7 +441,10 @@ def test_s3_full_hf_checkpoint_publishes_native_tensors_and_rebases(
         root_uri = "s3://weights/tests/v1/model.safetensors.index.json"
         index = json.loads(storage.objects[root_uri])
         assert index == {
-            "metadata": {"total_size": expected.numel() * expected.element_size()},
+            "metadata": {
+                "total_size": expected.numel() * expected.element_size(),
+                "checksum_format": "adler32",
+            },
             "weight_map": {"weight": "model-00001-of-00001.safetensors"},
         }
         shard = storage.objects[
@@ -440,7 +455,7 @@ def test_s3_full_hf_checkpoint_publishes_native_tensors_and_rebases(
         (header_size,) = struct.unpack("<Q", shard[:8])
         header = json.loads(shard[8 : 8 + header_size])
         assert header["__metadata__"] == {
-            "mx.adler32:weight": (
+            "weight": (
                 f"{zlib.adler32(expected.view(torch.uint8).numpy()):08x}"
             )
         }


### PR DESCRIPTION
## Summary

1. Full checkpoint weight update during delta refit no longer requires checksum inside `__metadata__`. It is optional and only gets checked when it exists.
2. Added a specifications for our delta index json file formats stored in S3.
3. Small refactor around the delta/full checkpoint index json file parsing.

The PR addresses https://github.com/ai-dynamo/modelexpress/issues/713 part 1. The part 2 is currently addressed by #709.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-tensor Adler-32 checksum support for full checkpoints.
  * Added validation for checkpoint metadata, tensor presence, and corrupted tensor data.

* **Bug Fixes**
  * Failed checkpoint preparation, downloads, validation, and installation now preserve the active checkpoint and support retry.
  * Temporary checkpoints are discarded when preparation fails, preventing incomplete updates from becoming active.

* **Documentation**
  * Updated deployment and refit guides with checkpoint lifecycle, validation, recovery, and artifact metadata details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->