### PR TITLE
ci: install cargo-audit with locked dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
       run: rustc --version
 
     - name: Install cargo-audit
-      run: cargo install cargo-audit
+      run: cargo install cargo-audit --locked
 
     - name: Run security audit
       run: cargo audit


### PR DESCRIPTION
## Summary

- install `cargo-audit` with `--locked`
- avoid resolving newer, incompatible transitive dependencies during CI tool installation

The Security Audit job failed before running the audit because `cargo install cargo-audit` resolved `tinyvec v1.13.0`, which failed to compile. Using the lockfile published with `cargo-audit` keeps its tested dependency versions.

Failed job: https://github.com/ai-dynamo/modelexpress/actions/runs/33823603359/job/100871442263?pr=723

## Verification

- `cargo install cargo-audit --locked --root /tmp/modelexpress-cargo-audit-locked-test`
- successfully installed `cargo-audit v0.22.2` using `tinyvec v1.11.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the consistency of security audit tooling installation in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->