### PR TITLE
fix(crypto): keep ring out of OpenSSL builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ modelexpress-common = { path = "modelexpress_common", version = "0.5.1", default
 modelexpress-client = { path = "modelexpress_client", version = "0.5.1", default-features = false }
 modelexpress-server = { path = "modelexpress_server", version = "0.5.1", default-features = false }
 once_cell = "1.21.3"
-object_store = { version = "0.14.1", default-features = false, features = ["aws-base", "reqwest", "ring"] }
+object_store = { version = "0.14.1", default-features = false, features = ["aws-base", "reqwest"] }
 object-store-reqwest = { package = "reqwest", version = "0.13", default-features = false }
 # Prometheus instrumentation (client_rust). Registration and `get_or_create` are
 # infallible, which is required here: the workspace denies `unwrap_used` and

--- a/modelexpress_common/Cargo.toml
+++ b/modelexpress_common/Cargo.toml
@@ -29,6 +29,7 @@ tls-rustls = [
     "dep:object-store-reqwest",
     "rustls/ring",
     "rustls/std",
+    "object_store/ring",
     "reqwest/rustls-tls",
     "object-store-reqwest/rustls-no-provider",
 ]


### PR DESCRIPTION
## Description
OpenSSL feature builds enabled `ring` through the workspace `object_store` dependency, even when the native-tls backend was selected. This caused the OpenSSL build to include the Rustls crypto backend.

## Changes
- Removed the global `ring` feature from the `object_store` dependency.
- Enabled `object_store/ring` only through the `tls-rustls` feature.
- Kept the OpenSSL path on the native-tls backend.
- Preserved the Rustls backend behavior.

## Testing
- `cargo check --workspace --all-targets --no-default-features --features openssl`
- `cargo check --workspace --all-targets --no-default-features --features tls-rustls`
- Confirmed `ring` is absent from the OpenSSL dependency tree.
- `pre-commit run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rustls-based TLS configuration so required cryptography support is enabled consistently when that TLS option is selected.
  - Preserved existing AWS and HTTP client integrations while avoiding unnecessary cryptography features in other configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->