### PR TITLE
docs(deployment): document sharing one mx server across namespaces

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1111,6 +1111,29 @@ kubectl -n $NAMESPACE apply -f examples/p2p_transfer_k8s/client/vllm/vllm-multi-
 
 See [`../examples/p2p_transfer_k8s/README.md`](../examples/p2p_transfer_k8s/README.md) for the full P2P transfer guide including architecture, prerequisites, and performance expectations.
 
+#### Sharing One Server Across Namespaces
+
+Workers do not have to run in the server's namespace. One server can back workers in several workload namespaces, and every worker that talks to it joins the same P2P source pool — a namespace added later boots over RDMA from the workers already registered with that server instead of reading the weights from storage. Running a separate server per namespace splits the pool instead: each namespace then loads from storage on its first start and shares sources only within itself.
+
+Only the worker's server address changes:
+
+```yaml
+# Worker pods, in any namespace
+env:
+  - name: MX_SERVER_ADDRESS
+    value: "modelexpress-server.modelexpress.svc.cluster.local:8001"
+  - name: MODEL_EXPRESS_URL   # deprecated alias; keep identical during the transition
+    value: "modelexpress-server.modelexpress.svc.cluster.local:8001"
+```
+
+`MX_METADATA_NAMESPACE` is a server setting, not a worker one: it selects the namespace the server writes `ModelMetadata` and `ModelCacheEntry` CRs into, and the client does not read it. The metadata RBAC in [Distributed backend selection](#distributed-backend-selection) is likewise needed only by the server — workers publish and list sources over gRPC and never call the Kubernetes API, and the weight transfer is Pod-to-Pod RDMA. The source pool is scoped by the server a worker connects to and by `SourceIdentity`, not by the worker's own namespace.
+
+Three consequences:
+
+- **Ownership falls back to the reaper.** Kubernetes does not let a Pod own a namespaced object in another namespace, so `ModelMetadata` CRs published by workers outside the server's `MX_METADATA_NAMESPACE` carry no `ownerReference` — the cross-namespace identity behavior described under [Distributed backend selection](#distributed-backend-selection). Rather than disappearing with the Pod, those records go STALE after `MX_HEARTBEAT_TIMEOUT_SECS` (default 90s) and are garbage-collected after `MX_GC_TIMEOUT_SECS` (default 3600s); see [Source Lifecycle](metadata.md#source-lifecycle). Setting `POD_NAME` / `POD_UID` / `POD_NAMESPACE` on such workers is harmless — ignored for ownership, and used if the worker later moves into the server's namespace.
+- **The auth allowlist is per namespace.** Under `enforce`, a shared server needs one allowlist entry per workload namespace — see [ServiceAccount Authentication](#serviceaccount-authentication).
+- **Model files stay per namespace.** PersistentVolumeClaims are namespaced, and the engine reads the model's config and tokenizer from the `--model` path even when every weight arrives over RDMA. That path must still resolve inside the worker's own namespace.
+
 #### K8s-Service-Routed Backend
 
 No `modelexpress-server`, no Redis, no CRDs. Source pods sit behind a Kubernetes Service; clients hit the Service DNS and kube-proxy load-balances. See [`K8S_SERVICE_BACKEND.md`](K8S_SERVICE_BACKEND.md) for when to use this backend and when to prefer the central-coordinator alternatives.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1115,23 +1115,29 @@ See [`../examples/p2p_transfer_k8s/README.md`](../examples/p2p_transfer_k8s/READ
 
 Workers do not have to run in the server's namespace. One server can back workers in several workload namespaces, and every worker that talks to it joins the same P2P source pool — a namespace added later boots over RDMA from the workers already registered with that server instead of reading the weights from storage. Running a separate server per namespace splits the pool instead: each namespace then loads from storage on its first start and shares sources only within itself.
 
-Only the worker's server address changes:
+Only the worker's server address changes. A worker outside the server's namespace has to qualify the Service name with the server's namespace, because the Pod's DNS search path resolves a bare name only within its own namespace:
 
 ```yaml
-# Worker pods, in any namespace
+# Worker pods, in any namespace.
+# <server-service>   the server's Service name — "modelexpress-server" in the
+#                    example manifests, the Helm release's fullname when installed
+#                    from the chart.
+# <server-namespace> the namespace that Service lives in, not the worker's.
 env:
   - name: MX_SERVER_ADDRESS
-    value: "modelexpress-server.modelexpress.svc.cluster.local:8001"
+    value: "<server-service>.<server-namespace>.svc.cluster.local:8001"
   - name: MODEL_EXPRESS_URL   # deprecated alias; keep identical during the transition
-    value: "modelexpress-server.modelexpress.svc.cluster.local:8001"
+    value: "<server-service>.<server-namespace>.svc.cluster.local:8001"
 ```
+
+For a server deployed as `modelexpress-server` in a namespace named `modelexpress`, that is `modelexpress-server.modelexpress.svc.cluster.local:8001`. Workers that do run in the server's namespace can keep the short `modelexpress-server:8001` used by the example manifests.
 
 `MX_METADATA_NAMESPACE` is a server setting, not a worker one: it selects the namespace the server writes `ModelMetadata` and `ModelCacheEntry` CRs into, and the client does not read it. The metadata RBAC in [Distributed backend selection](#distributed-backend-selection) is likewise needed only by the server — workers publish and list sources over gRPC and never call the Kubernetes API, and the weight transfer is Pod-to-Pod RDMA. The source pool is scoped by the server a worker connects to and by `SourceIdentity`, not by the worker's own namespace.
 
 Three consequences:
 
 - **Ownership falls back to the reaper.** Kubernetes does not let a Pod own a namespaced object in another namespace, so `ModelMetadata` CRs published by workers outside the server's `MX_METADATA_NAMESPACE` carry no `ownerReference` — the cross-namespace identity behavior described under [Distributed backend selection](#distributed-backend-selection). Rather than disappearing with the Pod, those records go STALE after `MX_HEARTBEAT_TIMEOUT_SECS` (default 90s) and are garbage-collected after `MX_GC_TIMEOUT_SECS` (default 3600s); see [Source Lifecycle](metadata.md#source-lifecycle). Setting `POD_NAME` / `POD_UID` / `POD_NAMESPACE` on such workers is harmless — ignored for ownership, and used if the worker later moves into the server's namespace.
-- **The auth allowlist is per namespace.** Under `enforce`, a shared server needs one allowlist entry per workload namespace — see [ServiceAccount Authentication](#serviceaccount-authentication).
+- **The auth allowlist is per ServiceAccount.** `MODEL_EXPRESS_SECURITY_ALLOWED_SERVICE_ACCOUNTS` is an exact-match list of `<namespace>:<serviceaccount>`, so under `enforce` a shared server needs one entry per allowed ServiceAccount in each workload namespace — two entries for `vllm:worker` and `vllm:router`, not one for `vllm`. Every workload namespace adds its own entries. See [ServiceAccount Authentication](#serviceaccount-authentication).
 - **Model files stay per namespace.** PersistentVolumeClaims are namespaced, and the engine reads the model's config and tokenizer from the `--model` path even when every weight arrives over RDMA. That path must still resolve inside the worker's own namespace.
 
 #### K8s-Service-Routed Backend


### PR DESCRIPTION
## Problem

One `modelexpress-server` can back workers in several namespaces, and every worker that talks to it joins the same P2P source pool — a namespace added later boots over RDMA instead of reading the weights from storage. [Distributed backend
selection](https://github.com/ai-dynamo/modelexpress/blob/main/docs/DEPLOYMENT.md#distributed-backend-selection) documents the server half (the cross-namespace `ClusterRole`, the owner-reference fallback); the worker-side setup and the shared-pool consequence are absent from `docs/DEPLOYMENT.md`, `docs/metadata.md` and `helm/README.md` alike. `MX_METADATA_NAMESPACE` compounds it by reading backwards — it looks like the worker knob but is server-side only (`modelexpress_common/src/envs.rs:281`, and absent from the client's `environment_variables` allowlist in `modelexpress/envs.py:220`). Only `MX_SERVER_ADDRESS` matters on a worker.

## Fix

Adds a `Sharing One Server Across Namespaces` subsection covering the worker-side setting, what is server-side only, how the pool is scoped, and three consequences: the owner-reference fallback to the reaper, the per-namespace auth allowlist, and the per-namespace model volume.

## Verification

**Measured.** Server `modelexpress-server:0.5.1` (`MX_METADATA_BACKEND=kubernetes`) in`test-a`; vLLM workers with the `modelexpress` 0.5.0 client from `vllm-runtime:1.4.2` (vLLM 0.26.0, NIXL 1.3.1) in `test-b`, set only with `MX_SERVER_ADDRESS=modelexpress-server.test-a:8001` and `--load-format modelexpress`. Both `test-b` workers pulled all 436 tensors / 16.39 GB from a worker in `test-a` with zero disk reads, at 250.3 and 252.0 Gbps (same-namespace restart: 254.1 Gbps). They still needed the model volume mounted — hence the `--model` note. The ledger landed as documented: nothing in `test-b`, 16 CRs in `test-a`, 8 of them without an `ownerReference`.

**From the source.** `mx_source_id` hashes model, parallelism, dtype and revision with no namespace among them (`metadata/source_id.py:56`), and `list_sources` returns every CR in the server's namespace without filtering by publisher (`kubernetes.rs:680`) — so the pool is namespace-agnostic by construction. The missing owner reference is `pod_owner_references` returning `None` on `pod_namespace != metadata_namespace` (`kubernetes.rs:53`). Workers need no metadata RBAC: the client has no Kubernetes dependency at all. The `enforce` allowlist is an exact-match set over `<namespace>:<serviceaccount>` (`auth.rs:85`) 

## A note on intent

If sharing one server across namespaces is deliberately left undocumented, say so and I will close this — corrections to individual claims equally welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added deployment guidance for sharing a ModelExpress server across worker namespaces.
  - Documented cross-namespace server addressing, shared source-pool behavior, and server-only metadata configuration.
  - Added Kubernetes RBAC and cleanup guidance for cross-namespace ownership limitations.
  - Clarified per-namespace authentication allowlists and namespace-local model-file requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->