### PR TITLE
docs: disable InstantTensor for object-store streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ vLLM 0.23.0 recognizes the load format natively; the ModelExpress Python package
 
 ### ModelStreamer on Kubernetes
 
-Set `MX_MODEL_URI` to an `s3://`, `gs://`, or `az://` URI or an absolute local path. For tensor-parallel deployments, participating ranks divide remote reads via `MX_MS_DISTRIBUTED` (on by default; set to `0` to disable); TP=1 ignores the setting. [ModelStreamer examples](examples/model_streamer_k8s/README.md) · [vLLM recipes](examples/model_streamer_k8s/client/vllm/README.md).
+Set `MX_MODEL_URI` to an `s3://`, `gs://`, or `az://` URI or an absolute local path. For vLLM object-storage URIs, also set `MX_INSTANT_TENSOR=0` so the earlier InstantTensor strategy does not treat ModelStreamer's partially materialized local cache as a complete checkpoint. For tensor-parallel deployments, participating ranks divide remote reads via `MX_MS_DISTRIBUTED` (on by default; set to `0` to disable); TP=1 ignores the setting. [ModelStreamer examples](examples/model_streamer_k8s/README.md) · [vLLM recipes](examples/model_streamer_k8s/client/vllm/README.md).
 
 ### Docker
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -118,7 +118,7 @@ An eligible strategy can still fail and allow the next strategy to run. If a str
 | MX_P2P_METADATA | 1 | Enables on-demand P2P metadata exchange; set 0 for full metadata through a central coordinator |
 | MX_MODEL_URI | unset | Enables ModelStreamer for s3://, gs://, az://, or absolute local paths |
 | MX_MS_DISTRIBUTED | 1 | Distributes ModelStreamer reads across CUDA TP ranks when TP > 1 |
-| MX_INSTANT_TENSOR | 1 | Enables the InstantTensor eligibility gate |
+| MX_INSTANT_TENSOR | 1 | Enables the InstantTensor eligibility gate; set to `0` for vLLM ModelStreamer object-storage URIs |
 | MX_DISABLE_PATCHES | false | Disables ModelExpress runtime compatibility patches |
 | MODEL_EXPRESS_LOG_LEVEL | runtime-dependent | Use DEBUG to inspect Eligible loaders and Trying strategy |
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1016,6 +1016,8 @@ InstantTensor loads the model's own safetensors directly onto CUDA using distrib
 
 The strategy is enabled by default. The `instanttensor` package is a core dependency on Linux (installed automatically alongside `runai-model-streamer`), so no extra install step is needed. The strategy activates on a CUDA device **when the engine adapter implements the InstantTensor capability**. Currently only the vLLM adapter implements it; on engines that do not (for example SGLang today), the strategy falls through even when `instanttensor` and a CUDA device are available. If the package is unavailable (for example on a non-Linux platform) the chain simply skips to the next strategy.
 
+For vLLM deployments that set `MX_MODEL_URI` to an object-storage URI, set `MX_INSTANT_TENSOR=0`. InstantTensor precedes ModelStreamer in the strategy chain and expects a complete local checkpoint. A ModelStreamer cache may contain the safetensors index before every referenced shard is materialized locally, causing InstantTensor to fail after weight loading has begun and forcing a model reinitialization before ModelStreamer can run. Keep InstantTensor enabled for complete local checkpoints, including weights synchronized to local disk by an init container.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MX_INSTANT_TENSOR` | `1` | Enable the InstantTensor strategy. Set to `0` to disable it and fall through to ModelStreamer/GDS/native loading after any eligible server-cache path. |
@@ -1028,11 +1030,14 @@ ModelStreamer reads safetensor ranges concurrently through a bounded CPU staging
 
 All storage backends (S3, GCS, Azure) are included as core dependencies — no extra install step needed. The strategy activates when `MX_MODEL_URI` is set. See [`../examples/model_streamer_k8s/`](../examples/model_streamer_k8s/) for Kubernetes examples, including the Azure Blob recipe.
 
+For vLLM with an object-storage URI, explicitly set `MX_INSTANT_TENSOR=0` to select ModelStreamer without first probing its partially materialized cache through InstantTensor. This is not required for SGLang, whose adapter does not currently implement the InstantTensor strategy.
+
 **General configuration:**
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MX_MODEL_URI` | (none) | Model location. Must be set to enable ModelStreamer. Accepts a remote URI (`s3://bucket/model`, `gs://...`, `az://...`) or absolute local path (`/models/deepseek-ai/DeepSeek-V4-Pro`). |
+| `MX_INSTANT_TENSOR` | `1` | For vLLM object-storage URIs, set to `0` so ModelStreamer runs after the P2P and server-cache strategies. |
 | `MX_MS_DISTRIBUTED` | `1` | Divide ModelStreamer reads across tensor-parallel ranks and share the results instead of having every rank read the full checkpoint. Requires tensor parallelism > 1 and a CUDA-capable platform; a no-op at TP1. On by default. Set to `0` to disable. |
 | `RUNAI_STREAMER_CONCURRENCY` | `8` | Number of concurrent read threads |
 | `RUNAI_STREAMER_MEMORY_LIMIT` | (none) | CPU staging buffer size in bytes. `0` reuses a single-tensor buffer (most memory efficient). See [runai-model-streamer docs](https://github.com/run-ai/runai-model-streamer). |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -61,6 +61,8 @@ P2P transfers weight tensors, not the whole model repository. Targets still need
 
 Verify `MX_MODEL_URI` and storage access from inside the runtime container. The prefix must contain the expected safetensors and index/configuration files. Direct ModelStreamer does not use the ModelExpress server.
 
+For vLLM object-storage URIs, set `MX_INSTANT_TENSOR=0`. If logs show InstantTensor reporting weight files referenced by the safetensors index as missing, it has inspected ModelStreamer's partially materialized local cache before ModelStreamer ran. Disabling InstantTensor avoids the failed partial load and subsequent model reinitialization. Complete checkpoints synchronized to local disk can continue to use InstantTensor.
+
 For SGLang, keep the model identity in `--model-path` and the object URI in `MX_MODEL_URI`. Passing the object URI as `--model-path` selects SGLang's native loader. Use the checked-in [vLLM](../examples/model_streamer_k8s/client/vllm/README.md) or [SGLang](../examples/model_streamer_k8s/client/sglang/README.md) examples as the baseline.
 
 ## Kubernetes rollout

--- a/examples/model_streamer_k8s/README.md
+++ b/examples/model_streamer_k8s/README.md
@@ -32,6 +32,7 @@ The vLLM manifests use:
 - `--load-format modelexpress`
 - `VLLM_PLUGINS=modelexpress`
 - `MX_MODEL_URI` as the model path passed to vLLM
+- `MX_INSTANT_TENSOR=0` for object-storage URIs, preventing InstantTensor from probing ModelStreamer's partially materialized local cache
 
 Distributed streaming is on by default. To disable it for a tensor parallel
 deployment with TP > 1, set the container's `MX_MS_DISTRIBUTED` env var to `0`

--- a/examples/model_streamer_k8s/client/vllm/README.md
+++ b/examples/model_streamer_k8s/client/vllm/README.md
@@ -102,6 +102,7 @@ Edit [`vllm-single-node-streamer-azure.yaml`](vllm-single-node-streamer-azure.ya
 - Set the `image` to a vLLM image that includes ModelExpress and vLLM `0.18.0` or newer.
 - Set `MODEL_NAME` to the Hugging Face model ID.
 - Set `MX_MODEL_URI` to the `az://<container>/<model-prefix>` URI.
+- Keep `MX_INSTANT_TENSOR=0` so InstantTensor does not inspect ModelStreamer's partially materialized local cache before ModelStreamer runs.
 - Set `--tensor-parallel-size` and GPU requests to match the target model and node shape.
 - Keep `VLLM_PLUGINS=modelexpress`.
 - Keep `MX_MS_DISTRIBUTED=1` for tensor-parallel deployments with TP > 1. It is ignored for TP1.
@@ -149,6 +150,7 @@ kubectl exec deployment/mx-vllm-azure -c vllm -- curl -s http://localhost:8000/v
 
 - Use `az://<container>/<model-prefix>` for `MX_MODEL_URI`; do not use an HTTPS blob URL.
 - Use vLLM `0.18.0` or newer for Azure Blob ModelStreamer support.
+- Keep `MX_INSTANT_TENSOR=0` for object-storage URIs. A missing-shard warning from InstantTensor means it inspected ModelStreamer's local cache before all referenced shards were materialized.
 - If the pod cannot list or read blobs, verify the pod identity has `Storage Blob Data Reader` and that `AZURE_STORAGE_ACCOUNT_NAME` is set.
 - If the upload command fails with missing permissions, the uploader identity needs `Storage Blob Data Contributor`.
 - For TP > 1, keep `MX_MS_DISTRIBUTED=1` so ModelExpress passes distributed streaming to vLLM's native RunAI ModelStreamer loader.

--- a/examples/model_streamer_k8s/client/vllm/vllm-single-node-streamer-azure.yaml
+++ b/examples/model_streamer_k8s/client/vllm/vllm-single-node-streamer-azure.yaml
@@ -73,6 +73,10 @@ spec:
             # Azure Blob path format: az://<container>/<model-prefix>
             - name: MX_MODEL_URI
               value: "az://models/models/deepseek-ai/DeepSeek-V3"
+            # InstantTensor expects a complete local checkpoint; disable it for
+            # object-storage ModelStreamer caches that materialize shards lazily.
+            - name: MX_INSTANT_TENSOR
+              value: "0"
             - name: VLLM_PLUGINS
               value: "modelexpress"
             - name: MX_MS_DISTRIBUTED

--- a/examples/model_streamer_k8s/client/vllm/vllm-single-node-streamer-s3.yaml
+++ b/examples/model_streamer_k8s/client/vllm/vllm-single-node-streamer-s3.yaml
@@ -67,6 +67,10 @@ spec:
             # S3 path format: s3://<bucket>/<model-prefix>
             - name: MX_MODEL_URI
               value: "s3://my-bucket/deepseek-ai/DeepSeek-V3"
+            # InstantTensor expects a complete local checkpoint; disable it for
+            # object-storage ModelStreamer caches that materialize shards lazily.
+            - name: MX_INSTANT_TENSOR
+              value: "0"
             - name: AWS_DEFAULT_REGION
               value: "us-west-2"
             - name: VLLM_PLUGINS


### PR DESCRIPTION
## Summary

- document `MX_INSTANT_TENSOR=0` for vLLM ModelStreamer deployments backed by S3, GCS, or Azure
- explain that InstantTensor expects a complete local checkpoint and can otherwise probe a partially materialized ModelStreamer cache before the streaming strategy runs
- keep InstantTensor recommended for complete local checkpoints, including init-container-synchronized weights
- update the checked-in vLLM S3 and Azure manifests with the safe setting

## Context

InstantTensor intentionally precedes ModelStreamer in the loading strategy chain. When a RunAI ModelStreamer cache contains a safetensors index but not every referenced shard, InstantTensor can begin applying weights and then fail on a missing shard. The resulting model reinitialization can prevent torch.compile artifacts from being reused by a P2P target.

We intentionally keep this as explicit deployment configuration rather than inferring eligibility from whether `MX_MODEL_URI` is set: that variable may also identify a complete local model or another environment where InstantTensor is appropriate.

## Validation

- `pre-commit run` (all hooks passed, including YAML validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to set `MX_INSTANT_TENSOR=0` when using vLLM with ModelStreamer object-storage URIs.
  * Clarified that this prevents incomplete, partially materialized local caches from being treated as complete checkpoints.
  * Updated deployment and troubleshooting instructions for Azure Blob and S3-backed ModelStreamer configurations.
  * Updated Kubernetes examples and manifests with the required setting for lazy checkpoint materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->