### PR TITLE
feat(refit): reuse manifest metadata

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -492,6 +492,15 @@ and leases, but it does not discover engine tensor layouts or transfer weights.
 For NIXL, `RefitWorkerService` is the trainer-local manifest endpoint.
 The manifest is an opaque description of the exact published source buffers;
 the generator uses it to compile and validate its receiver-local transfer plan.
+Full-tensor trainers reuse manifest bytes while registrations, addresses, and
+tensor geometry remain stable and content digests are disabled. Generators
+cache each selected worker manifest by endpoint and digest. A changed endpoint,
+registration metadata,
+address, dtype, shape, or sharding changes the structural fingerprint and
+rebuilds the transfer plan. Content-only digest changes refresh verification
+metadata without rebuilding that plan. Releasing a trainer shard evicts its
+worker-local version entry only after the central service accepts the deletion;
+the service rejects deletion while a version lease is active.
 For S3, `WeightVersion.object_storage` identifies the storage type and global
 `model.safetensors.index.json` URI directly; the server validates only this
 typed location and does not contact S3.

--- a/modelexpress_client/python/modelexpress/refit/__init__.py
+++ b/modelexpress_client/python/modelexpress/refit/__init__.py
@@ -8,8 +8,11 @@ from .timing import (
     REFIT_TIMING_STAGES,
     RefitTimingRecorder,
     add_refit_bytes,
+    add_refit_duration,
+    add_refit_metadata,
     current_refit_timing,
     refit_span,
+    set_refit_cold,
     use_refit_timing,
 )
 
@@ -18,7 +21,10 @@ __all__ = [
     "REFIT_TIMING_STAGES",
     "RefitTimingRecorder",
     "add_refit_bytes",
+    "add_refit_duration",
+    "add_refit_metadata",
     "current_refit_timing",
     "refit_span",
+    "set_refit_cold",
     "use_refit_timing",
 ]

--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -117,6 +117,12 @@ def _encode_shard(shard) -> dict:
 
 
 def _encode_tensor_entries(tensors: list) -> list[dict]:
+    """Encode published tensors, shared by the shard table and the blob wrapper.
+
+    The wrapper used to build the shard table and immediately parse it back to
+    reach these entries, paying a serialize and a parse of the whole table to
+    get at a value it could construct directly.
+    """
     return [
         {
             "name": tensor.name,
@@ -313,10 +319,29 @@ def wrap_rendezvous_blob(
 
 
 def structural_manifest_digest(blob: bytes) -> str:
-    """Hash transfer structure while excluding version-specific content digests."""
+    """Hash transfer structure while excluding version-specific content digests.
+
+    Falls back to hashing the raw bytes for anything this cannot read as a
+    rendezvous payload, and says so, because the fallback is not equivalent: a
+    raw-byte digest moves with the per-shard content digests, so every version
+    looks structurally different and plan reuse turns itself off. That is a
+    safe direction to fail in -- a replan is correct, just slower -- but it is
+    not one to fail in quietly, since the symptom is a warm refit that stays as
+    expensive as a cold one for no visible reason.
+    """
     try:
         payload = json.loads(blob.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
+        logger.warning(
+            "rendezvous manifest is not a decodable JSON blob; falling back to a "
+            "content-sensitive digest, which disables transfer-plan reuse"
+        )
+        return hashlib.sha256(blob).hexdigest()
+    if not isinstance(payload, dict):
+        logger.warning(
+            "rendezvous manifest did not decode to an object; falling back to a "
+            "content-sensitive digest, which disables transfer-plan reuse"
+        )
         return hashlib.sha256(blob).hexdigest()
     payload.pop("publisher_step", None)
     for tensor in payload.get("tensors", ()):

--- a/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
+++ b/modelexpress_client/python/modelexpress/refit/reshard/rendezvous.py
@@ -34,6 +34,7 @@ copy is byte-for-byte, so source and dest dtypes must agree).
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import time
@@ -115,21 +116,22 @@ def _encode_shard(shard) -> dict:
     return encoded
 
 
+def _encode_tensor_entries(tensors: list) -> list[dict]:
+    return [
+        {
+            "name": tensor.name,
+            "dtype": tensor.dtype,
+            "elsize": tensor.elsize,
+            "full_shape": list(tensor.full_shape),
+            "shards": [_encode_shard(shard) for shard in tensor.shards],
+        }
+        for tensor in tensors
+    ]
+
+
 def encode_shard_table(tensors: list) -> bytes:
     """Serialize published tensors + shards to a JSON blob."""
-    payload = {
-        "schema": _SCHEMA,
-        "tensors": [
-            {
-                "name": t.name,
-                "dtype": t.dtype,
-                "elsize": t.elsize,
-                "full_shape": list(t.full_shape),
-                "shards": [_encode_shard(s) for s in t.shards],
-            }
-            for t in tensors
-        ],
-    }
+    payload = {"schema": _SCHEMA, "tensors": _encode_tensor_entries(tensors)}
     return json.dumps(payload).encode("utf-8")
 
 
@@ -303,11 +305,25 @@ def wrap_rendezvous_blob(
         "agent_name": agent_name,
         "metadata_endpoint": metadata_endpoint,
         "agent_meta_b64": base64.b64encode(agent_metadata).decode("ascii"),
-        "tensors": json.loads(encode_shard_table(tensors).decode("utf-8"))["tensors"],
+        "tensors": _encode_tensor_entries(tensors),
     }
     if publisher_step is not None:
         payload["publisher_step"] = int(publisher_step)
     return json.dumps(payload).encode("utf-8")
+
+
+def structural_manifest_digest(blob: bytes) -> str:
+    """Hash transfer structure while excluding version-specific content digests."""
+    try:
+        payload = json.loads(blob.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return hashlib.sha256(blob).hexdigest()
+    payload.pop("publisher_step", None)
+    for tensor in payload.get("tensors", ()):
+        for shard in tensor.get("shards", ()):
+            shard.pop("digest", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 class RendezvousPayload(NamedTuple):

--- a/modelexpress_client/python/modelexpress/refit/timing.py
+++ b/modelexpress_client/python/modelexpress/refit/timing.py
@@ -17,9 +17,9 @@ import logging
 import os
 import sys
 import time
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import Any, Callable, Iterator
-
+from typing import Any
 
 MX_REFIT_TIMING_PREFIX = "MX_REFIT_TIMING"
 REFIT_TIMING_STAGES = (
@@ -35,7 +35,7 @@ REFIT_TIMING_STAGES = (
     "rollout_readiness",
 )
 _STAGE_SET = frozenset(REFIT_TIMING_STAGES)
-_current_recorder: contextvars.ContextVar["RefitTimingRecorder | None"] = (
+_current_recorder: contextvars.ContextVar[RefitTimingRecorder | None] = (
     contextvars.ContextVar("mx_refit_timing_recorder", default=None)
 )
 
@@ -115,6 +115,7 @@ class RefitTimingRecorder:
         *,
         status: str = "ok",
         metadata: dict[str, Any] | None = None,
+        accumulate_metadata: bool = False,
     ) -> None:
         """Add an externally measured duration to a normalized stage."""
         self._validate_stage(stage)
@@ -126,7 +127,15 @@ class RefitTimingRecorder:
         if status not in item.statuses:
             item.statuses.append(status)
         if metadata:
-            item.metadata.update(metadata)
+            for name, value in metadata.items():
+                if (
+                    accumulate_metadata
+                    and isinstance(value, (int, float))
+                    and isinstance(item.metadata.get(name, 0), (int, float))
+                ):
+                    item.metadata[name] = item.metadata.get(name, 0) + value
+                else:
+                    item.metadata[name] = value
 
     def mark_not_applicable(
         self,
@@ -220,15 +229,13 @@ class RefitTimingRecorder:
             return self._emitted_payload
         self.finish()
         payload = self.as_dict()
-        line = "%s %s" % (
-            MX_REFIT_TIMING_PREFIX,
-            json.dumps(
-                payload,
-                separators=(",", ":"),
-                sort_keys=False,
-                default=str,
-            ),
+        encoded = json.dumps(
+            payload,
+            separators=(",", ":"),
+            sort_keys=False,
+            default=str,
         )
+        line = f"{MX_REFIT_TIMING_PREFIX} {encoded}"
         logger.info("%s", line)
         if os.environ.get("MX_REFIT_TIMING_STDOUT", "0") != "0":
             print(line, flush=True, file=sys.stdout)

--- a/modelexpress_client/python/modelexpress/refit/timing.py
+++ b/modelexpress_client/python/modelexpress/refit/timing.py
@@ -86,27 +86,45 @@ class RefitTimingRecorder:
         *,
         status: str = "ok",
         metadata: dict[str, Any] | None = None,
-    ) -> Iterator[None]:
-        """Measure a stage; failed spans are retained and re-raised."""
+        accumulate_metadata: bool = False,
+        duration_key: str | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Measure a stage; failed spans are retained and re-raised.
+
+        Yields a dict for counters only knowable once the work has run -- a
+        shard count, a cache outcome, a byte total. Without it a caller with
+        something to report on exit has to time the region by hand instead,
+        which is how a span turns into a pair of clock reads.
+
+        ``duration_key`` also files the measured duration under that metadata
+        name. Several spans usually share one normalized stage, and the stage
+        total cannot say which of them was expensive; naming them is what
+        separates a slow fetch from a slow hash inside the same stage.
+        """
         self._validate_stage(stage)
+        discovered: dict[str, Any] = {}
         started = self._clock()
-        try:
-            yield
-        except BaseException:
+
+        def record(final_status: str) -> None:
+            elapsed = self._clock() - started
+            extra = {**(metadata or {}), **discovered}
+            if duration_key is not None:
+                extra[duration_key] = elapsed
             self.add_duration(
                 stage,
-                self._clock() - started,
-                status="error",
-                metadata=metadata,
+                elapsed,
+                status=final_status,
+                metadata=extra,
+                accumulate_metadata=accumulate_metadata,
             )
+
+        try:
+            yield discovered
+        except BaseException:
+            record("error")
             raise
         else:
-            self.add_duration(
-                stage,
-                self._clock() - started,
-                status=status,
-                metadata=metadata,
-            )
+            record(status)
 
     def add_duration(
         self,
@@ -136,6 +154,32 @@ class RefitTimingRecorder:
                     item.metadata[name] = item.metadata.get(name, 0) + value
                 else:
                     item.metadata[name] = value
+
+    def add_metadata(
+        self,
+        stage: str,
+        metadata: dict[str, Any],
+        *,
+        accumulate: bool = False,
+    ) -> None:
+        """Attach facts to a stage without claiming to have measured anything.
+
+        For sizes, counts and cache outcomes that describe a stage but have no
+        duration of their own. Passing them through :meth:`add_duration` with a
+        zero would work and would also add a span, leaving the stage looking
+        like it ran more times than it did.
+        """
+        self._validate_stage(stage)
+        item = self._stages[stage]
+        for name, value in metadata.items():
+            if (
+                accumulate
+                and isinstance(value, (int, float))
+                and isinstance(item.metadata.get(name, 0), (int, float))
+            ):
+                item.metadata[name] = item.metadata.get(name, 0) + value
+            else:
+                item.metadata[name] = value
 
     def mark_not_applicable(
         self,
@@ -272,14 +316,69 @@ def refit_span(
     *,
     status: str = "ok",
     metadata: dict[str, Any] | None = None,
-) -> Iterator[None]:
-    """Record a span when a cycle is active; otherwise act as a no-op."""
+    accumulate_metadata: bool = False,
+    duration_key: str | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Record a span when a cycle is active; otherwise act as a no-op.
+
+    The first choice for work the calling function owns and performs itself.
+    Reach for :func:`add_refit_duration` only when the duration was produced
+    somewhere else.
+    """
     recorder = current_refit_timing()
     if recorder is None:
-        yield
+        yield {}
         return
-    with recorder.span(stage, status=status, metadata=metadata):
-        yield
+    with recorder.span(
+        stage,
+        status=status,
+        metadata=metadata,
+        accumulate_metadata=accumulate_metadata,
+        duration_key=duration_key,
+    ) as discovered:
+        yield discovered
+
+
+def add_refit_duration(
+    stage: str,
+    seconds: float,
+    *,
+    status: str = "ok",
+    metadata: dict[str, Any] | None = None,
+    accumulate_metadata: bool = False,
+) -> None:
+    """Attribute an already-measured duration to a normalized stage.
+
+    For durations another layer produced, where the work cannot be wrapped in
+    a span from here: a transport that times its own wire read and hands the
+    number back, or a figure a legacy metric already reports. Work the calling
+    function performs itself belongs in :func:`refit_span`, which cannot
+    disagree with the clock about what it covered.
+
+    Negative values are clamped rather than rejected, since these arrive from
+    a clock this function did not read.
+    """
+    recorder = current_refit_timing()
+    if recorder is not None:
+        recorder.add_duration(
+            stage,
+            max(0.0, float(seconds)),
+            status=status,
+            metadata=metadata,
+            accumulate_metadata=accumulate_metadata,
+        )
+
+
+def add_refit_metadata(
+    stage: str,
+    metadata: dict[str, Any],
+    *,
+    accumulate: bool = False,
+) -> None:
+    """Attach facts to a stage without claiming to have measured anything."""
+    recorder = current_refit_timing()
+    if recorder is not None:
+        recorder.add_metadata(stage, metadata, accumulate=accumulate)
 
 
 def add_refit_bytes(count: int) -> None:
@@ -288,12 +387,26 @@ def add_refit_bytes(count: int) -> None:
         recorder.add_bytes(count)
 
 
+def set_refit_cold(cold: bool) -> None:
+    """Mark whether this cycle built its transfer plan or reused one.
+
+    The distinction dominates ``transfer_planning``: a reused plan makes it
+    almost free, so a mean over both is a number that describes neither.
+    """
+    recorder = current_refit_timing()
+    if recorder is not None:
+        recorder.set_cold(cold)
+
+
 __all__ = [
     "MX_REFIT_TIMING_PREFIX",
     "REFIT_TIMING_STAGES",
     "RefitTimingRecorder",
     "add_refit_bytes",
+    "add_refit_duration",
+    "add_refit_metadata",
     "current_refit_timing",
     "refit_span",
+    "set_refit_cold",
     "use_refit_timing",
 ]

--- a/modelexpress_client/python/modelexpress_rl/envs.py
+++ b/modelexpress_client/python/modelexpress_rl/envs.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     MX_REFIT_DELTA_WORKERS: int
     MX_REFIT_FULL_CHECKPOINT_BATCH_BYTES: int
     MX_REFIT_METADATA_PORT: int
+    MX_REFIT_TIMING: bool
     MX_S3_DOWNLOAD_RANGE_BYTES: int
     MX_S3_DOWNLOAD_RANGE_THRESHOLD_BYTES: int
     MX_S3_DOWNLOAD_IO_CHUNK_BYTES: int
@@ -135,6 +136,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MX_S3_TCP_KEEPALIVE": lambda: parse_bool(
         os.environ.get("MX_S3_TCP_KEEPALIVE", "true"),
         "MX_S3_TCP_KEEPALIVE",
+    ),
+    # One normalized timing record per generator refit. On by default: the
+    # durations are already being measured on the staging path, so recording
+    # them costs a few perf_counter calls and one log line, against a refit
+    # measured in seconds. Off is for callers that drive their own recorder and
+    # do not want a second one nested inside it.
+    "MX_REFIT_TIMING": lambda: parse_bool(
+        os.environ.get("MX_REFIT_TIMING", "true"),
+        "MX_REFIT_TIMING",
     ),
     "RANK": lambda: os.environ.get("RANK"),
 }

--- a/modelexpress_client/python/modelexpress_rl/inference/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/adapter.py
@@ -22,6 +22,7 @@ class NixlGeneratorSource:
 
     manifest_endpoint: str
     manifest: bytes
+    structural_digest: str = ""
 
 
 @dataclass(frozen=True)
@@ -39,7 +40,7 @@ class GeneratorSource:
         return (
             "NIXL",
             self.transport.manifest_endpoint,
-            self.manifest_digest,
+            self.transport.structural_digest or self.manifest_digest,
         )
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/adapter.py
@@ -22,7 +22,13 @@ class NixlGeneratorSource:
 
     manifest_endpoint: str
     manifest: bytes
-    structural_digest: str = ""
+    structural_digest: str
+    """Digest of the manifest's transfer structure, excluding content digests.
+
+    Required rather than defaulted: this is what decides plan reuse, and a
+    resolver that forgot it would fall back to the per-version manifest digest
+    and quietly replan on every refit.
+    """
 
 
 @dataclass(frozen=True)
@@ -40,7 +46,7 @@ class GeneratorSource:
         return (
             "NIXL",
             self.transport.manifest_endpoint,
-            self.transport.structural_digest or self.manifest_digest,
+            self.transport.structural_digest,
         )
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -15,7 +15,7 @@ from typing import Any
 import grpc
 from modelexpress import auth, envs
 from modelexpress.client import _get_server_url
-from modelexpress.refit.timing import RefitTimingRecorder
+from modelexpress.refit.timing import RefitTimingRecorder, refit_span
 
 from modelexpress_rl import envs as rl_envs
 from modelexpress_rl import timing
@@ -344,7 +344,7 @@ class ModelExpressGeneratorClient:
             try:
                 with timing.active(recorder):
                     if self._runtime.initial_version_id is not None:
-                        with timing.refit_span("control_discovery"):
+                        with refit_span("control_discovery"):
                             chain = self._resolve_replay_chain(version.version_id)
                         update = (
                             self._runtime.session.stage(chain[0])
@@ -352,7 +352,7 @@ class ModelExpressGeneratorClient:
                             else self._runtime.session.stage_chain(chain)
                         )
                     else:
-                        with timing.refit_span("control_discovery"):
+                        with refit_span("control_discovery"):
                             ready = self._get_ready_version(version.version_id)
                         update = self._runtime.session.stage(ready)
             except BaseException:

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -17,7 +17,8 @@ from modelexpress import auth, envs
 from modelexpress.client import _get_server_url
 from modelexpress.refit.timing import RefitTimingRecorder
 
-from modelexpress_rl import envs as rl_envs, timing
+from modelexpress_rl import envs as rl_envs
+from modelexpress_rl import timing
 from modelexpress_rl.version import WeightVersionRef
 
 from .. import refit_pb2, refit_pb2_grpc
@@ -340,19 +341,27 @@ class ModelExpressGeneratorClient:
                 version_id=version.version_id,
                 rank=rl_envs.LOCAL_RANK,
             )
-            with timing.active(recorder):
-                if self._runtime.initial_version_id is not None:
-                    with timing.refit_span("control_discovery"):
-                        chain = self._resolve_replay_chain(version.version_id)
-                    update = (
-                        self._runtime.session.stage(chain[0])
-                        if len(chain) == 1
-                        else self._runtime.session.stage_chain(chain)
-                    )
-                else:
-                    with timing.refit_span("control_discovery"):
-                        ready = self._get_ready_version(version.version_id)
-                    update = self._runtime.session.stage(ready)
+            try:
+                with timing.active(recorder):
+                    if self._runtime.initial_version_id is not None:
+                        with timing.refit_span("control_discovery"):
+                            chain = self._resolve_replay_chain(version.version_id)
+                        update = (
+                            self._runtime.session.stage(chain[0])
+                            if len(chain) == 1
+                            else self._runtime.session.stage_chain(chain)
+                        )
+                    else:
+                        with timing.refit_span("control_discovery"):
+                            ready = self._get_ready_version(version.version_id)
+                        update = self._runtime.session.stage(ready)
+            except BaseException:
+                # Nothing else will report this cycle: the recorder is handed on
+                # through the staged handle, and staging failed before there was
+                # one. A refit that died on the wire is exactly the case the
+                # stage split exists to explain.
+                timing.emit(recorder, logger)
+                raise
             self._active_handle = StagedWeightHandle(
                 client=self,
                 version_id=version.version_id,
@@ -615,11 +624,14 @@ class ModelExpressGeneratorClient:
             if staged._update.released:
                 return
             assert self._runtime is not None
-            self._runtime.session.release(staged._update)
-            # Covers a version that was staged and dropped without ever being
-            # installed, which the apply path never sees. A no-op once the apply
-            # has already reported the cycle.
-            timing.emit(staged._timing, logger)
+            try:
+                self._runtime.session.release(staged._update)
+            finally:
+                # Covers a version that was staged and dropped without ever
+                # being installed, which the apply path never sees, and a
+                # release that itself raised. A no-op once the apply has
+                # already reported the cycle.
+                timing.emit(staged._timing, logger)
             if self._active_handle is staged:
                 self._active_handle = None
 

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -15,8 +15,9 @@ from typing import Any
 import grpc
 from modelexpress import auth, envs
 from modelexpress.client import _get_server_url
+from modelexpress.refit.timing import RefitTimingRecorder
 
-from modelexpress_rl import envs as rl_envs
+from modelexpress_rl import envs as rl_envs, timing
 from modelexpress_rl.version import WeightVersionRef
 
 from .. import refit_pb2, refit_pb2_grpc
@@ -155,11 +156,15 @@ class StagedWeightHandle:
         client: ModelExpressGeneratorClient,
         version_id: str,
         update: SessionUpdate | None,
+        timing: RefitTimingRecorder | None = None,
     ) -> None:
         self._client = client
         self.version_id = version_id
         self._update = update
         self._no_op_released = False
+        # A refit's stages are measured across two client calls, so the cycle's
+        # recorder travels on the handle that connects them.
+        self._timing = timing
 
     def release(self) -> None:
         """Release local staging buffers; repeated calls are idempotent."""
@@ -331,20 +336,28 @@ class ModelExpressGeneratorClient:
                     update=None,
                 )
                 return self._active_handle
-            if self._runtime.initial_version_id is not None:
-                chain = self._resolve_replay_chain(version.version_id)
-                update = (
-                    self._runtime.session.stage(chain[0])
-                    if len(chain) == 1
-                    else self._runtime.session.stage_chain(chain)
-                )
-            else:
-                ready = self._get_ready_version(version.version_id)
-                update = self._runtime.session.stage(ready)
+            recorder = timing.start_cycle(
+                version_id=version.version_id,
+                rank=rl_envs.LOCAL_RANK,
+            )
+            with timing.active(recorder):
+                if self._runtime.initial_version_id is not None:
+                    with timing.refit_span("control_discovery"):
+                        chain = self._resolve_replay_chain(version.version_id)
+                    update = (
+                        self._runtime.session.stage(chain[0])
+                        if len(chain) == 1
+                        else self._runtime.session.stage_chain(chain)
+                    )
+                else:
+                    with timing.refit_span("control_discovery"):
+                        ready = self._get_ready_version(version.version_id)
+                    update = self._runtime.session.stage(ready)
             self._active_handle = StagedWeightHandle(
                 client=self,
                 version_id=version.version_id,
                 update=update,
+                timing=recorder,
             )
             return self._active_handle
 
@@ -361,11 +374,18 @@ class ModelExpressGeneratorClient:
                 raise RuntimeError("staged weight has already been released")
             assert self._runtime is not None
             try:
-                result = self._runtime.session.apply(staged._update)
+                with timing.active(staged._timing):
+                    result = self._runtime.session.apply(staged._update)
             except BaseException:
                 if staged._update.installation_started and not staged._update.applied:
                     self._engine_state = _EngineState.UNCERTAIN
                 raise
+            finally:
+                # Reported even when the install raised: a refit that failed
+                # after seconds on the wire is exactly the case the split has to
+                # explain, and dropping the record would leave the failure with
+                # no timing at all.
+                timing.emit(staged._timing, logger)
             self._serving_version_id = staged.version_id
             self._engine_state = _EngineState.READY
             return result
@@ -596,6 +616,10 @@ class ModelExpressGeneratorClient:
                 return
             assert self._runtime is not None
             self._runtime.session.release(staged._update)
+            # Covers a version that was staged and dropped without ever being
+            # installed, which the apply path never sees. A no-op once the apply
+            # has already reported the cycle.
+            timing.emit(staged._timing, logger)
             if self._active_handle is staged:
                 self._active_handle = None
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
@@ -20,13 +20,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
-
 from modelexpress.refit.reshard.geometry import (
     capture_weights,
     convert_source_weights,
 )
 from modelexpress.refit.reshard.types import IncompleteRefit
 from modelexpress.refit.timing import refit_span
+
 from modelexpress_rl.inference.plan import (
     EngineCapabilities,
     EngineInstaller,
@@ -37,10 +37,9 @@ from modelexpress_rl.inference.plan import (
 from modelexpress_rl.inference.receiver import PreparedCheckpoint
 
 if TYPE_CHECKING:
+    from modelexpress.refit.reshard.types import CaptureResult
     from torch.nn import Module
     from vllm.config import ModelConfig, VllmConfig
-
-    from modelexpress.refit.reshard.types import CaptureResult
 
 logger = logging.getLogger("modelexpress_rl.inference.engines.vllm.installer")
 

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
@@ -244,8 +244,11 @@ class _VllmInstaller(EngineInstaller):
         loader = DefaultModelLoader(load_config)
 
         self._reload(lambda: loader.load_weights(self._model, model_config))
-        _update_mla_absorbed_weights(self._model, quantized=self._is_quantized)
-        torch.cuda.synchronize(self._device)
+        # Same fixups and synchronize as install_tensors, so a checkpoint refit
+        # reports the stage too rather than charging it to the caller's total.
+        with refit_span("post_install"):
+            _update_mla_absorbed_weights(self._model, quantized=self._is_quantized)
+            torch.cuda.synchronize(self._device)
 
     @torch.no_grad()
     def _process_and_commit(self, tensors: dict[str, torch.Tensor]) -> None:

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/installer.py
@@ -26,6 +26,7 @@ from modelexpress.refit.reshard.geometry import (
     convert_source_weights,
 )
 from modelexpress.refit.reshard.types import IncompleteRefit
+from modelexpress.refit.timing import refit_span
 from modelexpress_rl.inference.plan import (
     EngineCapabilities,
     EngineInstaller,
@@ -213,8 +214,13 @@ class _VllmInstaller(EngineInstaller):
     def install_tensors(self, tensors: dict[str, torch.Tensor]) -> None:
         """Install verified load-layout tensors without changing graph addresses."""
         self._process_and_commit(tensors)
-        _update_mla_absorbed_weights(self._model, quantized=self._is_quantized)
-        torch.cuda.synchronize(self._device)
+        # Derived-weight fixups plus the synchronize that makes the whole
+        # install observable. Separate from the per-layer stages because it is
+        # paid once and does not scale with the number of layers, so folding it
+        # in would make those look worse than they are on small models.
+        with refit_span("post_install"):
+            _update_mla_absorbed_weights(self._model, quantized=self._is_quantized)
+            torch.cuda.synchronize(self._device)
 
     def install_checkpoint(self, path: str | Path) -> None:
         """Reload a prepared safetensors checkpoint into the live model."""
@@ -284,6 +290,12 @@ class _VllmInstaller(EngineInstaller):
                     f"unmatched={unmatched[:10]}"
                 )
 
+            # Per-layer spans, accumulated across every layer into two stages.
+            # This loop is the whole of what a framework sees as "install", and
+            # the two things it does have unrelated costs: post-load processing
+            # is compute that scales with quantization scheme, while the copy
+            # back is bandwidth into storage the CUDA graphs already point at.
+            # Charged together they cannot be acted on.
             for layer, parameters in groups.items():
                 info = LAYERWISE_INFO.get(layer)
                 for full_name, leaf in parameters:
@@ -296,9 +308,11 @@ class _VllmInstaller(EngineInstaller):
                 if isinstance(quant_method, QuantizeMethodBase):
                     if hasattr(layer, "_already_called_process_weights_after_loading"):
                         delattr(layer, "_already_called_process_weights_after_loading")
-                    quant_method.process_weights_after_loading(layer)
+                    with refit_span("transformation"):
+                        quant_method.process_weights_after_loading(layer)
                 if info is not None and info.kernel_tensors is not None:
-                    _copy_and_restore_kernel_tensors(layer, info)
+                    with refit_span("installation"):
+                        _copy_and_restore_kernel_tensors(layer, info)
                 if info is not None:
                     info.reset()
 

--- a/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
@@ -5,13 +5,17 @@
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClientBase
+from modelexpress.refit.timing import (
+    add_refit_bytes,
+    add_refit_duration,
+    refit_span,
+    set_refit_cold,
+)
 
-from ... import timing
 from ...train import WeightPayloadFormat
 from ..adapter import NixlGeneratorSource
 from ..nixl_staged_transfer import (
@@ -46,11 +50,11 @@ def _attribute_transfer(metrics: dict[str, float]) -> None:
     ``wire_transfer``. Keeping them apart is what distinguishes a slow fabric
     from an expensive layout.
     """
-    timing.record_bytes(metrics.get("bytes_received", 0))
+    add_refit_bytes(metrics.get("bytes_received", 0))
     if "wire_s" in metrics:
-        timing.record_measured("wire_transfer", metrics["wire_s"])
+        add_refit_duration("wire_transfer", metrics["wire_s"])
     if "reconstruct_s" in metrics:
-        timing.record_measured("receive_sync", metrics["reconstruct_s"])
+        add_refit_duration("receive_sync", metrics["reconstruct_s"])
 
 
 class FullTensorNixlUpdateMethod(UpdateMethod):
@@ -120,40 +124,35 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
                 self._active_plan is not None
                 and self._active_fingerprint == inputs.physical_fingerprint
             )
-            timing.record_cold(not reusable)
+            set_refit_cold(not reusable)
             manifests = [item.transport.manifest for item in inputs.sources]
             manifest_digests = tuple(item.manifest_digest for item in inputs.sources)
-            if not reusable:
-                started = time.perf_counter()
-                self._active_plan = self._transfer.prepare(
-                    manifests=manifests,
-                    capture_layout=self._capture_layout,
-                )
-                duration = time.perf_counter() - started
-                timing.record_measured(
-                    "transfer_planning",
-                    duration,
-                    metadata={"plan_cache_hits": 0, "plan_cache_misses": 1},
-                    accumulate_metadata=True,
-                )
-                self._active_fingerprint = inputs.physical_fingerprint
-            else:
-                timing.record_measured(
-                    "transfer_planning",
-                    0.0,
-                    metadata={"plan_cache_hits": 1, "plan_cache_misses": 0},
-                    accumulate_metadata=True,
-                )
-                if manifest_digests != self._active_manifest_digests:
-                    assert self._active_plan is not None
-                    started = time.perf_counter()
-                    self._transfer.refresh_sources(self._active_plan, manifests)
-                    duration = time.perf_counter() - started
-                    timing.record_measured(
-                        "source_preparation",
-                        duration,
-                        metadata={"manifest_refresh_s": duration},
+            # One span either way: planning on a cold cycle, and on a warm one
+            # the near-zero it actually costs. Two stages would make the mean
+            # over a run describe neither.
+            with refit_span(
+                "transfer_planning",
+                metadata={
+                    "plan_cache_hits": int(reusable),
+                    "plan_cache_misses": int(not reusable),
+                },
+                accumulate_metadata=True,
+            ):
+                if not reusable:
+                    self._active_plan = self._transfer.prepare(
+                        manifests=manifests,
+                        capture_layout=self._capture_layout,
                     )
+                    self._active_fingerprint = inputs.physical_fingerprint
+            if reusable and manifest_digests != self._active_manifest_digests:
+                assert self._active_plan is not None
+                with refit_span(
+                    "source_preparation",
+                    metadata={"manifest_refreshes": 1},
+                    accumulate_metadata=True,
+                    duration_key="manifest_refresh_s",
+                ):
+                    self._transfer.refresh_sources(self._active_plan, manifests)
             self._active_manifest_digests = manifest_digests
             staged = self._transfer.stage(self._active_plan)
         else:

--- a/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 
 from modelexpress import p2p_pb2
@@ -19,14 +20,14 @@ from ..nixl_staged_transfer import (
     _StagedNixlWeights,
 )
 from ..plan import (
-    MethodCapabilities,
     GeneratorPeerUpdateSource,
+    MethodCapabilities,
     PreparedArtifact,
     PreparedEngineTensors,
     ResolvedSource,
     TrainerUpdateSource,
-    WeightSource,
     UpdateMethod,
+    WeightSource,
 )
 
 
@@ -79,6 +80,7 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
         self._enable_peer_publication = enable_peer_publication
         self._active_plan: _PreparedNixlTransfer | None = None
         self._active_fingerprint: tuple | None = None
+        self._active_manifest_digests: tuple[str, ...] = ()
         self._active_staged: _StagedNixlWeights | None = None
 
     @property
@@ -106,6 +108,7 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
             )
             self._active_plan = None
             self._active_fingerprint = None
+            self._active_manifest_digests = ()
         elif isinstance(source, TrainerUpdateSource):
             inputs = source.inputs
             if any(
@@ -113,18 +116,53 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
                 for item in inputs.sources
             ):
                 raise ValueError("full-tensor method requires NIXL sources")
+            fingerprint_started = time.perf_counter()
             reusable = (
                 self._active_plan is not None
                 and self._active_fingerprint == inputs.physical_fingerprint
             )
+            fingerprint_s = time.perf_counter() - fingerprint_started
+            timing.record_measured(
+                "source_preparation",
+                fingerprint_s,
+                metadata={"fingerprint_compare_s": fingerprint_s},
+                accumulate_metadata=True,
+            )
             timing.record_cold(not reusable)
+            manifests = [item.transport.manifest for item in inputs.sources]
+            manifest_digests = tuple(item.manifest_digest for item in inputs.sources)
             if not reusable:
-                with timing.refit_span("transfer_planning"):
-                    self._active_plan = self._transfer.prepare(
-                        manifests=[item.transport.manifest for item in inputs.sources],
-                        capture_layout=self._capture_layout,
-                    )
+                started = time.perf_counter()
+                self._active_plan = self._transfer.prepare(
+                    manifests=manifests,
+                    capture_layout=self._capture_layout,
+                )
+                duration = time.perf_counter() - started
+                timing.record_measured(
+                    "transfer_planning",
+                    duration,
+                    metadata={"plan_cache_hits": 0, "plan_cache_misses": 1},
+                    accumulate_metadata=True,
+                )
                 self._active_fingerprint = inputs.physical_fingerprint
+            else:
+                timing.record_measured(
+                    "transfer_planning",
+                    0.0,
+                    metadata={"plan_cache_hits": 1, "plan_cache_misses": 0},
+                    accumulate_metadata=True,
+                )
+                if manifest_digests != self._active_manifest_digests:
+                    assert self._active_plan is not None
+                    started = time.perf_counter()
+                    self._transfer.refresh_sources(self._active_plan, manifests)
+                    duration = time.perf_counter() - started
+                    timing.record_measured(
+                        "source_preparation",
+                        duration,
+                        metadata={"manifest_refresh_s": duration},
+                    )
+            self._active_manifest_digests = manifest_digests
             staged = self._transfer.stage(self._active_plan)
         else:
             raise TypeError("full-tensor method received an unsupported source")
@@ -159,6 +197,7 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
         self._active_staged = None
         self._active_plan = None
         self._active_fingerprint = None
+        self._active_manifest_digests = ()
         self._transfer.close()
 
 

--- a/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
@@ -116,17 +116,9 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
                 for item in inputs.sources
             ):
                 raise ValueError("full-tensor method requires NIXL sources")
-            fingerprint_started = time.perf_counter()
             reusable = (
                 self._active_plan is not None
                 and self._active_fingerprint == inputs.physical_fingerprint
-            )
-            fingerprint_s = time.perf_counter() - fingerprint_started
-            timing.record_measured(
-                "source_preparation",
-                fingerprint_s,
-                metadata={"fingerprint_compare_s": fingerprint_s},
-                accumulate_metadata=True,
             )
             timing.record_cold(not reusable)
             manifests = [item.transport.manifest for item in inputs.sources]

--- a/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/methods/full_tensor.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClientBase
 
+from ... import timing
 from ...train import WeightPayloadFormat
 from ..adapter import NixlGeneratorSource
 from ..nixl_staged_transfer import (
@@ -27,6 +28,28 @@ from ..plan import (
     WeightSource,
     UpdateMethod,
 )
+
+
+def _attribute_transfer(metrics: dict[str, float]) -> None:
+    """Hand the staging path's own measurements to the active refit cycle.
+
+    Timed inside ``_NixlStagedTransfer`` rather than here, because the wire read
+    and the reconstruction are consecutive statements in one method and cannot be
+    separated from outside it. Both numbers were already on the staged handle;
+    without this they stayed there, and the cycle charged the whole staging call
+    as a single opaque span.
+
+    ``reconstruct_s`` covers replaying the copy chain, the dtype conversions and
+    the device synchronize that makes them observable, which is receive-side
+    work on data already pulled -- so it lands in ``receive_sync`` and not in
+    ``wire_transfer``. Keeping them apart is what distinguishes a slow fabric
+    from an expensive layout.
+    """
+    timing.record_bytes(metrics.get("bytes_received", 0))
+    if "wire_s" in metrics:
+        timing.record_measured("wire_transfer", metrics["wire_s"])
+    if "reconstruct_s" in metrics:
+        timing.record_measured("receive_sync", metrics["reconstruct_s"])
 
 
 class FullTensorNixlUpdateMethod(UpdateMethod):
@@ -94,15 +117,18 @@ class FullTensorNixlUpdateMethod(UpdateMethod):
                 self._active_plan is not None
                 and self._active_fingerprint == inputs.physical_fingerprint
             )
+            timing.record_cold(not reusable)
             if not reusable:
-                self._active_plan = self._transfer.prepare(
-                    manifests=[item.transport.manifest for item in inputs.sources],
-                    capture_layout=self._capture_layout,
-                )
+                with timing.refit_span("transfer_planning"):
+                    self._active_plan = self._transfer.prepare(
+                        manifests=[item.transport.manifest for item in inputs.sources],
+                        capture_layout=self._capture_layout,
+                    )
                 self._active_fingerprint = inputs.physical_fingerprint
             staged = self._transfer.stage(self._active_plan)
         else:
             raise TypeError("full-tensor method received an unsupported source")
+        _attribute_transfer(staged.metrics)
         self._active_staged = staged
         return PreparedEngineTensors(staged=staged)
 

--- a/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+
 from modelexpress import envs, p2p_pb2
 from modelexpress.client import MxClientBase
 from modelexpress.load_strategy.base import unpublish_metadata_for_worker
@@ -125,6 +126,12 @@ def _required_agent_metadata(
 
 
 def _source_structure(source) -> tuple:
+    """Reduce a source to the fields a reused transfer plan has baked in.
+
+    Deliberately excludes the per-shard content digests, which are exactly what
+    a refresh replaces, and includes the addresses, which a plan holds and must
+    never be allowed to drift underneath.
+    """
     return (
         source.dtype,
         tuple(source.global_shape),
@@ -341,7 +348,9 @@ class _NixlStagedTransfer:
             if self._loaded_agent_metadata.get(agent) != metadata
         }
         conflicting = sorted(
-            agent for agent in changed if agent in self._loaded_agent_metadata
+            agent
+            for agent in changed
+            if agent in self._loaded_agent_metadata
         )
         if conflicting:
             raise RuntimeError(
@@ -468,7 +477,10 @@ class _NixlStagedTransfer:
         )
 
         recv_params = set(recv_expected)
-        if self._registered_recv_params and self._registered_recv_params != recv_params:
+        if (
+            self._registered_recv_params
+            and self._registered_recv_params != recv_params
+        ):
             raise RuntimeError(
                 "receive parameter set changed; restart the generator engine"
             )
@@ -649,7 +661,9 @@ class _NixlStagedTransfer:
                     timeout_seconds=self._timeout,
                 )
             else:
-                remote_agent_name = self._manager.add_remote_agent(source.nixl_metadata)
+                remote_agent_name = self._manager.add_remote_agent(
+                    source.nixl_metadata
+                )
             bytes_received, tensor_count, wire_seconds = (
                 self._manager.receive_from_source(
                     source_metadata=b"",

--- a/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-
 from modelexpress import envs, p2p_pb2
 from modelexpress.client import MxClientBase
 from modelexpress.load_strategy.base import unpublish_metadata_for_worker
@@ -129,11 +128,12 @@ def _source_structure(source) -> tuple:
     return (
         source.dtype,
         tuple(source.global_shape),
+        source.elsize,
         tuple(
             (
-                shard.agent_name,
-                shard.device_id,
+                shard.session,
                 shard.addr,
+                shard.elsize,
                 tuple(shard.shard_offset),
                 tuple(shard.shape),
             )

--- a/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/nixl_staged_transfer.py
@@ -125,6 +125,23 @@ def _required_agent_metadata(
     }
 
 
+def _source_structure(source) -> tuple:
+    return (
+        source.dtype,
+        tuple(source.global_shape),
+        tuple(
+            (
+                shard.agent_name,
+                shard.device_id,
+                shard.addr,
+                tuple(shard.shard_offset),
+                tuple(shard.shape),
+            )
+            for shard in source.shards
+        ),
+    )
+
+
 def _load_agent_metadata(
     manager: NixlTransferManager, metadata_by_agent: dict[str, bytes]
 ) -> None:
@@ -324,9 +341,7 @@ class _NixlStagedTransfer:
             if self._loaded_agent_metadata.get(agent) != metadata
         }
         conflicting = sorted(
-            agent
-            for agent in changed
-            if agent in self._loaded_agent_metadata
+            agent for agent in changed if agent in self._loaded_agent_metadata
         )
         if conflicting:
             raise RuntimeError(
@@ -357,6 +372,28 @@ class _NixlStagedTransfer:
         )
         self._active = prepared
         return prepared
+
+    def refresh_sources(
+        self, prepared: _PreparedNixlTransfer, manifests: list[bytes]
+    ) -> None:
+        """Refresh version-specific source digests without rebuilding the plan."""
+        if prepared is not self._active:
+            raise RuntimeError("NIXL transfer plan is no longer active")
+        resolved = _resolve_sources(manifests)
+        used_sources = {
+            copy.src_name: resolved.sources[copy.src_name]
+            for copy in prepared.capture.copies
+            if copy.src_name in resolved.sources
+        }
+        if set(used_sources) != set(prepared.sources):
+            raise RuntimeError("source tensor set changed while reusing transfer plan")
+        if any(
+            _source_structure(source) != _source_structure(prepared.sources[name])
+            for name, source in used_sources.items()
+        ):
+            raise RuntimeError("source geometry changed while reusing transfer plan")
+        prepared.sources.clear()
+        prepared.sources.update(used_sources)
 
     @staticmethod
     def _validate_complete(
@@ -431,10 +468,7 @@ class _NixlStagedTransfer:
         )
 
         recv_params = set(recv_expected)
-        if (
-            self._registered_recv_params
-            and self._registered_recv_params != recv_params
-        ):
+        if self._registered_recv_params and self._registered_recv_params != recv_params:
             raise RuntimeError(
                 "receive parameter set changed; restart the generator engine"
             )
@@ -615,9 +649,7 @@ class _NixlStagedTransfer:
                     timeout_seconds=self._timeout,
                 )
             else:
-                remote_agent_name = self._manager.add_remote_agent(
-                    source.nixl_metadata
-                )
+                remote_agent_name = self._manager.add_remote_agent(source.nixl_metadata)
             bytes_received, tensor_count, wire_seconds = (
                 self._manager.receive_from_source(
                     source_metadata=b"",

--- a/modelexpress_client/python/modelexpress_rl/inference/session.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/session.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import grpc
+from modelexpress.refit.timing import refit_span
 from modelexpress.types import ManifestMismatchError
 
 from ..control import WeightVersion
@@ -81,7 +82,8 @@ class WeightUpdateSession:
         self._planner.validate(version)
 
     def stage(self, version: WeightVersion) -> SessionUpdate:
-        lease = self._start_lease(version.version_id)
+        with refit_span("setup_registration"):
+            lease = self._start_lease(version.version_id)
         try:
             last_error: BaseException | None = None
             found_plan = False
@@ -149,8 +151,9 @@ class WeightUpdateSession:
             raise ValueError("version chain is empty")
         leases = []
         try:
-            for version in versions:
-                leases.append(self._start_lease(version.version_id))
+            with refit_span("setup_registration"):
+                for version in versions:
+                    leases.append(self._start_lease(version.version_id))
         except BaseException as primary_error:
             self._close_lease(
                 _LeaseGroup(leases), versions[-1].version_id, primary_error

--- a/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
@@ -5,14 +5,14 @@
 
 import hashlib
 import logging
-import time
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 
 import grpc
 from modelexpress.refit.reshard.rendezvous import structural_manifest_digest
+from modelexpress.refit.timing import refit_span
 
-from ... import refit_pb2, refit_pb2_grpc, timing
+from ... import refit_pb2, refit_pb2_grpc
 from ...control import WeightVersion
 from ...train import WeightPayloadFormat
 from ..adapter import GeneratorSource, GeneratorTransferInputs, NixlGeneratorSource
@@ -47,12 +47,20 @@ class TrainerSourceResolver(SourceResolver):
         return version.payload_format
 
     def candidates(self, version: WeightVersion) -> Iterator[ResolvedSource]:
-        list_started = time.perf_counter()
         try:
-            response = self._service().ListWeightVersionShards(
-                refit_pb2.ListWeightVersionShardsRequest(version_id=version.version_id),
-                timeout=self._rpc_timeout_seconds,
-            )
+            with refit_span(
+                "source_preparation",
+                metadata={"manifest_list_count": 1},
+                accumulate_metadata=True,
+                duration_key="manifest_list_s",
+            ) as counters:
+                response = self._service().ListWeightVersionShards(
+                    refit_pb2.ListWeightVersionShardsRequest(
+                        version_id=version.version_id
+                    ),
+                    timeout=self._rpc_timeout_seconds,
+                )
+                counters["published_shard_count"] = len(response.shards)
         except grpc.RpcError as error:
             logger.warning(
                 "trainer source discovery failed for version %s: %s",
@@ -60,26 +68,13 @@ class TrainerSourceResolver(SourceResolver):
                 error,
             )
             return
-        list_s = time.perf_counter() - list_started
-        timing.record_measured(
-            "source_preparation",
-            list_s,
-            metadata={
-                "manifest_list_s": list_s,
-                "manifest_list_count": 1,
-                "published_shard_count": len(response.shards),
-            },
-            accumulate_metadata=True,
-        )
-        candidates = defaultdict(list)
+        published = defaultdict(list)
         for shard in response.shards:
-            candidates[shard.source_slot_id].append(shard)
+            published[shard.source_slot_id].append(shard)
 
         ordered_slots = []
         for source_slot_id in version.expected_source_slots:
-            ordered = sorted(
-                candidates[source_slot_id], key=lambda item: item.worker_id
-            )
+            ordered = sorted(published[source_slot_id], key=lambda item: item.worker_id)
             if not ordered:
                 logger.warning(
                     "no trainer source published for required slot %s",
@@ -99,19 +94,9 @@ class TrainerSourceResolver(SourceResolver):
                 continue
             seen.add(selection)
             resolved = []
-            stats: dict[str, int | float] = {
-                "manifest_fetch_s": 0.0,
-                "manifest_hash_s": 0.0,
-                "manifest_fingerprint_s": 0.0,
-                "manifest_bytes": 0,
-                "manifest_fetch_bytes": 0,
-                "manifest_cache_hits": 0,
-                "manifest_cache_misses": 0,
-                "manifest_fetch_count": 0,
-            }
             for shard in selected_shards:
                 try:
-                    source, source_stats = self._resolve_source(shard)
+                    resolved.append(self._resolve_source(shard))
                 except (grpc.RpcError, RuntimeError) as error:
                     logger.warning(
                         "trainer source %s failed for slot %s: %s",
@@ -120,20 +105,6 @@ class TrainerSourceResolver(SourceResolver):
                         error,
                     )
                     break
-                resolved.append(source)
-                for name, value in source_stats.items():
-                    stats[name] += value
-            source_preparation_s = (
-                float(stats["manifest_fetch_s"])
-                + float(stats["manifest_hash_s"])
-                + float(stats["manifest_fingerprint_s"])
-            )
-            timing.record_measured(
-                "source_preparation",
-                source_preparation_s,
-                metadata=stats,
-                accumulate_metadata=True,
-            )
             if len(resolved) != len(ordered_slots):
                 continue
             yield TrainerUpdateSource(
@@ -146,74 +117,45 @@ class TrainerSourceResolver(SourceResolver):
                 )
             )
 
-    def _resolve_source(
-        self, shard: refit_pb2.WeightVersionShard
-    ) -> tuple[GeneratorSource, dict[str, int | float]]:
+    def _resolve_source(self, shard: refit_pb2.WeightVersionShard) -> GeneratorSource:
         if not shard.manifest_endpoint:
             raise RuntimeError("NIXL source is missing its manifest endpoint")
         if not shard.manifest_digest:
             raise RuntimeError("source is missing its manifest digest")
         key = (shard.source_slot_id, shard.worker_id)
         cached = self._manifest_cache.get(key)
-        cache_hit = (
+        reusable = (
             cached is not None
             and cached[0] == shard.manifest_endpoint
             and cached[1] == shard.manifest_digest
         )
-        fetch_s = 0.0
-        hash_s = 0.0
-        fingerprint_s = 0.0
-        if cache_hit:
-            assert cached is not None
-            manifest = cached[2]
-            structure_digest = cached[3]
-        else:
-            fetch_started = time.perf_counter()
-            with grpc.insecure_channel(
-                shard.manifest_endpoint,
-                options=[
-                    (
-                        "grpc.max_receive_message_length",
-                        _MAX_MANIFEST_MESSAGE_SIZE_BYTES,
-                    )
-                ],
-            ) as channel:
-                response = refit_pb2_grpc.RefitWorkerServiceStub(
-                    channel
-                ).GetWeightVersionShardManifest(
-                    refit_pb2.GetWeightVersionShardManifestRequest(
-                        version_id=shard.version_id,
-                        source_slot_id=shard.source_slot_id,
-                    ),
-                    timeout=self._rpc_timeout_seconds,
+        with refit_span(
+            "source_preparation",
+            metadata={
+                "manifest_cache_hits": int(reusable),
+                "manifest_cache_misses": int(not reusable),
+            },
+            accumulate_metadata=True,
+        ) as counters:
+            if reusable:
+                # These bytes hashed to this digest when they were stored, so
+                # verifying them again would be checking them against
+                # themselves.
+                assert cached is not None
+                manifest = cached[2]
+                structure_digest = cached[3]
+            else:
+                manifest, structure_digest = self._fetch_manifest(shard)
+                self._manifest_cache[key] = (
+                    shard.manifest_endpoint,
+                    shard.manifest_digest,
+                    manifest,
+                    structure_digest,
                 )
-            fetch_s = time.perf_counter() - fetch_started
-            hash_started = time.perf_counter()
-            digest = hashlib.sha256(response.manifest).hexdigest()
-            hash_s = time.perf_counter() - hash_started
-            if (
-                response.manifest_digest != shard.manifest_digest
-                or digest != shard.manifest_digest
-            ):
-                raise RuntimeError(
-                    f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
-                )
-            fingerprint_started = time.perf_counter()
-            try:
-                structure_digest = structural_manifest_digest(response.manifest)
-            except (AttributeError, KeyError, TypeError, ValueError) as error:
-                raise RuntimeError(
-                    f"invalid manifest for source slot {shard.source_slot_id!r}"
-                ) from error
-            fingerprint_s = time.perf_counter() - fingerprint_started
-            manifest = response.manifest
-            self._manifest_cache[key] = (
-                shard.manifest_endpoint,
-                shard.manifest_digest,
-                manifest,
-                structure_digest,
-            )
-        source = GeneratorSource(
+                counters["manifest_fetch_bytes"] = len(manifest)
+                counters["manifest_fetch_count"] = 1
+            counters["manifest_bytes"] = len(manifest)
+        return GeneratorSource(
             source_slot_id=shard.source_slot_id,
             worker_id=shard.worker_id,
             manifest_digest=shard.manifest_digest,
@@ -223,16 +165,65 @@ class TrainerSourceResolver(SourceResolver):
                 structural_digest=structure_digest,
             ),
         )
-        return source, {
-            "manifest_fetch_s": fetch_s,
-            "manifest_hash_s": hash_s,
-            "manifest_fingerprint_s": fingerprint_s,
-            "manifest_bytes": len(manifest),
-            "manifest_fetch_bytes": len(manifest) * int(not cache_hit),
-            "manifest_cache_hits": int(cache_hit),
-            "manifest_cache_misses": int(not cache_hit),
-            "manifest_fetch_count": int(not cache_hit),
-        }
+
+    def _fetch_manifest(self, shard: refit_pb2.WeightVersionShard) -> tuple[bytes, str]:
+        """Fetch, verify and fingerprint one worker's manifest.
+
+        Three spans on one stage rather than one, because the stage total
+        cannot say whether a slow warm refit is waiting on the wire or on the
+        CPU, and with digests published these manifests are refetched by
+        construction on every version.
+        """
+        with (
+            refit_span(
+                "source_preparation",
+                accumulate_metadata=True,
+                duration_key="manifest_fetch_s",
+            ),
+            grpc.insecure_channel(
+                shard.manifest_endpoint,
+                options=[
+                    (
+                        "grpc.max_receive_message_length",
+                        _MAX_MANIFEST_MESSAGE_SIZE_BYTES,
+                    )
+                ],
+            ) as channel,
+        ):
+            response = refit_pb2_grpc.RefitWorkerServiceStub(
+                channel
+            ).GetWeightVersionShardManifest(
+                refit_pb2.GetWeightVersionShardManifestRequest(
+                    version_id=shard.version_id,
+                    source_slot_id=shard.source_slot_id,
+                ),
+                timeout=self._rpc_timeout_seconds,
+            )
+        with refit_span(
+            "source_preparation",
+            accumulate_metadata=True,
+            duration_key="manifest_hash_s",
+        ):
+            digest = hashlib.sha256(response.manifest).hexdigest()
+        if (
+            response.manifest_digest != shard.manifest_digest
+            or digest != shard.manifest_digest
+        ):
+            raise RuntimeError(
+                f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
+            )
+        try:
+            with refit_span(
+                "source_preparation",
+                accumulate_metadata=True,
+                duration_key="manifest_fingerprint_s",
+            ):
+                structure_digest = structural_manifest_digest(response.manifest)
+        except (AttributeError, KeyError, TypeError, ValueError) as error:
+            raise RuntimeError(
+                f"invalid manifest for source slot {shard.source_slot_id!r}"
+            ) from error
+        return response.manifest, structure_digest
 
 
 __all__ = ["TrainerSourceResolver"]

--- a/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
@@ -5,12 +5,15 @@
 
 import hashlib
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 
 import grpc
 
-from ... import refit_pb2, refit_pb2_grpc
+from modelexpress.refit.reshard.rendezvous import structural_manifest_digest
+
+from ... import refit_pb2, refit_pb2_grpc, timing
 from ...control import WeightVersion
 from ...train import WeightPayloadFormat
 from ..adapter import GeneratorSource, GeneratorTransferInputs, NixlGeneratorSource
@@ -32,6 +35,7 @@ class TrainerSourceResolver(SourceResolver):
     ) -> None:
         self._service = service
         self._rpc_timeout_seconds = rpc_timeout_seconds
+        self._manifest_cache: dict[tuple[str, str], tuple[str, str, bytes, str]] = {}
 
     @property
     def kind(self) -> WeightSource:
@@ -44,11 +48,10 @@ class TrainerSourceResolver(SourceResolver):
         return version.payload_format
 
     def candidates(self, version: WeightVersion) -> Iterator[ResolvedSource]:
+        list_started = time.perf_counter()
         try:
             response = self._service().ListWeightVersionShards(
-                refit_pb2.ListWeightVersionShardsRequest(
-                    version_id=version.version_id
-                ),
+                refit_pb2.ListWeightVersionShardsRequest(version_id=version.version_id),
                 timeout=self._rpc_timeout_seconds,
             )
         except grpc.RpcError as error:
@@ -58,96 +61,179 @@ class TrainerSourceResolver(SourceResolver):
                 error,
             )
             return
+        list_s = time.perf_counter() - list_started
+        timing.record_measured(
+            "source_preparation",
+            list_s,
+            metadata={
+                "manifest_list_s": list_s,
+                "manifest_list_count": 1,
+                "published_shard_count": len(response.shards),
+            },
+            accumulate_metadata=True,
+        )
         candidates = defaultdict(list)
         for shard in response.shards:
             candidates[shard.source_slot_id].append(shard)
 
-        resolved_slots: list[list[GeneratorSource]] = []
+        ordered_slots = []
         for source_slot_id in version.expected_source_slots:
             ordered = sorted(
                 candidates[source_slot_id], key=lambda item: item.worker_id
             )
+            if not ordered:
+                logger.warning(
+                    "no trainer source published for required slot %s",
+                    source_slot_id,
+                )
+                return
+            ordered_slots.append(ordered)
+
+        seen = set()
+        candidate_count = max((len(slot) for slot in ordered_slots), default=1)
+        for offset in range(candidate_count):
+            selected_shards = tuple(slot[offset % len(slot)] for slot in ordered_slots)
+            selection = tuple(
+                (shard.source_slot_id, shard.worker_id) for shard in selected_shards
+            )
+            if selection in seen:
+                continue
+            seen.add(selection)
             resolved = []
-            for shard in ordered:
+            stats: dict[str, int | float] = {
+                "manifest_fetch_s": 0.0,
+                "manifest_hash_s": 0.0,
+                "manifest_fingerprint_s": 0.0,
+                "manifest_bytes": 0,
+                "manifest_fetch_bytes": 0,
+                "manifest_cache_hits": 0,
+                "manifest_cache_misses": 0,
+                "manifest_fetch_count": 0,
+            }
+            for shard in selected_shards:
                 try:
-                    source = self._resolve_source(shard)
+                    source, source_stats = self._resolve_source(shard)
                 except (grpc.RpcError, RuntimeError) as error:
                     logger.warning(
                         "trainer source %s failed for slot %s: %s",
                         shard.worker_id,
-                        source_slot_id,
+                        shard.source_slot_id,
                         error,
                     )
-                    continue
+                    break
                 resolved.append(source)
-            if not resolved:
-                logger.warning(
-                    "no usable trainer source for required slot %s",
-                    source_slot_id,
-                )
-                return
-            resolved_slots.append(resolved)
-
-        seen = set()
-        candidate_count = max((len(slot) for slot in resolved_slots), default=1)
-        for offset in range(candidate_count):
-            selected = tuple(slot[offset % len(slot)] for slot in resolved_slots)
-            fingerprint = tuple(
-                (source.source_slot_id, source.worker_id) for source in selected
+                for name, value in source_stats.items():
+                    stats[name] += value
+            source_preparation_s = (
+                float(stats["manifest_fetch_s"])
+                + float(stats["manifest_hash_s"])
+                + float(stats["manifest_fingerprint_s"])
             )
-            if fingerprint in seen:
+            timing.record_measured(
+                "source_preparation",
+                source_preparation_s,
+                metadata=stats,
+                accumulate_metadata=True,
+            )
+            if len(resolved) != len(ordered_slots):
                 continue
-            seen.add(fingerprint)
             yield TrainerUpdateSource(
                 inputs=GeneratorTransferInputs(
                     version_id=version.version_id,
                     base_version_id=version.base_version_id,
                     layout_signature=version.layout_signature,
                     payload_format=version.payload_format,
-                    sources=selected,
+                    sources=tuple(resolved),
                 )
             )
 
-    def _resolve_source(self, shard: refit_pb2.WeightVersionShard) -> GeneratorSource:
+    def _resolve_source(
+        self, shard: refit_pb2.WeightVersionShard
+    ) -> tuple[GeneratorSource, dict[str, int | float]]:
         if not shard.manifest_endpoint:
             raise RuntimeError("NIXL source is missing its manifest endpoint")
-        with grpc.insecure_channel(
-            shard.manifest_endpoint,
-            options=[
-                (
-                    "grpc.max_receive_message_length",
-                    _MAX_MANIFEST_MESSAGE_SIZE_BYTES,
-                )
-            ],
-        ) as channel:
-            response = refit_pb2_grpc.RefitWorkerServiceStub(
-                channel
-            ).GetWeightVersionShardManifest(
-                refit_pb2.GetWeightVersionShardManifestRequest(
-                    version_id=shard.version_id,
-                    source_slot_id=shard.source_slot_id,
-                ),
-                timeout=self._rpc_timeout_seconds,
-            )
         if not shard.manifest_digest:
             raise RuntimeError("source is missing its manifest digest")
-        digest = hashlib.sha256(response.manifest).hexdigest()
-        if (
-            response.manifest_digest != shard.manifest_digest
-            or digest != shard.manifest_digest
-        ):
-            raise RuntimeError(
-                f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
+        key = (shard.source_slot_id, shard.worker_id)
+        cached = self._manifest_cache.get(key)
+        cache_hit = (
+            cached is not None
+            and cached[0] == shard.manifest_endpoint
+            and cached[1] == shard.manifest_digest
+        )
+        fetch_s = 0.0
+        hash_s = 0.0
+        fingerprint_s = 0.0
+        if cache_hit:
+            assert cached is not None
+            manifest = cached[2]
+            structure_digest = cached[3]
+        else:
+            fetch_started = time.perf_counter()
+            with grpc.insecure_channel(
+                shard.manifest_endpoint,
+                options=[
+                    (
+                        "grpc.max_receive_message_length",
+                        _MAX_MANIFEST_MESSAGE_SIZE_BYTES,
+                    )
+                ],
+            ) as channel:
+                response = refit_pb2_grpc.RefitWorkerServiceStub(
+                    channel
+                ).GetWeightVersionShardManifest(
+                    refit_pb2.GetWeightVersionShardManifestRequest(
+                        version_id=shard.version_id,
+                        source_slot_id=shard.source_slot_id,
+                    ),
+                    timeout=self._rpc_timeout_seconds,
+                )
+            fetch_s = time.perf_counter() - fetch_started
+            hash_started = time.perf_counter()
+            digest = hashlib.sha256(response.manifest).hexdigest()
+            hash_s = time.perf_counter() - hash_started
+            if (
+                response.manifest_digest != shard.manifest_digest
+                or digest != shard.manifest_digest
+            ):
+                raise RuntimeError(
+                    f"manifest digest mismatch for source slot {shard.source_slot_id!r}"
+                )
+            fingerprint_started = time.perf_counter()
+            try:
+                structure_digest = structural_manifest_digest(response.manifest)
+            except (AttributeError, KeyError, TypeError, ValueError) as error:
+                raise RuntimeError(
+                    f"invalid manifest for source slot {shard.source_slot_id!r}"
+                ) from error
+            fingerprint_s = time.perf_counter() - fingerprint_started
+            manifest = response.manifest
+            self._manifest_cache[key] = (
+                shard.manifest_endpoint,
+                shard.manifest_digest,
+                manifest,
+                structure_digest,
             )
-        return GeneratorSource(
+        source = GeneratorSource(
             source_slot_id=shard.source_slot_id,
             worker_id=shard.worker_id,
             manifest_digest=shard.manifest_digest,
             transport=NixlGeneratorSource(
                 manifest_endpoint=shard.manifest_endpoint,
-                manifest=response.manifest,
+                manifest=manifest,
+                structural_digest=structure_digest,
             ),
         )
+        return source, {
+            "manifest_fetch_s": fetch_s,
+            "manifest_hash_s": hash_s,
+            "manifest_fingerprint_s": fingerprint_s,
+            "manifest_bytes": len(manifest),
+            "manifest_fetch_bytes": len(manifest) * int(not cache_hit),
+            "manifest_cache_hits": int(cache_hit),
+            "manifest_cache_misses": int(not cache_hit),
+            "manifest_fetch_count": int(not cache_hit),
+        }
 
 
 __all__ = ["TrainerSourceResolver"]

--- a/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
@@ -23,6 +23,59 @@ logger = logging.getLogger("modelexpress_rl.inference.source.trainer")
 _MAX_MANIFEST_MESSAGE_SIZE_BYTES = 100 * 1024 * 1024
 
 
+class _SlotReplicas:
+    """Replicas published for one source slot, resolved as far as asked.
+
+    Health is decided per slot and independently of every other slot. Pairing
+    replicas by a shared offset instead means a fleet whose healthy replicas
+    sit at different offsets in different slots yields no candidate at all,
+    even though a complete healthy set exists: with only ``a0`` up in one slot
+    and only ``b1`` in the next, the aligned pairs ``(a0, b0)`` and
+    ``(a1, b1)`` both contain a dead source and ``(a0, b1)`` is never tried.
+
+    Resolution stays lazy because it is charged per manifest fetched, and the
+    first replica of each slot is all a healthy fleet ever needs.
+    """
+
+    def __init__(
+        self,
+        slot_id: str,
+        shards: list[refit_pb2.WeightVersionShard],
+        resolve: Callable[[refit_pb2.WeightVersionShard], GeneratorSource],
+    ) -> None:
+        self.slot_id = slot_id
+        self._pending = list(shards)
+        self._resolve = resolve
+        self._usable: list[GeneratorSource] = []
+
+    def usable(self, index: int) -> GeneratorSource | None:
+        """Return the index-th usable replica, resolving no further than needed."""
+        while len(self._usable) <= index and self._pending:
+            shard = self._pending.pop(0)
+            try:
+                self._usable.append(self._resolve(shard))
+            except (grpc.RpcError, RuntimeError) as error:
+                logger.warning(
+                    "trainer source %s failed for slot %s: %s",
+                    shard.worker_id,
+                    self.slot_id,
+                    error,
+                )
+        if index < len(self._usable):
+            return self._usable[index]
+        return None
+
+    @property
+    def exhausted(self) -> bool:
+        """Whether every published replica has been tried."""
+        return not self._pending
+
+    @property
+    def usable_count(self) -> int:
+        """How many replicas resolved so far; final once exhausted."""
+        return len(self._usable)
+
+
 class TrainerSourceResolver(SourceResolver):
     """Resolve trainer shard manifests without compiling a transfer plan."""
 
@@ -72,52 +125,59 @@ class TrainerSourceResolver(SourceResolver):
         for shard in response.shards:
             published[shard.source_slot_id].append(shard)
 
-        ordered_slots = []
+        slots = []
         for source_slot_id in version.expected_source_slots:
-            ordered = sorted(published[source_slot_id], key=lambda item: item.worker_id)
+            ordered = sorted(
+                published[source_slot_id], key=lambda item: item.worker_id
+            )
             if not ordered:
                 logger.warning(
                     "no trainer source published for required slot %s",
                     source_slot_id,
                 )
                 return
-            ordered_slots.append(ordered)
+            slots.append(_SlotReplicas(source_slot_id, ordered, self._resolve_source))
 
-        seen = set()
-        candidate_count = max((len(slot) for slot in ordered_slots), default=1)
-        for offset in range(candidate_count):
-            selected_shards = tuple(slot[offset % len(slot)] for slot in ordered_slots)
+        seen: set[tuple[tuple[str, str], ...]] = set()
+        offset = 0
+        while True:
+            selected = []
+            for slot in slots:
+                source = slot.usable(offset)
+                if source is None:
+                    if not slot.usable_count:
+                        logger.warning(
+                            "no usable trainer source for required slot %s",
+                            slot.slot_id,
+                        )
+                        return
+                    # Exhausted and shorter than the candidate index, so cycle
+                    # its healthy replicas rather than give up on a slot that
+                    # simply has fewer of them.
+                    source = slot.usable(offset % slot.usable_count)
+                selected.append(source)
             selection = tuple(
-                (shard.source_slot_id, shard.worker_id) for shard in selected_shards
+                (source.source_slot_id, source.worker_id) for source in selected
             )
-            if selection in seen:
-                continue
-            seen.add(selection)
-            resolved = []
-            for shard in selected_shards:
-                try:
-                    resolved.append(self._resolve_source(shard))
-                except (grpc.RpcError, RuntimeError) as error:
-                    logger.warning(
-                        "trainer source %s failed for slot %s: %s",
-                        shard.worker_id,
-                        shard.source_slot_id,
-                        error,
+            if selection not in seen:
+                seen.add(selection)
+                yield TrainerUpdateSource(
+                    inputs=GeneratorTransferInputs(
+                        version_id=version.version_id,
+                        base_version_id=version.base_version_id,
+                        layout_signature=version.layout_signature,
+                        payload_format=version.payload_format,
+                        sources=tuple(selected),
                     )
-                    break
-            if len(resolved) != len(ordered_slots):
-                continue
-            yield TrainerUpdateSource(
-                inputs=GeneratorTransferInputs(
-                    version_id=version.version_id,
-                    base_version_id=version.base_version_id,
-                    layout_signature=version.layout_signature,
-                    payload_format=version.payload_format,
-                    sources=tuple(resolved),
                 )
-            )
+            deepest = max((slot.usable_count for slot in slots), default=1)
+            if all(slot.exhausted for slot in slots) and offset + 1 >= deepest:
+                return
+            offset += 1
 
-    def _resolve_source(self, shard: refit_pb2.WeightVersionShard) -> GeneratorSource:
+    def _resolve_source(
+        self, shard: refit_pb2.WeightVersionShard
+    ) -> GeneratorSource:
         if not shard.manifest_endpoint:
             raise RuntimeError("NIXL source is missing its manifest endpoint")
         if not shard.manifest_digest:
@@ -166,7 +226,9 @@ class TrainerSourceResolver(SourceResolver):
             ),
         )
 
-    def _fetch_manifest(self, shard: refit_pb2.WeightVersionShard) -> tuple[bytes, str]:
+    def _fetch_manifest(
+        self, shard: refit_pb2.WeightVersionShard
+    ) -> tuple[bytes, str]:
         """Fetch, verify and fingerprint one worker's manifest.
 
         Three spans on one stage rather than one, because the stage total
@@ -174,22 +236,19 @@ class TrainerSourceResolver(SourceResolver):
         CPU, and with digests published these manifests are refetched by
         construction on every version.
         """
-        with (
-            refit_span(
-                "source_preparation",
-                accumulate_metadata=True,
-                duration_key="manifest_fetch_s",
-            ),
-            grpc.insecure_channel(
-                shard.manifest_endpoint,
-                options=[
-                    (
-                        "grpc.max_receive_message_length",
-                        _MAX_MANIFEST_MESSAGE_SIZE_BYTES,
-                    )
-                ],
-            ) as channel,
-        ):
+        with refit_span(
+            "source_preparation",
+            accumulate_metadata=True,
+            duration_key="manifest_fetch_s",
+        ), grpc.insecure_channel(
+            shard.manifest_endpoint,
+            options=[
+                (
+                    "grpc.max_receive_message_length",
+                    _MAX_MANIFEST_MESSAGE_SIZE_BYTES,
+                )
+            ],
+        ) as channel:
             response = refit_pb2_grpc.RefitWorkerServiceStub(
                 channel
             ).GetWeightVersionShardManifest(

--- a/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/source/trainer.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from collections.abc import Callable, Iterator
 
 import grpc
-
 from modelexpress.refit.reshard.rendezvous import structural_manifest_digest
 
 from ... import refit_pb2, refit_pb2_grpc, timing

--- a/modelexpress_client/python/modelexpress_rl/timing.py
+++ b/modelexpress_client/python/modelexpress_rl/timing.py
@@ -1,21 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Normalized refit timing for the RL generator path.
+"""Refit cycle ownership for the RL generator path.
 
-:mod:`modelexpress.refit.timing` already defines the record and its stage
-vocabulary. What was missing is a cycle owner on this path: the recorder is only
-populated while one is active, so with nothing activating it the RL client
-produced no stages at all, and a framework asking where a refit spent its time
-could only see the total.
+:mod:`modelexpress.refit.timing` owns the record, the stage vocabulary and the
+recording helpers. This module owns only the thing that was missing on this
+path: a cycle. The recorder is populated while one is active, so with nothing
+activating it the RL client produced no stages at all, and a framework asking
+where a refit spent its time could only see the total.
 
 That gap was measurable from outside. Instrumenting a refit at the framework
 boundary attributed about 18% of it, because the boundary can only see
 ``stage``, ``apply`` and ``release`` -- three calls, one of which contains the
 wire transfer, the reconstruction, post-load processing and the copy into kernel
-storage, all charged together as "install". The durations were being measured
-anyway: the staging path times its own wire and reconstruct phases and puts them
-on the staged handle. They just had nowhere to go.
+storage, all charged together as "install".
 
 A cycle here spans two client calls, ``stage_weight`` and ``apply_weight``, with
 the caller's own work in between at a safe point of its choosing. So it cannot be
@@ -23,6 +21,9 @@ one ``with`` block; the recorder is created when staging starts, carried on the
 staged handle, and re-activated for the apply. Its ``e2e_ms`` is therefore
 staging through install, including the caller's pause, which is why the stage
 durations are what to read for transport cost.
+
+Layers contributing stages inside a cycle should reach for
+:func:`modelexpress.refit.timing.refit_span` directly rather than anything here.
 """
 
 from __future__ import annotations
@@ -34,9 +35,7 @@ from typing import Any
 
 from modelexpress.refit.timing import (
     RefitTimingRecorder,
-    add_refit_bytes,
     current_refit_timing,
-    refit_span,
     use_refit_timing,
 )
 
@@ -92,53 +91,9 @@ def emit(
     return None
 
 
-def record_measured(
-    stage: str,
-    seconds: float,
-    *,
-    metadata: dict[str, Any] | None = None,
-    accumulate_metadata: bool = False,
-) -> None:
-    """Attribute an already-measured duration to a normalized stage.
-
-    The staging path measures the wire read and the reconstruction itself,
-    around code that has to be timed from the inside to be timed at all. Those
-    numbers are handed here rather than re-measured from outside, where they
-    would be bundled together.
-    """
-    recorder = current_refit_timing()
-    if recorder is not None:
-        recorder.add_duration(
-            stage,
-            max(0.0, float(seconds)),
-            metadata=metadata,
-            accumulate_metadata=accumulate_metadata,
-        )
-
-
-def record_bytes(count: int) -> None:
-    """Record payload bytes so the record carries throughput, not just time."""
-    add_refit_bytes(int(count))
-
-
-def record_cold(cold: bool) -> None:
-    """Mark whether this cycle had to build a transfer plan or reused one.
-
-    The distinction dominates ``transfer_planning``: a reused plan makes it
-    almost free, so a mean over both is a number that describes neither.
-    """
-    recorder = current_refit_timing()
-    if recorder is not None:
-        recorder.set_cold(cold)
-
-
 __all__ = [
     "BACKEND",
     "active",
     "emit",
-    "record_bytes",
-    "record_cold",
-    "record_measured",
-    "refit_span",
     "start_cycle",
 ]

--- a/modelexpress_client/python/modelexpress_rl/timing.py
+++ b/modelexpress_client/python/modelexpress_rl/timing.py
@@ -29,7 +29,8 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 from modelexpress.refit.timing import (
     RefitTimingRecorder,
@@ -48,6 +49,7 @@ def start_cycle(
     *,
     version_id: str,
     rank: int | None = None,
+    backend: str = BACKEND,
 ) -> RefitTimingRecorder | None:
     """Open a recorder for one generator refit, or ``None`` when disabled.
 
@@ -62,7 +64,7 @@ def start_cycle(
         # A caller driving its own cycle wins. Nesting a second recorder would
         # split one refit across two records and leave both looking incomplete.
         return None
-    return RefitTimingRecorder(backend=BACKEND, version=version_id, rank=rank)
+    return RefitTimingRecorder(backend=backend, version=version_id, rank=rank)
 
 
 @contextlib.contextmanager
@@ -75,7 +77,9 @@ def active(recorder: RefitTimingRecorder | None) -> Iterator[None]:
         yield
 
 
-def emit(recorder: RefitTimingRecorder | None, logger: logging.Logger) -> None:
+def emit(
+    recorder: RefitTimingRecorder | None, logger: logging.Logger
+) -> dict[str, Any] | None:
     """Emit the cycle's record, once, if there is one.
 
     Idempotent in the recorder, which is what lets the client call this from
@@ -84,7 +88,8 @@ def emit(recorder: RefitTimingRecorder | None, logger: logging.Logger) -> None:
     vanishing.
     """
     if recorder is not None:
-        recorder.emit(logger)
+        return recorder.emit(logger)
+    return None
 
 
 def record_measured(
@@ -92,6 +97,7 @@ def record_measured(
     seconds: float,
     *,
     metadata: dict[str, Any] | None = None,
+    accumulate_metadata: bool = False,
 ) -> None:
     """Attribute an already-measured duration to a normalized stage.
 
@@ -102,7 +108,12 @@ def record_measured(
     """
     recorder = current_refit_timing()
     if recorder is not None:
-        recorder.add_duration(stage, max(0.0, float(seconds)), metadata=metadata)
+        recorder.add_duration(
+            stage,
+            max(0.0, float(seconds)),
+            metadata=metadata,
+            accumulate_metadata=accumulate_metadata,
+        )
 
 
 def record_bytes(count: int) -> None:

--- a/modelexpress_client/python/modelexpress_rl/timing.py
+++ b/modelexpress_client/python/modelexpress_rl/timing.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Normalized refit timing for the RL generator path.
+
+:mod:`modelexpress.refit.timing` already defines the record and its stage
+vocabulary. What was missing is a cycle owner on this path: the recorder is only
+populated while one is active, so with nothing activating it the RL client
+produced no stages at all, and a framework asking where a refit spent its time
+could only see the total.
+
+That gap was measurable from outside. Instrumenting a refit at the framework
+boundary attributed about 18% of it, because the boundary can only see
+``stage``, ``apply`` and ``release`` -- three calls, one of which contains the
+wire transfer, the reconstruction, post-load processing and the copy into kernel
+storage, all charged together as "install". The durations were being measured
+anyway: the staging path times its own wire and reconstruct phases and puts them
+on the staged handle. They just had nowhere to go.
+
+A cycle here spans two client calls, ``stage_weight`` and ``apply_weight``, with
+the caller's own work in between at a safe point of its choosing. So it cannot be
+one ``with`` block; the recorder is created when staging starts, carried on the
+staged handle, and re-activated for the apply. Its ``e2e_ms`` is therefore
+staging through install, including the caller's pause, which is why the stage
+durations are what to read for transport cost.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import Any, Iterator
+
+from modelexpress.refit.timing import (
+    RefitTimingRecorder,
+    add_refit_bytes,
+    current_refit_timing,
+    refit_span,
+    use_refit_timing,
+)
+
+from . import envs
+
+BACKEND = "rl_generator"
+
+
+def start_cycle(
+    *,
+    version_id: str,
+    rank: int | None = None,
+) -> RefitTimingRecorder | None:
+    """Open a recorder for one generator refit, or ``None`` when disabled.
+
+    Returning ``None`` rather than a dummy keeps the disabled path free of the
+    recorder entirely, and every consumer here already has to handle the absence
+    of a cycle, since lower layers are also reachable from callers that never
+    started one.
+    """
+    if not envs.MX_REFIT_TIMING:
+        return None
+    if current_refit_timing() is not None:
+        # A caller driving its own cycle wins. Nesting a second recorder would
+        # split one refit across two records and leave both looking incomplete.
+        return None
+    return RefitTimingRecorder(backend=BACKEND, version=version_id, rank=rank)
+
+
+@contextlib.contextmanager
+def active(recorder: RefitTimingRecorder | None) -> Iterator[None]:
+    """Make ``recorder`` visible to the layers that contribute stages."""
+    if recorder is None:
+        yield
+        return
+    with use_refit_timing(recorder):
+        yield
+
+
+def emit(recorder: RefitTimingRecorder | None, logger: logging.Logger) -> None:
+    """Emit the cycle's record, once, if there is one.
+
+    Idempotent in the recorder, which is what lets the client call this from
+    both the apply and the release path: whichever ends the cycle reports it,
+    and a refit that failed before applying is still reported rather than
+    vanishing.
+    """
+    if recorder is not None:
+        recorder.emit(logger)
+
+
+def record_measured(
+    stage: str,
+    seconds: float,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Attribute an already-measured duration to a normalized stage.
+
+    The staging path measures the wire read and the reconstruction itself,
+    around code that has to be timed from the inside to be timed at all. Those
+    numbers are handed here rather than re-measured from outside, where they
+    would be bundled together.
+    """
+    recorder = current_refit_timing()
+    if recorder is not None:
+        recorder.add_duration(stage, max(0.0, float(seconds)), metadata=metadata)
+
+
+def record_bytes(count: int) -> None:
+    """Record payload bytes so the record carries throughput, not just time."""
+    add_refit_bytes(int(count))
+
+
+def record_cold(cold: bool) -> None:
+    """Mark whether this cycle had to build a transfer plan or reused one.
+
+    The distinction dominates ``transfer_planning``: a reused plan makes it
+    almost free, so a mean over both is a number that describes neither.
+    """
+    recorder = current_refit_timing()
+    if recorder is not None:
+        recorder.set_cold(cold)
+
+
+__all__ = [
+    "BACKEND",
+    "active",
+    "emit",
+    "record_bytes",
+    "record_cold",
+    "record_measured",
+    "refit_span",
+    "start_cycle",
+]

--- a/modelexpress_client/python/modelexpress_rl/train/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/train/adapter.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
@@ -94,7 +95,7 @@ class WeightVersionShardManifest:
         if not self.transport:
             raise ValueError("transport must not be empty")
 
-    @property
+    @cached_property
     def digest(self) -> str:
         """Return the SHA-256 digest advertised through RefitService."""
         return hashlib.sha256(self.data).hexdigest()
@@ -158,6 +159,9 @@ class WeightVersionShardManifestPublisher(Protocol):
         manifest: WeightVersionShardManifest,
     ) -> str:
         """Publish ``manifest`` and return its ready, worker-local endpoint."""
+
+    def release_manifest(self, *, version_id: str, source_slot_id: str) -> None:
+        """Stop serving a released version's manifest."""
 
 
 __all__ = [

--- a/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/adapter.py
@@ -22,12 +22,15 @@ the client passes each stage, so a trainer that re-materializes its state_dict
 from __future__ import annotations
 
 import math
+import time
 from typing import Any
 
 import torch
 import torch.distributed as dist
 
+from modelexpress import envs as mx_envs
 from modelexpress.refit.reshard.cuda_pool import classic_cuda_alloc
+from modelexpress_rl import timing
 from modelexpress_rl.train.adapter import (
     CompletionFence,
     NixlMetadataProvider,
@@ -75,6 +78,7 @@ class FSDPTrainerAdapter(TrainerEngineAdapter):
         # name -> the address we registered (the arena for COPY, the live source
         # for IN_PLACE). The served buffer must keep sitting here.
         self._registered_addrs: dict[str, int] = {}
+        self._manifest: WeightVersionShardManifest | None = None
 
     @property
     def source_slot_id(self) -> str:
@@ -176,17 +180,47 @@ class FSDPTrainerAdapter(TrainerEngineAdapter):
         # Re-read the rank-local views from THIS step's state_dict so a
         # re-materialized source still publishes the latest weights; these same
         # shards seed the one-time setup on the first stage (single capture).
+        started = time.perf_counter()
         shards = self._capture(tensors)
+        duration = time.perf_counter() - started
+        timing.record_measured(
+            "source_preparation",
+            duration,
+            metadata={"shard_capture_s": duration},
+        )
+        initialized = self._initialized
+        started = time.perf_counter()
         self.initialize(shards=shards, staging_mode=staging_mode)
+        duration = time.perf_counter() - started
+        if not initialized:
+            timing.record_measured(
+                "setup_registration",
+                duration,
+                metadata={"trainer_registration_s": duration},
+            )
         if staging_mode is not self._staging_mode:
             raise ValueError(
                 f"FSDPTrainerAdapter initialized for {self._staging_mode.value} "
                 f"staging; cannot stage {staging_mode.value}"
             )
+        started = time.perf_counter()
         self._require_same_layout(shards)
+        duration = time.perf_counter() - started
+        timing.record_measured(
+            "source_preparation",
+            duration,
+            metadata={"layout_validation_s": duration},
+        )
 
         if staging_mode is TrainerStagingMode.COPY_TO_DEVICE:
+            started = time.perf_counter()
             publish_ready = self._snapshot_into_arenas(shards)
+            duration = time.perf_counter() - started
+            timing.record_measured(
+                "source_preparation",
+                duration,
+                metadata={"staging_copy_enqueue_s": duration},
+            )
         else:  # IN_PLACE serves live storage; nothing to copy.
             self._require_sources_pinned(shards)
             publish_ready = CompletionFence(lambda: None)
@@ -271,20 +305,44 @@ class FSDPTrainerAdapter(TrainerEngineAdapter):
     def _staged(
         self, shards: list[LocalTensorShard], publish_ready: CompletionFence
     ) -> StagedWeightVersionShardData:
-        blob = build_fsdp_reshard_manifest(
-            manager=self._manager,
-            shards=shards,
-            metadata_endpoint=self._nixl_metadata_endpoint,
-        )
-        wire_elsize = torch.empty((), dtype=WIRE_DTYPE).element_size()
-        total_bytes = sum(math.prod(s.local_shape) * wire_elsize for s in shards)
-        return StagedWeightVersionShardData(
-            manifest=WeightVersionShardManifest(
+        cache_hit = self._manifest is not None and not mx_envs.MX_RESHARD_PUBLISH_DIGEST
+        if not cache_hit:
+            manifest_metrics: dict[str, int | float] = {}
+            blob = build_fsdp_reshard_manifest(
+                manager=self._manager,
+                shards=shards,
+                metadata_endpoint=self._nixl_metadata_endpoint,
+                metrics=manifest_metrics,
+            )
+            wire_elsize = torch.empty((), dtype=WIRE_DTYPE).element_size()
+            total_bytes = sum(
+                math.prod(shard.local_shape) * wire_elsize for shard in shards
+            )
+            self._manifest = WeightVersionShardManifest(
                 data=blob,
-                tensor_count=len({s.name for s in shards}),
+                tensor_count=len({shard.name for shard in shards}),
                 total_bytes=total_bytes,
                 transport="NIXL",
-            ),
+            )
+            for name in ("manifest_generation_s", "manifest_serialization_s"):
+                duration = float(manifest_metrics[name])
+                timing.record_measured(
+                    "source_preparation",
+                    duration,
+                    metadata={name: duration},
+                )
+        assert self._manifest is not None
+        timing.record_measured(
+            "source_preparation",
+            0.0,
+            metadata={
+                "manifest_bytes": len(self._manifest.data),
+                "manifest_cache_hit": cache_hit,
+                "manifest_tensor_count": self._manifest.tensor_count,
+            },
+        )
+        return StagedWeightVersionShardData(
+            manifest=self._manifest,
             publish_ready=publish_ready,
             # Keep the served buffers alive while the version can be selected.
             buffer_owner=tuple(s.served_tensor for s in shards),

--- a/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/adapter.py
@@ -21,8 +21,8 @@ the client passes each stage, so a trainer that re-materializes its state_dict
 
 from __future__ import annotations
 
+import contextlib
 import math
-import time
 from typing import Any
 
 import torch
@@ -30,7 +30,11 @@ import torch.distributed as dist
 
 from modelexpress import envs as mx_envs
 from modelexpress.refit.reshard.cuda_pool import classic_cuda_alloc
-from modelexpress_rl import timing
+from modelexpress.refit.timing import (
+    add_refit_duration,
+    add_refit_metadata,
+    refit_span,
+)
 from modelexpress_rl.train.adapter import (
     CompletionFence,
     NixlMetadataProvider,
@@ -180,47 +184,49 @@ class FSDPTrainerAdapter(TrainerEngineAdapter):
         # Re-read the rank-local views from THIS step's state_dict so a
         # re-materialized source still publishes the latest weights; these same
         # shards seed the one-time setup on the first stage (single capture).
-        started = time.perf_counter()
-        shards = self._capture(tensors)
-        duration = time.perf_counter() - started
-        timing.record_measured(
+        with refit_span(
             "source_preparation",
-            duration,
-            metadata={"shard_capture_s": duration},
-        )
-        initialized = self._initialized
-        started = time.perf_counter()
-        self.initialize(shards=shards, staging_mode=staging_mode)
-        duration = time.perf_counter() - started
-        if not initialized:
-            timing.record_measured(
+            metadata={"shard_captures": 1},
+            accumulate_metadata=True,
+            duration_key="shard_capture_s",
+        ):
+            shards = self._capture(tensors)
+        # Charged only on the first stage. Later calls are a no-op, and a stage
+        # reporting near-zero registration would read as though registering
+        # were free rather than already done.
+        registration = (
+            contextlib.nullcontext()
+            if self._initialized
+            else refit_span(
                 "setup_registration",
-                duration,
-                metadata={"trainer_registration_s": duration},
+                metadata={"trainer_registrations": 1},
+                accumulate_metadata=True,
+                duration_key="trainer_registration_s",
             )
+        )
+        with registration:
+            self.initialize(shards=shards, staging_mode=staging_mode)
         if staging_mode is not self._staging_mode:
             raise ValueError(
                 f"FSDPTrainerAdapter initialized for {self._staging_mode.value} "
                 f"staging; cannot stage {staging_mode.value}"
             )
-        started = time.perf_counter()
-        self._require_same_layout(shards)
-        duration = time.perf_counter() - started
-        timing.record_measured(
+        with refit_span(
             "source_preparation",
-            duration,
-            metadata={"layout_validation_s": duration},
-        )
+            metadata={"layout_validations": 1},
+            accumulate_metadata=True,
+            duration_key="layout_validation_s",
+        ):
+            self._require_same_layout(shards)
 
         if staging_mode is TrainerStagingMode.COPY_TO_DEVICE:
-            started = time.perf_counter()
-            publish_ready = self._snapshot_into_arenas(shards)
-            duration = time.perf_counter() - started
-            timing.record_measured(
+            with refit_span(
                 "source_preparation",
-                duration,
-                metadata={"staging_copy_enqueue_s": duration},
-            )
+                metadata={"staging_copy_enqueues": 1},
+                accumulate_metadata=True,
+                duration_key="staging_copy_enqueue_s",
+            ):
+                publish_ready = self._snapshot_into_arenas(shards)
         else:  # IN_PLACE serves live storage; nothing to copy.
             self._require_sources_pinned(shards)
             publish_ready = CompletionFence(lambda: None)
@@ -324,18 +330,18 @@ class FSDPTrainerAdapter(TrainerEngineAdapter):
                 total_bytes=total_bytes,
                 transport="NIXL",
             )
+            # Measured by the publisher while it built the blob, which is the
+            # only place the generation and serialization halves are separable.
             for name in ("manifest_generation_s", "manifest_serialization_s"):
-                duration = float(manifest_metrics[name])
-                timing.record_measured(
+                add_refit_duration(
                     "source_preparation",
-                    duration,
-                    metadata={name: duration},
+                    float(manifest_metrics[name]),
+                    metadata={name: float(manifest_metrics[name])},
                 )
         assert self._manifest is not None
-        timing.record_measured(
+        add_refit_metadata(
             "source_preparation",
-            0.0,
-            metadata={
+            {
                 "manifest_bytes": len(self._manifest.data),
                 "manifest_cache_hit": cache_hit,
                 "manifest_tensor_count": self._manifest.tensor_count,

--- a/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/fsdp/publisher.py
@@ -22,6 +22,7 @@ Extraction rules (per state_dict tensor, floating point only):
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 
 import torch
@@ -66,7 +67,11 @@ class LocalTensorShard:
     @property
     def served_tensor(self) -> torch.Tensor:
         """The tensor NIXL actually registers/serves (staging if copied, else source)."""
-        return self.staging_tensor if self.staging_tensor is not None else self.source_tensor
+        return (
+            self.staging_tensor
+            if self.staging_tensor is not None
+            else self.source_tensor
+        )
 
 
 def capture_local_shards(
@@ -153,6 +158,7 @@ def build_fsdp_reshard_manifest(
     manager: NixlMetadataProvider,
     shards: list[LocalTensorShard],
     metadata_endpoint: str,
+    metrics: dict[str, int | float] | None = None,
 ) -> bytes:
     """Describe already-registered FSDP source shards as an MX manifest blob.
 
@@ -167,6 +173,7 @@ def build_fsdp_reshard_manifest(
     if not shards:
         raise ValueError("no local shards to publish")
 
+    generation_started = time.perf_counter()
     by_name: dict[str, PublishedTensor] = {}
     for shard in shards:
         served = shard.served_tensor
@@ -196,12 +203,30 @@ def build_fsdp_reshard_manifest(
             tensor.shards.append(published_shard)
 
     published = list(by_name.values())
-    return wrap_rendezvous_blob(
+    generation_s = time.perf_counter() - generation_started
+    serialization_started = time.perf_counter()
+    blob = wrap_rendezvous_blob(
         manager.nixl_metadata,
         agent_name,
         metadata_endpoint,
         published,
     )
+    serialization_s = time.perf_counter() - serialization_started
+    if metrics is not None:
+        metrics.update(
+            {
+                "manifest_generation_s": generation_s,
+                "manifest_serialization_s": serialization_s,
+                "manifest_bytes": len(blob),
+                "manifest_tensor_count": len(published),
+            }
+        )
+    return blob
 
 
-__all__ = ["WIRE_DTYPE", "LocalTensorShard", "capture_local_shards", "build_fsdp_reshard_manifest"]
+__all__ = [
+    "WIRE_DTYPE",
+    "LocalTensorShard",
+    "build_fsdp_reshard_manifest",
+    "capture_local_shards",
+]

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/adapter.py
@@ -8,13 +8,12 @@ from __future__ import annotations
 import hashlib
 import json
 import math
-import time
 from typing import Any
 
 import torch.distributed as dist
 from modelexpress import envs as mx_envs
+from modelexpress.refit.timing import add_refit_metadata, refit_span
 
-from modelexpress_rl import timing
 from modelexpress_rl.train.adapter import (
     CompletionFence,
     NixlMetadataProvider,
@@ -116,14 +115,13 @@ class MegatronTrainerAdapter(TrainerEngineAdapter):
             raise ValueError("Megatron tensor names must be unique within this rank")
         addresses = {name: tensor.data_ptr() for name, tensor in sources.items()}
         if self._registered_addrs is None:
-            started = time.perf_counter()
-            self._manager.register_tensors(sources)
-            duration = time.perf_counter() - started
-            timing.record_measured(
+            with refit_span(
                 "setup_registration",
-                duration,
-                metadata={"trainer_registration_s": duration},
-            )
+                metadata={"trainer_registrations": 1},
+                accumulate_metadata=True,
+                duration_key="trainer_registration_s",
+            ):
+                self._manager.register_tensors(sources)
             self._registered_addrs = addresses
         elif addresses != self._registered_addrs:
             raise RuntimeError(
@@ -132,17 +130,21 @@ class MegatronTrainerAdapter(TrainerEngineAdapter):
             )
         cache_hit = self._manifest is not None and not mx_envs.MX_RESHARD_PUBLISH_DIGEST
         if not cache_hit:
-            started = time.perf_counter()
-            published = build_hf_aliases(
-                tensors,
-                agent_name=str(self._manager.agent_name),
-            )
-            manifest = build_megatron_reshard_manifest(
-                manager=self._manager,
-                published=published,
-                metadata_endpoint=self._nixl_metadata_endpoint,
-            )
-            duration = time.perf_counter() - started
+            with refit_span(
+                "source_preparation",
+                metadata={"manifest_generations": 1},
+                accumulate_metadata=True,
+                duration_key="manifest_generation_s",
+            ):
+                published = build_hf_aliases(
+                    tensors,
+                    agent_name=str(self._manager.agent_name),
+                )
+                manifest = build_megatron_reshard_manifest(
+                    manager=self._manager,
+                    published=published,
+                    metadata_endpoint=self._nixl_metadata_endpoint,
+                )
             total_bytes = sum(
                 math.prod(shard.shape) * tensor.elsize
                 for tensor in manifest.tensors
@@ -154,16 +156,10 @@ class MegatronTrainerAdapter(TrainerEngineAdapter):
                 total_bytes=total_bytes,
                 transport="NIXL",
             )
-            timing.record_measured(
-                "source_preparation",
-                duration,
-                metadata={"manifest_generation_s": duration},
-            )
         assert self._manifest is not None
-        timing.record_measured(
+        add_refit_metadata(
             "source_preparation",
-            0.0,
-            metadata={
+            {
                 "manifest_bytes": len(self._manifest.data),
                 "manifest_cache_hit": cache_hit,
                 "manifest_tensor_count": self._manifest.tensor_count,

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/adapter.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import time
 from typing import Any
 
 import torch.distributed as dist
 
+from modelexpress import envs as mx_envs
+from modelexpress_rl import timing
 from modelexpress_rl.train.adapter import (
     CompletionFence,
     NixlMetadataProvider,
@@ -41,6 +44,7 @@ class MegatronTrainerAdapter(TrainerEngineAdapter):
         self._nixl_metadata_endpoint = nixl_metadata_endpoint
         self._source_slot_id: str | None = None
         self._registered_addrs: dict[str, int] | None = None
+        self._manifest: WeightVersionShardManifest | None = None
 
     @property
     def source_slot_id(self) -> str:
@@ -73,7 +77,9 @@ class MegatronTrainerAdapter(TrainerEngineAdapter):
         ).hexdigest()
         source_slot_id = f"megatron:partition:{digest}"
         if self._source_slot_id is not None and self._source_slot_id != source_slot_id:
-            raise RuntimeError("Megatron logical tensor partition changed after binding")
+            raise RuntimeError(
+                "Megatron logical tensor partition changed after binding"
+            )
         self._source_slot_id = source_slot_id
         return source_slot_id
 
@@ -110,35 +116,62 @@ class MegatronTrainerAdapter(TrainerEngineAdapter):
             raise ValueError("Megatron tensor names must be unique within this rank")
         addresses = {name: tensor.data_ptr() for name, tensor in sources.items()}
         if self._registered_addrs is None:
+            started = time.perf_counter()
             self._manager.register_tensors(sources)
+            duration = time.perf_counter() - started
+            timing.record_measured(
+                "setup_registration",
+                duration,
+                metadata={"trainer_registration_s": duration},
+            )
             self._registered_addrs = addresses
         elif addresses != self._registered_addrs:
             raise RuntimeError(
                 "Megatron source storage changed after NIXL registration; "
                 "IN_PLACE requires stable tensor addresses"
             )
-        published = build_hf_aliases(
-            tensors,
-            agent_name=str(self._manager.agent_name),
-        )
-        manifest = build_megatron_reshard_manifest(
-            manager=self._manager,
-            published=published,
-            metadata_endpoint=self._nixl_metadata_endpoint,
-        )
-        total_bytes = sum(
-            math.prod(shard.shape) * tensor.elsize
-            for tensor in manifest.tensors
-            for shard in tensor.shards
-        )
-
-        return StagedWeightVersionShardData(
-            manifest=WeightVersionShardManifest(
+        cache_hit = self._manifest is not None and not mx_envs.MX_RESHARD_PUBLISH_DIGEST
+        if not cache_hit:
+            started = time.perf_counter()
+            published = build_hf_aliases(
+                tensors,
+                agent_name=str(self._manager.agent_name),
+            )
+            manifest = build_megatron_reshard_manifest(
+                manager=self._manager,
+                published=published,
+                metadata_endpoint=self._nixl_metadata_endpoint,
+            )
+            duration = time.perf_counter() - started
+            total_bytes = sum(
+                math.prod(shard.shape) * tensor.elsize
+                for tensor in manifest.tensors
+                for shard in tensor.shards
+            )
+            self._manifest = WeightVersionShardManifest(
                 data=manifest.blob,
                 tensor_count=len(manifest.tensors),
                 total_bytes=total_bytes,
                 transport="NIXL",
-            ),
+            )
+            timing.record_measured(
+                "source_preparation",
+                duration,
+                metadata={"manifest_generation_s": duration},
+            )
+        assert self._manifest is not None
+        timing.record_measured(
+            "source_preparation",
+            0.0,
+            metadata={
+                "manifest_bytes": len(self._manifest.data),
+                "manifest_cache_hit": cache_hit,
+                "manifest_tensor_count": self._manifest.tensor_count,
+            },
+        )
+
+        return StagedWeightVersionShardData(
+            manifest=self._manifest,
             # IN_PLACE performs no asynchronous copy, so the shard is ready to
             # publish as soon as its manifest has been built.
             publish_ready=CompletionFence(lambda: None),

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/adapter.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/adapter.py
@@ -12,8 +12,8 @@ import time
 from typing import Any
 
 import torch.distributed as dist
-
 from modelexpress import envs as mx_envs
+
 from modelexpress_rl import timing
 from modelexpress_rl.train.adapter import (
     CompletionFence,

--- a/modelexpress_client/python/modelexpress_rl/train/engines/megatron/aliases.py
+++ b/modelexpress_client/python/modelexpress_rl/train/engines/megatron/aliases.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from modelexpress.refit.reshard.rendezvous import PublishedShard, PublishedTensor
-from modelexpress.refit.reshard.verify import tensor_digest
+from modelexpress.refit.reshard.verify import published_digest
 
 
 @dataclass(frozen=True)
@@ -104,7 +104,7 @@ def _one_shard(
                 addr=int(tensor.data_ptr()),
                 shard_offset=tuple(offset),
                 shape=local_shape,
-                digest=tensor_digest(tensor),
+                digest=published_digest(tensor),
             )
         ],
     )
@@ -322,7 +322,7 @@ def _build_global_qkv_aliases(
                 shard_offset=(band.destination_start + overlap_lo - band.start,)
                 + (0,) * len(trailing_shape),
                 shape=tuple(int(dim) for dim in tensor.shape),
-                digest=tensor_digest(tensor),
+                digest=published_digest(tensor),
             )
         )
         mapped_rows += overlap_hi - overlap_lo
@@ -394,7 +394,7 @@ def _build_legacy_qkv_aliases(
                     shape=tuple(int(dim) for dim in tensor.shape),
                     # The narrow, not the fused parent: this is the box a receiver
                     # reads from ``addr``, so it is the box whose bytes must match.
-                    digest=tensor_digest(tensor),
+                    digest=published_digest(tensor),
                 )
             )
     return [

--- a/modelexpress_client/python/modelexpress_rl/train/manifest.py
+++ b/modelexpress_client/python/modelexpress_rl/train/manifest.py
@@ -51,6 +51,11 @@ class WeightVersionShardManifestService(refit_pb2_grpc.RefitWorkerServiceService
             self._manifests[key] = manifest
         return self.endpoint
 
+    def release_manifest(self, *, version_id: str, source_slot_id: str) -> None:
+        key = (version_id, source_slot_id)
+        with self._lock:
+            self._manifests.pop(key, None)
+
     def GetWeightVersionShardManifest(self, request, context):
         key = (request.version_id, request.source_slot_id)
         with self._lock:

--- a/modelexpress_client/python/modelexpress_rl/train/manifest.py
+++ b/modelexpress_client/python/modelexpress_rl/train/manifest.py
@@ -52,6 +52,11 @@ class WeightVersionShardManifestService(refit_pb2_grpc.RefitWorkerServiceService
         return self.endpoint
 
     def release_manifest(self, *, version_id: str, source_slot_id: str) -> None:
+        """Drop a served manifest once its version is released.
+
+        Without this the worker holds every manifest it ever published for the
+        life of the process, which on a large MoE is megabytes per step.
+        """
         key = (version_id, source_slot_id)
         with self._lock:
             self._manifests.pop(key, None)

--- a/modelexpress_client/python/modelexpress_rl/train/methods/full_tensor.py
+++ b/modelexpress_client/python/modelexpress_rl/train/methods/full_tensor.py
@@ -5,11 +5,12 @@
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from typing import Any
 
-from ... import refit_pb2, refit_pb2_grpc, timing
+from modelexpress.refit.timing import refit_span
+
+from ... import refit_pb2, refit_pb2_grpc
 from ...version import WeightVersionRef
 from ..adapter import (
     StagedWeightVersionShardData,
@@ -81,38 +82,37 @@ class FullTensorNixlPublicationMethod:
     ) -> None:
         if not isinstance(staged, StagedWeightVersionShardData):
             raise TypeError("full-tensor publication received an invalid shard")
-        started = time.perf_counter()
-        staged.publish_ready.wait()
-        duration = time.perf_counter() - started
-        timing.record_measured(
+        with refit_span(
             "source_preparation",
-            duration,
-            metadata={"staging_sync_s": duration},
-        )
+            metadata={"staging_syncs": 1},
+            accumulate_metadata=True,
+            duration_key="staging_sync_s",
+        ):
+            staged.publish_ready.wait()
         if staged.manifest.transport.upper() != "NIXL":
             raise ValueError(
                 f"unsupported shard transport {staged.manifest.transport!r}"
             )
-        started = time.perf_counter()
-        manifest_digest = staged.manifest.digest
-        duration = time.perf_counter() - started
-        timing.record_measured(
+        # A cached property that hashes the whole manifest, so the first read is
+        # the digest being computed and every later one is free.
+        with refit_span(
             "source_preparation",
-            duration,
-            metadata={"manifest_digest_s": duration},
-        )
-        started = time.perf_counter()
-        endpoint = self._manifest_publisher.publish_manifest(
-            version_id=version.version_id,
-            source_slot_id=self.source_slot_id,
-            manifest=staged.manifest,
-        )
-        duration = time.perf_counter() - started
-        timing.record_measured(
+            metadata={"manifest_digests": 1},
+            accumulate_metadata=True,
+            duration_key="manifest_digest_s",
+        ):
+            manifest_digest = staged.manifest.digest
+        with refit_span(
             "setup_registration",
-            duration,
-            metadata={"manifest_publish_s": duration},
-        )
+            metadata={"manifest_publications": 1},
+            accumulate_metadata=True,
+            duration_key="manifest_publish_s",
+        ):
+            endpoint = self._manifest_publisher.publish_manifest(
+                version_id=version.version_id,
+                source_slot_id=self.source_slot_id,
+                manifest=staged.manifest,
+            )
         if not endpoint.strip():
             raise ValueError("manifest_endpoint is required")
         shard = refit_pb2.WeightVersionShard(
@@ -124,17 +124,16 @@ class FullTensorNixlPublicationMethod:
             manifest_digest=manifest_digest,
             manifest_endpoint=endpoint,
         )
-        started = time.perf_counter()
-        self._service().CreateWeightVersionShard(
-            refit_pb2.CreateWeightVersionShardRequest(shard=shard),
-            timeout=self._rpc_timeout_seconds,
-        )
-        duration = time.perf_counter() - started
-        timing.record_measured(
+        with refit_span(
             "setup_registration",
-            duration,
-            metadata={"publication_rpc_s": duration},
-        )
+            metadata={"publication_rpcs": 1},
+            accumulate_metadata=True,
+            duration_key="publication_rpc_s",
+        ):
+            self._service().CreateWeightVersionShard(
+                refit_pb2.CreateWeightVersionShardRequest(shard=shard),
+                timeout=self._rpc_timeout_seconds,
+            )
         self.published.setdefault(version.version_id, []).append(staged)
 
     def release(self, *, version: WeightVersionRef) -> None:

--- a/modelexpress_client/python/modelexpress_rl/train/methods/full_tensor.py
+++ b/modelexpress_client/python/modelexpress_rl/train/methods/full_tensor.py
@@ -5,10 +5,11 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import Any
 
-from ... import refit_pb2, refit_pb2_grpc
+from ... import refit_pb2, refit_pb2_grpc, timing
 from ...version import WeightVersionRef
 from ..adapter import (
     StagedWeightVersionShardData,
@@ -80,15 +81,37 @@ class FullTensorNixlPublicationMethod:
     ) -> None:
         if not isinstance(staged, StagedWeightVersionShardData):
             raise TypeError("full-tensor publication received an invalid shard")
+        started = time.perf_counter()
         staged.publish_ready.wait()
+        duration = time.perf_counter() - started
+        timing.record_measured(
+            "source_preparation",
+            duration,
+            metadata={"staging_sync_s": duration},
+        )
         if staged.manifest.transport.upper() != "NIXL":
             raise ValueError(
                 f"unsupported shard transport {staged.manifest.transport!r}"
             )
+        started = time.perf_counter()
+        manifest_digest = staged.manifest.digest
+        duration = time.perf_counter() - started
+        timing.record_measured(
+            "source_preparation",
+            duration,
+            metadata={"manifest_digest_s": duration},
+        )
+        started = time.perf_counter()
         endpoint = self._manifest_publisher.publish_manifest(
             version_id=version.version_id,
             source_slot_id=self.source_slot_id,
             manifest=staged.manifest,
+        )
+        duration = time.perf_counter() - started
+        timing.record_measured(
+            "setup_registration",
+            duration,
+            metadata={"manifest_publish_s": duration},
         )
         if not endpoint.strip():
             raise ValueError("manifest_endpoint is required")
@@ -98,12 +121,19 @@ class FullTensorNixlPublicationMethod:
             worker_id=self._worker_id,
             tensor_count=staged.manifest.tensor_count,
             total_bytes=staged.manifest.total_bytes,
-            manifest_digest=staged.manifest.digest,
+            manifest_digest=manifest_digest,
             manifest_endpoint=endpoint,
         )
+        started = time.perf_counter()
         self._service().CreateWeightVersionShard(
             refit_pb2.CreateWeightVersionShardRequest(shard=shard),
             timeout=self._rpc_timeout_seconds,
+        )
+        duration = time.perf_counter() - started
+        timing.record_measured(
+            "setup_registration",
+            duration,
+            metadata={"publication_rpc_s": duration},
         )
         self.published.setdefault(version.version_id, []).append(staged)
 
@@ -117,6 +147,10 @@ class FullTensorNixlPublicationMethod:
                 worker_id=self._worker_id,
             ),
             timeout=self._rpc_timeout_seconds,
+        )
+        self._manifest_publisher.release_manifest(
+            version_id=version.version_id,
+            source_slot_id=self.source_slot_id,
         )
         del self.published[version.version_id]
 

--- a/modelexpress_client/python/modelexpress_rl/train/runtime.py
+++ b/modelexpress_client/python/modelexpress_rl/train/runtime.py
@@ -44,6 +44,12 @@ logger = logging.getLogger("modelexpress_rl.train.runtime")
 
 
 def _flatten_timing(payload: dict[str, Any]) -> dict[str, int | float]:
+    """Flatten one refit record into scalar metrics a framework can chart.
+
+    Stages with no measurements are dropped rather than reported as zero, since
+    a stage that did not run and a stage that took no time are different facts
+    and only one of them is worth a point on a graph.
+    """
     metrics: dict[str, int | float] = {
         "trainer_refit_e2e_s": float(payload["e2e_ms"]) / 1000.0,
     }

--- a/modelexpress_client/python/modelexpress_rl/train/runtime.py
+++ b/modelexpress_client/python/modelexpress_rl/train/runtime.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from .. import envs as rl_envs
+from .. import timing
 from ..s3 import S3Client
 from ..utils import make_tensor_reader
 from ..version import WeightVersionRef
@@ -42,6 +43,21 @@ PublicationArtifact = (
 logger = logging.getLogger("modelexpress_rl.train.runtime")
 
 
+def _flatten_timing(payload: dict[str, Any]) -> dict[str, int | float]:
+    metrics: dict[str, int | float] = {
+        "trainer_refit_e2e_s": float(payload["e2e_ms"]) / 1000.0,
+    }
+    for stage, values in payload["stages"].items():
+        if values["count"]:
+            metrics[f"{stage}_s"] = float(values["duration_ms"]) / 1000.0
+        for name, value in values.get("metadata", {}).items():
+            if isinstance(value, bool):
+                metrics[name] = int(value)
+            elif isinstance(value, (int, float)):
+                metrics[name] = value
+    return metrics
+
+
 class TrainerRuntime:
     """Own one publication method and all transport resources it requires."""
 
@@ -62,6 +78,7 @@ class TrainerRuntime:
             resources.worker_endpoint if resources is not None else ""
         )
         self._bound_tensors: Any | None = None
+        self._last_full_tensor_metrics: dict[str, int | float] = {}
         self._closed = False
 
     @classmethod
@@ -124,6 +141,7 @@ class TrainerRuntime:
             host = envs.MX_WORKER_HOST
             if not host.strip():
                 raise ValueError("MX_WORKER_HOST is required")
+
             def create_full_tensor() -> FullTensorNixlPublicationMethod:
                 adapter = _create_trainer_adapter(
                     engine_context,
@@ -167,7 +185,9 @@ class TrainerRuntime:
 
     def _canonical_delta(self) -> CanonicalDeltaPublicationMethod:
         if not isinstance(self.method, CanonicalDeltaPublicationMethod):
-            raise RuntimeError("operation requires canonical-delta publication")
+            raise RuntimeError(  # noqa: TRY004
+                "operation requires canonical-delta publication"
+            )
         return self.method
 
     @property
@@ -222,11 +242,22 @@ class TrainerRuntime:
         if self._bound_tensors is None:
             raise RuntimeError("bind_tensors() must be called before publish_version()")
         method = self._full_tensor()
-        staged = method.stage(
-            version=version,
-            tensors=self._bound_tensors,
+        recorder = timing.start_cycle(
+            version_id=version.version_id,
+            rank=rl_envs.LOCAL_RANK,
+            backend="rl_trainer",
         )
-        method.publish(version=version, staged=staged)
+        try:
+            with timing.active(recorder):
+                staged = method.stage(
+                    version=version,
+                    tensors=self._bound_tensors,
+                )
+                method.publish(version=version, staged=staged)
+        finally:
+            payload = timing.emit(recorder, logger)
+            if payload is not None:
+                self._last_full_tensor_metrics = _flatten_timing(payload)
 
     def release(self, *, version: WeightVersionRef) -> None:
         if isinstance(self.method, FullTensorNixlPublicationMethod):
@@ -235,7 +266,9 @@ class TrainerRuntime:
     def pop_metrics(self) -> dict[str, int | float]:
         if isinstance(self.method, CanonicalDeltaPublicationMethod):
             return self.method.pop_metrics()
-        return {}
+        metrics = self._last_full_tensor_metrics
+        self._last_full_tensor_metrics = {}
+        return metrics
 
     def close(self) -> None:
         if self._closed:

--- a/modelexpress_client/python/tests/test_refit_fsdp_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_fsdp_adapter.py
@@ -59,9 +59,7 @@ def test_source_slot_id_is_rank_stamped(dist_ready):
 def test_bind_tensors_validates_state_dict_and_returns_rank_slot(dist_ready):
     adapter = _adapter()
 
-    assert adapter.bind_tensors({"w": torch.ones(2, 4)}) == (
-        "publisher:global-rank:0"
-    )
+    assert adapter.bind_tensors({"w": torch.ones(2, 4)}) == ("publisher:global-rank:0")
     with pytest.raises(TypeError, match="state_dict"):
         adapter.bind_tensors([torch.ones(2, 4)])
 
@@ -81,6 +79,30 @@ def test_in_place_stage_registers_once(dist_ready):
     # Re-staging the same weights must not re-register (setup is one-time).
     _stage(adapter, state_dict)
     assert len(manager.registered) == 1
+
+
+def test_warm_stage_reuses_structural_manifest(dist_ready, monkeypatch):
+    monkeypatch.delenv("MX_RESHARD_PUBLISH_DIGEST", raising=False)
+    adapter = _adapter()
+    state_dict = {"w": torch.ones(2, 4, dtype=torch.bfloat16)}
+
+    first = _stage(adapter, state_dict)
+    state_dict["w"].fill_(2)
+    second = _stage(adapter, state_dict)
+
+    assert second.manifest is first.manifest
+
+
+def test_digest_mode_rebuilds_version_manifest(dist_ready, monkeypatch):
+    monkeypatch.setenv("MX_RESHARD_PUBLISH_DIGEST", "1")
+    adapter = _adapter()
+    state_dict = {"w": torch.ones(2, 4, dtype=torch.bfloat16)}
+
+    first = _stage(adapter, state_dict)
+    state_dict["w"].fill_(2)
+    second = _stage(adapter, state_dict)
+
+    assert second.manifest.data != first.manifest.data
 
 
 def test_in_place_rejects_a_moved_source(dist_ready):

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -782,6 +782,28 @@ def test_generator_fetches_trainer_manifest_larger_than_grpc_default(monkeypatch
     )
 
 
+def test_generator_reports_timing_for_a_refit_that_never_staged(monkeypatch, caplog):
+    """A staging failure is the case the stage split most needs to explain, and
+    it is the one path where nothing downstream can report it: the recorder is
+    handed on through the staged handle, and there is no handle yet."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+    server, endpoint, service = _start_server(manifest_digest="bad-digest")
+    adapter = _Adapter(service)
+    generator = _initialize(monkeypatch, endpoint, adapter)
+
+    try:
+        with (
+            caplog.at_level(logging.INFO),
+            pytest.raises(RuntimeError, match=r"no usable refit source"),
+        ):
+            generator.stage_weight(version=WeightVersionRef("version-a"))
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert "MX_REFIT_TIMING" in caplog.text
+
+
 def test_generator_reports_missing_trainer_manifest_digest(monkeypatch, caplog):
     server, endpoint, service = _start_server()
     service.shards[0].manifest_digest = ""

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 
 import grpc
 import pytest
-
 from modelexpress import p2p_pb2, p2p_pb2_grpc
 from modelexpress.client import MxClient
 from modelexpress.types import ManifestMismatchError
@@ -1314,7 +1313,11 @@ def test_generator_preserves_transfer_error_when_lease_cleanup_also_fails(
         server.stop(grace=None).wait()
 
 
-def test_generator_reports_lease_cleanup_failure_after_success(monkeypatch):
+def test_generator_reports_lease_cleanup_failure_after_success(
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
     server, endpoint, service = _start_server()
     service.fail_lease_deletion = True
     adapter = _Adapter(service)
@@ -1322,8 +1325,12 @@ def test_generator_reports_lease_cleanup_failure_after_success(monkeypatch):
 
     try:
         staged = generator.stage_weight(version=WeightVersionRef("version-a"))
-        with pytest.raises(grpc.RpcError, match="lease backend unavailable"):
+        with (
+            caplog.at_level(logging.INFO),
+            pytest.raises(grpc.RpcError, match="lease backend unavailable"),
+        ):
             staged.release()
+        assert "MX_REFIT_TIMING" in caplog.text
     finally:
         generator.close()
         server.stop(grace=None).wait()

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -1278,6 +1278,48 @@ def test_generator_retries_with_redundant_worker_for_same_slot(monkeypatch):
     ]
 
 
+def test_generator_assembles_healthy_replicas_from_different_offsets(monkeypatch):
+    """Health is per slot, so the healthy replicas need not line up across slots.
+
+    Pairing them by a shared offset yields nothing here: the aligned pairs are
+    (trainer-0, trainer-1) and (trainer-a1, trainer-b1), and each contains one
+    unusable source, though the complete healthy set (trainer-0, trainer-b1)
+    exists the whole time.
+    """
+    server, endpoint, service = _start_server()
+    unusable = "0" * 64
+    # rank:0 keeps its first replica and gains a broken second one.
+    broken_first_slot = refit_pb2.WeightVersionShard()
+    broken_first_slot.CopyFrom(service.shards[0])
+    broken_first_slot.worker_id = "trainer-a1"
+    broken_first_slot.manifest_digest = unusable
+    # rank:1 is the mirror image: its first replica is the broken one.
+    healthy_second_slot = refit_pb2.WeightVersionShard()
+    healthy_second_slot.CopyFrom(service.shards[1])
+    healthy_second_slot.worker_id = "trainer-b1"
+    service.shards[1].manifest_digest = unusable
+    service.shards.extend([broken_first_slot, healthy_second_slot])
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        source_order=(WeightSource.TRAINER,),
+    )
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert [source.worker_id for source in adapter.stage_calls[0].sources] == [
+        "trainer-0",
+        "trainer-b1",
+    ]
+
+
 def test_generator_fetches_fallback_manifest_only_after_primary_failure(monkeypatch):
     server, endpoint, service = _start_server()
     replica = refit_pb2.WeightVersionShard()

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 
 import grpc
 import pytest
+
 from modelexpress import p2p_pb2, p2p_pb2_grpc
 from modelexpress.client import MxClient
 from modelexpress.types import ManifestMismatchError
@@ -139,8 +140,10 @@ class _RefitService(refit_pb2_grpc.RefitServiceServicer):
 class _WorkerService(refit_pb2_grpc.RefitWorkerServiceServicer):
     def __init__(self, manifest=b"manifest"):
         self.manifest = manifest
+        self.requests = []
 
-    def GetWeightVersionShardManifest(self, _request, _context):
+    def GetWeightVersionShardManifest(self, request, _context):
+        self.requests.append(request)
         return refit_pb2.GetWeightVersionShardManifestResponse(
             manifest=self.manifest,
             manifest_digest=hashlib.sha256(self.manifest).hexdigest(),
@@ -329,9 +332,7 @@ class _TestInstaller(EngineInstaller):
 
     @property
     def capabilities(self):
-        return EngineCapabilities(
-            artifact_types=frozenset({PreparedEngineTensors})
-        )
+        return EngineCapabilities(artifact_types=frozenset({PreparedEngineTensors}))
 
     def install(self, prepared):
         return self._adapter.apply_weight(prepared.staged)
@@ -419,9 +420,8 @@ def _start_server(*, state=None, manifest=b"manifest", manifest_digest=None):
         manifest_digest=manifest_digest or hashlib.sha256(manifest).hexdigest(),
     )
     refit_pb2_grpc.add_RefitServiceServicer_to_server(service, server)
-    refit_pb2_grpc.add_RefitWorkerServiceServicer_to_server(
-        _WorkerService(manifest), server
-    )
+    service.worker = _WorkerService(manifest)
+    refit_pb2_grpc.add_RefitWorkerServiceServicer_to_server(service.worker, server)
     p2p_service = _P2pService()
     p2p_pb2_grpc.add_P2pServiceServicer_to_server(p2p_service, server)
     service.p2p = p2p_service
@@ -582,9 +582,7 @@ def test_generator_rejects_unsupported_object_storage_before_adapter_creation(
     monkeypatch.setattr(
         GeneratorRuntime,
         "initialize",
-        classmethod(
-            lambda _cls, **_kwargs: pytest.fail("runtime must not be created")
-        ),
+        classmethod(lambda _cls, **_kwargs: pytest.fail("runtime must not be created")),
     )
 
     with pytest.raises(ValueError, match="only S3 object storage"):
@@ -687,13 +685,12 @@ def test_generator_stages_applies_releases_and_reuses_valid_plan(monkeypatch):
     assert len(adapter.publish_calls) == 1
     assert len(adapter.release_calls) == 3
     assert adapter.close_calls == 1
+    assert len(service.worker.requests) == 3
     assert [source.source_slot_id for source in adapter.create_calls[0].sources] == [
         "rank:0",
         "rank:1",
     ]
-    assert (
-        adapter.create_calls[0].payload_format is WeightPayloadFormat.FULL_TENSOR
-    )
+    assert adapter.create_calls[0].payload_format is WeightPayloadFormat.FULL_TENSOR
 
 
 def test_generator_logs_weight_update_lifecycle(monkeypatch, caplog):
@@ -792,9 +789,11 @@ def test_generator_reports_missing_trainer_manifest_digest(monkeypatch, caplog):
     generator = _initialize(monkeypatch, endpoint, adapter)
 
     try:
-        with caplog.at_level(logging.WARNING):
-            with pytest.raises(RuntimeError, match=r"no usable refit source"):
-                generator.stage_weight(version=WeightVersionRef("version-a"))
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.raises(RuntimeError, match=r"no usable refit source"),
+        ):
+            generator.stage_weight(version=WeightVersionRef("version-a"))
     finally:
         generator.close()
         server.stop(grace=None).wait()
@@ -1258,6 +1257,24 @@ def test_generator_retries_with_redundant_worker_for_same_slot(monkeypatch):
     ]
 
 
+def test_generator_fetches_fallback_manifest_only_after_primary_failure(monkeypatch):
+    server, endpoint, service = _start_server()
+    replica = refit_pb2.WeightVersionShard()
+    replica.CopyFrom(service.shards[0])
+    replica.worker_id = "trainer-replica"
+    service.shards.append(replica)
+    generator = _initialize(monkeypatch, endpoint, _Adapter(service))
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert len(service.worker.requests) == 2
+
+
 def test_generator_preserves_transfer_error_when_lease_cleanup_also_fails(
     monkeypatch,
 ):
@@ -1320,9 +1337,7 @@ def test_generator_recovers_uncertain_engine_with_active_or_new_version(
             uri="s3://weights/base-a/model.safetensors.index.json",
         )
     )
-    service.additional_versions["version-b"] = _canonical_version(
-        "version-b", "base-a"
-    )
+    service.additional_versions["version-b"] = _canonical_version("version-b", "base-a")
     adapter = _Adapter(service)
     adapter.apply_failure = True
     generator = _initialize(monkeypatch, endpoint, adapter, object_storage=True)
@@ -1438,19 +1453,17 @@ def test_generator_discovers_rank_matched_p2p_peer(monkeypatch):
             ),
         ]
     )
-    service.p2p.metadata[("peer-source", "generator-peer")] = (
-        p2p_pb2.WorkerMetadata(
-            worker_rank=0,
-            tensors=[
-                p2p_pb2.TensorDescriptor(
-                    name="weight",
-                    addr=1234,
-                    size=16,
-                    device_id=0,
-                    dtype="torch.float32",
-                )
-            ],
-        )
+    service.p2p.metadata[("peer-source", "generator-peer")] = p2p_pb2.WorkerMetadata(
+        worker_rank=0,
+        tensors=[
+            p2p_pb2.TensorDescriptor(
+                name="weight",
+                addr=1234,
+                size=16,
+                device_id=0,
+                dtype="torch.float32",
+            )
+        ],
     )
     adapter = _Adapter(service)
     generator = _initialize(monkeypatch, endpoint, adapter)
@@ -1596,19 +1609,17 @@ def test_object_storage_generator_skips_full_peer_for_delta_version(monkeypatch)
             worker_rank=0,
         )
     )
-    service.p2p.metadata[("peer-source", "generator-peer")] = (
-        p2p_pb2.WorkerMetadata(
-            worker_rank=0,
-            tensors=[
-                p2p_pb2.TensorDescriptor(
-                    name="weight",
-                    addr=1234,
-                    size=16,
-                    device_id=0,
-                    dtype="torch.float32",
-                )
-            ],
-        )
+    service.p2p.metadata[("peer-source", "generator-peer")] = p2p_pb2.WorkerMetadata(
+        worker_rank=0,
+        tensors=[
+            p2p_pb2.TensorDescriptor(
+                name="weight",
+                addr=1234,
+                size=16,
+                device_id=0,
+                dtype="torch.float32",
+            )
+        ],
     )
     adapter = _Adapter(service)
     generator = _initialize(monkeypatch, endpoint, adapter, object_storage=True)

--- a/modelexpress_client/python/tests/test_refit_megatron_adapter.py
+++ b/modelexpress_client/python/tests/test_refit_megatron_adapter.py
@@ -7,8 +7,9 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import grpc
-import modelexpress_rl.train.runtime as runtime_module
 import pytest
+
+import modelexpress_rl.train.runtime as runtime_module
 from modelexpress.refit.reshard.rendezvous import unwrap_rendezvous_blob
 from modelexpress_rl import (
     MegatronTrainerContext,
@@ -21,11 +22,11 @@ from modelexpress_rl import (
     refit_pb2_grpc,
 )
 from modelexpress_rl.train.adapter import TrainerEngineAdapter
-from modelexpress_rl.train.manifest import WeightVersionShardManifestService
 from modelexpress_rl.train.engines.megatron import (
     MegatronTensorSpec,
     MegatronTrainerAdapter,
 )
+from modelexpress_rl.train.manifest import WeightVersionShardManifestService
 
 
 class _Tensor:
@@ -129,14 +130,15 @@ def test_megatron_source_slot_groups_replicas_by_logical_partition(monkeypatch):
 
     assert first.bind_tensors(tensors) == second.bind_tensors(tensors)
     assert first.source_slot_id == second.source_slot_id
-    assert other_partition.bind_tensors(
-        [replace(tensors[0], local_shard_range=(8, 16))]
-    ) != first.source_slot_id
+    assert (
+        other_partition.bind_tensors([replace(tensors[0], local_shard_range=(8, 16))])
+        != first.source_slot_id
+    )
 
 
 def test_megatron_adapter_uses_shared_trainer_publication_flow(monkeypatch):
     monkeypatch.setattr(
-        "modelexpress_rl.train.engines.megatron.aliases.tensor_digest",
+        "modelexpress_rl.train.engines.megatron.aliases.published_digest",
         lambda _tensor: "tensor-digest",
     )
     monkeypatch.setattr(

--- a/modelexpress_client/python/tests/test_refit_nixl_staged_transfer.py
+++ b/modelexpress_client/python/tests/test_refit_nixl_staged_transfer.py
@@ -3,10 +3,9 @@
 
 from contextlib import nullcontext
 
+import modelexpress_rl.inference.nixl_staged_transfer as transfer_module
 import pytest
 import torch
-
-import modelexpress_rl.inference.nixl_staged_transfer as transfer_module
 from modelexpress import p2p_pb2
 from modelexpress.refit.reshard.rendezvous import (
     PublishedShard,
@@ -29,6 +28,7 @@ from modelexpress_rl.inference.nixl_staged_transfer import (
     _required_agent_metadata,
     _resolve_sources,
     _ResolvedSources,
+    _source_structure,
 )
 
 
@@ -55,6 +55,29 @@ def _manifest(*, agent_name: str, endpoint: str, offset: int, address: int) -> b
             )
         ],
     )
+
+
+def test_source_structure_uses_planner_shard_fields_and_ignores_digest():
+    source = SourceInfo(
+        global_shape=(4,),
+        dtype=torch.float32,
+        elsize=4,
+        shards=[
+            Shard(
+                shard_offset=(0,),
+                shape=(4,),
+                session="trainer-0",
+                addr=100,
+                elsize=4,
+                digest="version-a",
+            )
+        ],
+    )
+
+    expected = _source_structure(source)
+    source.shards[0].digest = "version-b"
+
+    assert _source_structure(source) == expected
 
 
 def test_exact_manifests_resolve_without_legacy_source_discovery():

--- a/modelexpress_client/python/tests/test_refit_timing.py
+++ b/modelexpress_client/python/tests/test_refit_timing.py
@@ -5,11 +5,12 @@ import json
 import logging
 
 import pytest
-
 from modelexpress.refit import (
     MX_REFIT_TIMING_PREFIX,
     REFIT_TIMING_STAGES,
     RefitTimingRecorder,
+    add_refit_duration,
+    add_refit_metadata,
     current_refit_timing,
     refit_span,
     use_refit_timing,
@@ -75,10 +76,9 @@ def test_error_span_is_recorded_and_reraised():
     clock = _Clock()
     timing = RefitTimingRecorder(backend="test", version="bad", clock=clock)
 
-    with pytest.raises(RuntimeError, match="boom"):
-        with timing.span("transformation"):
-            clock.advance(0.25)
-            raise RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"), timing.span("transformation"):
+        clock.advance(0.25)
+        raise RuntimeError("boom")
 
     stage = timing.as_dict()["stages"]["transformation"]
     assert stage["status"] == "error"
@@ -115,3 +115,80 @@ def test_unknown_stage_and_negative_bytes_rejected():
         timing.add_duration("download", 1.0)
     with pytest.raises(ValueError, match="non-negative"):
         timing.add_bytes(-1)
+
+
+def test_a_span_can_name_its_duration_and_report_what_it_discovered():
+    """Several spans usually share one normalized stage, so the stage total
+    cannot say which of them was expensive. Naming them can, and a counter only
+    knowable once the work has run has somewhere to go."""
+    clock = _Clock()
+    recorder = RefitTimingRecorder(backend="test", version="v1", clock=clock)
+
+    with use_refit_timing(recorder):
+        with refit_span(
+            "source_preparation",
+            accumulate_metadata=True,
+            duration_key="manifest_fetch_s",
+        ) as discovered:
+            clock.advance(0.25)
+            discovered["manifest_bytes"] = 4096
+        with refit_span(
+            "source_preparation",
+            accumulate_metadata=True,
+            duration_key="manifest_hash_s",
+        ) as discovered:
+            clock.advance(0.5)
+            discovered["manifest_bytes"] = 1024
+
+    stage = recorder.as_dict()["stages"]["source_preparation"]
+    assert stage["count"] == 2
+    assert stage["duration_ms"] == pytest.approx(750.0)
+    assert stage["metadata"]["manifest_fetch_s"] == pytest.approx(0.25)
+    assert stage["metadata"]["manifest_hash_s"] == pytest.approx(0.5)
+    assert stage["metadata"]["manifest_bytes"] == 5120
+
+
+def test_a_failed_span_still_names_the_duration_it_spent():
+    clock = _Clock()
+    recorder = RefitTimingRecorder(backend="test", version="v1", clock=clock)
+
+    with (
+        use_refit_timing(recorder),
+        pytest.raises(RuntimeError),
+        refit_span("source_preparation", duration_key="manifest_fetch_s"),
+    ):
+        clock.advance(0.125)
+        raise RuntimeError("manifest fetch failed")
+
+    stage = recorder.as_dict()["stages"]["source_preparation"]
+    assert stage["status"] == "error"
+    assert stage["metadata"]["manifest_fetch_s"] == pytest.approx(0.125)
+
+
+def test_metadata_can_be_attached_without_inventing_a_span():
+    """Sizes and cache outcomes describe a stage but have no duration of their
+    own. Filing them through a zero-second span would leave the stage looking
+    like it ran more times than it did."""
+    recorder = RefitTimingRecorder(backend="test", version="v1")
+
+    with use_refit_timing(recorder):
+        add_refit_metadata(
+            "source_preparation", {"manifest_bytes": 32}, accumulate=True
+        )
+        add_refit_metadata("source_preparation", {"manifest_bytes": 8}, accumulate=True)
+        add_refit_metadata("source_preparation", {"manifest_cache_hit": True})
+
+    stage = recorder.as_dict()["stages"]["source_preparation"]
+    assert stage["count"] == 0
+    assert stage["metadata"] == {"manifest_bytes": 40, "manifest_cache_hit": True}
+
+
+def test_a_duration_from_another_layer_is_clamped_not_rejected():
+    """These arrive from a clock this process did not read, so a small negative
+    is a clock artifact rather than a caller bug worth raising on."""
+    recorder = RefitTimingRecorder(backend="test", version="v1")
+
+    with use_refit_timing(recorder):
+        add_refit_duration("wire_transfer", -0.01)
+
+    assert recorder.as_dict()["stages"]["wire_transfer"]["duration_ms"] == 0.0

--- a/modelexpress_client/python/tests/test_refit_trainer_client.py
+++ b/modelexpress_client/python/tests/test_refit_trainer_client.py
@@ -6,10 +6,9 @@ from concurrent import futures
 from unittest.mock import MagicMock
 
 import grpc
-import pytest
-
 import modelexpress_rl.train.client as client_module
 import modelexpress_rl.train.runtime as runtime_module
+import pytest
 from modelexpress_rl import (
     FSDPTrainerContext,
     ModelExpressTrainerClient,

--- a/modelexpress_client/python/tests/test_refit_trainer_client.py
+++ b/modelexpress_client/python/tests/test_refit_trainer_client.py
@@ -6,9 +6,10 @@ from concurrent import futures
 from unittest.mock import MagicMock
 
 import grpc
+import pytest
+
 import modelexpress_rl.train.client as client_module
 import modelexpress_rl.train.runtime as runtime_module
-import pytest
 from modelexpress_rl import (
     FSDPTrainerContext,
     ModelExpressTrainerClient,
@@ -160,6 +161,30 @@ def test_refit_service_uses_named_response_messages():
     )
 
 
+def test_released_manifests_do_not_accumulate():
+    service = WeightVersionShardManifestService(endpoint="trainer:9000")
+    manifest = WeightVersionShardManifest(
+        data=b"manifest",
+        tensor_count=1,
+        total_bytes=2,
+        transport="NIXL",
+    )
+
+    for index in range(1000):
+        version_id = f"version-{index}"
+        service.publish_manifest(
+            version_id=version_id,
+            source_slot_id="rank:0",
+            manifest=manifest,
+        )
+        service.release_manifest(
+            version_id=version_id,
+            source_slot_id="rank:0",
+        )
+
+    assert service._manifests == {}
+
+
 def test_trainer_stages_then_publishes_one_rank_local_shard(monkeypatch):
     service = _RefitService()
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
@@ -205,6 +230,9 @@ def test_trainer_stages_then_publishes_one_rank_local_shard(monkeypatch):
             trainer.bind_tensors("replacement")
         assert service.shards == []
         trainer.publish_version(version=WeightVersionRef("version-a"))
+        metrics = trainer.pop_metrics()
+        assert metrics["trainer_refit_e2e_s"] >= 0
+        assert metrics["publication_rpc_s"] >= 0
 
         worker_stub = refit_pb2_grpc.RefitWorkerServiceStub(
             grpc.insecure_channel(service.shards[0].manifest_endpoint)
@@ -228,6 +256,14 @@ def test_trainer_stages_then_publishes_one_rank_local_shard(monkeypatch):
         trainer.release_version(version=WeightVersionRef("version-a"))
         trainer.release_version(version=WeightVersionRef("version-a"))
         assert "version-a" not in method.published
+        with pytest.raises(grpc.RpcError) as released:
+            worker_stub.GetWeightVersionShardManifest(
+                refit_pb2.GetWeightVersionShardManifestRequest(
+                    version_id="version-a",
+                    source_slot_id="rank:0",
+                )
+            )
+        assert released.value.code() is grpc.StatusCode.NOT_FOUND
     finally:
         if "trainer" in locals():
             trainer.close()

--- a/modelexpress_client/python/tests/test_refit_vllm_installer.py
+++ b/modelexpress_client/python/tests/test_refit_vllm_installer.py
@@ -7,13 +7,13 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
-from torch import nn
-
 from modelexpress.refit.reshard.types import IncompleteRefit
+from modelexpress.refit.timing import RefitTimingRecorder, use_refit_timing
 from modelexpress_rl.inference.engines.vllm.installer import (
     _update_mla_absorbed_weights,
     _VllmInstaller,
 )
+from torch import nn
 
 
 def _install_fake_vllm(monkeypatch, initialize):
@@ -157,8 +157,10 @@ def test_installer_loads_prepared_checkpoint_inside_vllm_config(monkeypatch, tmp
         device=torch.device("cpu"),
     )
     prepared = tmp_path / "prepared"
+    recorder = RefitTimingRecorder(backend="test", version="version-a")
 
-    installer.install_checkpoint(prepared)
+    with use_refit_timing(recorder):
+        installer.install_checkpoint(prepared)
 
     assert events == [
         ("loader", "safetensors"),
@@ -171,6 +173,7 @@ def test_installer_loads_prepared_checkpoint_inside_vllm_config(monkeypatch, tmp
     assert model_config.revision == "main"
     assert vllm_config.load_config.load_format == "modelexpress"
     assert synchronized == [torch.device("cpu")]
+    assert recorder.as_dict()["stages"]["post_install"]["count"] == 1
 
 
 def test_installer_caches_parameter_layout():

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
+import logging
 from importlib import metadata
 from threading import Event
 from types import SimpleNamespace
@@ -82,6 +84,21 @@ def test_structural_digest_ignores_version_and_content_digest():
     )
     assert structural_manifest_digest(first_blob) != structural_manifest_digest(
         restarted_blob
+    )
+
+
+@pytest.mark.parametrize(
+    "blob", [b"\xff\xfe not json", b"{ definitely not json", b'["a", "list"]']
+)
+def test_an_unreadable_manifest_says_it_disabled_plan_reuse(caplog, blob):
+    """The raw-byte fallback moves with the per-shard content digests, so every
+    version looks structurally different and plan reuse stops. Correct, but the
+    symptom is a warm refit priced like a cold one, which needs a reason."""
+    with caplog.at_level(logging.WARNING):
+        assert structural_manifest_digest(blob) == hashlib.sha256(blob).hexdigest()
+
+    assert [m for m in caplog.messages if "disables transfer-plan reuse" in m], (
+        f"an unreadable manifest must say so, got {caplog.messages}"
     )
 
 

--- a/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
+++ b/modelexpress_client/python/tests/test_reshard_refit_rendezvous.py
@@ -13,6 +13,7 @@ from modelexpress.refit.reshard.rendezvous import (
     PublishedShard,
     PublishedTensor,
     _mx_version,
+    structural_manifest_digest,
     wrap_rendezvous_blob,
 )
 
@@ -36,6 +37,52 @@ def _one_tensor(agent_name="trainer-agent"):
             ],
         )
     ]
+
+
+def test_structural_digest_ignores_version_and_content_digest():
+    first = _one_tensor()
+    first[0].shards[0].digest = "version-a"
+    second = _one_tensor()
+    second[0].shards[0].digest = "version-b"
+
+    first_blob = wrap_rendezvous_blob(
+        b"nixl",
+        "trainer-agent",
+        "trainer:1234",
+        first,
+        publisher_step=1,
+    )
+    second_blob = wrap_rendezvous_blob(
+        b"nixl",
+        "trainer-agent",
+        "trainer:1234",
+        second,
+        publisher_step=2,
+    )
+
+    assert structural_manifest_digest(first_blob) == structural_manifest_digest(
+        second_blob
+    )
+    moved = _one_tensor()
+    moved[0].shards[0].addr = 8192
+    moved_blob = wrap_rendezvous_blob(
+        b"nixl",
+        "trainer-agent",
+        "trainer:1234",
+        moved,
+    )
+    restarted_blob = wrap_rendezvous_blob(
+        b"new-registration",
+        "trainer-agent",
+        "trainer:1234",
+        second,
+    )
+    assert structural_manifest_digest(first_blob) != structural_manifest_digest(
+        moved_blob
+    )
+    assert structural_manifest_digest(first_blob) != structural_manifest_digest(
+        restarted_blob
+    )
 
 
 def test_mx_version_falls_back_only_when_package_is_missing(monkeypatch):
@@ -145,8 +192,9 @@ def test_published_rendezvous_stays_ready_and_closes_stale(monkeypatch):
     last = client.status_updates[-1]
     # Compare the identity/status fields under test; the heartbeat also carries
     # advisory telemetry (source_load) that is not what this test asserts.
-    assert {k: last.get(k) for k in
-            ("mx_source_id", "worker_id", "worker_rank", "status")} == {
+    assert {
+        k: last.get(k) for k in ("mx_source_id", "worker_id", "worker_rank", "status")
+    } == {
         "mx_source_id": "source-id",
         "worker_id": "trainer-2",
         "worker_rank": 2,

--- a/modelexpress_client/python/tests/test_rl_generator_timing.py
+++ b/modelexpress_client/python/tests/test_rl_generator_timing.py
@@ -12,10 +12,25 @@ processing and the copy into kernel storage all charged as one span.
 """
 
 import logging
+from types import SimpleNamespace
 
-from modelexpress.refit import RefitTimingRecorder, current_refit_timing, use_refit_timing
+from modelexpress.refit import (
+    RefitTimingRecorder,
+    current_refit_timing,
+    use_refit_timing,
+)
 from modelexpress_rl import timing
-from modelexpress_rl.inference.methods.full_tensor import _attribute_transfer
+from modelexpress_rl.inference.adapter import (
+    GeneratorSource,
+    GeneratorTransferInputs,
+    NixlGeneratorSource,
+)
+from modelexpress_rl.inference.methods.full_tensor import (
+    FullTensorNixlUpdateMethod,
+    _attribute_transfer,
+)
+from modelexpress_rl.inference.plan import TrainerUpdateSource
+from modelexpress_rl.train import WeightPayloadFormat
 
 STAGED_METRICS = {
     "bytes_received": 4_000_000_000,
@@ -104,6 +119,68 @@ def test_reusing_a_transfer_plan_is_marked_warm(monkeypatch):
         timing.record_cold(False)
 
     assert recorder.as_dict()["cold_warm"] == "warm"
+
+
+def test_version_digest_refreshes_verification_without_replanning():
+    class Transfer:
+        def __init__(self):
+            self.prepare_calls = 0
+            self.refresh_calls = 0
+
+        def unpublish_peer(self):
+            pass
+
+        def prepare(self, **_kwargs):
+            self.prepare_calls += 1
+            return object()
+
+        def refresh_sources(self, _prepared, _manifests):
+            self.refresh_calls += 1
+
+        def stage(self, _prepared):
+            return SimpleNamespace(metrics={"bytes_received": 0})
+
+    transfer = Transfer()
+    method = FullTensorNixlUpdateMethod(
+        transfer=transfer,
+        capture_layout=lambda _manifest: None,
+        parameter_layout=dict,
+        build_identity=lambda _version: None,
+        worker_rank=0,
+        worker_id="worker",
+        accelerator="cuda",
+        p2p_client=object(),
+    )
+
+    def source(version, digest):
+        return TrainerUpdateSource(
+            inputs=GeneratorTransferInputs(
+                version_id=version,
+                base_version_id=None,
+                layout_signature="layout",
+                payload_format=WeightPayloadFormat.FULL_TENSOR,
+                sources=(
+                    GeneratorSource(
+                        source_slot_id="rank:0",
+                        worker_id="trainer-0",
+                        manifest_digest=digest,
+                        transport=NixlGeneratorSource(
+                            manifest_endpoint="trainer:9000",
+                            manifest=version.encode(),
+                            structural_digest="stable-structure",
+                        ),
+                    ),
+                ),
+            )
+        )
+
+    first = method.prepare(version=None, source=source("v1", "digest-1"))
+    method.release(first)
+    second = method.prepare(version=None, source=source("v2", "digest-2"))
+    method.release(second)
+
+    assert transfer.prepare_calls == 1
+    assert transfer.refresh_calls == 1
 
 
 def test_the_record_is_emitted_once(monkeypatch, caplog):

--- a/modelexpress_client/python/tests/test_rl_generator_timing.py
+++ b/modelexpress_client/python/tests/test_rl_generator_timing.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Timing for the RL generator refit path.
+
+The recorder and its stage vocabulary are covered by ``test_refit_timing``.
+What these tests cover is the part that was missing: something on this path
+opening a cycle, and the layers underneath it contributing the durations they
+already measure. Without it a framework could see the total refit and roughly
+18% of its breakdown, with the wire transfer, the reconstruction, post-load
+processing and the copy into kernel storage all charged as one span.
+"""
+
+import logging
+
+from modelexpress.refit import RefitTimingRecorder, current_refit_timing, use_refit_timing
+from modelexpress_rl import timing
+from modelexpress_rl.inference.methods.full_tensor import _attribute_transfer
+
+STAGED_METRICS = {
+    "bytes_received": 4_000_000_000,
+    "segments": 12,
+    "wire_s": 1.5,
+    "reconstruct_s": 0.25,
+}
+
+
+def test_a_cycle_is_opened_by_default(monkeypatch):
+    """On by default, because the durations are measured either way and a refit
+    nobody can break down is the state this replaced."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+
+    assert timing.start_cycle(version_id="run.a1:7", rank=0) is not None
+
+
+def test_a_cycle_can_be_turned_off(monkeypatch):
+    monkeypatch.setenv("MX_REFIT_TIMING", "0")
+
+    assert timing.start_cycle(version_id="run.a1:7", rank=0) is None
+
+
+def test_a_caller_driving_its_own_cycle_is_not_displaced(monkeypatch):
+    """Nesting would split one refit across two records and leave both looking
+    partial, so an outer cycle wins and this path contributes to it instead."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+    outer = RefitTimingRecorder(backend="caller", version=1)
+
+    with use_refit_timing(outer):
+        assert timing.start_cycle(version_id="run.a1:7", rank=0) is None
+        _attribute_transfer(STAGED_METRICS)
+
+    assert outer.has_measurements("wire_transfer")
+
+
+def test_the_wire_and_the_work_after_it_are_charged_apart(monkeypatch):
+    """The distinction the split exists for: time on the fabric against time
+    replaying the copy chain and converting dtypes. Together they cannot
+    separate a slow fabric from an expensive layout."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+    recorder = timing.start_cycle(version_id="run.a1:7", rank=0)
+
+    with timing.active(recorder):
+        _attribute_transfer(STAGED_METRICS)
+
+    stages = recorder.as_dict()["stages"]
+    assert stages["wire_transfer"]["duration_ms"] == 1500.0
+    assert stages["receive_sync"]["duration_ms"] == 250.0
+
+
+def test_the_payload_size_travels_with_the_timing(monkeypatch):
+    """A duration without its bytes cannot be turned into a rate, and the rate
+    is what says whether a transfer was near line speed."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+    recorder = timing.start_cycle(version_id="run.a1:7", rank=0)
+
+    with timing.active(recorder):
+        _attribute_transfer(STAGED_METRICS)
+
+    assert recorder.as_dict()["bytes"] == 4_000_000_000
+
+
+def test_a_peer_pull_reports_a_wire_time_and_no_reconstruction(monkeypatch):
+    """Pulling an identical-rank peer's canonical buffers needs no replay, and
+    reports no ``reconstruct_s``. The stage has to stay unmeasured rather than
+    be recorded as zero, so a mean over cycles is not dragged down by cycles
+    that never had the work."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+    recorder = timing.start_cycle(version_id="run.a1:7", rank=0)
+
+    with timing.active(recorder):
+        _attribute_transfer({"bytes_received": 1, "wire_s": 0.5, "peer_s": 0.6})
+
+    assert recorder.has_measurements("wire_transfer")
+    assert not recorder.has_measurements("receive_sync")
+
+
+def test_reusing_a_transfer_plan_is_marked_warm(monkeypatch):
+    """Planning dominates a cold cycle and is close to free on a warm one, so a
+    record that did not say which is a number describing neither."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+    recorder = timing.start_cycle(version_id="run.a1:7", rank=0)
+
+    with timing.active(recorder):
+        timing.record_cold(False)
+
+    assert recorder.as_dict()["cold_warm"] == "warm"
+
+
+def test_the_record_is_emitted_once(monkeypatch, caplog):
+    """The client reports from both the apply and the release path, so that a
+    version staged and dropped without ever installing is still reported. Only
+    one of them may actually produce a record."""
+    monkeypatch.delenv("MX_REFIT_TIMING", raising=False)
+    recorder = timing.start_cycle(version_id="run.a1:7", rank=0)
+    logger = logging.getLogger("test_rl_generator_timing")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        timing.emit(recorder, logger)
+        timing.emit(recorder, logger)
+
+    assert len([r for r in caplog.records if "MX_REFIT_TIMING" in r.getMessage()]) == 1
+
+
+def test_nothing_is_emitted_when_there_is_no_cycle():
+    """Every helper here is reachable from a caller that never started a cycle,
+    so absence has to be ordinary rather than an error."""
+    logger = logging.getLogger("test_rl_generator_timing")
+
+    timing.emit(None, logger)
+    with timing.active(None):
+        _attribute_transfer(STAGED_METRICS)
+        timing.record_cold(True)
+
+    assert current_refit_timing() is None

--- a/modelexpress_client/python/tests/test_rl_generator_timing.py
+++ b/modelexpress_client/python/tests/test_rl_generator_timing.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from modelexpress.refit import (
     RefitTimingRecorder,
     current_refit_timing,
+    set_refit_cold,
     use_refit_timing,
 )
 from modelexpress_rl import timing
@@ -116,7 +117,7 @@ def test_reusing_a_transfer_plan_is_marked_warm(monkeypatch):
     recorder = timing.start_cycle(version_id="run.a1:7", rank=0)
 
     with timing.active(recorder):
-        timing.record_cold(False)
+        set_refit_cold(False)
 
     assert recorder.as_dict()["cold_warm"] == "warm"
 
@@ -148,6 +149,7 @@ def test_version_digest_refreshes_verification_without_replanning():
         build_identity=lambda _version: None,
         worker_rank=0,
         worker_id="worker",
+        enable_peer_publication=False,
         accelerator="cuda",
         p2p_client=object(),
     )
@@ -206,6 +208,6 @@ def test_nothing_is_emitted_when_there_is_no_cycle():
     timing.emit(None, logger)
     with timing.active(None):
         _attribute_transfer(STAGED_METRICS)
-        timing.record_cold(True)
+        set_refit_cold(True)
 
     assert current_refit_timing() is None


### PR DESCRIPTION
## Summary

Reuses stable manifest metadata and transfer plans across warm refits. Version-specific content digests are refreshed without rebuilding the transfer plan.

The PR also adds trainer and receiver timing so refits report manifest work, discovery, transfer, reconstruction, and installation separately.

## Changes

- Reuse trainer manifests while tensor registration and layout stay unchanged.
- Reuse receiver transfer plans while endpoints, addresses, dtypes, shapes, and sharding stay unchanged.
- Refresh content digests without rebuilding a valid plan.
- Fetch fallback replicas only when the selected source fails.
- Remove released manifests and an extra JSON conversion.
- Report timing, manifest bytes, and cache hits for successful and failed refits.

## Validation

- Full Python client suite: 1931 passed, 4 skipped.
- GCP Qwen3-30B-A3B: 30 warm refits completed without restart, OOM, or refit errors.
- All warm manifest and transfer-plan lookups hit the cache.
- Warm receivers fetched 0 manifest bytes, with 4.0 ms median source discovery.
- Digest-enabled validation completed four warm refits with no digest mismatch and reused the transfer plan each time.

## Dependency

None outstanding. #704 has merged, and this branch is rebased on top of it.

## Review

Rebased onto current `main` and conflict-free. Conflicts were with #704 and were resolved by keeping its 100 MB manifest receive limit on the relocated fetch, and by keeping both its large-manifest test and this branch's staging-failure test.

Addressing @zhengluo-nv:

- **One timing API** (0dd601a). Owned work goes through `refit_span`; `modelexpress_rl.timing` is reduced to cycle ownership, and the generic helpers now live beside `refit_span` as `add_refit_duration`, `add_refit_metadata` and `set_refit_cold`. About twenty call sites converted. `refit_span` gained two things so nothing was lost: it yields a dict for counters only knowable once the work has run, and takes `duration_key` so several spans sharing one normalized stage can still say which of them was expensive.
- **Replica health is per slot again** (57d1107). The lazy fetching had started pairing replicas at a shared offset, so a fleet whose healthy replicas sat at different indices in different slots yielded no candidate even though a complete healthy set existed. Health is resolved per slot again without giving up laziness: a slot's replicas are walked only as far as the requested candidate index. Covered by `test_generator_assembles_healthy_replicas_from_different_offsets`, which fails against the offset-aligned selection and passes with the fix.

Earlier in review, both CodeRabbit findings were addressed in 6645ddf, along with a third instance of the same problem: a staging failure emitted no timing record at all, since the recorder is handed forward on the staged handle and a staging failure happens before there is one.
