### PR TITLE
fix(refit): reconcile distributed RL cold starts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -592,10 +592,25 @@ activation.
 
 RL cold-start bootstrap populates only the immutable full-checkpoint cache; it
 does not rewrite preparation or activation state. Generator ranks sharing that
-cache serialize reconstruction through the same store locks, so the first rank
-prepares the desired target and later ranks attach to the verified `READY`
-checkpoint. Node-local caches elect one preparer per node, while a shared volume
-elects one preparer for the volume.
+cache use local rank 0 as the preparer. Global rank 0 first broadcasts one
+immutable desired UID, and every rank verifies its local configuration against
+that pinned value before agreeing on the replay chain. Node-local followers attach to the
+verified `READY` checkpoint. A CPU-process-group barrier keeps every rank out of
+the engine's distributed checkpoint loader until all nodes are prepared. The
+cache activation commit runs only after every engine rank reports a successful
+load; configuration drift, phase disagreement, or a partial load fails the
+cold start without advancing `active.json`.
+
+The engine's serving version remains separate from checkpoint-cache state.
+vLLM constructs its Control server only after EngineCore and its workers finish
+loading. Because an explicit desired UID makes the MX loader fail closed, the
+Control endpoint is reachable only after every rank loads that UID. The MX
+startup probe then calls vLLM's native `UpdateWeightVersion`, reads it back with
+`GetWeightVersion`, and succeeds only on an exact match. Dynamo's main sidecar
+therefore cannot start or admit the worker before vLLM reports the loaded UID.
+When the weight-transfer backend is initialized later, the controller passes
+that observed UID as `initial_serving_version_id`; the canonical
+`initial_base_version_id` continues to describe only replay lineage.
 
 `WeightVersion.uid` is MX's opaque version identity. A create request may supply
 the UID; MX generates one when it is omitted. Creating another version with an
@@ -910,6 +925,8 @@ RL framework integrations live in the separate `modelexpress_rl` package:
 | `train/engines/fsdp/adapter.py` | FSDP/DTensor source capture with in-place or device-copy staging |
 | `inference/client.py` | Rank-local generator lifecycle, leases, exact-version source discovery, staging, and apply |
 | `inference/runtime.py` | Generator source policy, method/resource composition, and update-session ownership |
+| `inference/engines/vllm/control.py` | Direct vLLM Control gRPC client |
+| `inference/engines/vllm/startup_probe.py` | Serving-version reconciliation and startup gate |
 | `inference/source/` | Independent generator-peer, trainer-memory, and object-storage discovery |
 | `inference/methods/` | Independent full-tensor NIXL and canonical-checkpoint preparation |
 | `inference/checkpoint_store.py` | Host-local immutable lineage, locking, temporary-directory promotion, atomic JSON persistence, artifact fingerprints, and activation state |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -543,6 +543,13 @@ kubectl apply -f examples/dynamo_model_cache_k8s/agg.yaml
 
 See [`../examples/dynamo_model_cache_k8s/README.md`](../examples/dynamo_model_cache_k8s/README.md) for the full guide.
 
+For RL cold start and active weight refit, see
+[`../examples/rl/dynamo_vllm_refit/README.md`](../examples/rl/dynamo_vllm_refit/README.md).
+Its vLLM startup probe directly reconciles the desired MX UID through vLLM's
+native Control gRPC service. Keep that probe on the restartable vLLM init
+container: Kubernetes does not start the Dynamo sidecar until vLLM reports the
+desired UID, so a failed or mismatched reconciliation cannot admit the worker.
+
 ## P2P GPU Weight Transfers
 
 ModelExpress supports GPU-to-GPU model weight transfers between supported inference instances using NVIDIA NIXL over RDMA. vLLM 0.23.0 and newer recognize `--load-format modelexpress` natively, which runs the fixed priority chain P2P RDMA -> server cache -> InstantTensor -> ModelStreamer -> GDS -> native loader; the ModelExpress Python package must still be installed, and `mx` remains a backward-compatible alias. SGLang uses `remote_instance` with the `modelexpress` backend; see [SGLang Clients](#sglang-clients).

--- a/examples/rl/dynamo_vllm_refit/README.md
+++ b/examples/rl/dynamo_vllm_refit/README.md
@@ -5,10 +5,14 @@ ModelExpress `WeightVersion` updates:
 
 1. A GPU trainer job loads `Qwen/Qwen3-0.6B`, publishes one immutable full-weight
    version through `modelexpress_rl`, and waits as the NIXL source.
-2. Dynamo discovers the vLLM worker and pauses generation.
-3. vLLM invokes the `modelexpress` weight-transfer backend for initialization,
+2. On cold start, all vLLM ranks agree on the desired UID and load it through
+   desired-version P2P or canonical S3 replay. The vLLM init container's startup
+   probe then writes and verifies that UID through vLLM's native Control gRPC
+   service before Dynamo starts its sidecar.
+3. Dynamo discovers the admitted vLLM worker and pauses generation.
+4. vLLM invokes the `modelexpress` weight-transfer backend for initialization,
    `start_weight_update`, `update_weights`, and `finish_weight_update`.
-4. The RL coordinator verifies the exact UID on every worker, resumes generation,
+5. The RL coordinator verifies the exact UID on every worker, resumes generation,
    and compares deterministic inference before and after the refit.
 
 The DGD uses the current `nvidia.com/v1beta1` schema and Dynamo's native Rust
@@ -17,6 +21,13 @@ is newer than the latest v1.4.1 release. The engine image pins the current vLLM
 nightly digest built from commit `a9a17e7095a66ef6c6685a1c7ddd657781a78d3c`.
 The latest vLLM v0.27.1 release predates the merged RL Control gRPC service, so
 it cannot serve this Dynamo sidecar flow.
+
+Global rank 0 broadcasts its `MX_REFIT_DESIRED_VERSION_UID`, and every vLLM rank
+checks its local value against that pinned UID before loading. Local rank 0 on
+each node reconstructs the canonical S3 checkpoint; followers reuse the
+node-local result. A rank disagreement or partial distributed load fails
+startup, and the checkpoint activation marker is committed only after every
+rank succeeds.
 
 ## Build
 
@@ -81,7 +92,5 @@ kubectl logs -n "$NAMESPACE" job/mx-vllm-rl-job
 A successful run ends with `E2E PASS` and includes the installed WeightVersion
 UID, worker count, and post-refit generation. Keep worker, server, and coordinator
 logs as separate evidence; the pass line does not by itself qualify throughput
-or delta/S3 behavior. This first slice is the full-weight NIXL lifecycle needed
-by the existing `modelexpress_rl` protocol. XOR/ADD artifact-backed S3 deltas
-require the planned protocol extension for an artifact URI and are not claimed
-by this example.
+or delta/S3 behavior. The checked-in coordinator exercises the full-weight NIXL
+active-refit lifecycle; it does not qualify canonical S3 delta cold start.

--- a/examples/rl/dynamo_vllm_refit/dgd.yaml
+++ b/examples/rl/dynamo_vllm_refit/dgd.yaml
@@ -37,6 +37,7 @@ spec:
             containerPort: 8001
   - name: VLLMWorker
     type: worker
+    runtimeVersionOverride: 1.4.1
     replicas: 1
     podTemplate:
       spec:
@@ -107,8 +108,10 @@ spec:
             exec:
               command:
               - python3
-              - -c
-              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+              - -m
+              - modelexpress_rl.inference.engines.vllm.startup_probe
+              - --address
+              - 127.0.0.1:50051
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 120

--- a/examples/rl/dynamo_vllm_refit/rl_coordinator.py
+++ b/examples/rl/dynamo_vllm_refit/rl_coordinator.py
@@ -101,6 +101,7 @@ def _route(worker: dict[str, Any], group: str, name: str) -> str:
 
 
 def main() -> None:
+    """Run the end-to-end Dynamo and vLLM refit example."""
     dist.init_process_group(
         "nccl",
         init_method="tcp://127.0.0.1:29500",
@@ -147,9 +148,23 @@ def main() -> None:
                 )
                 paused.append(worker)
             for worker in workers:
+                installed = _post(
+                    _route(worker, "control", "get_weight_version"), {}
+                )
+                observed = installed.get("version", installed.get("weight_version"))
+                if not isinstance(observed, str) or not observed:
+                    raise RuntimeError(
+                        f"worker returned invalid serving version: {installed}"
+                    )
                 _post(
                     _route(worker, "update", "init_weight_transfer_engine"),
-                    {"init_info": {}},
+                    {
+                        "init_info": (
+                            {"initial_serving_version_id": observed}
+                            if observed != "default"
+                            else {}
+                        )
+                    },
                 )
                 _post(_route(worker, "update", "start_weight_update"), {})
                 _post(

--- a/modelexpress_client/python/modelexpress/adapter.py
+++ b/modelexpress_client/python/modelexpress/adapter.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import functools
 import os
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 
 import torch
 
@@ -208,3 +208,11 @@ class EngineAdapter:
     def after_native_load(self, result: LoadResult) -> LoadResult:
         """Run engine post-processing after load_via_native() succeeds."""
         return result
+
+    def all_gather_state(self, state: Any) -> tuple[Any, ...]:
+        """All-gather one state value from every engine rank."""
+        return (state,)
+
+    def broadcast_state(self, state: Any) -> Any:
+        """Broadcast one state value from global rank zero."""
+        return state

--- a/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/sglang/adapter.py
@@ -62,6 +62,17 @@ class SglangAdapter(EngineAdapter):
             return int(torch.distributed.get_rank())
         return self.get_worker_rank()
 
+    def get_local_rank(self) -> int:
+        """Return this worker's rank within its local node."""
+        if not (
+            torch.distributed.is_available() and torch.distributed.is_initialized()
+        ):
+            return 0
+
+        from sglang.srt import distributed
+
+        return int(distributed.get_world_group().local_rank)
+
     def get_device_id(self) -> int:
         gpu_id = getattr(self.device_config, "gpu_id", None)
         if gpu_id is not None:
@@ -379,6 +390,7 @@ def build_sglang_load_context(
         target_device=adapter.get_target_device(),
         global_rank=global_rank,
         worker_rank=worker_rank,
+        local_rank=adapter.get_local_rank(),
         device_id=adapter.get_device_id(),
         identity=adapter.build_identity(),
         mx_client=create_metadata_client(

--- a/modelexpress_client/python/modelexpress/engines/trtllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/trtllm/adapter.py
@@ -264,6 +264,7 @@ def build_trtllm_load_context(
         target_device=adapter.get_target_device(),
         global_rank=adapter.get_global_rank(),
         worker_rank=worker_rank,
+        local_rank=int(mapping.local_rank),
         device_id=adapter.get_device_id(),
         identity=adapter.build_identity(),
         mx_client=create_metadata_client(

--- a/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
+++ b/modelexpress_client/python/modelexpress/engines/vllm/adapter.py
@@ -205,6 +205,25 @@ class VllmAdapter(EngineAdapter):
 
         return bool(current_platform.is_cuda_alike())
 
+    def all_gather_state(self, state) -> tuple[object, ...]:
+        """Gather rank-local state through vLLM's CPU process group."""
+        from vllm.distributed import get_world_group
+
+        group = get_world_group()
+        states = [None] * group.world_size
+        torch.distributed.all_gather_object(
+            states,
+            state,
+            group=group.cpu_group,
+        )
+        return tuple(states)
+
+    def broadcast_state(self, state):
+        """Broadcast rank-zero state through vLLM's world group."""
+        from vllm.distributed import get_world_group
+
+        return get_world_group().broadcast_object(state, src=0)
+
     def discover_tensors(self, result: LoadResult) -> dict[str, torch.Tensor]:
         if result.model is None:
             raise RuntimeError("vLLM tensor discovery requires result.model")
@@ -723,6 +742,8 @@ def _get_vllm_device_id(target_device: torch.device) -> int:
 def build_vllm_load_context(vllm_config, model_config) -> LoadContext:
     """Build a LoadContext from vLLM config objects."""
 
+    from vllm.distributed import get_world_group
+
     adapter = VllmAdapter(vllm_config, model_config)
     global_rank = adapter.get_global_rank()
     worker_rank = adapter.get_worker_rank()
@@ -732,6 +753,7 @@ def build_vllm_load_context(vllm_config, model_config) -> LoadContext:
         target_device=adapter.get_target_device(),
         global_rank=global_rank,
         worker_rank=worker_rank,
+        local_rank=int(get_world_group().local_rank),
         device_id=adapter.get_device_id(),
         identity=adapter.build_identity(),
         mx_client=create_metadata_client(worker_rank=worker_rank),

--- a/modelexpress_client/python/modelexpress/load_strategy/context.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/context.py
@@ -57,8 +57,13 @@ class LoadContext:
     model_config: EngineModelConfig
     load_config: EngineLoadConfig
     target_device: torch.device
+    # Unique process rank in the engine's distributed world.
     global_rank: int
+    # Model-shard key used to match compatible MX source and target workers.
     worker_rank: int
+    # Process rank within its node; local rank 0 coordinates node-local state.
+    local_rank: int
+    # Local accelerator ordinal; topology must not be inferred from this value.
     device_id: int
     identity: p2p_pb2.SourceIdentity
     mx_client: MxClientBase
@@ -75,6 +80,8 @@ class LoadContext:
     )
     # False keeps a secondary in-process load (the MTP drafter) out of P2P.
     p2p_enabled: bool = True
+    # RL cold start snapshots this once after distributed rank agreement.
+    desired_version_uid: str | None = None
     # Optional engine-level gate checked before weight metadata is advertised.
     source_ready_fn: Callable[[], bool] | None = None
     nixl_manager: NixlTransferManager | None = None

--- a/modelexpress_client/python/modelexpress_rl/inference/client.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/client.py
@@ -67,6 +67,8 @@ class ModelExpressGeneratorConfig:
     rpc_timeout_seconds: float = 30.0
     # Canonical object-storage checkpoint settings.
     object_storage: ObjectStorageGeneratorConfig | None = None
+    # Version read from the engine's serving-version API after cold start.
+    initial_serving_version_id: str | None = None
     # Ordered fallback for full-tensor sources. Canonical object storage is
     # currently isolated because peer installation does not advance its local
     # checkpoint base.
@@ -74,6 +76,11 @@ class ModelExpressGeneratorConfig:
 
     def __post_init__(self) -> None:
         """Validate explicit settings before client initialization."""
+        if (
+            self.initial_serving_version_id is not None
+            and not self.initial_serving_version_id.strip()
+        ):
+            raise ValueError("initial_serving_version_id must not be empty")
         if self.registration_ttl_seconds is not None:
             rl_envs.require_positive_int(
                 self.registration_ttl_seconds, "registration_ttl_seconds"
@@ -188,6 +195,7 @@ class ModelExpressGeneratorClient:
     """Synchronous rank-local generator client for exact-version refit."""
 
     def __init__(self) -> None:
+        """Create an uninitialized rank-local generator client."""
         self._channel: grpc.Channel | None = None
         self._stub: refit_pb2_grpc.RefitServiceStub | None = None
         self._registration_stop = threading.Event()
@@ -195,6 +203,7 @@ class ModelExpressGeneratorClient:
         self._operation_lock = threading.RLock()
         self._active_handle: StagedWeightHandle | None = None
         self._serving_version_id: str | None = None
+        self._has_initial_serving_version = False
         self._engine_state = _EngineState.READY
         self._runtime: GeneratorRuntime | None = None
         self._closed = False
@@ -250,9 +259,14 @@ class ModelExpressGeneratorClient:
                 start_lease=client._start_version_lease,
             )
             client._runtime = runtime
-            client._serving_version_id = runtime.initial_version_id
+            client._has_initial_serving_version = (
+                config.initial_serving_version_id is not None
+            )
+            client._serving_version_id = (
+                config.initial_serving_version_id or runtime.initial_version_id
+            )
             if client._serving_version_id is not None:
-                client._validate_initial_base(client._serving_version_id)
+                client._validate_initial_serving_version(client._serving_version_id)
             client._register_worker()
             client._registration_thread = threading.Thread(
                 target=client._renew_worker_registration,
@@ -280,7 +294,10 @@ class ModelExpressGeneratorClient:
                 raise RuntimeError("another generator update is still active")
             assert self._runtime is not None
             if (
-                self._runtime.initial_version_id is not None
+                (
+                    self._runtime.initial_version_id is not None
+                    or self._has_initial_serving_version
+                )
                 and version.version_id == self._serving_version_id
                 and self._engine_state is _EngineState.READY
             ):
@@ -461,7 +478,8 @@ class ModelExpressGeneratorClient:
             self._runtime.session.validate(version)
         return chain
 
-    def _validate_initial_base(self, version_id: str) -> None:
+    def _validate_initial_serving_version(self, version_id: str) -> None:
+        """Verify that the engine-observed initial version is ready and compatible."""
         response = self._service.GetWeightVersion(
             refit_pb2.GetWeightVersionRequest(uid=version_id),
             timeout=self._rpc_timeout_seconds,
@@ -470,9 +488,13 @@ class ModelExpressGeneratorClient:
             raise RuntimeError("MX GetWeightVersion response is missing version")
         version = _weight_version(response.version)
         if version.state is not WeightVersionState.READY:
-            raise RuntimeError(f"initial base {version_id!r} is not READY")
+            raise RuntimeError(
+                f"initial serving version {version_id!r} is not READY"
+            )
         if version.model_name != self.model_name:
-            raise RuntimeError("initial base model_name does not match the generator")
+            raise RuntimeError(
+                "initial serving version model_name does not match the generator"
+            )
 
     def _register_lease(self, version_id: str):
         response = self._service.RegisterVersionLease(

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/control.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/control.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct client for vLLM's native serving-version Control service."""
+
+from __future__ import annotations
+
+import grpc
+from google.protobuf import empty_pb2, wrappers_pb2
+
+_CONTROL_SERVICE = "/vllm.Control"
+
+
+class VllmControlClient:
+    """Call the weight-version methods exposed by vLLM's Rust gRPC server."""
+
+    def __init__(self, address: str, *, timeout_seconds: float = 3.0) -> None:
+        """Connect to the native vLLM Control service at ``address``."""
+        self._timeout_seconds = timeout_seconds
+        self._channel = grpc.insecure_channel(address)
+        # vLLM's request/response messages are either empty or one string at
+        # field 1, which are wire-compatible with these standard protobuf types.
+        self._update_weight_version = self._channel.unary_unary(
+            f"{_CONTROL_SERVICE}/UpdateWeightVersion",
+            request_serializer=wrappers_pb2.StringValue.SerializeToString,
+            response_deserializer=empty_pb2.Empty.FromString,
+        )
+        self._get_weight_version = self._channel.unary_unary(
+            f"{_CONTROL_SERVICE}/GetWeightVersion",
+            request_serializer=empty_pb2.Empty.SerializeToString,
+            response_deserializer=wrappers_pb2.StringValue.FromString,
+        )
+
+    def update_weight_version(self, version_uid: str) -> None:
+        """Set the serving weight version reported by vLLM."""
+        self._update_weight_version(
+            wrappers_pb2.StringValue(value=version_uid),
+            timeout=self._timeout_seconds,
+        )
+
+    def get_weight_version(self) -> str:
+        """Return the serving weight version reported by vLLM."""
+        response = self._get_weight_version(
+            empty_pb2.Empty(),
+            timeout=self._timeout_seconds,
+        )
+        return response.value
+
+    def close(self) -> None:
+        """Close the underlying gRPC channel."""
+        self._channel.close()
+
+    def __enter__(self) -> VllmControlClient:
+        """Return this client for use as a context manager."""
+        return self
+
+    def __exit__(self, *_args) -> None:
+        """Close the client when leaving its context."""
+        self.close()
+
+
+__all__ = ["VllmControlClient"]

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/startup_probe.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/startup_probe.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gate vLLM startup on serving-version reconciliation."""
+
+from __future__ import annotations
+
+import argparse
+
+from .... import envs
+from .control import VllmControlClient
+
+
+def reconcile_serving_version(
+    *,
+    address: str,
+    desired_version_uid: str | None,
+    timeout_seconds: float = 3.0,
+) -> str:
+    """Record the desired version after EngineCore startup, then verify it."""
+    with VllmControlClient(
+        address,
+        timeout_seconds=timeout_seconds,
+    ) as client:
+        if desired_version_uid is not None:
+            # vLLM exposes Control only after its workers finish loading. The
+            # desired-version loader fails startup unless every rank loads this UID.
+            client.update_weight_version(desired_version_uid)
+        observed_version_uid = client.get_weight_version()
+    if desired_version_uid is not None and observed_version_uid != desired_version_uid:
+        raise RuntimeError(
+            "vLLM serving-version reconciliation failed: "
+            f"desired={desired_version_uid!r}, observed={observed_version_uid!r}"
+        )
+    return observed_version_uid
+
+
+def main() -> None:
+    """Reconcile the configured version against a running vLLM server."""
+    parser = argparse.ArgumentParser(
+        description="Reconcile vLLM's reported serving weight version",
+    )
+    parser.add_argument("--address", default="127.0.0.1:50051")
+    parser.add_argument("--timeout-seconds", type=float, default=3.0)
+    args = parser.parse_args()
+    observed = reconcile_serving_version(
+        address=args.address,
+        desired_version_uid=envs.MX_REFIT_DESIRED_VERSION_UID,
+        timeout_seconds=args.timeout_seconds,
+    )
+    print(f"vLLM serving version: {observed}", flush=True)
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["reconcile_serving_version"]

--- a/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/engines/vllm/weight_transfer_engine.py
@@ -39,6 +39,7 @@ class ModelExpressWeightTransferInitInfo(WeightTransferInitInfo):
     """Optional ModelExpress connection and object-storage settings."""
 
     model_name: str | None = None
+    initial_serving_version_id: str | None = None
     initial_base_version_id: str | None = None
     seed_checkpoint_path: str | None = None
     refit_checkpoint_dir: str | None = None
@@ -165,6 +166,7 @@ class ModelExpressWeightTransferEngine(WeightTransferEngine):
                 max_replay_chain_length=init_info.max_replay_chain_length,
                 rpc_timeout_seconds=init_info.rpc_timeout_seconds,
                 object_storage=object_storage,
+                initial_serving_version_id=init_info.initial_serving_version_id,
             )
         )
         logger.info("ModelExpress weight transfer initialized model=%s", model_name)

--- a/modelexpress_client/python/modelexpress_rl/inference/load_strategy.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/load_strategy.py
@@ -9,7 +9,7 @@ import logging
 
 import torch.nn as nn
 
-from modelexpress.adapter import StrategyFailed
+from modelexpress.adapter import StrategyFailed, StrategyRecoveryError
 from modelexpress.load_strategy import execute_load_strategies
 from modelexpress.load_strategy.context import LoadContext, LoadResult
 from modelexpress.load_strategy.default_strategy import DefaultStrategy
@@ -31,6 +31,80 @@ from .version_chain import resolve_replay_chain
 
 _MAX_REPLAY_CHAIN_LENGTH = 64
 logger = logging.getLogger(__name__)
+
+
+def _gather_phase(
+    ctx: LoadContext,
+    *,
+    phase: str,
+    desired_version_uid: str | None,
+    result: object,
+) -> tuple[object, ...]:
+    """Synchronize one cold-start phase and reject desired-version drift."""
+    configured_version_uid = envs.MX_REFIT_DESIRED_VERSION_UID
+    state = (phase, desired_version_uid, configured_version_uid, result)
+    states = (
+        ctx.adapter.all_gather_state(state)
+        if ctx.adapter is not None
+        else (state,)
+    )
+    for rank, peer in enumerate(states):
+        if not isinstance(peer, tuple) or len(peer) != 4:
+            raise StrategyRecoveryError(
+                f"invalid distributed RL cold-start state from rank {rank}: {peer!r}"
+            )
+        peer_phase, peer_desired, peer_configured, _peer_result = peer
+        if peer_phase != phase:
+            raise StrategyRecoveryError(
+                "distributed RL cold-start phase disagreement: "
+                f"local={phase!r}, rank {rank}={peer_phase!r}"
+            )
+        if (
+            peer_desired != desired_version_uid
+            or peer_configured != desired_version_uid
+        ):
+            raise StrategyRecoveryError(
+                "distributed RL cold-start desired-version disagreement: "
+                f"pinned={desired_version_uid!r}, rank {rank} "
+                f"pinned={peer_desired!r}, configured={peer_configured!r}"
+            )
+    return tuple(peer[3] for peer in states)
+
+
+def _agree_desired_version(ctx: LoadContext) -> str | None:
+    """Pin the desired version from global rank zero across all workers."""
+    configured = envs.MX_REFIT_DESIRED_VERSION_UID
+    desired_version_uid = (
+        ctx.adapter.broadcast_state(configured)
+        if ctx.adapter is not None
+        else configured
+    )
+    if desired_version_uid is not None and not isinstance(desired_version_uid, str):
+        raise StrategyRecoveryError(
+            "global rank 0 broadcast an invalid RL cold-start desired version: "
+            f"{desired_version_uid!r}"
+        )
+    _gather_phase(
+        ctx,
+        phase="desired_version",
+        desired_version_uid=desired_version_uid,
+        result=None,
+    )
+    return desired_version_uid
+
+
+def _require_uniform_result(
+    results: tuple[object, ...],
+    *,
+    phase: str,
+) -> object:
+    """Return the shared result or reject disagreement between ranks."""
+    first = results[0]
+    if any(result != first for result in results[1:]):
+        raise StrategyRecoveryError(
+            f"distributed RL cold-start result disagreement during {phase}: {results!r}"
+        )
+    return first
 
 
 def _fetch_ready_version(
@@ -67,12 +141,27 @@ class DesiredVersionP2PStrategy(RdmaStrategy):
     name = "desired_version_p2p"
 
     def is_available(self, ctx: LoadContext) -> bool:
-        return envs.MX_REFIT_DESIRED_VERSION_UID is not None and super().is_available(ctx)
+        """Report P2P availability only when every rank agrees."""
+        desired_version_uid = ctx.desired_version_uid
+        if desired_version_uid is None:
+            return False
+        available = super().is_available(ctx)
+        results = _gather_phase(
+            ctx,
+            phase="p2p_available",
+            desired_version_uid=desired_version_uid,
+            result=available,
+        )
+        return bool(_require_uniform_result(results, phase="P2P availability"))
 
     def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
-        desired_version_uid = envs.MX_REFIT_DESIRED_VERSION_UID
+        """Load the pinned version over P2P and reconcile rank outcomes."""
+        desired_version_uid = ctx.desired_version_uid
         if desired_version_uid is None:
             raise StrategyFailed("desired version is not configured", mutated=False)
+        loaded = None
+        failure: BaseException | None = None
+        outcome = "loaded"
         try:
             with ModelExpressControlClient.connect(
                 server_url=ctx.mx_server_url
@@ -83,17 +172,39 @@ class DesiredVersionP2PStrategy(RdmaStrategy):
                     desired_version_uid,
                     require_s3=False,
                 )
+            original_revision = ctx.identity.revision
+            ctx.identity.revision = desired_version_uid
+            try:
+                loaded = super().load(result, ctx)
+            except BaseException:
+                # P2P mutates the identity before interruptible transfer work.
+                ctx.identity.revision = original_revision
+                raise
+        except StrategyRecoveryError as error:
+            failure = error
+            outcome = "fatal"
+        except StrategyFailed as error:
+            failure = error
+            outcome = "miss"
         except Exception as error:
-            raise StrategyFailed(str(error), mutated=False) from error
+            failure = StrategyFailed(str(error), mutated=False)
+            outcome = "miss"
 
-        original_revision = ctx.identity.revision
-        ctx.identity.revision = desired_version_uid
-        try:
-            return super().load(result, ctx)
-        except BaseException:
-            # P2P mutates the identity before interruptible transfer work.
-            ctx.identity.revision = original_revision
-            raise
+        outcomes = _gather_phase(
+            ctx,
+            phase="p2p_result",
+            desired_version_uid=desired_version_uid,
+            result=outcome,
+        )
+        agreed_outcome = _require_uniform_result(outcomes, phase="P2P load")
+        if agreed_outcome == "fatal":
+            raise StrategyRecoveryError(
+                "a rank could not recover from desired-version P2P loading"
+            ) from failure
+        if failure is not None:
+            raise failure
+        assert loaded is not None
+        return loaded
 
 
 class DesiredVersionS3Strategy(ModelStreamerStrategy):
@@ -102,54 +213,56 @@ class DesiredVersionS3Strategy(ModelStreamerStrategy):
     name = "desired_version_s3"
 
     def is_available(self, ctx: LoadContext) -> bool:
-        return (
-            envs.MX_REFIT_DESIRED_VERSION_UID is not None
-            and envs.MX_REFIT_CHECKPOINT_DIR is not None
-            and self.supports_explicit_uri(ctx)
+        """Report S3 availability only when every rank can use it."""
+        desired_version_uid = ctx.desired_version_uid
+        if desired_version_uid is None:
+            return False
+        available = envs.MX_REFIT_CHECKPOINT_DIR is not None and (
+            self.supports_explicit_uri(ctx)
         )
+        results = _gather_phase(
+            ctx,
+            phase="s3_available",
+            desired_version_uid=desired_version_uid,
+            result=available,
+        )
+        return bool(_require_uniform_result(results, phase="S3 availability"))
 
-    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
-        desired_version_uid = envs.MX_REFIT_DESIRED_VERSION_UID
-        checkpoint_dir = envs.MX_REFIT_CHECKPOINT_DIR
-        if desired_version_uid is None or checkpoint_dir is None:
-            raise StrategyFailed(
-                "desired version or checkpoint directory is not configured",
-                mutated=False,
-            )
-
-        original_revision = ctx.identity.revision
-        method = None
-        prepared = None
-        engine_loaded = False
+    @staticmethod
+    def _prepare(
+        ctx: LoadContext,
+        chain: tuple[WeightVersion, ...],
+        checkpoint_dir: str,
+    ):
+        """Materialize a replay chain without activating its checkpoint."""
+        root = chain[0]
+        assert root.object_storage is not None
+        s3 = S3Client()
         try:
-            chain = _resolve_s3_replay_chain(ctx, desired_version_uid)
-            root = chain[0]
-            assert root.object_storage is not None
-            s3 = S3Client()
-            try:
-                seed_path = bootstrap_s3_checkpoint(
-                    model_name=ctx.identity.model_name,
-                    version=_S3Version(
-                        version_id=root.version_id,
-                        base_version_id=root.base_version_id,
-                        payload_format=root.payload_format,
-                        uri=root.object_storage.uri,
-                    ),
-                    refit_checkpoint_dir=checkpoint_dir,
-                    s3=s3,
-                )
-            finally:
-                s3.close()
-
-            method = CanonicalDeltaUpdateMethod(
+            seed_path = bootstrap_s3_checkpoint(
                 model_name=ctx.identity.model_name,
-                config=ObjectStorageGeneratorConfig(
-                    storage_type=ObjectStorageType.S3,
-                    initial_base_version_id=root.version_id,
-                    seed_checkpoint_path=seed_path,
-                    refit_checkpoint_dir=checkpoint_dir,
+                version=_S3Version(
+                    version_id=root.version_id,
+                    base_version_id=root.base_version_id,
+                    payload_format=root.payload_format,
+                    uri=root.object_storage.uri,
                 ),
+                refit_checkpoint_dir=checkpoint_dir,
+                s3=s3,
             )
+        finally:
+            s3.close()
+
+        method = CanonicalDeltaUpdateMethod(
+            model_name=ctx.identity.model_name,
+            config=ObjectStorageGeneratorConfig(
+                storage_type=ObjectStorageType.S3,
+                initial_base_version_id=root.version_id,
+                seed_checkpoint_path=seed_path,
+                refit_checkpoint_dir=checkpoint_dir,
+            ),
+        )
+        try:
             prepared = method.prepare_chain(
                 tuple(
                     (
@@ -162,17 +275,144 @@ class DesiredVersionS3Strategy(ModelStreamerStrategy):
                     for version in chain
                 )
             )
-            with method.installation_context(prepared):
-                loaded = self.load_uri(result, ctx, str(prepared.checkpoint.path))
-                engine_loaded = True
+        except BaseException:
+            method.close()
+            raise
+        return method, prepared
+
+    def load(self, result: LoadResult, ctx: LoadContext) -> LoadResult:
+        """Coordinate node-local reconstruction and distributed engine loading."""
+        desired_version_uid = ctx.desired_version_uid
+        checkpoint_dir = envs.MX_REFIT_CHECKPOINT_DIR
+        if desired_version_uid is None or checkpoint_dir is None:
+            raise StrategyFailed(
+                "desired version or checkpoint directory is not configured",
+                mutated=False,
+            )
+
+        original_revision = ctx.identity.revision
+        method = None
+        prepared = None
+        try:
+            chain = None
+            chain_error = None
+            try:
+                chain = _resolve_s3_replay_chain(ctx, desired_version_uid)
+            except BaseException as error:
+                chain_error = error
+            chain_result = (
+                ("ready", tuple(version.version_id for version in chain))
+                if chain is not None
+                else ("failed",)
+            )
+            chain_results = _gather_phase(
+                ctx,
+                phase="s3_chain",
+                desired_version_uid=desired_version_uid,
+                result=chain_result,
+            )
+            agreed_chain = _require_uniform_result(
+                chain_results,
+                phase="S3 replay-chain resolution",
+            )
+            if agreed_chain[0] != "ready":
+                raise StrategyRecoveryError(
+                    "at least one rank failed to resolve the S3 replay chain"
+                ) from chain_error
+            assert chain is not None
+
+            is_local_leader = ctx.local_rank == 0
+            leader_error = None
+            if is_local_leader:
+                try:
+                    method, prepared = self._prepare(ctx, chain, checkpoint_dir)
+                except BaseException as error:
+                    leader_error = error
+            leader_results = _gather_phase(
+                ctx,
+                phase="s3_local_leader_prepared",
+                desired_version_uid=desired_version_uid,
+                result=(is_local_leader, leader_error is None),
+            )
+            if any(
+                is_leader and not succeeded for is_leader, succeeded in leader_results
+            ):
+                raise StrategyRecoveryError(
+                    "a local leader failed to prepare the S3 checkpoint"
+                ) from leader_error
+
+            follower_error = None
+            if not is_local_leader:
+                try:
+                    method, prepared = self._prepare(ctx, chain, checkpoint_dir)
+                except BaseException as error:
+                    follower_error = error
+            prepared_results = _gather_phase(
+                ctx,
+                phase="s3_all_prepared",
+                desired_version_uid=desired_version_uid,
+                result=leader_error is None and follower_error is None,
+            )
+            if not all(prepared_results):
+                raise StrategyRecoveryError(
+                    "at least one rank failed to attach to the S3 checkpoint"
+                ) from follower_error
+            assert method is not None and prepared is not None
+
+            loaded = None
+            load_error = None
+            try:
+                with method.installation_context(prepared, activate=False):
+                    loaded = self.load_uri(
+                        result,
+                        ctx,
+                        str(prepared.checkpoint.path),
+                    )
+            except BaseException as error:
+                load_error = error
+            load_results = _gather_phase(
+                ctx,
+                phase="s3_engine_loaded",
+                desired_version_uid=desired_version_uid,
+                result=load_error is None,
+            )
+            if not all(load_results):
+                raise StrategyRecoveryError(
+                    "at least one rank failed to load the prepared S3 checkpoint"
+                ) from load_error
+
+            activation_error = None
+            if is_local_leader:
+                try:
+                    method.activate(prepared)
+                except BaseException as error:
+                    activation_error = error
+            activation_results = _gather_phase(
+                ctx,
+                phase="s3_checkpoint_activated",
+                desired_version_uid=desired_version_uid,
+                result=(is_local_leader, activation_error is None),
+            )
+            if any(
+                is_leader and not succeeded
+                for is_leader, succeeded in activation_results
+            ):
+                raise StrategyRecoveryError(
+                    "a local leader failed to activate the S3 checkpoint"
+                ) from activation_error
+
             ctx.identity.revision = desired_version_uid
+            assert loaded is not None
             return loaded
+        except StrategyRecoveryError:
+            ctx.identity.revision = original_revision
+            raise
         except StrategyFailed:
             ctx.identity.revision = original_revision
             raise
         except Exception as error:
             ctx.identity.revision = original_revision
-            raise StrategyFailed(str(error), mutated=engine_loaded) from error
+            raise StrategyFailed(str(error), mutated=False) from error
         finally:
             if method is not None:
                 try:
@@ -218,9 +458,11 @@ class RLLoadStrategyChain:
 
     @staticmethod
     def run(model: nn.Module, ctx: LoadContext) -> nn.Module:
+        """Execute the cold-start strategy chain for the agreed version."""
+        ctx.desired_version_uid = _agree_desired_version(ctx)
         # A desired UID is a correctness constraint: version-agnostic fallbacks
         # could load different weights and let the worker serve the wrong version.
-        if envs.MX_REFIT_DESIRED_VERSION_UID is not None:
+        if ctx.desired_version_uid is not None:
             strategies = [
                 DesiredVersionP2PStrategy(),
                 DesiredVersionS3Strategy(),

--- a/modelexpress_client/python/modelexpress_rl/inference/methods/canonical_delta.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/methods/canonical_delta.py
@@ -109,10 +109,25 @@ class CanonicalDeltaUpdateMethod(UpdateMethod):
             uri=storage.uri,
         )
 
-    def installation_context(self, prepared: PreparedArtifact):
+    def installation_context(
+        self,
+        prepared: PreparedArtifact,
+        *,
+        activate: bool = True,
+    ):
+        """Install a prepared checkpoint and optionally activate it afterward."""
         if prepared is not self._active:
             raise RuntimeError("canonical checkpoint is no longer active")
-        return self._checkpoint.installation_context(prepared.checkpoint)
+        return self._checkpoint.installation_context(
+            prepared.checkpoint,
+            activate=activate,
+        )
+
+    def activate(self, prepared: PreparedArtifact) -> None:
+        """Activate the prepared checkpoint after distributed loading succeeds."""
+        if prepared is not self._active:
+            raise RuntimeError("canonical checkpoint is no longer active")
+        self._checkpoint.activate(prepared.checkpoint)
 
     def release(self, prepared: PreparedArtifact) -> None:
         if prepared is not self._active:

--- a/modelexpress_client/python/modelexpress_rl/inference/receiver.py
+++ b/modelexpress_client/python/modelexpress_rl/inference/receiver.py
@@ -1117,38 +1117,59 @@ class _LocalCheckpoint:
                 mapped.close()
                 file_handle.close()
 
+    def _validate_prepared(
+        self,
+        prepared: PreparedCheckpoint,
+        *,
+        message: str,
+    ) -> None:
+        """Ensure the prepared checkpoint still matches durable store state."""
+        state = self.store.state()
+        if (
+            state is None
+            or state.status is not CheckpointState.READY
+            or state.version != prepared.target_version
+            or state.files != checkpoint_files_state(self.checkpoint_paths)
+        ):
+            raise ReceiverInstallError(message)
+
+    def activate(self, prepared: PreparedCheckpoint) -> None:
+        """Commit a prepared checkpoint after every local installer succeeds."""
+        with self.store.installation_locked(), self.store.locked():
+            self._validate_prepared(
+                prepared,
+                message="prepared checkpoint changed before activation",
+            )
+            self.store.activate(prepared.target_version)
+            self.store.enforce_capacity(
+                protected_versions={prepared.target_version},
+            )
+
     @contextmanager
-    def installation_context(self, prepared: PreparedCheckpoint):
+    def installation_context(
+        self,
+        prepared: PreparedCheckpoint,
+        *,
+        activate: bool = True,
+    ):
+        """Hold installation locks and optionally activate on successful exit."""
         with self.store.installation_locked(shared=True):
             with self.store.locked(shared=True):
-                state = self.store.state()
-                if (
-                    state is None
-                    or state.status is not CheckpointState.READY
-                    or state.version != prepared.target_version
-                    or state.files
-                    != checkpoint_files_state(self.checkpoint_paths)
-                ):
-                    raise ReceiverInstallError(
-                        "prepared checkpoint changed before installation"
-                    )
-                yield
-            with self.store.locked():
-                state = self.store.state()
-                if (
-                    state is None
-                    or state.status is not CheckpointState.READY
-                    or state.version != prepared.target_version
-                    or state.files
-                    != checkpoint_files_state(self.checkpoint_paths)
-                ):
-                    raise ReceiverInstallError(
-                        "prepared checkpoint changed during installation"
-                    )
-                self.store.activate(prepared.target_version)
-                self.store.enforce_capacity(
-                    protected_versions={prepared.target_version},
+                self._validate_prepared(
+                    prepared,
+                    message="prepared checkpoint changed before installation",
                 )
+                yield
+            if activate:
+                with self.store.locked():
+                    self._validate_prepared(
+                        prepared,
+                        message="prepared checkpoint changed during installation",
+                    )
+                    self.store.activate(prepared.target_version)
+                    self.store.enforce_capacity(
+                        protected_versions={prepared.target_version},
+                    )
 
 
 __all__ = [

--- a/modelexpress_client/python/tests/test_accelerator_backend.py
+++ b/modelexpress_client/python/tests/test_accelerator_backend.py
@@ -288,6 +288,7 @@ class TestAcceleratorCapabilityGates:
         self,
         mock_accelerator_backend_cls,
     ):
+        """GDS is unavailable when the selected backend lacks GDS support."""
         from modelexpress.load_strategy.context import LoadContext
         from modelexpress.load_strategy.gds_strategy import GdsStrategy
 
@@ -301,6 +302,7 @@ class TestAcceleratorCapabilityGates:
             target_device=torch.device("cpu"),
             global_rank=0,
             worker_rank=0,
+            local_rank=0,
             device_id=0,
             identity=MagicMock(),
             mx_client=MagicMock(),

--- a/modelexpress_client/python/tests/test_gds_loader.py
+++ b/modelexpress_client/python/tests/test_gds_loader.py
@@ -224,6 +224,7 @@ class TestGdsStrategyIntegration:
             return result
 
     def _make_context(self):
+        """Build a CPU load context for GDS strategy tests."""
         from modelexpress.load_strategy import LoadContext
         return LoadContext(
             model_config=MagicMock(),
@@ -231,6 +232,7 @@ class TestGdsStrategyIntegration:
             target_device=torch.device("cpu"),
             global_rank=0,
             worker_rank=0,
+            local_rank=0,
             device_id=0,
             identity=MagicMock(),
             mx_client=MagicMock(),

--- a/modelexpress_client/python/tests/test_instant_tensor_strategy.py
+++ b/modelexpress_client/python/tests/test_instant_tensor_strategy.py
@@ -71,6 +71,7 @@ def _make_load_context(**overrides):
         target_device=torch.device("cpu"),
         global_rank=0,
         worker_rank=0,
+        local_rank=0,
         device_id=0,
         identity=p2p_pb2.SourceIdentity(
             model_name="test-model",

--- a/modelexpress_client/python/tests/test_lifecycle.py
+++ b/modelexpress_client/python/tests/test_lifecycle.py
@@ -31,6 +31,7 @@ def _make_load_context(**overrides):
         target_device=torch.device("cpu"),
         global_rank=0,
         worker_rank=0,
+        local_rank=0,
         device_id=0,
         identity=p2p_pb2.SourceIdentity(model_name="test-model"),
         mx_client=MagicMock(),

--- a/modelexpress_client/python/tests/test_model_streamer_strategy.py
+++ b/modelexpress_client/python/tests/test_model_streamer_strategy.py
@@ -53,6 +53,7 @@ def _make_load_context(**overrides):
         target_device=torch.device("cpu"),
         global_rank=0,
         worker_rank=0,
+        local_rank=0,
         device_id=0,
         identity=p2p_pb2.SourceIdentity(
             model_name="test-model",

--- a/modelexpress_client/python/tests/test_refit_generator_client.py
+++ b/modelexpress_client/python/tests/test_refit_generator_client.py
@@ -433,7 +433,9 @@ def _initialize(
     max_transfer_attempts=3,
     max_replay_chain_length=64,
     source_order=None,
+    initial_serving_version_id=None,
 ):
+    """Initialize a generator client backed by the test runtime."""
     monkeypatch.setattr(
         GeneratorRuntime,
         "initialize",
@@ -463,6 +465,7 @@ def _initialize(
             max_transfer_attempts=max_transfer_attempts,
             max_replay_chain_length=max_replay_chain_length,
             source_order=source_order,
+            initial_serving_version_id=initial_serving_version_id,
         )
     )
 
@@ -829,6 +832,31 @@ def test_generator_treats_installed_initial_base_as_successful_no_op(monkeypatch
     assert adapter.apply_calls == []
 
 
+def test_generator_uses_engine_observed_serving_version_after_cold_start(
+    monkeypatch,
+):
+    """Use the engine-observed version as the initial serving version."""
+    server, endpoint, service = _start_server()
+    service.version.uid = "version-a"
+    adapter = _Adapter(service)
+    generator = _initialize(
+        monkeypatch,
+        endpoint,
+        adapter,
+        initial_serving_version_id="version-a",
+    )
+
+    try:
+        staged = generator.stage_weight(version=WeightVersionRef("version-a"))
+        assert staged.applied is True
+        staged.release()
+    finally:
+        generator.close()
+        server.stop(grace=None).wait()
+
+    assert adapter.stage_calls == []
+
+
 def _canonical_version(uid, base_version_id):
     return refit_pb2.WeightVersion(
         uid=uid,
@@ -1076,12 +1104,13 @@ def test_generator_rejects_wrong_delta_base_before_lease(monkeypatch):
 
 
 def test_generator_validates_the_initial_s3_base_before_registration(monkeypatch):
+    """Validate an initial S3 base before registering the generator."""
     server, endpoint, service = _start_server()
     service.base.state = refit_pb2.WEIGHT_VERSION_STATE_STAGING
     adapter = _Adapter(service)
 
     try:
-        with pytest.raises(RuntimeError, match="initial base.*not READY"):
+        with pytest.raises(RuntimeError, match=r"initial serving version.*not READY"):
             _initialize(
                 monkeypatch,
                 endpoint,

--- a/modelexpress_client/python/tests/test_refit_load_strategy.py
+++ b/modelexpress_client/python/tests/test_refit_load_strategy.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch.nn as nn
 
-from modelexpress.adapter import StrategyFailed
+from modelexpress.adapter import EngineAdapter, StrategyFailed, StrategyRecoveryError
 from modelexpress.load_strategy import LoadResult
 from modelexpress_rl import (
     ObjectStorageSource,
@@ -20,6 +20,7 @@ from modelexpress_rl import (
     WeightVersion,
     WeightVersionState,
 )
+from modelexpress_rl import envs as rl_envs
 from modelexpress_rl.inference.load_strategy import (
     DesiredVersionP2PStrategy,
     DesiredVersionS3Strategy,
@@ -29,12 +30,31 @@ from modelexpress_rl.inference.load_strategy import (
 
 
 def _context():
+    """Build a default load context for cold-start strategy tests."""
     ctx = MagicMock()
     ctx.global_rank = 0
     ctx.identity.model_name = "test-model"
     ctx.identity.revision = "base"
     ctx.mx_server_url = "http://mx:8001"
+    ctx.local_rank = 0
+    ctx.desired_version_uid = rl_envs.MX_REFIT_DESIRED_VERSION_UID
+    ctx.adapter = EngineAdapter()
     return ctx
+
+
+class _DistributedAdapter(EngineAdapter):
+    def __init__(self, gather, *, broadcast=None):
+        """Configure deterministic collective results for a test."""
+        self._gather = gather
+        self._broadcast = broadcast
+
+    def all_gather_state(self, state):
+        """Return the states supplied by the configured gather callback."""
+        return tuple(self._gather(state))
+
+    def broadcast_state(self, state):
+        """Return the configured rank-zero value or the local state."""
+        return self._broadcast if self._broadcast is not None else state
 
 
 def _version(
@@ -89,6 +109,102 @@ def test_desired_version_does_not_use_version_agnostic_fallbacks(monkeypatch):
         RLLoadStrategyChain.run(model, ctx)
 
     fallback.load.assert_not_called()
+
+
+def test_distributed_cold_start_rejects_desired_version_disagreement(monkeypatch):
+    """Reject desired-version disagreement reported by another rank."""
+    monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "version-7")
+    model = nn.Linear(1, 1)
+    ctx = _context()
+    ctx.adapter = _DistributedAdapter(
+        lambda state: (
+            state,
+            ("desired_version", "version-8", "version-8", True),
+        )
+    )
+
+    with pytest.raises(
+        StrategyRecoveryError,
+        match="desired-version disagreement",
+    ):
+        RLLoadStrategyChain.run(model, ctx)
+
+
+def test_distributed_cold_start_rejects_local_config_different_from_rank_zero(
+    monkeypatch,
+):
+    """Reject a local desired version that differs from rank zero."""
+    monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "version-8")
+    model = nn.Linear(1, 1)
+    ctx = _context()
+    ctx.adapter = _DistributedAdapter(lambda state: (state,), broadcast="version-7")
+
+    with pytest.raises(
+        StrategyRecoveryError,
+        match="desired-version disagreement",
+    ):
+        RLLoadStrategyChain.run(model, ctx)
+
+
+def test_p2p_rejects_desired_version_change_during_load(monkeypatch):
+    """Reject configuration drift while a desired-version P2P load runs."""
+    monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "version-7")
+    ctx = _context()
+    result = LoadResult(value=nn.Linear(1, 1))
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.get_weight_version.return_value = _version(
+        "version-7", WeightPayloadFormat.FULL_HF_CHECKPOINT
+    )
+
+    def change_desired(*_args):
+        """Change the configured version while returning a successful load."""
+        monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "version-8")
+        return result
+
+    with patch(
+        "modelexpress_rl.inference.load_strategy.ModelExpressControlClient.connect",
+        return_value=client,
+    ), patch(
+        "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.load",
+        side_effect=change_desired,
+    ), pytest.raises(
+        StrategyRecoveryError,
+        match="desired-version disagreement",
+    ):
+        DesiredVersionP2PStrategy().load(result, ctx)
+
+
+def test_p2p_rejects_rank_load_outcome_disagreement(monkeypatch):
+    """Reject disagreement between rank-local P2P load outcomes."""
+    monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "version-7")
+    ctx = _context()
+
+    def gather(state):
+        """Inject a peer P2P miss into the gathered outcomes."""
+        phase, desired, configured, result = state
+        peer_result = "miss" if phase == "p2p_result" else result
+        return state, (phase, desired, configured, peer_result)
+
+    ctx.adapter = _DistributedAdapter(gather)
+    result = LoadResult(value=nn.Linear(1, 1))
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.get_weight_version.return_value = _version(
+        "version-7", WeightPayloadFormat.FULL_HF_CHECKPOINT
+    )
+
+    with patch(
+        "modelexpress_rl.inference.load_strategy.ModelExpressControlClient.connect",
+        return_value=client,
+    ), patch(
+        "modelexpress.load_strategy.rdma_strategy.RdmaStrategy.load",
+        return_value=result,
+    ), pytest.raises(
+        StrategyRecoveryError,
+        match="result disagreement during P2P load",
+    ):
+        DesiredVersionP2PStrategy().load(result, ctx)
 
 
 def test_desired_p2p_is_skipped_without_desired_version(monkeypatch):
@@ -259,6 +375,7 @@ def test_resolve_s3_chain_rejects_mismatched_returned_uid():
 
 
 def test_desired_s3_loads_materialized_checkpoint(monkeypatch, tmp_path):
+    """Load and activate a checkpoint materialized from the desired S3 chain."""
     monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "delta")
     monkeypatch.setenv("MX_REFIT_CHECKPOINT_DIR", str(tmp_path))
     ctx = _context()
@@ -290,6 +407,108 @@ def test_desired_s3_loads_materialized_checkpoint(monkeypatch, tmp_path):
 
     load_uri.assert_called_once_with(result, ctx, "/cache/delta")
     assert ctx.identity.revision == "delta"
+    method.installation_context.assert_called_once_with(
+        method.prepare_chain.return_value,
+        activate=False,
+    )
+    method.activate.assert_called_once_with(method.prepare_chain.return_value)
     method.release.assert_called_once_with(method.prepare_chain.return_value)
     method.close.assert_called_once()
     s3.close.assert_called_once()
+
+
+def test_desired_s3_does_not_activate_until_every_rank_loads(monkeypatch, tmp_path):
+    """Do not activate a checkpoint when another rank fails engine loading."""
+    monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "delta")
+    monkeypatch.setenv("MX_REFIT_CHECKPOINT_DIR", str(tmp_path))
+    ctx = _context()
+
+    def gather(state):
+        """Inject a peer engine-load failure into gathered phase state."""
+        phase, desired, configured, result = state
+        peer_result = False if phase == "s3_engine_loaded" else result
+        return state, (phase, desired, configured, peer_result)
+
+    ctx.adapter = _DistributedAdapter(gather)
+    root = _version("root", WeightPayloadFormat.FULL_HF_CHECKPOINT)
+    delta = _version("delta", WeightPayloadFormat.XOR_DELTA, base="root")
+    result = LoadResult(value=nn.Linear(1, 1))
+    method = MagicMock()
+    method.installation_context.return_value = nullcontext()
+    method.prepare_chain.return_value = SimpleNamespace(
+        checkpoint=SimpleNamespace(path=Path("/cache/delta"))
+    )
+
+    with patch(
+        "modelexpress_rl.inference.load_strategy._resolve_s3_replay_chain",
+        return_value=(root, delta),
+    ), patch.object(
+        DesiredVersionS3Strategy,
+        "_prepare",
+        return_value=(method, method.prepare_chain.return_value),
+    ), patch.object(
+        DesiredVersionS3Strategy,
+        "load_uri",
+        return_value=result,
+    ), pytest.raises(
+        StrategyRecoveryError,
+        match="at least one rank failed to load",
+    ):
+        DesiredVersionS3Strategy().load(result, ctx)
+
+    method.activate.assert_not_called()
+
+
+def test_desired_s3_only_local_leader_activates(monkeypatch, tmp_path):
+    """Allow only the node-local leader to prepare and activate checkpoints."""
+    monkeypatch.setenv("MX_REFIT_DESIRED_VERSION_UID", "delta")
+    monkeypatch.setenv("MX_REFIT_CHECKPOINT_DIR", str(tmp_path))
+    ctx = _context()
+    events = []
+
+    def gather(state):
+        """Record phases and report successful leader-only operations."""
+        phase, desired, configured, result = state
+        events.append(phase)
+        peer_result = (
+            (True, True)
+            if phase in {
+                "s3_local_leader_prepared",
+                "s3_checkpoint_activated",
+            }
+            else result
+        )
+        return state, (phase, desired, configured, peer_result)
+
+    ctx.adapter = _DistributedAdapter(gather)
+    ctx.local_rank = 1
+    root = _version("root", WeightPayloadFormat.FULL_HF_CHECKPOINT)
+    delta = _version("delta", WeightPayloadFormat.XOR_DELTA, base="root")
+    result = LoadResult(value=nn.Linear(1, 1))
+    method = MagicMock()
+    method.installation_context.return_value = nullcontext()
+    method.prepare_chain.return_value = SimpleNamespace(
+        checkpoint=SimpleNamespace(path=Path("/cache/delta"))
+    )
+
+    def prepare(*_args):
+        """Record an unexpected follower preparation attempt."""
+        events.append("prepare")
+        return method, method.prepare_chain.return_value
+
+    with patch(
+        "modelexpress_rl.inference.load_strategy._resolve_s3_replay_chain",
+        return_value=(root, delta),
+    ), patch.object(
+        DesiredVersionS3Strategy,
+        "_prepare",
+        side_effect=prepare,
+    ), patch.object(
+        DesiredVersionS3Strategy,
+        "load_uri",
+        return_value=result,
+    ):
+        assert DesiredVersionS3Strategy().load(result, ctx) is result
+
+    method.activate.assert_not_called()
+    assert events.index("s3_local_leader_prepared") < events.index("prepare")

--- a/modelexpress_client/python/tests/test_refit_s3_receiver.py
+++ b/modelexpress_client/python/tests/test_refit_s3_receiver.py
@@ -1331,6 +1331,27 @@ def test_canonical_s3_failed_install_keeps_previous_active_version(
     adapter.close()
 
 
+def test_canonical_s3_can_defer_activation_until_distributed_load_completes(
+    monkeypatch, tmp_path
+):
+    """Defer checkpoint activation until distributed loading completes."""
+    objects = _full_artifact(torch.tensor([7.0, 8.0]))
+    adapter, _storage = _build(monkeypatch, tmp_path, objects)
+    prepared = adapter.stage_weight(_full_inputs())
+
+    with adapter._method.installation_context(
+        adapter._active,
+        activate=False,
+    ):
+        pass
+
+    assert adapter._checkpoint.store.active_version() == "base-a"
+    adapter._method.activate(adapter._active)
+    assert adapter._checkpoint.store.active_version() == "full-a"
+    adapter.release_staged_weight(prepared)
+    adapter.close()
+
+
 def test_canonical_s3_applies_one_delta_to_the_active_checkpoint(
     monkeypatch, tmp_path
 ):

--- a/modelexpress_client/python/tests/test_server_cache_strategy.py
+++ b/modelexpress_client/python/tests/test_server_cache_strategy.py
@@ -99,6 +99,7 @@ def fake_client(monkeypatch):
 
 
 def _make_context(model_name, *, adapter=None, model_path=None, revision=None):
+    """Build a load context for server-cache strategy tests."""
     from modelexpress.load_strategy import LoadContext
 
     return LoadContext(
@@ -107,6 +108,7 @@ def _make_context(model_name, *, adapter=None, model_path=None, revision=None):
         target_device=torch.device("cpu"),
         global_rank=0,
         worker_rank=0,
+        local_rank=0,
         device_id=0,
         identity=p2p_pb2.SourceIdentity(model_name=model_name, tensor_parallel_size=1),
         mx_client=MagicMock(),

--- a/modelexpress_client/python/tests/test_sglang_loader.py
+++ b/modelexpress_client/python/tests/test_sglang_loader.py
@@ -94,12 +94,14 @@ def test_sglang_context_uses_tp_rank_for_matching_and_url_override():
 
 
 def test_sglang_context_separates_worker_rank_from_global_rank(monkeypatch):
+    """Keep SGLang's engine worker rank separate from the distributed rank."""
     sglang_mod = ModuleType("sglang")
     srt_mod = ModuleType("sglang.srt")
     distributed_mod = ModuleType("sglang.srt.distributed")
     distributed_mod.get_tensor_model_parallel_rank = lambda: 1
     distributed_mod.get_pipeline_model_parallel_rank = lambda: 2
     distributed_mod.get_tensor_model_parallel_world_size = lambda: 4
+    distributed_mod.get_world_group = lambda: SimpleNamespace(local_rank=3)
     srt_mod.distributed = distributed_mod
 
     monkeypatch.setitem(sys.modules, "sglang", sglang_mod)
@@ -117,6 +119,7 @@ def test_sglang_context_separates_worker_rank_from_global_rank(monkeypatch):
 
     assert ctx.worker_rank == 9
     assert ctx.global_rank == 17
+    assert ctx.local_rank == 3
     assert ctx.mx_client.server_url == "mx.example:9000"
 
 

--- a/modelexpress_client/python/tests/test_tracing.py
+++ b/modelexpress_client/python/tests/test_tracing.py
@@ -25,12 +25,14 @@ def tracer_and_exporter():
 
 
 def _ctx():
+    """Build a load context for tracing tests."""
     return LoadContext(
         model_config=MagicMock(),
         load_config=MagicMock(),
         target_device=torch.device("cpu"),
         global_rank=3,
         worker_rank=3,
+        local_rank=0,
         device_id=0,
         identity=p2p_pb2.SourceIdentity(model_name="test/model"),
         mx_client=MagicMock(),

--- a/modelexpress_client/python/tests/test_trtllm_adapter.py
+++ b/modelexpress_client/python/tests/test_trtllm_adapter.py
@@ -173,6 +173,20 @@ def test_adapter_uses_global_rank_for_worker_and_local_rank_for_device():
     assert adapter.get_target_device() == torch.device("cuda", 1)
 
 
+def test_context_uses_mapping_local_rank():
+    """Populate the load context's local rank from the TRT-LLM mapping."""
+    context = build_trtllm_load_context(
+        model_config=object(),
+        load_config=object(),
+        mapping=_mapping(local_rank=3),
+        source_identity=_TrtIdentity(),
+        p2p_enabled=True,
+        **_adapter_kwargs(),
+    )
+
+    assert context.local_rank == 3
+
+
 def test_adapter_discovers_canonical_parameters_only():
     model = nn.Module()
     model.primary = nn.Linear(2, 2, bias=False)

--- a/modelexpress_client/python/tests/test_vllm_adapter.py
+++ b/modelexpress_client/python/tests/test_vllm_adapter.py
@@ -113,6 +113,42 @@ def test_vllm_is_cuda_alike_uses_current_platform(
     assert adapter.is_cuda_alike() is True
 
 
+def test_vllm_all_gathers_state_on_cpu_group(monkeypatch):
+    """Use vLLM's CPU group for state collectives."""
+    cpu_group = object()
+    broadcasts = []
+
+    def broadcast(state, *, src):
+        """Record a broadcast and return the simulated rank-zero value."""
+        broadcasts.append((state, src))
+        return "rank-zero"
+
+    world_group = SimpleNamespace(
+        world_size=2,
+        cpu_group=cpu_group,
+        local_rank=0,
+        broadcast_object=broadcast,
+    )
+    distributed = ModuleType("vllm.distributed")
+    distributed.get_world_group = lambda: world_group
+    monkeypatch.setitem(sys.modules, "vllm.distributed", distributed)
+
+    def all_gather(states, state, *, group):
+        """Populate the gather destination with local and peer state."""
+        assert group is cpu_group
+        states[:] = [state, ("peer",)]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", all_gather)
+    adapter = object.__new__(VllmAdapter)
+
+    assert adapter.all_gather_state(("local",)) == (
+        ("local",),
+        ("peer",),
+    )
+    assert adapter.broadcast_state("local") == "rank-zero"
+    assert broadcasts == [("local", 0)]
+
+
 def test_vllm_adapter_discovery_uses_backend_predicate(
     monkeypatch,
     mock_accelerator_backend_cls,
@@ -132,8 +168,10 @@ def test_vllm_adapter_discovery_uses_backend_predicate(
 
 
 def test_build_vllm_load_context_uses_current_platform_for_bare_cuda(monkeypatch):
+    """Resolve a bare CUDA device through vLLM's current platform."""
     _stub_vllm_current_device(monkeypatch, current_device=2)
     _stub_metadata_client(monkeypatch)
+    sys.modules["vllm.distributed"].get_world_group.return_value.local_rank = 2
     vllm_config = _context_config(load_device=None)
 
     ctx = build_vllm_load_context(vllm_config, _model_config())
@@ -141,11 +179,14 @@ def test_build_vllm_load_context_uses_current_platform_for_bare_cuda(monkeypatch
     assert ctx.target_device == torch.device("cuda")
     assert ctx.target_device.index is None
     assert ctx.device_id == 2
+    assert ctx.local_rank == 2
 
 
 def test_build_vllm_load_context_keeps_explicit_cuda_index(monkeypatch):
+    """Preserve an explicitly configured CUDA device index."""
     _stub_vllm_current_device(monkeypatch, current_device=2)
     _stub_metadata_client(monkeypatch)
+    sys.modules["vllm.distributed"].get_world_group.return_value.local_rank = 3
     vllm_config = _context_config(load_device="cuda:3")
 
     ctx = build_vllm_load_context(vllm_config, _model_config())
@@ -153,10 +194,13 @@ def test_build_vllm_load_context_keeps_explicit_cuda_index(monkeypatch):
     assert ctx.target_device == torch.device("cuda:3")
     assert ctx.target_device.index == 3
     assert ctx.device_id == ctx.target_device.index
+    assert ctx.local_rank == 3
 
 
 def test_build_vllm_load_context_uses_node_rank_as_node_rank(monkeypatch):
+    """Populate node rank from vLLM's parallel configuration."""
     _stub_metadata_client(monkeypatch)
+    sys.modules["vllm.distributed"].get_world_group.return_value.local_rank = 0
     vllm_config = _context_config(load_device="cuda:0")
     vllm_config.parallel_config.node_rank = 1
 

--- a/modelexpress_client/python/tests/test_vllm_control.py
+++ b/modelexpress_client/python/tests/test_vllm_control.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from concurrent import futures
+
+import grpc
+import pytest
+from google.protobuf import empty_pb2, wrappers_pb2
+
+from modelexpress_rl.inference.engines.vllm.startup_probe import (
+    reconcile_serving_version,
+)
+
+
+def _start_control_server(*, initial="default", accept_update=True):
+    """Start a test server implementing vLLM's native Control methods."""
+    state = {"version": initial, "updates": []}
+
+    def update(request, _context):
+        """Record and optionally apply a serving-version update."""
+        state["updates"].append(request.value)
+        if accept_update:
+            state["version"] = request.value
+        return empty_pb2.Empty()
+
+    def get(_request, _context):
+        """Return the server's current serving version."""
+        return wrappers_pb2.StringValue(value=state["version"])
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    server.add_generic_rpc_handlers(
+        (
+            grpc.method_handlers_generic_handler(
+                "vllm.Control",
+                {
+                    "UpdateWeightVersion": grpc.unary_unary_rpc_method_handler(
+                        update,
+                        request_deserializer=wrappers_pb2.StringValue.FromString,
+                        response_serializer=empty_pb2.Empty.SerializeToString,
+                    ),
+                    "GetWeightVersion": grpc.unary_unary_rpc_method_handler(
+                        get,
+                        request_deserializer=empty_pb2.Empty.FromString,
+                        response_serializer=wrappers_pb2.StringValue.SerializeToString,
+                    ),
+                },
+            ),
+        )
+    )
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    return server, f"127.0.0.1:{port}", state
+
+
+def test_reconcile_serving_version_updates_then_reads_vllm_control():
+    """Update and read back the desired version through vLLM Control."""
+    server, address, state = _start_control_server()
+    try:
+        observed = reconcile_serving_version(
+            address=address,
+            desired_version_uid="version-7",
+        )
+    finally:
+        server.stop(grace=None).wait()
+
+    assert observed == "version-7"
+    assert state["updates"] == ["version-7"]
+
+
+def test_reconcile_serving_version_rejects_observed_mismatch():
+    """Reject a serving version that differs after reconciliation."""
+    server, address, _state = _start_control_server(accept_update=False)
+    try:
+        with pytest.raises(RuntimeError, match="observed='default'"):
+            reconcile_serving_version(
+                address=address,
+                desired_version_uid="version-7",
+            )
+    finally:
+        server.stop(grace=None).wait()
+
+
+def test_reconcile_without_desired_version_only_checks_control_readiness():
+    """Check Control readiness without updating when no version is desired."""
+    server, address, state = _start_control_server(initial="default")
+    try:
+        observed = reconcile_serving_version(
+            address=address,
+            desired_version_uid=None,
+        )
+    finally:
+        server.stop(grace=None).wait()
+
+    assert observed == "default"
+    assert state["updates"] == []

--- a/modelexpress_client/python/tests/test_vllm_loader.py
+++ b/modelexpress_client/python/tests/test_vllm_loader.py
@@ -127,6 +127,7 @@ def _make_load_context(**overrides):
         target_device=torch.device("cpu"),
         global_rank=0,
         worker_rank=0,
+        local_rank=0,
         device_id=0,
         identity=_make_identity(),
         mx_client=MagicMock(),

--- a/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
+++ b/modelexpress_client/python/tests/test_vllm_weight_transfer_engine.py
@@ -64,6 +64,7 @@ def test_weight_transfer_engine_initializes_client_in_init_hook(monkeypatch):
 
 
 def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch):
+    """Parse VIME object-storage metadata into generator initialization."""
     client = MagicMock()
     initialize = MagicMock(return_value=client)
     monkeypatch.setattr(
@@ -82,6 +83,7 @@ def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch
 
     init_info = {
         "model_name": "policy",
+        "initial_serving_version_id": "version-c",
         "initial_base_version_id": "base-a",
         "seed_checkpoint_path": "/models/launch",
         "refit_checkpoint_dir": "/cache/modelexpress",
@@ -99,6 +101,7 @@ def test_weight_transfer_engine_parses_vime_object_storage_init_info(monkeypatch
 
     config = initialize.call_args.args[0]
     assert config.model_name == "policy"
+    assert config.initial_serving_version_id == "version-c"
     assert config.engine_context.model is model
     assert config.server_url == "mx:8001"
     assert config.registration_ttl_seconds == 90


### PR DESCRIPTION
## Why

RL cold start needs two guarantees before Dynamo admits a worker:

- every distributed engine rank loads the same immutable `desired_version_uid`
- vLLM reports that exact version as the version it is serving

Without both, ranks can diverge during P2P/S3 fallback or a worker can become routable before its observed serving version matches the orchestrator's intent.

## What changed

### Distributed desired-version loading

- global rank 0 pins and broadcasts one desired UID; every rank verifies its local configuration still agrees
- P2P availability and load outcomes are synchronized across ranks
- when a desired UID exists, cold start is fail-closed: only exact-version P2P and S3 replay are eligible
- without a desired UID, the existing ModelStreamer and engine-default fallback behavior is preserved

### Node-local S3 reconstruction

- local rank 0 reconstructs each node's shared full-checkpoint plus delta chain
- follower ranks attach to the prepared checkpoint only after their local leader succeeds
- the cache is activated only after every engine rank finishes loading successfully

### vLLM serving-version reconciliation

- MX calls vLLM's native Control gRPC API after EngineCore finishes loading
- the startup probe records the pinned UID, reads it back, and fails on mismatch
- Kubernetes starts the Dynamo sidecar only after the probe succeeds, so `/v1/rl/workers` cannot advertise the worker earlier
- the later active-refit client initializes from this engine-observed serving version; canonical checkpoint lineage remains independent

### Example and documentation

- wires the probe into the Dynamo vLLM DGD example
- supplies the required `runtimeVersionOverride: 1.4.1`
- documents distributed agreement, S3 coordination, reconciliation, and failure behavior

## Testing

- changed Python test modules: `448 passed, 8 skipped`
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- nscale B200 functional smoke test using Dynamo 1.4.1, vLLM `0.26.1rc1.dev1177+ga9a17e709`, and Qwen3-0.6B:
  1. booted a DGD through `--load-format modelexpress`
  2. actively refit a generator to full-tensor version `925d80a3` through Dynamo's native RL routes
  3. confirmed that generator published `925d80a3` as an exact-version P2P source
  4. cold-started a separate DGD with desired UID `925d80a3`
  5. observed `desired_version_p2p` select one rank-matched source and transfer 1.19 GB over NIXL in 0.045 s; S3 was not selected
  6. verified vLLM Control reported `925d80a3`, Dynamo admitted exactly one worker through `/v1/rl/workers`, and routed inference returned HTTP 200

The smoke image was built from functional head `80285f17`. Changes between that image and the final head are comments/docstrings, a raw test-regex literal, and the tested DGD runtime-version field; loader and control behavior are unchanged.

## Qualification limits

- the GPU smoke test used TP1; TP>1 agreement and disagreement failure remain covered by unit tests, not GPU E2E
- positive desired-version P2P cold start is covered; positive S3 full-checkpoint plus delta-chain replay still needs E2E coverage
- the observed transfer timing is diagnostic evidence, not a performance benchmark
