### PR TITLE
fix(client): retain PCI root complex in affinity scoring

### DIFF
--- a/modelexpress_client/python/modelexpress/ucx_utils.py
+++ b/modelexpress_client/python/modelexpress/ucx_utils.py
@@ -167,9 +167,8 @@ def _pci_path_components(bdf: str) -> list[str]:
     The returned list keeps the root-complex component (``pci0000:00``)
     followed by the BDF-shaped components, in order from closest-to-root
     to leaf. Common-prefix length between two such lists encodes PCIe
-    affinity (longer prefix = same root complex / switch / bridge), which
-    is exactly the metric nvidia-smi topo -m uses to label PIX / PXB / PHB
-    / NODE / SYS connections.
+    affinity, which is exactly the metric nvidia-smi topo -m uses to label
+    PIX / PXB / PHB / NODE / SYS connections.
 
     Returns [] on any read failure.
     """

--- a/modelexpress_client/python/modelexpress/ucx_utils.py
+++ b/modelexpress_client/python/modelexpress/ucx_utils.py
@@ -262,7 +262,7 @@ def _list_compute_ib_nics(
     Returns a list of (nic_name, numa_node, rate_gbps, pci_path)
     sorted alphabetically by NIC name. The PCIe path is the BDF chain
     from /sys realpath; pair-wise common-prefix depth between a GPU's
-    path and a NIC's path encodes affinity (PIX > PXB > NODE > SYS)
+    path and a NIC's path encodes affinity (PIX > PXB > PHB > NODE > SYS)
     and is the actual selection signal in probe_nic_pin_for_device().
     NIC name ordering only affects the final lex tiebreak.
 
@@ -323,7 +323,7 @@ def probe_nic_pin_for_device(
     Selection signal is PCIe sysfs path distance: each device's
     /sys/bus/pci/devices/<bdf> realpath exposes the full bus tree, and
     the longest common PCIe component prefix between a GPU's path and a NIC's
-    path encodes affinity (PIX > PXB > NODE > SYS, the same metric
+    path encodes affinity (PIX > PXB > PHB > NODE > SYS, the same metric
     nvidia-smi topo -m reports). NIC names and GPU indices stop
     mattering for correctness; they only affect the final lex tiebreak.
 

--- a/modelexpress_client/python/modelexpress/ucx_utils.py
+++ b/modelexpress_client/python/modelexpress/ucx_utils.py
@@ -159,16 +159,17 @@ def _gpu_numa_node(device_id: int) -> int | None:
 
 
 def _pci_path_components(bdf: str) -> list[str]:
-    """Resolve a PCI BDF to its sysfs realpath and return the BDF chain.
+    """Resolve a PCI BDF to its sysfs realpath and return the PCIe chain.
 
     For a device at 0000:0f:00.0, the realpath of
     /sys/bus/pci/devices/0000:0f:00.0 typically looks like:
         /sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:0f:00.0
-    The returned list keeps only the BDF-shaped components, in order
-    from closest-to-root to leaf. Common-prefix length between two such
-    lists encodes PCIe affinity (longer prefix = same switch / bridge),
-    which is exactly the metric nvidia-smi topo -m uses to label PIX /
-    PXB / NODE / SYS connections.
+    The returned list keeps the root-complex component (``pci0000:00``)
+    followed by the BDF-shaped components, in order from closest-to-root
+    to leaf. Common-prefix length between two such lists encodes PCIe
+    affinity (longer prefix = same root complex / switch / bridge), which
+    is exactly the metric nvidia-smi topo -m uses to label PIX / PXB / PHB
+    / NODE / SYS connections.
 
     Returns [] on any read failure.
     """
@@ -176,27 +177,24 @@ def _pci_path_components(bdf: str) -> list[str]:
         rp = os.path.realpath(f"/sys/bus/pci/devices/{bdf}")
     except OSError:
         return []
-    bdf_re = re.compile(r"^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$")
-    return [p for p in rp.split("/") if bdf_re.match(p)]
+    pci_component_re = re.compile(
+        r"^(?:pci[0-9a-f]{4}:[0-9a-f]{2}|"
+        r"[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f])$"
+    )
+    return [p for p in rp.split("/") if pci_component_re.match(p)]
 
 
 def _pci_common_depth(a: list[str], b: list[str]) -> int:
     """Length of the longest shared prefix between two PCIe path component lists.
 
     Higher values mean closer in the PCIe tree:
-      - 4+ shared = PIX (single PCIe bridge), best
-      - 2-3 shared = PXB / PHB (multiple bridges, same root port)
-      - 1 shared = same root port
-      - 0 shared = NODE or SYS, indistinguishable here
+      - 2+ shared = same downstream bridge ancestry, with larger values closer
+      - 1 shared = same root complex, including flat-tree PHB connections
+      - 0 shared = different root complexes
 
-    That last line is the one to remember. ``_pci_path_components`` keeps
-    only BDF-shaped components, and the root complex appears in the
-    realpath as ``pci0000:97``, which is not BDF-shaped and so is dropped.
-    Two devices under the same root complex but different root ports
-    therefore share no retained component and score 0, exactly like two
-    devices on opposite sockets. Anything needing to tell NODE from SYS
-    must read numa_node instead; this metric cannot, and the caller's
-    cross-socket term exists for that reason.
+    A score of 0 does not by itself distinguish NODE from SYS: distinct root
+    complexes can still belong to the same NUMA node. The caller therefore
+    uses ``numa_node`` as a cross-socket tiebreak after PCIe depth.
     """
     n = min(len(a), len(b))
     for i in range(n):
@@ -325,7 +323,7 @@ def probe_nic_pin_for_device(
 
     Selection signal is PCIe sysfs path distance: each device's
     /sys/bus/pci/devices/<bdf> realpath exposes the full bus tree, and
-    the longest common BDF prefix between a GPU's path and a NIC's
+    the longest common PCIe component prefix between a GPU's path and a NIC's
     path encodes affinity (PIX > PXB > NODE > SYS, the same metric
     nvidia-smi topo -m reports). NIC names and GPU indices stop
     mattering for correctness; they only affect the final lex tiebreak.
@@ -486,11 +484,11 @@ def probe_nic_pin_for_device(
         for nic_name, nic_numa, _nic_rate, nic_path in nics:
             score = _pci_common_depth(gpu_path, nic_path)
             # NUMA locality ranks BELOW load balancing. PCIe common depth
-            # separates PIX from everything else but cannot separate NODE from
-            # SYS - see _pci_common_depth, the root complex is filtered out of
-            # the path - so without this term a same-socket rail ties with a
-            # cross-socket one at depth 0 and the tiebreak falls through to name
-            # order, leaving the local rail unused. It stays for that reason.
+            # distinguishes shared root-complex and bridge ancestry but cannot
+            # separate same-NUMA from cross-socket devices under different root
+            # complexes. Without this term those devices tie at depth 0 and the
+            # tiebreak falls through to name order, possibly leaving the local
+            # rail unused. It stays for that reason.
             # What it must not do is outrank distinctness: measured, sharing a
             # rail costs 4.45x and crossing a socket costs ~0, and ranking it
             # higher forces every GPU onto a lone same-socket rail in turn. An

--- a/modelexpress_client/python/tests/test_ucx_utils.py
+++ b/modelexpress_client/python/tests/test_ucx_utils.py
@@ -144,21 +144,36 @@ def test_flat_topology_selection_keeps_gpus_on_local_nics(monkeypatch):
 # plugin handed the pod three rails rooted on NUMA 0 and one on NUMA 1.
 #
 # The paths matter as much as the NUMA numbers, and are the real measured ones.
-# Only GPU3 shares a component with mlx5_11; GPU0/1/2 share nothing with any
-# rail and so score 0 against all four, including the same-socket one. The
-# omitted root-complex components are distinct for those pairs, so retaining
-# them in production does not change these nested-topology common depths.
+# Only GPU3 shares a root complex and bridge with mlx5_11; GPU0/1/2 share
+# nothing with any rail and so score 0 against all four, including the
+# same-socket one.
 _MISAFFINE_GPUS = {
-    0: ("0000:9a:00.0", 1, ["0000:97:01.0", "0000:98:00.0", "0000:9a:00.0"]),
-    1: ("0000:aa:00.0", 1, ["0000:a7:01.0", "0000:a8:00.0", "0000:aa:00.0"]),
-    2: ("0000:ba:00.0", 1, ["0000:b7:01.0", "0000:b8:00.0", "0000:ba:00.0"]),
-    3: ("0000:ca:00.0", 1, ["0000:c7:01.0", "0000:c8:00.0", "0000:ca:00.0"]),
+    0: (
+        "0000:9a:00.0",
+        1,
+        ["pci0000:97", "0000:97:01.0", "0000:98:00.0", "0000:9a:00.0"],
+    ),
+    1: (
+        "0000:aa:00.0",
+        1,
+        ["pci0000:a7", "0000:a7:01.0", "0000:a8:00.0", "0000:aa:00.0"],
+    ),
+    2: (
+        "0000:ba:00.0",
+        1,
+        ["pci0000:b7", "0000:b7:01.0", "0000:b8:00.0", "0000:ba:00.0"],
+    ),
+    3: (
+        "0000:ca:00.0",
+        1,
+        ["pci0000:c7", "0000:c7:01.0", "0000:c8:00.0", "0000:ca:00.0"],
+    ),
 }
 _MISAFFINE_NICS = [
-    ("mlx5_0", 0, 400.0, ["0000:15:01.0", "0000:19:00.0"]),
-    ("mlx5_1", 0, 400.0, ["0000:26:01.0", "0000:2a:00.0"]),
-    ("mlx5_11", 1, 400.0, ["0000:c7:01.0", "0000:cb:00.0"]),
-    ("mlx5_2", 0, 400.0, ["0000:37:01.0", "0000:3b:00.0"]),
+    ("mlx5_0", 0, 400.0, ["pci0000:15", "0000:15:01.0", "0000:19:00.0"]),
+    ("mlx5_1", 0, 400.0, ["pci0000:26", "0000:26:01.0", "0000:2a:00.0"]),
+    ("mlx5_11", 1, 400.0, ["pci0000:c7", "0000:c7:01.0", "0000:cb:00.0"]),
+    ("mlx5_2", 0, 400.0, ["pci0000:37", "0000:37:01.0", "0000:3b:00.0"]),
 ]
 
 

--- a/modelexpress_client/python/tests/test_ucx_utils.py
+++ b/modelexpress_client/python/tests/test_ucx_utils.py
@@ -127,6 +127,7 @@ def test_flat_topology_selection_keeps_gpus_on_local_nics(monkeypatch):
 
     chosen = {gpu: ucx_utils.probe_nic_pin_for_device(gpu) for gpu in gpus}
 
+    # NIC names are the final tiebreak, so mlx5_10 sorts before mlx5_9.
     assert chosen == {
         0: "mlx5_5:1",
         1: "mlx5_6:1",

--- a/modelexpress_client/python/tests/test_ucx_utils.py
+++ b/modelexpress_client/python/tests/test_ucx_utils.py
@@ -99,29 +99,41 @@ def _install_fake_topology(monkeypatch, gpus, nics, visible=None):
     )
 
 
-def test_flat_topology_selection_keeps_gpus_on_local_nics(monkeypatch):
+def test_flat_topology_selection_uses_root_complex_when_numa_unknown(monkeypatch):
+    gpu_bdfs = [
+        "0002:00:01.0",
+        "0002:00:02.0",
+        "0002:00:03.0",
+        "0002:00:04.0",
+        "0003:00:01.0",
+        "0003:00:02.0",
+        "0003:00:03.0",
+        "0003:00:04.0",
+    ]
+    nic_bdfs = [
+        ("mlx5_5", "0002:00:09.0"),
+        ("mlx5_6", "0002:00:0a.0"),
+        ("mlx5_7", "0002:00:0b.0"),
+        ("mlx5_8", "0002:00:0c.0"),
+        ("mlx5_9", "0003:00:09.0"),
+        ("mlx5_10", "0003:00:0a.0"),
+        ("mlx5_11", "0003:00:0b.0"),
+        ("mlx5_12", "0003:00:0c.0"),
+    ]
+
+    def _flat_realpath(path):
+        bdf = os.path.basename(path)
+        domain = bdf.split(":", 1)[0]
+        return f"/sys/devices/pci{domain}:00/{bdf}"
+
+    monkeypatch.setattr(ucx_utils.os.path, "realpath", _flat_realpath)
     gpus = {
-        gpu: (
-            f"000{2 + gpu // 4}:00:{1 + gpu % 4:02x}.0",
-            gpu // 4,
-            [
-                f"pci000{2 + gpu // 4}:00",
-                f"000{2 + gpu // 4}:00:{1 + gpu % 4:02x}.0",
-            ],
-        )
-        for gpu in range(8)
+        gpu: (bdf, -1, ucx_utils._pci_path_components(bdf))
+        for gpu, bdf in enumerate(gpu_bdfs)
     }
     nics = [
-        (
-            f"mlx5_{5 + nic}",
-            nic // 4,
-            400.0,
-            [
-                f"pci000{2 + nic // 4}:00",
-                f"000{2 + nic // 4}:00:{9 + nic % 4:02x}.0",
-            ],
-        )
-        for nic in range(8)
+        (name, -1, 400.0, ucx_utils._pci_path_components(bdf))
+        for name, bdf in nic_bdfs
     ]
     _install_fake_topology(monkeypatch, gpus, nics)
 

--- a/modelexpress_client/python/tests/test_ucx_utils.py
+++ b/modelexpress_client/python/tests/test_ucx_utils.py
@@ -55,43 +55,6 @@ def test_flat_pci_topology_scores_local_phb_above_remote_sys(monkeypatch):
     assert ucx_utils._pci_common_depth(gpu_path, remote_nic_path) == 0
 
 
-def test_nested_pci_topology_keeps_root_and_bridge_components(monkeypatch):
-    paths = {
-        "0000:0f:00.0": (
-            "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/"
-            "0000:02:00.0/0000:0f:00.0"
-        ),
-        "0000:10:00.0": (
-            "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/"
-            "0000:02:00.0/0000:10:00.0"
-        ),
-    }
-    monkeypatch.setattr(
-        ucx_utils.os.path,
-        "realpath",
-        lambda path: paths[path.rsplit("/", 1)[-1]],
-    )
-
-    gpu_path = ucx_utils._pci_path_components("0000:0f:00.0")
-    nic_path = ucx_utils._pci_path_components("0000:10:00.0")
-
-    assert gpu_path == [
-        "pci0000:00",
-        "0000:00:01.1",
-        "0000:01:00.0",
-        "0000:02:00.0",
-        "0000:0f:00.0",
-    ]
-    assert nic_path == [
-        "pci0000:00",
-        "0000:00:01.1",
-        "0000:01:00.0",
-        "0000:02:00.0",
-        "0000:10:00.0",
-    ]
-    assert ucx_utils._pci_common_depth(gpu_path, nic_path) == 4
-
-
 def _install_fake_topology(monkeypatch, gpus, nics, visible=None):
     """Drive probe_nic_pin_for_device from an in-memory topology.
 

--- a/modelexpress_client/python/tests/test_ucx_utils.py
+++ b/modelexpress_client/python/tests/test_ucx_utils.py
@@ -32,6 +32,66 @@ def test_nic_access_rejects_host_only_uverbs_device(monkeypatch):
     assert not ucx_utils._nic_has_accessible_verbs_device("mlx5_0")
 
 
+def test_flat_pci_topology_scores_local_phb_above_remote_sys(monkeypatch):
+    paths = {
+        "0002:00:01.0": "/sys/devices/pci0002:00/0002:00:01.0",
+        "0002:00:09.0": "/sys/devices/pci0002:00/0002:00:09.0",
+        "0003:00:09.0": "/sys/devices/pci0003:00/0003:00:09.0",
+    }
+    monkeypatch.setattr(
+        ucx_utils.os.path,
+        "realpath",
+        lambda path: paths[path.rsplit("/", 1)[-1]],
+    )
+
+    gpu_path = ucx_utils._pci_path_components("0002:00:01.0")
+    local_nic_path = ucx_utils._pci_path_components("0002:00:09.0")
+    remote_nic_path = ucx_utils._pci_path_components("0003:00:09.0")
+
+    assert gpu_path == ["pci0002:00", "0002:00:01.0"]
+    assert local_nic_path == ["pci0002:00", "0002:00:09.0"]
+    assert remote_nic_path == ["pci0003:00", "0003:00:09.0"]
+    assert ucx_utils._pci_common_depth(gpu_path, local_nic_path) == 1
+    assert ucx_utils._pci_common_depth(gpu_path, remote_nic_path) == 0
+
+
+def test_nested_pci_topology_keeps_root_and_bridge_components(monkeypatch):
+    paths = {
+        "0000:0f:00.0": (
+            "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/"
+            "0000:02:00.0/0000:0f:00.0"
+        ),
+        "0000:10:00.0": (
+            "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/"
+            "0000:02:00.0/0000:10:00.0"
+        ),
+    }
+    monkeypatch.setattr(
+        ucx_utils.os.path,
+        "realpath",
+        lambda path: paths[path.rsplit("/", 1)[-1]],
+    )
+
+    gpu_path = ucx_utils._pci_path_components("0000:0f:00.0")
+    nic_path = ucx_utils._pci_path_components("0000:10:00.0")
+
+    assert gpu_path == [
+        "pci0000:00",
+        "0000:00:01.1",
+        "0000:01:00.0",
+        "0000:02:00.0",
+        "0000:0f:00.0",
+    ]
+    assert nic_path == [
+        "pci0000:00",
+        "0000:00:01.1",
+        "0000:01:00.0",
+        "0000:02:00.0",
+        "0000:10:00.0",
+    ]
+    assert ucx_utils._pci_common_depth(gpu_path, nic_path) == 4
+
+
 def _install_fake_topology(monkeypatch, gpus, nics, visible=None):
     """Drive probe_nic_pin_for_device from an in-memory topology.
 
@@ -76,15 +136,54 @@ def _install_fake_topology(monkeypatch, gpus, nics, visible=None):
     )
 
 
+def test_flat_topology_selection_keeps_gpus_on_local_nics(monkeypatch):
+    gpus = {
+        gpu: (
+            f"000{2 + gpu // 4}:00:{1 + gpu % 4:02x}.0",
+            gpu // 4,
+            [
+                f"pci000{2 + gpu // 4}:00",
+                f"000{2 + gpu // 4}:00:{1 + gpu % 4:02x}.0",
+            ],
+        )
+        for gpu in range(8)
+    }
+    nics = [
+        (
+            f"mlx5_{5 + nic}",
+            nic // 4,
+            400.0,
+            [
+                f"pci000{2 + nic // 4}:00",
+                f"000{2 + nic // 4}:00:{9 + nic % 4:02x}.0",
+            ],
+        )
+        for nic in range(8)
+    ]
+    _install_fake_topology(monkeypatch, gpus, nics)
+
+    chosen = {gpu: ucx_utils.probe_nic_pin_for_device(gpu) for gpu in gpus}
+
+    assert chosen == {
+        0: "mlx5_5:1",
+        1: "mlx5_6:1",
+        2: "mlx5_7:1",
+        3: "mlx5_8:1",
+        4: "mlx5_10:1",
+        5: "mlx5_11:1",
+        6: "mlx5_12:1",
+        7: "mlx5_9:1",
+    }
+
+
 # Measured on cluster node hx78c: 4 GPUs all on NUMA 1, but the RDMA device
 # plugin handed the pod three rails rooted on NUMA 0 and one on NUMA 1.
 #
 # The paths matter as much as the NUMA numbers, and are the real measured ones.
 # Only GPU3 shares a component with mlx5_11; GPU0/1/2 share nothing with any
-# rail and so score 0 against all four, including the same-socket one. That is
-# not a simplification of the fixture - it is what the metric does on this
-# hardware, because _pci_common_depth drops the root complex. The tests below
-# depend on it, so test_the_fixture_reproduces_the_depth_collapse asserts it.
+# rail and so score 0 against all four, including the same-socket one. The
+# omitted root-complex components are distinct for those pairs, so retaining
+# them in production does not change these nested-topology common depths.
 _MISAFFINE_GPUS = {
     0: ("0000:9a:00.0", 1, ["0000:97:01.0", "0000:98:00.0", "0000:9a:00.0"]),
     1: ("0000:aa:00.0", 1, ["0000:a7:01.0", "0000:a8:00.0", "0000:aa:00.0"]),


### PR DESCRIPTION
## Summary

- retain `pci<domain>:<bus>` root-complex components in PCIe sysfs paths
- distinguish flat-tree local PHB affinity from remote SYS affinity
- add flat topology and 8-GPU/8-NIC mapping coverage
- update PCIe common-depth documentation and selection comments

## Example

Given this flat PCI topology:

```text
GPU0:   /sys/devices/pci0002:00/0002:00:01.0  (NUMA 0)
mlx5_5: /sys/devices/pci0002:00/0002:00:09.0  (NUMA 0)
mlx5_9: /sys/devices/pci0003:00/0003:00:09.0  (NUMA 1)
```

The path components returned by `_pci_path_components()` differ as follows.

Without this PR, the function retains only BDF-shaped components:

```text
GPU0:   ["0002:00:01.0"]
mlx5_5: ["0002:00:09.0"]
mlx5_9: ["0003:00:09.0"]
```

With this PR, `_pci_path_components()` also retains the PCI root-complex component:

```text
GPU0:   ["pci0002:00", "0002:00:01.0"]
mlx5_5: ["pci0002:00", "0002:00:09.0"]
mlx5_9: ["pci0003:00", "0003:00:09.0"]
```

This changes the affinity scores from:

```text
# Without this PR
GPU0 <-> mlx5_5 = 0  # PHB incorrectly ties with SYS
GPU0 <-> mlx5_9 = 0  # SYS
```

to:

```text
# With this PR
GPU0 <-> mlx5_5 = 1  # PHB
GPU0 <-> mlx5_9 = 0  # SYS
```

Previously the root-complex components were filtered out, causing both pairs to score `0`; that is, the scoring could not distinguish PHB from SYS.

For the topology above, `numa_node` is readable, so the NUMA-affinity cross-socket tiebreak introduced in [#689](https://github.com/ai-dynamo/modelexpress/pull/689) already selects `mlx5_5`; therefore, this PR does not change the final mapping on that host. It corrects the PCIe common-depth score and diagnostics there. It changes selection when NUMA information is unavailable (`-1`), and can also matter when multiple PCI root complexes belong to the same NUMA node, where NUMA cannot break the tie.


The screenshot below is the output of nvidia-smi topo -m: mlx5_5 is NIC1 (PHB) and mlx5_9 is NIC5 (SYS).

<img width="105" height="320" alt="image" src="https://github.com/user-attachments/assets/9bd919c0-06cb-457b-8ca7-d170acc9177e" />


## Testing

- `python3 -m compileall -q modelexpress_client/python/modelexpress/ucx_utils.py modelexpress_client/python/tests/test_ucx_utils.py`
- `cargo fmt --all -- --check`
- all 15 `test_ucx_utils.py` test functions passed with local dependency stubs (the workspace environment does not have `uv`, `pytest`, or `torch` installed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU-to-network interface affinity scoring by distinguishing shared PCIe root complexes.
  * Improved local GPU–NIC selection on flat and multi-device PCIe topologies.
  * Preserved NUMA-aware fallback behavior when PCIe locality cannot resolve a tie.

* **Tests**
  * Added coverage for PCIe locality scoring and balanced GPU–NIC assignments across larger hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->