### PR TITLE
feat(metrics): time validate and extract per artifact archive

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -421,6 +421,8 @@ touched.
 | `mx_nixl_receive_total` | Counter | `scheme`, `result` |
 | `mx_load_seconds` | Histogram | `engine`, `model`, `model_role`, `scheme`, `outcome` |
 | `mx_load_phase_seconds` | Histogram | `engine`, `model`, `phase`, `scheme` |
+| `mx_artifact_install_step_seconds` | Histogram | `artifact`, `archive`, `step`, `scheme` |
+| `mx_artifact_install_bytes_total` | Counter | `artifact`, `archive`, `scheme` |
 
 ### Load timing, and what it does not measure
 
@@ -534,6 +536,62 @@ rather than an edge.
 Quantiles still need observations to mean anything. A single load gives a p95
 that is bucket interpolation whatever the boundaries are; these are fleet
 statistics, and on one pod the mean per phase is the honest panel to read.
+
+### Inside `artifact_install`: validate and extract
+
+`artifact_install` is one interval, and it is a wide one: it covers finding a
+source, fetching the manifest header, the RDMA copy of the archive, a validation
+pass over the tar, and `tar -xf` into the engine's cache directory. A slow
+install is ambiguous until the last two are visible on their own, because they
+are the only part the target does by itself. That is what
+`mx_artifact_install_step_seconds` is for.
+
+| Step | What runs | Scales with |
+| --- | --- | --- |
+| `validate` | A Python walk over every tar member, rejecting unsafe paths | file count |
+| `extract` | `tar -xf` into `target_root` | bytes, and the target filesystem |
+
+One observation per step per archive, recorded from `install()` and nowhere
+else. The steps are **not** load phases and must not be added to
+`LOAD_PHASES`: they sit inside `artifact_install` rather than beside it, so
+they sum to *less* than the phase, and the remainder is the network. Read the
+three together:
+
+```promql
+# Of the artifact_install phase, how much was the target unpacking the archive?
+sum(mx_artifact_install_step_seconds_sum) / sum(mx_load_phase_seconds_sum{phase="artifact_install"})
+
+# Extraction throughput. Separates a slow disk from a large cache: a ten-second
+# extract is fine for 4 GiB on a healthy volume and alarming for 200 MiB on an
+# overlay filesystem, and only the ratio tells them apart.
+sum by (artifact, archive) (mx_artifact_install_bytes_total)
+  / sum by (artifact, archive) (mx_artifact_install_step_seconds_sum{step="extract"})
+```
+
+`artifact` is the factory name (`torch_compile_cache`, `flashinfer_cache`, ...),
+a closed enum with an `other` fallback; a test asserts the enum matches the
+factories in `artifact_transfer.py`. `archive` is the cache-root name the engine
+adapter declared in code -- `primary` for every artifact, plus any additional
+roots such as FlashInfer's -- so its domain is fixed by the adapter rather than
+by the deployment. `step` is closed; an unknown step is dropped for the same
+reason an unknown phase is.
+
+A step that raises is still recorded. A `tar -xf` that dies after thirty
+seconds on a full disk is precisely the reading someone goes looking for.
+
+Throughput is only meaningful for archives of at least a few MiB. Measured on
+nscale, a 42 MiB torch compile cache extracted at 1.26 GB/s while 10-40 KiB
+Triton and FlashInfer archives all took about 2 ms regardless of size -- the cost
+of spawning `tar` -- so their bytes-over-seconds says nothing about the disk.
+
+The same two numbers are also on the `[TIMING] Artifact archive extracted` and
+`[TIMING] Artifact install complete` log lines, per archive and in total, so a
+log-only benchmark run gets them without a scrape endpoint.
+
+The buckets run from 0.1 s to 300 s rather than the hour-scale load band. A
+healthy extract of a compile cache is sub-second and a pathological one is
+minutes, and a band whose first boundary is 0.5 s would put every healthy
+reading in one bucket.
 
 ### The `model` label is bounded by convention, not by code
 
@@ -726,17 +784,19 @@ ConfigMap for the Grafana sidecar to discover. Adjust `metrics.dashboard.label`
 if your sidecar watches something other than `grafana_dashboard`.
 
 It covers the server end to end -- gRPC, storage backend, download lifecycle,
-capacity -- and the client down to total transfer time. It does **not** yet plot
-the load tiers: `mx_load_seconds` and `mx_load_phase_seconds` exist as of this
-change but have no panel, so a load's phase split is queryable and not yet
-visible. Below the phase level there is still nothing — the transfer panel can
-say a transfer took 90 seconds but not where inside it the 90 seconds went.
+capacity -- and the client from the load tiers down to total transfer time. The
+**Model load** row plots `mx_load_seconds`, the phase split of
+`mx_load_phase_seconds`, and the validate/extract steps inside
+`artifact_install`. Below that there is still nothing for the weight transfer
+itself — the transfer panel can say a transfer took 90 seconds but not where
+inside it the 90 seconds went.
 
 Read **Overview** first; the rows below it answer *why* once a tile is not green.
 
 | Row | Answers | Panels |
 | --- | --- | --- |
 | **Overview** | Is anything wrong right now? | 8 stat tiles |
+| **Model load** | How long did a load take, and which part? | 5 |
 | **Downloads** | Is the primary job working, and how fast? | 6 |
 | **Server internals** | gRPC and storage backend: rate, errors, p99, in flight | 8 + 1 note |
 | **P2P clients** | Selection funnel, transfer time, NIXL health | 8 + 1 note |

--- a/helm/dashboards/modelexpress.json
+++ b/helm/dashboards/modelexpress.json
@@ -686,6 +686,133 @@
       }
     },
     {
+      "id": 114,
+      "type": "table",
+      "title": "Artifact install: validate and extract per archive",
+      "description": "Mean on-target time for each step of installing one compile-cache archive, per artifact and archive: validate walks the tar's member list in Python and scales with file count; extract is tar -xf and scales with bytes and with the target filesystem.\n\nThis is the breakdown inside the artifact_install phase in the table above. That phase also covers source discovery and the RDMA copy, so these two steps sum to less than it, and the remainder is the network. A phase that is slow with small steps here is a transfer problem; a phase that is slow because extract is slow is the target's disk.\n\nSeries: mx_artifact_install_step_seconds.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 14,
+        "x": 0,
+        "y": 20
+      },
+      "targets": [
+        {
+          "expr": "sum by (artifact, archive, step) (mx_artifact_install_step_seconds_sum) / sum by (artifact, archive, step) (mx_artifact_install_step_seconds_count)",
+          "format": "table",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "artifact": 0,
+              "archive": 1,
+              "step": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "Value": "mean"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "artifact",
+                "desc": false
+              },
+              {
+                "field": "archive",
+                "desc": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 115,
+      "type": "bargauge",
+      "title": "Artifact extraction throughput",
+      "description": "Archive bytes extracted divided by time spent in tar -xf, per artifact and archive: mx_artifact_install_bytes_total over the extract step of mx_artifact_install_step_seconds_sum.\n\nSeparates a slow disk from a large cache. Two installs can both show a ten-second extract; one is 4 GiB on a healthy volume and the other is 200 MiB on an overlay filesystem, and only the throughput tells them apart. Both are process-local counters, so this is the mean over the pods currently scraped.\n\nRead only the bars for archives of at least a few MiB. An archive under a megabyte extracts in about 2 ms regardless of size, which is the cost of spawning tar, so its throughput reflects process startup rather than disk I/O.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 14,
+        "y": 20
+      },
+      "targets": [
+        {
+          "expr": "sum by (artifact, archive) (mx_artifact_install_bytes_total) / sum by (artifact, archive) (mx_artifact_install_step_seconds_sum{step=\"extract\"})",
+          "legendFormat": "{{artifact}}  {{archive}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "noValue": "0",
+          "min": 0
+        }
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      }
+    },
+    {
       "id": 6,
       "type": "row",
       "title": "Downloads",
@@ -694,7 +821,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 30
       },
       "panels": []
     },
@@ -710,7 +837,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "targets": [
         {
@@ -760,7 +887,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 21
+        "y": 31
       },
       "targets": [
         {
@@ -792,7 +919,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 21
+        "y": 31
       },
       "targets": [
         {
@@ -824,7 +951,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 21
+        "y": 31
       },
       "targets": [
         {
@@ -856,7 +983,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 39
       },
       "targets": [
         {
@@ -888,7 +1015,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 39
       },
       "targets": [
         {
@@ -917,7 +1044,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 47
       },
       "panels": []
     },
@@ -933,7 +1060,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 38
+        "y": 48
       },
       "targets": [
         {
@@ -965,7 +1092,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 38
+        "y": 48
       },
       "targets": [
         {
@@ -998,7 +1125,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 38
+        "y": 48
       },
       "targets": [
         {
@@ -1030,7 +1157,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 38
+        "y": 48
       },
       "targets": [
         {
@@ -1058,7 +1185,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 56
       },
       "options": {
         "mode": "markdown",
@@ -1077,7 +1204,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 51
+        "y": 61
       },
       "targets": [
         {
@@ -1109,7 +1236,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 51
+        "y": 61
       },
       "targets": [
         {
@@ -1151,7 +1278,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 51
+        "y": 61
       },
       "targets": [
         {
@@ -1183,7 +1310,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 51
+        "y": 61
       },
       "targets": [
         {
@@ -1212,7 +1339,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 69
       },
       "panels": []
     },
@@ -1228,7 +1355,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 60
+        "y": 70
       },
       "targets": [
         {
@@ -1260,7 +1387,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 60
+        "y": 70
       },
       "targets": [
         {
@@ -1322,7 +1449,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 60
+        "y": 70
       },
       "targets": [
         {
@@ -1354,7 +1481,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 60
+        "y": 70
       },
       "targets": [
         {
@@ -1386,7 +1513,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 68
+        "y": 78
       },
       "targets": [
         {
@@ -1436,7 +1563,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 68
+        "y": 78
       },
       "targets": [
         {
@@ -1468,7 +1595,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 68
+        "y": 78
       },
       "targets": [
         {
@@ -1500,7 +1627,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 68
+        "y": 78
       },
       "targets": [
         {
@@ -1532,7 +1659,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 76
+        "y": 86
       },
       "targets": [
         {
@@ -1571,7 +1698,7 @@
         "h": 6,
         "w": 18,
         "x": 6,
-        "y": 76
+        "y": 86
       },
       "options": {
         "mode": "markdown",
@@ -1587,7 +1714,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 92
       },
       "panels": []
     },
@@ -1603,7 +1730,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 83
+        "y": 93
       },
       "targets": [
         {
@@ -1635,7 +1762,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 83
+        "y": 93
       },
       "targets": [
         {
@@ -1668,7 +1795,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 83
+        "y": 93
       },
       "targets": [
         {

--- a/modelexpress_client/python/modelexpress/metadata/artifact_transfer.py
+++ b/modelexpress_client/python/modelexpress/metadata/artifact_transfer.py
@@ -22,6 +22,7 @@ import grpc
 import torch
 
 from .. import p2p_pb2
+from ..metrics import metrics as install_metrics
 from ..nixl_transfer import NIXL_DRAM_MEM_TYPE, NixlTransferManager
 from .artifact_manifest import (
     _crc32c_hex,
@@ -333,20 +334,48 @@ class TarredP2PArtifactTransfer(P2PArtifactTransfer):
                 f"{sorted(files_by_name)} != {sorted(expected_names)}"
             )
         installed_targets = []
+        validate_total = 0.0
+        extract_total = 0.0
         for tar_name, root in root_archives:
             tar_file = Path(files_by_name[tar_name].path).resolve(strict=True)
             output_path = root.target_root.resolve()
             output_path.mkdir(parents=True, exist_ok=True)
-            _validate_tar_members(tar_file)
-            _run_tar(["-xf", str(tar_file), "-C", str(output_path)])
+            archive_bytes = tar_file.stat().st_size
+            # The two steps are timed separately because they fail differently:
+            # validate is a Python walk over the member list and scales with
+            # file count; extract is `tar -xf` and scales with bytes and with
+            # the target filesystem. One number could not say which is slow.
+            step_start = time.perf_counter()
+            with install_metrics.time_artifact_install_step(self.name, root.name, "validate"):
+                _validate_tar_members(tar_file)
+            validate_seconds = time.perf_counter() - step_start
+            step_start = time.perf_counter()
+            with install_metrics.time_artifact_install_step(self.name, root.name, "extract"):
+                _run_tar(["-xf", str(tar_file), "-C", str(output_path)])
+            extract_seconds = time.perf_counter() - step_start
+            install_metrics.record_artifact_install_bytes(self.name, root.name, archive_bytes)
+            validate_total += validate_seconds
+            extract_total += extract_seconds
+            logger.info(
+                "[TIMING] Artifact archive extracted: name=%s archive=%s target=%s "
+                "size=%.2f MiB validate=%.3fs extract=%.3fs",
+                self.name,
+                root.name,
+                output_path,
+                _mib(archive_bytes),
+                validate_seconds,
+                extract_seconds,
+            )
             installed_targets.append(str(output_path))
         elapsed = time.perf_counter() - start
         logger.info(
             "[TIMING] Artifact install complete: artifact_id=%s targets=%s "
-            "size=%.2f MiB elapsed=%.3fs",
+            "size=%.2f MiB validate=%.3fs extract=%.3fs elapsed=%.3fs",
             header.artifact_id,
             installed_targets,
             _mib(header.total_size),
+            validate_total,
+            extract_total,
             elapsed,
         )
 

--- a/modelexpress_client/python/modelexpress/metrics.py
+++ b/modelexpress_client/python/modelexpress/metrics.py
@@ -105,6 +105,34 @@ LOAD_PHASES = ("artifact_install", "model_init", "chain", "publish")
 #: Terminal outcomes of a load. A load either returns a model or raises.
 LOAD_OUTCOMES = ("success", "error")
 
+#: Compile-cache artifacts the install path knows how to unpack: the ``name`` of
+#: each factory in ``metadata.artifact_transfer``. Closed with an ``other``
+#: fallback so an out-of-tree transfer cannot open the label domain.
+ARTIFACT_KINDS = (
+    "torch_compile_cache",
+    "triton_cache",
+    "tvm_ffi_cache",
+    "deep_gemm_cache",
+    "tilelang_cache",
+    "cute_dsl_cache",
+    "flashinfer_cache",
+    "other",
+)
+
+#: The two on-target steps of installing one archive, in the order they run.
+#: Neither is a load phase. Both happen inside ``artifact_install``, which also
+#: covers source discovery and the RDMA copy, so the two sum to *less* than that
+#: phase -- the remainder is the network.
+#:
+#:   validate  a Python pass over every tar member, rejecting unsafe paths
+#:   extract   ``tar -xf`` into the engine's cache directory
+ARTIFACT_INSTALL_STEPS = ("validate", "extract")
+
+#: Sub-second floor, minutes ceiling. A compile cache is tens of MiB to a few
+#: GiB of small files, so a healthy extract is well under a second and a
+#: pathological one (slow overlay filesystem, tar in D state) is minutes.
+_ARTIFACT_STEP_BUCKETS = (0.1, 0.25, 0.5, 1, 2.5, 5, 15, 30, 60, 120, 300)
+
 #: Longest model id kept in the ``model`` label; longer ones are truncated.
 #:
 #: This is the one label on the load families whose domain is NOT a closed enum,
@@ -409,6 +437,31 @@ class MetricsCollector:
             "their sum is bounded by mx_load_seconds.",
             ["engine", "model", "phase", "scheme"],
             buckets=_XSLOW_BUCKETS,
+            registry=registry,
+        )
+        # Inside artifact_install, not beside it. The phase says how long the
+        # whole artifact step took; this says how much of that was the target
+        # unpacking the archive rather than waiting on the network. Recorded per
+        # archive from install(), which is the only place the two steps run.
+        # ``archive`` is the cache-root name the engine adapter declared in
+        # code ("primary" plus any additional roots), so its domain is fixed by
+        # the adapter rather than by the deployment.
+        self.artifact_install_step_seconds = Histogram(
+            "mx_artifact_install_step_seconds",
+            "On-target time for one step of an artifact install, per archive: "
+            "validate (walk the tar members) or extract (tar -xf). Both run "
+            "inside the artifact_install load phase, which also covers "
+            "discovery and the RDMA copy, so they sum to less than it.",
+            ["artifact", "archive", "step", "scheme"],
+            buckets=_ARTIFACT_STEP_BUCKETS,
+            registry=registry,
+        )
+        self.artifact_install_bytes = Counter(
+            "mx_artifact_install_bytes_total",
+            "Archive bytes extracted on the target, per artifact and archive. "
+            "Divided by the extract step's _sum this is extraction throughput, "
+            "which is what separates a slow disk from a large cache.",
+            ["artifact", "archive", "scheme"],
             registry=registry,
         )
 
@@ -732,6 +785,56 @@ class MetricsCollector:
                 ).observe(seconds)
             except Exception:
                 pass
+
+    def observe_artifact_install_step_seconds(
+        self, artifact: str, archive: str, step: str, seconds: float
+    ) -> None:
+        """Record one on-target step of installing one archive.
+
+        An unknown step is dropped, for the same reason an unknown phase is: the
+        two steps are meant to be read against each other and against the
+        phase, and a stray name folded into one of them would inflate it while
+        looking sound. An unknown artifact clamps to ``other``.
+        """
+        if self._ensure():
+            try:
+                if step not in ARTIFACT_INSTALL_STEPS:
+                    return
+                if artifact not in ARTIFACT_KINDS:
+                    artifact = "other"
+                self.artifact_install_step_seconds.labels(
+                    artifact, archive, step, self.scheme
+                ).observe(seconds)
+            except Exception:
+                pass
+
+    def record_artifact_install_bytes(self, artifact: str, archive: str, nbytes: int) -> None:
+        """Count the bytes of one archive extracted on the target."""
+        if self._ensure():
+            try:
+                if artifact not in ARTIFACT_KINDS:
+                    artifact = "other"
+                self.artifact_install_bytes.labels(artifact, archive, self.scheme).inc(
+                    nbytes
+                )
+            except Exception:
+                pass
+
+    @contextlib.contextmanager
+    def time_artifact_install_step(self, artifact: str, archive: str, step: str):
+        """Time one install step of one archive.
+
+        Recorded on the way out of both paths. A ``tar -xf`` that fails after
+        thirty seconds on a full disk is the observation an operator is looking
+        for; dropping it would leave only the healthy installs.
+        """
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.observe_artifact_install_step_seconds(
+                artifact, archive, step, time.perf_counter() - start
+            )
 
     @contextlib.contextmanager
     def time_load(self, engine: str, model: object, model_role: str):

--- a/modelexpress_client/python/tests/test_artifact_transfer.py
+++ b/modelexpress_client/python/tests/test_artifact_transfer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import io
 import logging
+import re
 import tarfile
 from concurrent import futures
 from pathlib import Path
@@ -677,6 +678,81 @@ def test_tarred_p2p_artifact_transfer_keeps_empty_directories(tmp_path):
     assert (target / "cached_ops" / "kernel.so").read_bytes() == b"compiled"
 
 
+def test_install_records_validate_and_extract_per_archive(tmp_path, monkeypatch):
+    """Each archive of a multi-root artifact gets both steps and its byte count.
+
+    Asserted against the collector calls rather than a registry because the
+    property under test is the call site: install() is the one place the two
+    steps run, and a second site would double-count the way a second phase
+    site would.
+    """
+    recorder = MagicMock()
+    recorder.time_artifact_install_step.return_value.__enter__ = MagicMock()
+    recorder.time_artifact_install_step.return_value.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(artifact_transfer_module, "install_metrics", recorder)
+
+    source = tmp_path / "source"
+    (source / "cubin").mkdir(parents=True)
+    (source / "kernel.so").write_bytes(b"k" * 100)
+    (source / "cubin" / "a.cubin").write_bytes(b"c" * 50)
+    extra = ArtifactCacheRoot(
+        name="cubin",
+        source_root=source / "cubin",
+        target_root=tmp_path / "extract-cubin",
+    )
+    transfer = flashinfer_cache_artifact_transfer(
+        source,
+        tmp_path / "extract",
+        tmp_path / "bundle",
+        additional_roots=(extra,),
+    )
+    bundle = transfer.prepare_source()
+    transfer.install(
+        p2p_pb2.GetArtifactManifestHeaderResponse(files=bundle.manifest.files)
+    )
+
+    steps = [call.args for call in recorder.time_artifact_install_step.call_args_list]
+    assert steps == [
+        ("flashinfer_cache", "primary", "validate"),
+        ("flashinfer_cache", "primary", "extract"),
+        ("flashinfer_cache", "cubin", "validate"),
+        ("flashinfer_cache", "cubin", "extract"),
+    ]
+    sizes = {Path(file.path).name: file.size for file in bundle.manifest.files}
+    assert [call.args for call in recorder.record_artifact_install_bytes.call_args_list] == [
+        ("flashinfer_cache", "primary", sizes["artifact.tar"]),
+        ("flashinfer_cache", "cubin", sizes["cubin.tar"]),
+    ]
+
+
+def test_install_stops_at_validate_for_an_unsafe_archive(tmp_path, monkeypatch):
+    """A rejected archive records its validate step and never reaches extract."""
+    recorder = MagicMock()
+    recorder.time_artifact_install_step.return_value.__enter__ = MagicMock()
+    recorder.time_artifact_install_step.return_value.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(artifact_transfer_module, "install_metrics", recorder)
+
+    tar_path = tmp_path / "artifact.tar"
+    info = tarfile.TarInfo("../escape.txt")
+    info.size = 6
+    with tarfile.open(tar_path, "w") as archive:
+        archive.addfile(info, io.BytesIO(b"escape"))
+    transfer = torch_compile_cache_artifact_transfer(
+        tmp_path, tmp_path / "extract", tmp_path / "bundle"
+    )
+    header = p2p_pb2.GetArtifactManifestHeaderResponse(
+        files=[p2p_pb2.ArtifactManifestFile(path=tar_path.as_posix())]
+    )
+
+    with pytest.raises(ValueError, match="unsafe tar member"):
+        transfer.install(header)
+
+    assert [call.args for call in recorder.time_artifact_install_step.call_args_list] == [
+        ("torch_compile_cache", "primary", "validate"),
+    ]
+    recorder.record_artifact_install_bytes.assert_not_called()
+
+
 def test_extract_tarred_artifact_rejects_unsafe_member(tmp_path):
     tar_path = tmp_path / "artifact.tar"
     data = b"escape"
@@ -798,6 +874,15 @@ def test_tarred_p2p_artifact_transfer_splits_transfer_and_install(tmp_path, capl
         chunk.chunk_index for chunk in bundle.manifest.chunks
     ]
     assert "[TIMING] Artifact prepare complete: name=torch_compile_cache" in caplog.text
+    assert (
+        "[TIMING] Artifact archive extracted: name=torch_compile_cache archive=primary"
+        in caplog.text
+    )
+    assert re.search(
+        r"\[TIMING\] Artifact install complete: .*validate=\d+\.\d{3}s extract=\d+\.\d{3}s "
+        r"elapsed=\d+\.\d{3}s",
+        caplog.text,
+    ), caplog.text
     assert "[TIMING] Artifact transfer complete" in caplog.text
     assert "[TIMING] Artifact install complete" in caplog.text
 

--- a/modelexpress_client/python/tests/test_metrics.py
+++ b/modelexpress_client/python/tests/test_metrics.py
@@ -67,6 +67,11 @@ _RECORDERS = [
     ("record_nixl_receive", ("complete",)),
     ("observe_load_seconds", ("vllm", "Qwen/Qwen2.5-0.5B-Instruct", "main", "success", 12.0)),
     ("observe_load_phase_seconds", ("vllm", "Qwen/Qwen2.5-0.5B-Instruct", "chain", 4.0)),
+    (
+        "observe_artifact_install_step_seconds",
+        ("torch_compile_cache", "primary", "extract", 2.0),
+    ),
+    ("record_artifact_install_bytes", ("torch_compile_cache", "primary", 4096)),
 ]
 
 _PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -1216,6 +1221,94 @@ def test_load_timers_never_raise_into_the_load_path(monkeypatch):
 
     collector.observe_load_seconds("vllm", "m", "main", "success", 1.0)
     collector.observe_load_phase_seconds("vllm", "m", "chain", 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Inside artifact_install: validate / extract per archive
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_install_steps_are_recorded_per_archive(monkeypatch):
+    """Both steps land on their own series, keyed by artifact and archive.
+
+    This is the breakdown the ``artifact_install`` phase cannot give: the
+    phase also covers discovery and the RDMA copy, so a slow install is
+    ambiguous until the on-target steps are visible on their own.
+    """
+    collector = _fresh_collector(monkeypatch)
+    with collector.time_artifact_install_step("flashinfer_cache", "primary", "validate"):
+        pass
+    with collector.time_artifact_install_step("flashinfer_cache", "primary", "extract"):
+        pass
+    with collector.time_artifact_install_step("flashinfer_cache", "cubin", "extract"):
+        pass
+    collector.record_artifact_install_bytes("flashinfer_cache", "primary", 1024)
+    collector.record_artifact_install_bytes("flashinfer_cache", "primary", 1024)
+
+    exposition = _exposition(collector)
+    for archive, step in (("primary", "validate"), ("primary", "extract"), ("cubin", "extract")):
+        assert (
+            "mx_artifact_install_step_seconds_count"
+            f'{{archive="{archive}",artifact="flashinfer_cache",scheme="",step="{step}"}} 1.0'
+        ) in exposition, exposition
+    assert (
+        "mx_artifact_install_bytes_total"
+        '{archive="primary",artifact="flashinfer_cache",scheme=""} 2048.0'
+    ) in exposition, exposition
+
+
+def test_an_artifact_step_that_raises_is_still_recorded(monkeypatch):
+    """A ``tar -xf`` that dies on a full disk is the observation worth having."""
+    collector = _fresh_collector(monkeypatch)
+    with pytest.raises(RuntimeError):
+        with collector.time_artifact_install_step("torch_compile_cache", "primary", "extract"):
+            raise RuntimeError("tar command failed")
+
+    exposition = _exposition(collector)
+    assert (
+        "mx_artifact_install_step_seconds_count"
+        '{archive="primary",artifact="torch_compile_cache",scheme="",step="extract"} 1.0'
+    ) in exposition, exposition
+
+
+def test_artifact_step_labels_are_closed_enums(monkeypatch):
+    """An unknown step is dropped; an unknown artifact clamps to ``other``.
+
+    Same asymmetry as the load phases: the steps are read against each other,
+    so a stray step name folded into one would inflate it while looking sound,
+    whereas an out-of-tree artifact kind is still worth an ``other`` reading.
+    """
+    collector = _fresh_collector(monkeypatch)
+    collector.observe_artifact_install_step_seconds(
+        "torch_compile_cache", "primary", "unpack", 1.0
+    )
+    collector.observe_artifact_install_step_seconds("my_custom_cache", "primary", "extract", 1.0)
+    collector.record_artifact_install_bytes("my_custom_cache", "primary", 7)
+
+    exposition = _exposition(collector)
+    assert 'step="unpack"' not in exposition, exposition
+    assert (
+        "mx_artifact_install_step_seconds_count"
+        '{archive="primary",artifact="other",scheme="",step="extract"} 1.0'
+    ) in exposition, exposition
+    assert (
+        'mx_artifact_install_bytes_total{archive="primary",artifact="other",scheme=""} 7.0'
+        in exposition
+    ), exposition
+
+
+def test_artifact_kinds_match_the_transfer_factories():
+    """The closed enum is the factory list, so a new factory cannot silently
+    land in ``other``."""
+    from modelexpress import metrics as metrics_module
+    from modelexpress.metadata import artifact_transfer
+
+    source = Path(artifact_transfer.__file__).read_text()
+    factories = set(
+        re.findall(r'^\s+"([a-z_]+_cache)",\n\s+p2p_pb2\.MX_SOURCE_TYPE_', source, re.M)
+    )
+    assert factories, "the factory regex no longer matches artifact_transfer.py"
+    assert factories == set(metrics_module.ARTIFACT_KINDS) - {"other"}
 
 
 def test_load_buckets_match_the_rust_xslow_band():

--- a/workspace-tests/tests/helm_alert_rules.rs
+++ b/workspace-tests/tests/helm_alert_rules.rs
@@ -37,6 +37,9 @@ use tower::{Layer, ServiceExt};
 /// these against exact exported series names, not against the exposition as
 /// text, so `mx_p2p_transfer_seconds` would not stand in for its `_bucket`.
 const CLIENT_FAMILIES: &[&str] = &[
+    "mx_artifact_install_bytes_total",
+    "mx_artifact_install_step_seconds_count",
+    "mx_artifact_install_step_seconds_sum",
     "mx_load_phase_seconds_count",
     "mx_load_phase_seconds_sum",
     "mx_load_seconds_bucket",


### PR DESCRIPTION
The `artifact_install` load phase spans source discovery, the RDMA copy, tar validation and `tar -xf`, so a slow install cannot say whether the network or the target's disk was at fault. This records the two on-target steps per archive from `install()`, the one place they run, and adds the same split to the `[TIMING]` install log lines so a log-only benchmark gets it too. The steps sit inside `artifact_install`. 

| Family | Type | Labels | Meaning |
| --- | --- | --- | --- |
| `mx_artifact_install_step_seconds` | Histogram | `artifact`, `archive`, `step`, `scheme` | On-target time per archive; `step` is `validate` (Python walk over tar members) or `extract` (`tar -xf`). A step that raises is still recorded. |
| `mx_artifact_install_bytes_total` | Counter | `artifact`, `archive`, `scheme` | Archive bytes extracted; divided by the `extract` step's `_sum` gives extraction throughput. |

Dashboard: two panels under the **Model load** row (per-archive step table, extraction throughput bar). 

### Measured on nscale (Qwen2.5-32B-Instruct, TP=1, B200, source and target on different nodes, artifact transfer on)

| Archive | Size | validate | extract | Throughput |
| --- | ---: | ---: | ---: | ---: |
| `torch_compile_cache/primary` | 42.0 MiB | 7.7 ms | 34.9 ms | 1.26 GB/s |
| `triton_cache/primary` | 40 KiB | 0.14 ms | 2.3 ms | 17.9 MB/s* |
| `flashinfer_cache/primary` | 10 KiB | 0.19 ms | 2.1 ms | 4.9 MB/s* |
| `flashinfer_cache/autotune` | 10 KiB | 0.06 ms | 2.0 ms | 5.1 MB/s* |

\* Archives under a megabyte extract in ~2 ms regardless of size, which is the cost of spawning `tar`, so their throughput reflects process startup rather than disk I/O.

The `artifact_install` phase on that target was 1.32 s; the on-target steps above account for 0.05 s of it, so on this setup the phase is discovery plus RDMA copy, not extraction. Same numbers on the target's log:

```
[TIMING] Artifact archive extracted: name=torch_compile_cache archive=primary target=/home/dynamo/.cache/vllm/torch_compile_cache size=42.01 MiB validate=0.008s extract=0.035s
[TIMING] Artifact install complete: artifact_id=6a5ce0e3... targets=['/home/dynamo/.cache/vllm/torch_compile_cache'] size=42.01 MiB validate=0.008s extract=0.035s elapsed=0.044s
```

![Artifact install panels](https://raw.githubusercontent.com/yixinh-nv/modelexpress/assets/pr-744-dashboard/artifact_install_panels_real.png)


