### PR TITLE
feat(metrics): split a P2P source attempt into the phases the strategy owns

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -15,10 +15,11 @@ and storage-backend coverage on the server, the download lifecycle, NIXL client
 health, the Kubernetes scrape, alerting and dashboard surface, and the first two
 load-timing tiers — the `load_model()` window and the phases that partition it.
 
-The tiers below those do not exist yet. Nothing here attributes time to an
-individual strategy attempt or splits a transfer into registration, handshake
-and wire, so the dashboard can say a load spent ninety seconds in `chain` but
-not which strategy spent it or where inside the transfer it went.
+The per-strategy tier between those and the transfer is a separate change.
+Below it, a P2P source attempt is split into its phases — `metadata`,
+`prepare`, `register`, `handshake`, `receive`, `finalize`, `release` — so the
+dashboard can say not just that a transfer took ninety seconds but which of
+those it spent them in.
 
 ---
 
@@ -417,6 +418,7 @@ touched.
 | `mx_p2p_candidates` | Histogram | `policy`, `scheme`, `stage` |
 | `mx_p2p_source_selection_seconds` | Histogram | `policy`, `scheme` |
 | `mx_p2p_transfer_seconds` | Histogram | `policy`, `scheme`, `outcome` |
+| `mx_p2p_source_attempt_phase_seconds` | Histogram | `policy`, `phase`, `outcome`, `scheme` |
 | `mx_nixl_data_plane_errors_total` | Counter | `scheme`, `kind` |
 | `mx_nixl_receive_total` | Counter | `scheme`, `result` |
 | `mx_load_seconds` | Histogram | `engine`, `model`, `model_role`, `scheme`, `outcome` |
@@ -616,6 +618,59 @@ says more than no model at all, and 96 characters clears every id in the wild by
 a wide margin. An absent or blank id records as `unknown` rather than as an
 empty string, which would render as `model=""` and read as an exporter bug.
 
+### Inside a source attempt: where the transfer time went
+
+`mx_p2p_transfer_seconds` is one interval per source attempt, from the moment
+the strategy commits to a candidate until the adapter hands the weights back.
+Ninety seconds there is ambiguous: the RDMA read, or a registration that
+crawled, or a peer that took a minute to answer the handshake all look the
+same. `mx_p2p_source_attempt_phase_seconds` splits it.
+
+| Phase | What runs | Inside the transfer span |
+| --- | --- | --- |
+| `metadata` | `GetMetadata`, plus the tensor-manifest fetch when the response did not carry one | no — it runs before the span opens |
+| `prepare` | the adapter readies the target model to receive | yes |
+| `register` | NIXL memory registration and the agent metadata blob | yes |
+| `handshake` | loading the peer's NIXL metadata: fetched over P2P, or added from the central record | yes |
+| `receive` | name matching, descriptor prep, the RDMA READ, and the device sync | yes |
+| `finalize` | the adapter's post-receive processing | yes |
+| `release` | dropping the remote agent, from the `finally` | yes |
+
+One observation per phase per attempt, recorded from `RdmaStrategy` — the code
+that already brackets each of these calls — and nowhere else. Nothing inside the
+NIXL manager was touched to get them, which is why `receive` is one phase rather
+than three: separating the descriptor work from the wire would mean timing
+inside the manager instead of around it.
+
+Two invariants, both by construction:
+
+```promql
+# Phases inside the span sum to less than the transfer. The remainder is
+# descriptor bookkeeping and logging that no phase owns.
+sum(mx_p2p_source_attempt_phase_seconds_sum{phase!="metadata"})
+  <= sum(mx_p2p_transfer_seconds_sum)
+
+# Where did a failed attempt die? Every phase before it is ok, the one it died
+# in is error, and the ones after it never ran -- except release, which runs
+# from the finally.
+sum by (phase, outcome) (mx_p2p_source_attempt_phase_seconds_count)
+```
+
+`metadata` is the phase that belongs to the attempt but not to the transfer.
+It was log-timed and nothing else until now, and it is where a slow or
+unreachable metadata backend shows up — a candidate that fails there records
+`metadata` with `error` and no other phase at all, because the transfer span
+never opened.
+
+`outcome` is on the family because a receive that hit the transfer deadline and
+one that finished are not the same duration. A phase that raises is still
+recorded; it is the reading someone comes looking for.
+
+The band runs from 10 ms to 10 minutes. A handshake is milliseconds, a
+registration tens of milliseconds to seconds, a receive anything from under a
+second to the transfer timeout — no existing band covers both ends, and a
+sub-second floor would put every handshake in one bucket.
+
 ### NIXL data-plane health
 
 `mx_nixl_data_plane_errors_total{kind}` counts the failures that demote an agent
@@ -787,9 +842,9 @@ It covers the server end to end -- gRPC, storage backend, download lifecycle,
 capacity -- and the client from the load tiers down to total transfer time. The
 **Model load** row plots `mx_load_seconds`, the phase split of
 `mx_load_phase_seconds`, and the validate/extract steps inside
-`artifact_install`. Below that there is still nothing for the weight transfer
-itself — the transfer panel can say a transfer took 90 seconds but not where
-inside it the 90 seconds went.
+`artifact_install`. The **P2P clients** row now carries the transfer's own
+breakdown: a table of mean phase durations under the two transfer panels, and
+a count per phase that shows where a failed attempt died.
 
 Read **Overview** first; the rows below it answer *why* once a tile is not green.
 
@@ -799,7 +854,7 @@ Read **Overview** first; the rows below it answer *why* once a tile is not green
 | **Model load** | How long did a load take, and which part? | 5 |
 | **Downloads** | Is the primary job working, and how fast? | 6 |
 | **Server internals** | gRPC and storage backend: rate, errors, p99, in flight | 8 + 1 note |
-| **P2P clients** | Selection funnel, transfer time, NIXL health | 8 + 1 note |
+| **P2P clients** | Selection funnel, transfer time and its phases, NIXL health | 11 + 1 note |
 | **Capacity** | Map growth, evictions, version skew | 3 |
 
 Six of the eight Overview tiles are coloured by the same condition an alert fires

--- a/helm/dashboards/modelexpress.json
+++ b/helm/dashboards/modelexpress.json
@@ -1651,20 +1651,20 @@
       "id": 116,
       "type": "table",
       "title": "Where a source attempt's time went",
-      "description": "Mean duration of each phase of a P2P source attempt, by outcome. This is the breakdown of the two transfer panels above: they say a transfer took ninety seconds, these rows say whether that was the registration, the handshake with the peer, or the RDMA read itself.\n\nAll phases but `metadata` fall inside mx_p2p_transfer_seconds, so they sum to less than it -- the remainder is descriptor bookkeeping and logging. `metadata` is the GetMetadata and manifest fetch that runs before the transfer span opens; it belongs to the attempt but not to the transfer.\n\nOutcome is on the table because a receive that hit the transfer deadline and one that finished are not the same duration, and a mean across the two describes neither.",
+      "description": "Mean duration of each phase of a P2P source attempt, by outcome. This is the breakdown of the two transfer panels above: they say a transfer took ninety seconds, these rows say whether that was the registration, the handshake with the peer, or the RDMA read itself.\n\nAll phases but `metadata` fall inside mx_p2p_transfer_seconds, so they sum to less than it -- the remainder is descriptor bookkeeping and logging. `metadata` is the GetMetadata and manifest fetch that runs before the transfer span opens; it belongs to the attempt but not to the transfer.\n\nOutcome is on the table because a receive that hit the transfer deadline and one that finished are not the same duration, and a mean across the two describes neither.\n\nReads the last sample inside the dashboard range rather than the instant value. A load happens once in a process's life and the pod is often gone before anyone looks; an instant query goes empty five minutes after the last scrape, which would show this table as 0 for exactly the attempt someone came to read about.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 14,
         "x": 0,
         "y": 86
       },
       "targets": [
         {
-          "expr": "sum by (phase, outcome) (mx_p2p_source_attempt_phase_seconds_sum) / sum by (phase, outcome) (mx_p2p_source_attempt_phase_seconds_count)",
+          "expr": "sum by (phase, outcome) (last_over_time(mx_p2p_source_attempt_phase_seconds_sum[$__range])) / sum by (phase, outcome) (last_over_time(mx_p2p_source_attempt_phase_seconds_count[$__range]))",
           "format": "table",
           "instant": true,
           "refId": "A",
@@ -1758,7 +1758,7 @@
         "uid": "${datasource}"
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 10,
         "x": 14,
         "y": 86
@@ -1805,7 +1805,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 94
+        "y": 96
       },
       "targets": [
         {
@@ -1844,7 +1844,7 @@
         "h": 6,
         "w": 18,
         "x": 6,
-        "y": 94
+        "y": 96
       },
       "options": {
         "mode": "markdown",
@@ -1860,7 +1860,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 100
+        "y": 102
       },
       "panels": []
     },
@@ -1876,7 +1876,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 101
+        "y": 103
       },
       "targets": [
         {
@@ -1908,7 +1908,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 101
+        "y": 103
       },
       "targets": [
         {
@@ -1941,7 +1941,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 101
+        "y": 103
       },
       "targets": [
         {

--- a/helm/dashboards/modelexpress.json
+++ b/helm/dashboards/modelexpress.json
@@ -1648,6 +1648,152 @@
       "description": "NIXL failures by classified kind. A non-zero count is what demotes an agent from READY."
     },
     {
+      "id": 116,
+      "type": "table",
+      "title": "Where a source attempt's time went",
+      "description": "Mean duration of each phase of a P2P source attempt, by outcome. This is the breakdown of the two transfer panels above: they say a transfer took ninety seconds, these rows say whether that was the registration, the handshake with the peer, or the RDMA read itself.\n\nAll phases but `metadata` fall inside mx_p2p_transfer_seconds, so they sum to less than it -- the remainder is descriptor bookkeeping and logging. `metadata` is the GetMetadata and manifest fetch that runs before the transfer span opens; it belongs to the attempt but not to the transfer.\n\nOutcome is on the table because a receive that hit the transfer deadline and one that finished are not the same duration, and a mean across the two describes neither.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 86
+      },
+      "targets": [
+        {
+          "expr": "sum by (phase, outcome) (mx_p2p_source_attempt_phase_seconds_sum) / sum by (phase, outcome) (mx_p2p_source_attempt_phase_seconds_count)",
+          "format": "table",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "phase"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outcome"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "phase": 0,
+              "outcome": 1,
+              "Value": 2
+            },
+            "renameByName": {
+              "Value": "mean"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "phase",
+                "desc": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 117,
+      "type": "bargauge",
+      "title": "Attempt phases recorded",
+      "description": "How many times each phase ran, by outcome. Every phase of a completed attempt records once, so on a healthy fleet these are equal and all `ok`; a phase that is short by one against its neighbours is an attempt that died before reaching it, and an `error` bar names the phase it died in.\n\nA cumulative count rather than a rate: a load happens a handful of times in a process's life, so rate() over a scrape window reads zero on a fleet that is working.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 14,
+        "y": 86
+      },
+      "targets": [
+        {
+          "expr": "sum by (phase, outcome) (mx_p2p_source_attempt_phase_seconds_count)",
+          "legendFormat": "{{phase}}  {{outcome}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        }
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      }
+    },
+    {
       "id": 38,
       "type": "stat",
       "title": "Client pods exporting",
@@ -1659,7 +1805,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 86
+        "y": 94
       },
       "targets": [
         {
@@ -1698,7 +1844,7 @@
         "h": 6,
         "w": 18,
         "x": 6,
-        "y": 86
+        "y": 94
       },
       "options": {
         "mode": "markdown",
@@ -1714,7 +1860,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 92
+        "y": 100
       },
       "panels": []
     },
@@ -1730,7 +1876,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 93
+        "y": 101
       },
       "targets": [
         {
@@ -1762,7 +1908,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 93
+        "y": 101
       },
       "targets": [
         {
@@ -1795,7 +1941,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 93
+        "y": 101
       },
       "targets": [
         {

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -167,11 +167,12 @@ class RdmaStrategy(LoadStrategy):
             )
 
             try:
-                source_worker = self._fetch_worker_metadata(
-                    ctx,
-                    mx_source_id,
-                    worker_id,
-                )
+                with selection_metrics.time_source_attempt_phase(policy, "metadata"):
+                    source_worker = self._fetch_worker_metadata(
+                        ctx,
+                        mx_source_id,
+                        worker_id,
+                    )
             except Exception as e:
                 logger.warning(
                     f"[Worker {ctx.global_rank}] Failed to fetch metadata for worker {worker_id}: {e}. "
@@ -480,11 +481,14 @@ class RdmaStrategy(LoadStrategy):
         source_worker_id: str,
     ) -> LoadResult:
         """Receive fully-processed weights via RDMA from an existing source."""
+        policy = configured_policy_label()
         try:
-            result = ctx.adapter.prepare_rdma_target(result)
-            result = ctx.adapter.before_rdma_receive(result)
+            with selection_metrics.time_source_attempt_phase(policy, "prepare"):
+                result = ctx.adapter.prepare_rdma_target(result)
+                result = ctx.adapter.before_rdma_receive(result)
             self._receive_from_peer(result, ctx, source_worker, mx_source_id)
-            return ctx.adapter.after_rdma_receive(result)
+            with selection_metrics.time_source_attempt_phase(policy, "finalize"):
+                return ctx.adapter.after_rdma_receive(result)
         except StrategyFailed:
             raise
         except Exception as e:
@@ -499,7 +503,9 @@ class RdmaStrategy(LoadStrategy):
     ) -> None:
         """Receive fully-processed tensors via RDMA from the detected source."""
         receive_start = time.perf_counter()
-        register_tensors(result, ctx)
+        policy = configured_policy_label()
+        with selection_metrics.time_source_attempt_phase(policy, "register"):
+            register_tensors(result, ctx)
 
         is_p2p = bool(source_worker.worker_grpc_endpoint)
         remote_agent_name = None
@@ -525,11 +531,12 @@ class RdmaStrategy(LoadStrategy):
                 # Claimed before the dial so a fetch that fails part-way, leaving
                 # metadata that lands later, is still released.
                 remote_agent_name = source_worker.agent_name
-                ctx.nixl_manager.fetch_remote_and_wait(
-                    remote_agent_name=source_worker.agent_name,
-                    ip=host,
-                    port=int(port_str),
-                )
+                with selection_metrics.time_source_attempt_phase(policy, "handshake"):
+                    ctx.nixl_manager.fetch_remote_and_wait(
+                        remote_agent_name=source_worker.agent_name,
+                        ip=host,
+                        port=int(port_str),
+                    )
                 nixl_fetch_time = time.perf_counter() - nixl_fetch_start
                 logger.info(
                     f"[Worker {ctx.global_rank}] [TIMING] P2P NIXL metadata fetch: "
@@ -549,9 +556,10 @@ class RdmaStrategy(LoadStrategy):
                 # Loaded here rather than inside receive_from_source so this method
                 # holds the name it is responsible for releasing.
                 add_start = time.perf_counter()
-                remote_agent_name = ctx.nixl_manager.add_remote_agent(
-                    source_worker.nixl_metadata
-                )
+                with selection_metrics.time_source_attempt_phase(policy, "handshake"):
+                    remote_agent_name = ctx.nixl_manager.add_remote_agent(
+                        source_worker.nixl_metadata
+                    )
                 logger.info(
                     f"[Worker {ctx.global_rank}] [TIMING] add_remote_agent: "
                     f"{time.perf_counter() - add_start:.3f}s (agent={remote_agent_name})"
@@ -576,17 +584,18 @@ class RdmaStrategy(LoadStrategy):
 
             transfer_start = time.perf_counter()
             try:
-                (
-                    bytes_transferred,
-                    tensor_count,
-                    _,
-                ) = ctx.nixl_manager.receive_from_source(
-                    source_metadata=source_worker.nixl_metadata,
-                    source_tensors=source_tensors,
-                    timeout_seconds=_transfer_timeout_seconds(),
-                    remote_agent_name=remote_agent_name,
-                    require_exact_match=require_exact_match,
-                )
+                with selection_metrics.time_source_attempt_phase(policy, "receive"):
+                    (
+                        bytes_transferred,
+                        tensor_count,
+                        _,
+                    ) = ctx.nixl_manager.receive_from_source(
+                        source_metadata=source_worker.nixl_metadata,
+                        source_tensors=source_tensors,
+                        timeout_seconds=_transfer_timeout_seconds(),
+                        remote_agent_name=remote_agent_name,
+                        require_exact_match=require_exact_match,
+                    )
             except Exception as e:
                 raise SourceTransferError(f"RDMA receive failed: {e}") from e
             transfer_time = time.perf_counter() - transfer_start
@@ -609,7 +618,8 @@ class RdmaStrategy(LoadStrategy):
             # hooks, and in P2P only the reader holds a record of the peer to
             # invalidate. None means acquisition failed with nothing to release.
             if remote_agent_name is not None:
-                ctx.nixl_manager.remove_remote_agent(remote_agent_name)
+                with selection_metrics.time_source_attempt_phase(policy, "release"):
+                    ctx.nixl_manager.remove_remote_agent(remote_agent_name)
 
         total_time = time.perf_counter() - receive_start
         logger.info(

--- a/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
+++ b/modelexpress_client/python/modelexpress/load_strategy/rdma_strategy.py
@@ -481,6 +481,9 @@ class RdmaStrategy(LoadStrategy):
         source_worker_id: str,
     ) -> LoadResult:
         """Receive fully-processed weights via RDMA from an existing source."""
+        # The source-selection policy (random, rendezvous_hash, load_aware, ...)
+        # that chose this candidate. Every P2P client family carries it, so a
+        # phase duration can be read against the policy that picked the peer.
         policy = configured_policy_label()
         try:
             with selection_metrics.time_source_attempt_phase(policy, "prepare"):
@@ -525,22 +528,26 @@ class RdmaStrategy(LoadStrategy):
                     )
                     for t in tensor_protos
                 ]
-                nixl_fetch_start = time.perf_counter()
                 ep = source_worker.metadata_endpoint
                 host, port_str = ep.rsplit(":", 1)
                 # Claimed before the dial so a fetch that fails part-way, leaving
                 # metadata that lands later, is still released.
                 remote_agent_name = source_worker.agent_name
-                with selection_metrics.time_source_attempt_phase(policy, "handshake"):
+                # One handshake phase, two transports: here the peer's NIXL
+                # metadata is fetched from the peer itself; the centralized
+                # branch below loads the copy the MX server holds. Exactly one
+                # of the two runs per attempt.
+                with selection_metrics.time_source_attempt_phase(
+                    policy, "handshake"
+                ) as handshake:
                     ctx.nixl_manager.fetch_remote_and_wait(
                         remote_agent_name=source_worker.agent_name,
                         ip=host,
                         port=int(port_str),
                     )
-                nixl_fetch_time = time.perf_counter() - nixl_fetch_start
                 logger.info(
                     f"[Worker {ctx.global_rank}] [TIMING] P2P NIXL metadata fetch: "
-                    f"{nixl_fetch_time:.3f}s"
+                    f"{handshake.seconds:.3f}s"
                 )
             else:
                 source_tensors = [
@@ -555,14 +562,15 @@ class RdmaStrategy(LoadStrategy):
                 ]
                 # Loaded here rather than inside receive_from_source so this method
                 # holds the name it is responsible for releasing.
-                add_start = time.perf_counter()
-                with selection_metrics.time_source_attempt_phase(policy, "handshake"):
+                with selection_metrics.time_source_attempt_phase(
+                    policy, "handshake"
+                ) as handshake:
                     remote_agent_name = ctx.nixl_manager.add_remote_agent(
                         source_worker.nixl_metadata
                     )
                 logger.info(
                     f"[Worker {ctx.global_rank}] [TIMING] add_remote_agent: "
-                    f"{time.perf_counter() - add_start:.3f}s (agent={remote_agent_name})"
+                    f"{handshake.seconds:.3f}s (agent={remote_agent_name})"
                 )
 
             logger.info(
@@ -582,9 +590,10 @@ class RdmaStrategy(LoadStrategy):
                 and target_accelerator != source_accelerator
             )
 
-            transfer_start = time.perf_counter()
             try:
-                with selection_metrics.time_source_attempt_phase(policy, "receive"):
+                with selection_metrics.time_source_attempt_phase(
+                    policy, "receive"
+                ) as received:
                     (
                         bytes_transferred,
                         tensor_count,
@@ -598,7 +607,7 @@ class RdmaStrategy(LoadStrategy):
                     )
             except Exception as e:
                 raise SourceTransferError(f"RDMA receive failed: {e}") from e
-            transfer_time = time.perf_counter() - transfer_start
+            transfer_time = received.seconds
 
             bandwidth_gbps = (
                 (bytes_transferred * 8) / (transfer_time * 1e9)

--- a/modelexpress_client/python/modelexpress/metrics.py
+++ b/modelexpress_client/python/modelexpress/metrics.py
@@ -260,6 +260,19 @@ def reset_multiproc_dir(path: str | None = None) -> None:
         logger.warning("Failed to reset metrics directory %s: %s", directory, e)
 
 
+class _PhaseSpan:
+    """Duration holder for :meth:`MetricsCollector.time_source_attempt_phase`.
+
+    Set on exit, so a caller that logs the same span reads it from here instead
+    of keeping a second clock for the same interval.
+    """
+
+    __slots__ = ("seconds",)
+
+    def __init__(self) -> None:
+        self.seconds = 0.0
+
+
 class MetricsCollector:
     """Lazy holder for prometheus_client collectors.
 
@@ -819,23 +832,26 @@ class MetricsCollector:
     def time_source_attempt_phase(self, policy: str, phase: str):
         """Time one phase of a source attempt, recording how it ended.
 
-        No handle to set: unlike a strategy attempt, a phase has two outcomes
-        and the exception path is the whole distinction, so the context manager
-        can classify it alone. A phase that raises is still recorded -- a
-        receive that hits the transfer deadline is the reading someone comes
-        looking for.
+        Unlike a strategy attempt, a phase has two outcomes and the exception
+        path is the whole distinction, so the context manager classifies it
+        alone. A phase that raises is still recorded, as ``error``: that is what
+        lets the dashboard say which phase a failed attempt died in, and it keeps
+        a receive that ran to the transfer deadline out of the ``ok`` mean.
+
+        The yielded handle carries the measured duration after exit, for the
+        caller's own log line -- one clock per span.
         """
+        span = _PhaseSpan()
         start = time.perf_counter()
         outcome = "ok"
         try:
-            yield
+            yield span
         except BaseException:
             outcome = "error"
             raise
         finally:
-            self.observe_source_attempt_phase_seconds(
-                policy, phase, outcome, time.perf_counter() - start
-            )
+            span.seconds = time.perf_counter() - start
+            self.observe_source_attempt_phase_seconds(policy, phase, outcome, span.seconds)
 
     def observe_load_seconds(
         self, engine: str, model: object, model_role: str, outcome: str, seconds: float

--- a/modelexpress_client/python/modelexpress/metrics.py
+++ b/modelexpress_client/python/modelexpress/metrics.py
@@ -133,6 +133,46 @@ ARTIFACT_INSTALL_STEPS = ("validate", "extract")
 #: pathological one (slow overlay filesystem, tar in D state) is minutes.
 _ARTIFACT_STEP_BUCKETS = (0.1, 0.25, 0.5, 1, 2.5, 5, 15, 30, 60, 120, 300)
 
+#: The phases of one P2P source attempt, in the order they run. A source attempt
+#: is one candidate in ``RdmaStrategy.load`` -- the unit ``mx_p2p_source_attempts_total``
+#: already counts -- and these partition it: every one is a disjoint interval
+#: the strategy itself brackets, so their sum is bounded by the attempt.
+#:
+#:   metadata   GetMetadata, plus the tensor-manifest fetch when the response
+#:              did not carry one. Before the transfer span opens.
+#:   prepare    the adapter readies the target model to receive
+#:   register   NIXL memory registration and the agent metadata blob
+#:   handshake  loading the peer's NIXL metadata (fetched P2P, or added from
+#:              the central record)
+#:   receive    name matching, descriptor prep, the RDMA READ, and the sync
+#:   finalize   the adapter's post-receive processing
+#:   release    dropping the remote agent
+#:
+#: ``mx_p2p_transfer_seconds`` covers everything after ``metadata``, so
+#: ``sum(phase != "metadata") <= transfer`` and ``sum(all) <= the rdma attempt``.
+#: The ``receive`` phase is the wire plus the descriptor work around it; splitting
+#: those apart would mean timing inside the NIXL manager rather than around it.
+SOURCE_ATTEMPT_PHASES = (
+    "metadata",
+    "prepare",
+    "register",
+    "handshake",
+    "receive",
+    "finalize",
+    "release",
+)
+
+#: Whether the phase returned or raised. A receive that times out at the
+#: transfer deadline and one that finishes are not the same duration, and a
+#: mean across them describes neither.
+SOURCE_ATTEMPT_PHASE_OUTCOMES = ("ok", "error")
+
+#: Ten milliseconds to ten minutes. A handshake or a metadata fetch is
+#: milliseconds, a registration is tens of milliseconds to seconds, and a receive
+#: runs from under a second on a small model to the transfer timeout on a wedged
+#: one. No existing band covers both ends.
+_ATTEMPT_PHASE_BUCKETS = (0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600)
+
 #: Longest model id kept in the ``model`` label; longer ones are truncated.
 #:
 #: This is the one label on the load families whose domain is NOT a closed enum,
@@ -411,6 +451,20 @@ class MetricsCollector:
             "End-to-end transfer time in seconds.",
             ["policy", "scheme", "outcome"],  # success|retry|fallback
             buckets=(0.5, 1, 2, 5, 10, 30, 60, 120, 300),
+            registry=registry,
+        )
+        # Below the transfer: the phases of one source attempt, recorded from
+        # the strategy that brackets each of them. The transfer span above is
+        # left exactly as it was -- this is a sibling, not new labels on it, so
+        # its two panels and its place in the family list do not move.
+        self.source_attempt_phase_seconds = Histogram(
+            "mx_p2p_source_attempt_phase_seconds",
+            "Duration of one phase of a P2P source attempt: metadata, prepare, "
+            "register, handshake, receive, finalize or release. The phases "
+            "partition the attempt; all but metadata fall inside "
+            "mx_p2p_transfer_seconds.",
+            ["policy", "phase", "outcome", "scheme"],
+            buckets=_ATTEMPT_PHASE_BUCKETS,
             registry=registry,
         )
         # L0. The window the caller actually waited on: one observation per
@@ -739,6 +793,49 @@ class MetricsCollector:
                 self.transfer_seconds.labels(policy, self.scheme, outcome).observe(seconds)
             except Exception:
                 pass
+
+    def observe_source_attempt_phase_seconds(
+        self, policy: str, phase: str, outcome: str, seconds: float
+    ) -> None:
+        """Record one phase of a P2P source attempt.
+
+        An unknown phase is dropped rather than clamped: these partition the
+        attempt, and folding a stray name into a real phase would inflate it
+        while the sum still looked sound. An unknown outcome clamps to ``error``.
+        """
+        if self._ensure():
+            try:
+                if phase not in SOURCE_ATTEMPT_PHASES:
+                    return
+                if outcome not in SOURCE_ATTEMPT_PHASE_OUTCOMES:
+                    outcome = "error"
+                self.source_attempt_phase_seconds.labels(
+                    policy, phase, outcome, self.scheme
+                ).observe(seconds)
+            except Exception:
+                pass
+
+    @contextlib.contextmanager
+    def time_source_attempt_phase(self, policy: str, phase: str):
+        """Time one phase of a source attempt, recording how it ended.
+
+        No handle to set: unlike a strategy attempt, a phase has two outcomes
+        and the exception path is the whole distinction, so the context manager
+        can classify it alone. A phase that raises is still recorded -- a
+        receive that hits the transfer deadline is the reading someone comes
+        looking for.
+        """
+        start = time.perf_counter()
+        outcome = "ok"
+        try:
+            yield
+        except BaseException:
+            outcome = "error"
+            raise
+        finally:
+            self.observe_source_attempt_phase_seconds(
+                policy, phase, outcome, time.perf_counter() - start
+            )
 
     def observe_load_seconds(
         self, engine: str, model: object, model_role: str, outcome: str, seconds: float

--- a/modelexpress_client/python/tests/test_metrics.py
+++ b/modelexpress_client/python/tests/test_metrics.py
@@ -63,6 +63,7 @@ _RECORDERS = [
     ("observe_candidates", ("random", "listed", 2)),
     ("observe_selection_seconds", ("random", 0.001)),
     ("observe_transfer_seconds", ("random", "success", 1.0)),
+    ("observe_source_attempt_phase_seconds", ("random", "receive", "ok", 1.0)),
     ("record_nixl_error", ("timeout",)),
     ("record_nixl_receive", ("complete",)),
     ("observe_load_seconds", ("vllm", "Qwen/Qwen2.5-0.5B-Instruct", "main", "success", 12.0)),
@@ -157,6 +158,7 @@ def test_recorders_never_raise_into_load_path(monkeypatch):
     m.candidates = boom
     m.selection_seconds = boom
     m.transfer_seconds = boom
+    m.source_attempt_phase_seconds = boom
     m.nixl_errors = boom
     m.nixl_receives = boom
     # None of these may propagate the RuntimeError.
@@ -1355,9 +1357,14 @@ class TestObserveCandidateLoads:
     def _collector(monkeypatch, label_on):
         from prometheus_client import CollectorRegistry
         from modelexpress import metrics as M
-        monkeypatch.setattr(M.envs, "MX_METRICS_ENABLED", True, raising=False)
-        monkeypatch.setattr(M.envs, "MX_METRICS_SOURCE_ID_LABEL", label_on, raising=False)
-        monkeypatch.setattr(M.envs, "PROMETHEUS_MULTIPROC_DIR", None, raising=False)
+        # Through the environment, never setattr on the envs module: envs resolves
+        # names dynamically, so getattr succeeds when monkeypatch records the old
+        # value and the teardown pins a real attribute that shadows the lookup
+        # for the rest of the process -- every later test that relies on
+        # MX_METRICS_ENABLED then records nothing.
+        monkeypatch.setenv("MX_METRICS_ENABLED", "1")
+        monkeypatch.setenv("MX_METRICS_SOURCE_ID_LABEL", "1" if label_on else "0")
+        monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
         reg = CollectorRegistry()
         c = M.MetricsCollector(registry=reg)
         assert c._ensure()

--- a/modelexpress_client/python/tests/test_source_selection.py
+++ b/modelexpress_client/python/tests/test_source_selection.py
@@ -1309,6 +1309,18 @@ def test_a_metadata_miss_records_only_the_metadata_phase(monkeypatch):
     assert transfer == 0.0
 
 
+def test_the_phase_span_hands_its_duration_back_for_the_log_line(monkeypatch):
+    """One clock per span: the strategy logs what the metric measured."""
+    import time
+
+    collector = _real_metrics(monkeypatch)
+    with collector.time_source_attempt_phase("random", "receive") as span:
+        time.sleep(0.005)
+    assert span.seconds >= 0.005
+    phases, _ = _phase_series(collector)
+    assert phases[("receive", "ok")][1] == pytest.approx(span.seconds)
+
+
 def test_an_unknown_phase_is_dropped_and_an_unknown_outcome_clamps(monkeypatch):
     collector = _real_metrics(monkeypatch)
     collector.observe_source_attempt_phase_seconds("random", "not_a_phase", "ok", 1.0)

--- a/modelexpress_client/python/tests/test_source_selection.py
+++ b/modelexpress_client/python/tests/test_source_selection.py
@@ -1160,3 +1160,158 @@ class TestSourceLoadPresence:
         la = [c.worker_id for c in ss.LoadAwareSelector().order(cands, self._ctx())]
         rz = [c.worker_id for c in ss.RendezvousHashSelector().order(cands, self._ctx())]
         assert la == rz
+
+
+# ---------------------------------------------------------------------------
+# RdmaStrategy.load() -> source attempt phases
+# ---------------------------------------------------------------------------
+
+
+def _real_metrics(monkeypatch):
+    """A collector on a private registry, wired into the strategy module."""
+    from prometheus_client import CollectorRegistry
+
+    from modelexpress.metrics import MetricsCollector
+
+    monkeypatch.setenv("MX_METRICS_ENABLED", "1")
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+    monkeypatch.delenv(ENV_SELECTOR, raising=False)
+    collector = MetricsCollector(registry=CollectorRegistry())
+    monkeypatch.setattr("modelexpress.load_strategy.rdma_strategy.selection_metrics", collector)
+    monkeypatch.setattr(
+        "modelexpress.load_strategy.rdma_strategy.worker_tensor_count", lambda w: 1
+    )
+    monkeypatch.setattr(
+        "modelexpress.load_strategy.rdma_strategy.register_tensors", lambda result, ctx: None
+    )
+    return collector
+
+
+def _phase_series(collector):
+    """{(phase, outcome): (count, sum)} and the transfer _sum, from the exposition."""
+    import re
+
+    from prometheus_client import generate_latest
+
+    text = generate_latest(collector._exposition_registry()).decode()
+    phases = {}
+    for kind in ("count", "sum"):
+        for m in re.finditer(
+            r"mx_p2p_source_attempt_phase_seconds_" + kind
+            + r'\{[^}]*outcome="([^"]+)"[^}]*phase="([^"]+)"[^}]*\} (\S+)',
+            text,
+        ):
+            key = (m.group(2), m.group(1))
+            c, s = phases.get(key, (0.0, 0.0))
+            phases[key] = (float(m.group(3)), s) if kind == "count" else (c, float(m.group(3)))
+    transfer = sum(
+        float(m.group(1))
+        for m in re.finditer(r"mx_p2p_transfer_seconds_sum\{[^}]*\} (\S+)", text)
+    )
+    return phases, transfer
+
+
+def _receiving_ctx():
+    """A context whose adapter and NIXL manager accept everything."""
+    ctx = MagicMock(global_rank=0)
+    ctx.accelerator_backend.name = ""  # unknown target -> accelerator gate accepts
+    ctx.nixl_manager.receive_from_source.return_value = (0, 0, 0.0)
+    ctx.nixl_manager.add_remote_agent.return_value = "peer"
+    return ctx
+
+
+def _centralized_source():
+    """A source served through the central record: no gRPC endpoint, so the
+    handshake is add_remote_agent rather than a P2P metadata fetch."""
+    source = MagicMock()
+    source.worker_grpc_endpoint = ""
+    source.tensor_source.tensors = []
+    source.nixl_metadata = b"meta"
+    source.accelerator = ""
+    return source
+
+
+def test_a_successful_attempt_records_every_phase_once_and_they_nest_in_the_transfer(
+    monkeypatch,
+):
+    """The tier-C invariant on real timings: sum(phase != metadata) <= transfer.
+
+    Every phase is a with-block around a call the strategy already made, so the
+    nesting holds by construction. The test exists so that a phase recorded
+    from a second site, or one that drifts outside the transfer span, fails
+    instead of quietly inflating a phase.
+    """
+    collector = _real_metrics(monkeypatch)
+    strat = RdmaStrategy()
+    strat._find_source_instances = MagicMock(return_value=_sources(1))
+    strat._fetch_worker_metadata = MagicMock(return_value=_centralized_source())
+    ctx = _receiving_ctx()
+
+    strat.load(MagicMock(), ctx)
+
+    phases, transfer = _phase_series(collector)
+    assert {p for p, _ in phases} == {
+        "metadata", "prepare", "register", "handshake", "receive", "finalize", "release"
+    }, phases
+    assert all(outcome == "ok" for _, outcome in phases), phases
+    assert all(count == 1.0 for count, _ in phases.values()), phases
+    inside = sum(s for (p, _), (_, s) in phases.items() if p != "metadata")
+    assert inside <= transfer, (
+        f"phases inside the transfer summed to {inside:.6f}s but the transfer took "
+        f"{transfer:.6f}s; a phase is recorded outside the span or from two sites"
+    )
+
+
+def test_a_receive_that_raises_is_recorded_as_an_error_in_that_phase(monkeypatch):
+    """The phase a failed attempt died in is the reading worth having.
+
+    The RDMA read raises, so `receive` records `error`, the phases before it
+    record `ok`, `finalize` never runs, and `release` still runs from the
+    finally -- which is the one place a partition on failed attempts can be
+    checked at all.
+    """
+    collector = _real_metrics(monkeypatch)
+    strat = RdmaStrategy()
+    strat._find_source_instances = MagicMock(return_value=_sources(1))
+    strat._fetch_worker_metadata = MagicMock(return_value=_centralized_source())
+    ctx = _receiving_ctx()
+    ctx.nixl_manager.receive_from_source.side_effect = RuntimeError("READ timed out")
+
+    with pytest.raises(StrategyFailed):
+        strat.load(MagicMock(), ctx)
+
+    phases, _ = _phase_series(collector)
+    by_phase = {p: outcome for p, outcome in phases}
+    assert by_phase == {
+        "metadata": "ok",
+        "prepare": "ok",
+        "register": "ok",
+        "handshake": "ok",
+        "receive": "error",
+        "release": "ok",
+    }, by_phase
+
+
+def test_a_metadata_miss_records_only_the_metadata_phase(monkeypatch):
+    """A candidate that fails GetMetadata never opens the transfer span, so
+    `metadata` is the only phase it leaves -- with `error`, since the fetch
+    raised -- and the attempt is counted as metadata_miss, not as a transfer."""
+    collector = _real_metrics(monkeypatch)
+    strat = RdmaStrategy()
+    strat._find_source_instances = MagicMock(return_value=_sources(1))
+    strat._fetch_worker_metadata = MagicMock(side_effect=RuntimeError("unreachable"))
+
+    with pytest.raises(StrategyFailed):
+        strat.load(MagicMock(), _receiving_ctx())
+
+    phases, transfer = _phase_series(collector)
+    assert set(phases) == {("metadata", "error")}, phases
+    assert transfer == 0.0
+
+
+def test_an_unknown_phase_is_dropped_and_an_unknown_outcome_clamps(monkeypatch):
+    collector = _real_metrics(monkeypatch)
+    collector.observe_source_attempt_phase_seconds("random", "not_a_phase", "ok", 1.0)
+    collector.observe_source_attempt_phase_seconds("random", "receive", "not_an_outcome", 1.0)
+    phases, _ = _phase_series(collector)
+    assert set(phases) == {("receive", "error")}, phases

--- a/workspace-tests/tests/helm_alert_rules.rs
+++ b/workspace-tests/tests/helm_alert_rules.rs
@@ -51,6 +51,8 @@ const CLIENT_FAMILIES: &[&str] = &[
     "mx_p2p_candidates_count",
     "mx_p2p_candidates_sum",
     "mx_p2p_list_sources_total",
+    "mx_p2p_source_attempt_phase_seconds_count",
+    "mx_p2p_source_attempt_phase_seconds_sum",
     "mx_p2p_source_attempts_total",
     "mx_p2p_source_selections_total",
     "mx_p2p_transfer_seconds_bucket",


### PR DESCRIPTION
`mx_p2p_transfer_seconds` is one interval per source attempt, so ninety seconds
there cannot tell an RDMA read from a slow registration or a peer that took a
minute to answer the handshake. This splits the attempt into seven phases, each
recorded from the `with`-block `RdmaStrategy` already wraps around that call —
ten added lines in the strategy, nothing in the NIXL manager or any adapter
changed. `metadata` is the GetMetadata/manifest fetch that ran before the
transfer span and was never measured; the other six sum to less than the
transfer by construction.

| Family | Type | Labels | Answers |
| --- | --- | --- | --- |
| `mx_p2p_source_attempt_phase_seconds` | Histogram | `policy`, `phase`, `outcome`, `scheme` | Which part of the transfer took the time, and which phase a failed attempt died in? |

Phases: `metadata`, `prepare`, `register`, `handshake`, `receive`, `finalize`, `release`.
Two panels join the P2P clients row under the transfer panels.

## Measured on hardware

Two H200 pods on one nebius node, `Qwen2.5-7B-Instruct` (15.25 GB), SGLang, NIXL
over RDMA. The source loaded natively in 37.62 s and published; the target pulled
from it in **2.36 s** end to end.

| Phase | Mean | Share of transfer |
| --- | ---: | ---: |
| `metadata` | 8.66 ms | — (before the span) |
| `prepare` | 4.56 ms | 0.2% |
| `register` | 1.653 s | 72.8% |
| `handshake` | 181 ms | 8.0% |
| `receive` | 431 ms | 19.0% |
| `finalize` | 3.3 µs | 0.0% |
| `release` | 118 µs | 0.0% |
| **transfer** | **2.271 s** | Σ phases = 99.92% |

The RDMA read itself was 0.43 s at 283 Gbps. Most of the "transfer" is
`register`: bringing up the NIXL agent and registering 201 memory regions, of
which the `ibv_reg_mr` calls were 0.29 s. That is the distinction the single
interval could not make.

<img width="1100" alt="phases table" src="https://raw.githubusercontent.com/yixinh-nv/modelexpress/assets/pr-745-phases/phases_table.png" />

## Overhead: before and after

Same source, same 7B, same image; the only difference is which client is
pip-installed on the target — `main` at this branch's merge-base (`644d53dd`,
no phase metrics) or this branch. Metrics enabled on both. Times are the
loader's own `load_model() COMPLETE` and `Total receive time` log lines.

| Pull | `main` receive / load | branch receive / load |
| --- | ---: | ---: |
| 1 | 2.05 s / 2.14 s | 2.06 s / 2.15 s |
| 2 | 2.07 s / 2.15 s | 2.05 s / 2.14 s |

The branch is within **10 ms** of `main` on every pull, and the spread within
each variant is the same size as the gap between them. Seven `perf_counter`
pairs and seven histogram observations per attempt are not measurable against a
two-second transfer.

