### PR TITLE
fix(crd): bound uint32 fields in OpenAPI schema

### DIFF
--- a/examples/crds.yaml
+++ b/examples/crds.yaml
@@ -120,17 +120,20 @@ spec:
                       chunkCount:
                         description: Number of transfer chunks in the sealed artifact manifest.
                         format: int64
+                        maximum: 4294967295.0
                         minimum: 0.0
                         type: integer
                       fileCount:
                         description: Number of files in the sealed artifact manifest.
                         format: int64
+                        maximum: 4294967295.0
                         minimum: 0.0
                         type: integer
                       nodeRank:
                         default: 0
                         description: Distributed node rank that owns this node-scoped artifact.
                         format: int64
+                        maximum: 4294967295.0
                         minimum: 0.0
                         type: integer
                       totalSize:

--- a/helm/crds/modelexpress-crds.yaml
+++ b/helm/crds/modelexpress-crds.yaml
@@ -120,17 +120,20 @@ spec:
                       chunkCount:
                         description: Number of transfer chunks in the sealed artifact manifest.
                         format: int64
+                        maximum: 4294967295.0
                         minimum: 0.0
                         type: integer
                       fileCount:
                         description: Number of files in the sealed artifact manifest.
                         format: int64
+                        maximum: 4294967295.0
                         minimum: 0.0
                         type: integer
                       nodeRank:
                         default: 0
                         description: Distributed node rank that owns this node-scoped artifact.
                         format: int64
+                        maximum: 4294967295.0
                         minimum: 0.0
                         type: integer
                       totalSize:

--- a/modelexpress_server/src/p2p/k8s_types.rs
+++ b/modelexpress_server/src/p2p/k8s_types.rs
@@ -171,17 +171,17 @@ pub struct ArtifactSourceStatus {
 
     /// Number of files in the sealed artifact manifest.
     #[serde(rename = "fileCount")]
-    #[schemars(with = "i64", range(min = 0))]
+    #[schemars(with = "i64", range(min = 0, max = 4294967295u32))]
     pub file_count: u32,
 
     /// Number of transfer chunks in the sealed artifact manifest.
     #[serde(rename = "chunkCount")]
-    #[schemars(with = "i64", range(min = 0))]
+    #[schemars(with = "i64", range(min = 0, max = 4294967295u32))]
     pub chunk_count: u32,
 
     /// Distributed node rank that owns this node-scoped artifact.
     #[serde(rename = "nodeRank", default)]
-    #[schemars(with = "i64", range(min = 0))]
+    #[schemars(with = "i64", range(min = 0, max = 4294967295u32))]
     pub node_rank: u32,
 }
 


### PR DESCRIPTION
## Summary

- cap the generated OpenAPI schemas for `fileCount`, `chunkCount`, and `nodeRank` at `u32::MAX`
- keep the Rust and protobuf fields as unsigned 32-bit integers while representing them as bounded `int64` values in Kubernetes

## Motivation

This follows up on the unsigned integer TODO in #722. Kubernetes CRD OpenAPI schemas support `int32` and `int64` formats, but not `uint32`. The existing non-negative `int64` schemas accept values above `u32::MAX`, which the Kubernetes API server can store but ModelExpress cannot deserialize into the corresponding Rust fields.

These fields are all part of the CR status, and the ModelExpress server should be their only writer, so an overflow should not occur during normal operation. However, defining the upper bounds is still useful because it keeps Kubernetes OpenAPI validation consistent with the Rust and protobuf `u32` contract and prevents the API server from storing values that the server cannot deserialize.

Using `format: int64` with a minimum of `0` and a maximum of `4294967295` represents the full `u32` range and rejects incompatible values at API validation time.

## Testing

- `cargo test -p modelexpress-server --bin crdgen`
- `cargo run --quiet -p modelexpress-server --bin crdgen | cmp - examples/crds.yaml`
- verified that the example and Helm CRD manifests are identical
- `python3 -m pre_commit run`


* Manually patch a CR status to `u32_max + 1`.
  <img width="1724" height="124" alt="image" src="https://github.com/user-attachments/assets/c54359bc-15d2-4ca5-9241-c0976feb0cfc" />
