### PR TITLE
fix(rbac): remove unused CRD reader role

### DIFF
--- a/examples/dynamo_p2p_transfer_k8s/vllm/rbac-modelmetadata.yaml
+++ b/examples/dynamo_p2p_transfer_k8s/vllm/rbac-modelmetadata.yaml
@@ -94,21 +94,3 @@ subjects:
   # RoleBinding's own namespace (whatever `kubectl apply -n <ns>` lands in).
   - kind: ServiceAccount
     name: modelexpress
----
-# ClusterRole for CRD management (cluster-admin typically handles this)
-# Only needed if server creates/manages the CRD itself
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: modelexpress-crd-reader
-  labels:
-    app.kubernetes.io/name: modelexpress
-rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch

--- a/examples/p2p_transfer_k8s/server/kubernetes_backend/rbac-modelmetadata.yaml
+++ b/examples/p2p_transfer_k8s/server/kubernetes_backend/rbac-modelmetadata.yaml
@@ -94,21 +94,3 @@ subjects:
   # RoleBinding's own namespace (whatever `kubectl apply -n <ns>` lands in).
   - kind: ServiceAccount
     name: modelexpress
----
-# ClusterRole for CRD management (cluster-admin typically handles this)
-# Only needed if server creates/manages the CRD itself
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: modelexpress-crd-reader
-  labels:
-    app.kubernetes.io/name: modelexpress
-rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch


### PR DESCRIPTION
## Summary

The Modelexpress server does not read CustomResourceDefinition objects. It uses typed Kubernetes APIs to manage ModelMetadata and ModelCacheEntry custom resources, while the CRDs are installed separately by the deployment process. In addition, the removed ClusterRole had no ClusterRoleBinding and therefore granted no permissions.

In addition, it is pretty rare for a K8s controller to read "CRD" directly.

## Testing
- validated both files as multi-document YAML
- verified both manifests remain identical
- ran git diff --check

pre-commit was not available in the local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary cluster-wide permissions to read Kubernetes custom resource definitions from model metadata deployment configurations.
  * Existing service account, role, and role binding access remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->